### PR TITLE
Some more preliminary changes for the queijo repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 __pycache__
 .cache
 .clangd
+compile_commands.json
+*~

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ include(Sources.cmake)
 
 target_compile_features(Queijo.Lib PUBLIC cxx_std_17)
 target_include_directories(Queijo.Lib PUBLIC Lib/include ${LIBUV_INCLUDE_DIR})
+target_link_libraries(Queijo.Lib PRIVATE Luau.VM uv)
 target_link_libraries(Queijo.CLI PRIVATE Luau.Compiler Luau.Config Luau.CodeGen Luau.VM Queijo.Lib uv)
 
 target_compile_options(Queijo.Lib PRIVATE ${QUEIJO_OPTIONS})

--- a/cli/queijo.cpp
+++ b/cli/queijo.cpp
@@ -27,20 +27,29 @@ static Luau::CompileOptions copts()
     return result;
 }
 
+void load_queijo_runtime(lua_State* L, const luaL_Reg* libs)
+{
+    const luaL_Reg* lib = libs;
+    for (; lib->func; lib++)
+    {
+        lua_pushcfunction(L, lib->func, NULL);
+        lua_pushstring(L, lib->name);
+        lua_call(L, 1, 0);
+    }
+}
+
 void setupState(lua_State* L)
 {
-    if (codegen)
-        Luau::CodeGen::create(L);
-
+    /* register new libraries */
+    Luau::CodeGen::create(L);
+    // register the builtin tables
     luaL_openlibs(L);
 
     static const luaL_Reg funcs[] = {
         {NULL, NULL},
     };
 
-    lua_pushvalue(L, LUA_GLOBALSINDEX);
-    luaL_register(L, NULL, funcs);
-    lua_pop(L, 1);
+    load_queijo_runtime(L, funcs);
 
     luaL_sandbox(L);
 }
@@ -167,7 +176,7 @@ int main(int argc, char** argv)
 
     if (files.empty())
     {
-        fprintf(stderr, "Error: quiejo expects a file to run.\n\n");
+        fprintf(stderr, "Error: queijo expects a file to run.\n\n");
         displayHelp(argv[0]);
         return 1;
     }


### PR DESCRIPTION
1. Cmake now produces compile_commands by default
2. test directory for basic lua files
3. Queijo.lib now links in Lua.VM
4. simple registration functions for the queijo runtime