### PR TITLE
Adding 'spawn' to create an async table interface to a module in a different VM

### DIFF
--- a/cli/queijo.cpp
+++ b/cli/queijo.cpp
@@ -454,6 +454,14 @@ static int lua_spawn(lua_State* L)
     return 1;
 }
 
+static int lua_defer(lua_State* L)
+{
+    auto runtime = getRuntime(L);
+
+    runtime->runningThreads.push_back({ true, getRefForThread(L), 0 });
+    return lua_yield(L, 0);
+}
+
 lua_State* setupState(Runtime& runtime)
 {
     // Separate VM for data copies
@@ -483,6 +491,7 @@ lua_State* setupState(Runtime& runtime)
     static const luaL_Reg funcs[] = {
         {"require", lua_require},
         {"spawn", lua_spawn},
+        {"defer", lua_defer},
         {nullptr, nullptr},
     };
 

--- a/cli/queijo.cpp
+++ b/cli/queijo.cpp
@@ -449,12 +449,7 @@ static int lua_spawn(lua_State* L)
 
     lua_pop(child->GL, 1);
 
-    // TODO: another place for libuv
-    // FIXME: this strong reference to Runtime prevents it from being freed
-    std::thread thread([child] {
-        child->runContinuously();
-    });
-    thread.detach();
+    child->runContinuously();
 
     return 1;
 }

--- a/examples/fib.luau
+++ b/examples/fib.luau
@@ -1,0 +1,11 @@
+local module = {}
+
+function module.fib(n: number)
+    return if n <= 2 then 1 else module.fib(n - 1) + module.fib(n - 2)
+end
+
+function module.fibTable(t: { n: number })
+    return if t.n <= 2 then 1 else module.fibTable({ n = t.n - 1}) + module.fibTable({ n = t.n - 2 })
+end
+
+return module

--- a/examples/parallel.luau
+++ b/examples/parallel.luau
@@ -1,7 +1,0 @@
-local module = {}
-
-function module.fib(n: number)
-    return if n <= 2 then 1 else module.fib(n - 1) + module.fib(n - 2)
-end
-
-return module

--- a/examples/parallel.luau
+++ b/examples/parallel.luau
@@ -1,0 +1,7 @@
+local module = {}
+
+function module.fib(n: number)
+    return if n <= 2 then 1 else module.fib(n - 1) + module.fib(n - 2)
+end
+
+return module

--- a/examples/spawn_example.luau
+++ b/examples/spawn_example.luau
@@ -6,7 +6,6 @@ local vm1 = spawn("./fib")
 local vm2 = spawn("./fib")
 local vm3 = spawn("./fib")
 
---[[ TODO: would be nice to have multiple yields in a task auto-continue
 do
     local start = os.clock();
 
@@ -18,7 +17,6 @@ do
 
     print("multiple direct fib in", os.clock() - start)
 end
-]]
 
 do
     local start = os.clock();

--- a/examples/spawn_example.luau
+++ b/examples/spawn_example.luau
@@ -1,0 +1,11 @@
+print("start")
+
+local parallel1 = spawn("./parallel")
+local parallel2 = spawn("./parallel")
+local parallel3 = spawn("./parallel")
+
+print(os.clock())
+
+print(parallel1.fib(22))
+
+print(os.clock())

--- a/examples/spawn_example.luau
+++ b/examples/spawn_example.luau
@@ -1,11 +1,59 @@
+local task = require("./task")
+
 print("start")
 
-local parallel1 = spawn("./parallel")
-local parallel2 = spawn("./parallel")
-local parallel3 = spawn("./parallel")
+local vm1 = spawn("./fib")
+local vm2 = spawn("./fib")
+local vm3 = spawn("./fib")
 
-print(os.clock())
+--[[ TODO: would be nice to have multiple yields in a task auto-continue
+do
+    local start = os.clock();
 
-print(parallel1.fib(22))
+    task.await(task.create(function()
+        print(vm1.fib(10))
+        print(vm1.fib(20))
+        print(vm1.fib(33))
+    end))
 
-print(os.clock())
+    print("multiple direct fib in", os.clock() - start)
+end
+]]
+
+do
+    local start = os.clock();
+
+    print(task.await(task.create(vm1.fib, 33)))
+
+    print("single task fib in", os.clock() - start)
+end
+
+do
+    local start = os.clock();
+
+    print(task.await(task.create(vm1.fibTable, { n = 33 })))
+
+    print("single task fibTable in", os.clock() - start)
+end
+
+do
+    local start = os.clock();
+
+    local s1, s2, s3 = task.create(vm1.fib, 33), task.create(vm1.fib, 33), task.create(vm1.fib, 33)
+
+    print(task.awaitAll(s1, s2, s3))
+
+    print("3 serial fibs in", os.clock() - start)
+end
+
+do
+    local start = os.clock();
+
+    local p1, p2, p3 = task.create(vm1.fib, 33), task.create(vm2.fib, 33), task.create(vm3.fib, 33)
+
+    print(task.awaitAll(p1, p2, p3))
+
+    print("3 parallel fibs in", os.clock() - start)
+end
+
+print("completed")

--- a/examples/task.luau
+++ b/examples/task.luau
@@ -20,7 +20,7 @@ end
 
 local function await(t: Task)
     while t.success == nil do
-        coroutine.yield()
+        defer()
     end
 
     if t.success then
@@ -41,7 +41,7 @@ local function awaitAll(...: Task)
         for i, v in tasks do
             if v.success == nil then
                 done = false
-                coroutine.yield()
+                defer()
             end
         end
     end

--- a/runtime/include/queijo/runtime.h
+++ b/runtime/include/queijo/runtime.h
@@ -2,6 +2,8 @@
 
 #include "queijo/ref.h"
 
+#include <atomic>
+#include <thread>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -12,15 +14,22 @@ struct ThreadToContinue
     bool success = false;
     std::shared_ptr<Ref> ref;
     int argumentCount = 0;
+    std::function<void()> cont;
 };
 
 struct Runtime
 {
     Runtime();
+    ~Runtime();
 
     bool runToCompletion();
 
+    // For child runtimes, run a thread waiting for work
+    void runContinuously();
+
     bool hasContinuations();
+
+    void schedule(std::function<void()> f);
 
     // Resume thread with the specified error
     void scheduleLuauError(std::shared_ptr<Ref> ref, std::string error);
@@ -34,15 +43,21 @@ struct Runtime
     // VM for this runtime
     std::unique_ptr<lua_State, void (*)(lua_State*)> globalState;
 
-    // Short-hand for global state
+    // Shorthand for global state
     lua_State* GL = nullptr;
 
-    std::mutex continuationMutex;
-    std::vector<std::function<void()>> continuations;
+    std::mutex dataCopyMutex;
+    std::unique_ptr<lua_State, void (*)(lua_State*)> dataCopy;
 
     std::vector<ThreadToContinue> runningThreads;
 
-    std::vector<std::shared_ptr<Runtime>> childRuntimes;
+private:
+    std::mutex continuationMutex;
+    std::vector<std::function<void()>> continuations;
+
+    // TODO: can this be handled by libuv?
+    std::atomic<bool> stop;
+    std::condition_variable runLoopCv;
 };
 
 Runtime* getRuntime(lua_State* L);

--- a/runtime/include/queijo/runtime.h
+++ b/runtime/include/queijo/runtime.h
@@ -3,6 +3,7 @@
 #include "queijo/ref.h"
 
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -15,6 +16,10 @@ struct ThreadToContinue
 
 struct Runtime
 {
+    Runtime();
+
+    bool runToCompletion();
+
     bool hasContinuations();
 
     // Resume thread with the specified error
@@ -26,12 +31,18 @@ struct Runtime
     // Run 'f' in a libuv work queue
     void runInWorkQueue(std::function<void()> f);
 
+    // VM for this runtime
+    std::unique_ptr<lua_State, void (*)(lua_State*)> globalState;
+
+    // Short-hand for global state
     lua_State* GL = nullptr;
 
     std::mutex continuationMutex;
     std::vector<std::function<void()>> continuations;
 
     std::vector<ThreadToContinue> runningThreads;
+
+    std::vector<std::shared_ptr<Runtime>> childRuntimes;
 };
 
 Runtime* getRuntime(lua_State* L);

--- a/runtime/include/queijo/runtime.h
+++ b/runtime/include/queijo/runtime.h
@@ -3,7 +3,7 @@
 #include "queijo/ref.h"
 
 #include <atomic>
-#include <thread>
+#include <condition_variable>
 #include <functional>
 #include <memory>
 #include <mutex>

--- a/runtime/include/queijo/runtime.h
+++ b/runtime/include/queijo/runtime.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <thread>
 #include <vector>
 
 struct ThreadToContinue
@@ -58,6 +59,7 @@ private:
     // TODO: can this be handled by libuv?
     std::atomic<bool> stop;
     std::condition_variable runLoopCv;
+    std::thread runLoopThread;
 };
 
 Runtime* getRuntime(lua_State* L);

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -1,8 +1,98 @@
 #include "queijo/runtime.h"
 
+#include "lua.h"
+
 #include "uv.h"
 
 #include <assert.h>
+
+static void lua_close_checked(lua_State* L)
+{
+    if (L)
+        lua_close(L);
+}
+
+Runtime::Runtime()
+    : globalState(nullptr, lua_close_checked)
+{
+}
+
+bool Runtime::runToCompletion()
+{
+    // While there is some C++ or Luau code left to run
+    while (!runningThreads.empty() || hasContinuations())
+    {
+        // Complete all C++ continuations
+        std::vector<std::function<void()>> copy;
+
+        {
+            std::unique_lock lock(continuationMutex);
+            copy = std::move(continuations);
+            continuations.clear();
+        }
+
+        for (auto&& continuation : copy)
+            continuation();
+
+        if (runningThreads.empty())
+            continue;
+
+        auto next = std::move(runningThreads.front());
+        runningThreads.erase(runningThreads.begin());
+
+        next.ref->push(GL);
+        lua_State* L = lua_tothread(GL, -1);
+
+        if (L == nullptr)
+        {
+            fprintf(stderr, "Cannot resume a non-thread reference");
+            return false;
+        }
+
+        // We still have 'next' on stack to hold on to thread we are about to run
+        lua_pop(GL, 1);
+
+        int status = LUA_OK;
+
+        if (!next.success)
+            status = lua_resumeerror(L, nullptr);
+        else
+            status = lua_resume(L, nullptr, next.argumentCount);
+
+        if (status == LUA_YIELD)
+        {
+            int results = lua_gettop(L);
+
+            if (results != 0)
+            {
+                std::string error = "Top level yield cannot return any results";
+                error += "\nstacktrace:\n";
+                error += lua_debugtrace(L);
+                fprintf(stderr, "%s", error.c_str());
+                return false;
+            }
+
+            runningThreads.push_back({ true, getRefForThread(L), 0 });
+            continue;
+        }
+
+        if (status != LUA_OK)
+        {
+            std::string error;
+
+            if (const char* str = lua_tostring(L, -1))
+                error = str;
+
+            error += "\nstacktrace:\n";
+            error += lua_debugtrace(L);
+
+            fprintf(stderr, "%s", error.c_str());
+            return false;
+        }
+    }
+
+    return true;
+}
 
 bool Runtime::hasContinuations()
 {

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -90,7 +90,6 @@ bool Runtime::runToCompletion()
                 return false;
             }
 
-            runningThreads.push_back({ true, getRefForThread(L), 0 });
             continue;
         }
 

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -127,9 +127,6 @@ void Runtime::runContinuously()
 
         runToCompletion();
     }
-
-    // Debug
-    printf("Runtime::runContinuously() done\n");
 }
 
 bool Runtime::hasContinuations()


### PR DESCRIPTION
The idea is that you pass a module name into `spawn` and get back a table with methods of that module where each method performs a yielding request to the target method to perform the operation with the provided arguments.

An intermediate VM is used to copy the arguments over (two copies) to not wait for the target to complete whatever operation it has and to not introduce a new way of serializing Luau values.

Improved the await API to allow running tasks with multiple yield points correctly.

Example of the example output:
```
start
55
6765
3524578
multiple direct fib in  1.1284413333196426
3524578
single task fib in      1.1245120416715508
3524578
single task fibTable in 2.496818583327695
3524578 3524578 3524578
3 serial fibs in        3.54964370833477
3524578 3524578 3524578
3 parallel fibs in      1.1711355416628066
completed
```
