### PR TITLE
Fixes for allocator/name table memory management and stack reservations

### DIFF
--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -13,22 +13,33 @@
 namespace luau
 {
 
-static Luau::ParseResult parse(std::string& source)
+struct StatResult
 {
-    Luau::Allocator allocator;
-    Luau::AstNameTable names{allocator};
+    std::shared_ptr<Luau::Allocator> allocator;
+    std::shared_ptr<Luau::AstNameTable> names;
+
+    Luau::ParseResult parseResult;
+};
+
+static StatResult parse(std::string& source)
+{
+    auto allocator = std::make_shared<Luau::Allocator>();
+    auto names = std::make_shared<Luau::AstNameTable>(*allocator);
 
     Luau::ParseOptions options;
     options.captureComments = true;
     options.allowDeclarationSyntax = false;
 
-    Luau::ParseResult parseResult = Luau::Parser::parse(source.data(), source.size(), names, allocator, options);
+    auto parseResult = Luau::Parser::parse(source.data(), source.size(), *names, *allocator, options);
 
-    return parseResult;
+    return StatResult{allocator, names, std::move(parseResult)};
 }
 
 struct ExprResult
 {
+    std::shared_ptr<Luau::Allocator> allocator;
+    std::shared_ptr<Luau::AstNameTable> names;
+
     Luau::AstExpr* root;
     size_t lines = 0;
 
@@ -40,28 +51,28 @@ struct ExprResult
 
 static ExprResult parseExpr(std::string& source)
 {
-    Luau::Allocator allocator;
-    Luau::AstNameTable names{allocator};
+    auto allocator = std::make_shared<Luau::Allocator>();
+    auto names = std::make_shared<Luau::AstNameTable>(*allocator);
 
     Luau::ParseOptions options;
     options.captureComments = true;
     options.allowDeclarationSyntax = false;
 
-    Luau::Parser p(source.data(), source.size(), names, allocator, options);
+    Luau::Parser p(source.data(), source.size(), *names, *allocator, options);
 
     try
     {
         Luau::AstExpr* expr = p.parseExpr();
         size_t lines = p.lexer.current().location.end.line + (source.size() > 0 && source.data()[source.size() - 1] != '\n');
 
-        return ExprResult{expr, lines, std::move(p.hotcomments), std::move(p.parseErrors), std::move(p.commentLocations)};
+        return ExprResult{allocator, names, expr, lines, std::move(p.hotcomments), std::move(p.parseErrors), std::move(p.commentLocations)};
     }
     catch (Luau::ParseError& err)
     {
         // when catching a fatal error, append it to the list of non-fatal errors and return
         p.parseErrors.push_back(err);
 
-        return ExprResult{nullptr, 0, {}, std::move(p.parseErrors)};
+        return ExprResult{nullptr, nullptr, nullptr, 0, {}, std::move(p.parseErrors)};
     }
 }
 
@@ -81,6 +92,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::Position position)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, 2);
 
         lua_pushnumber(L, position.line);
@@ -92,6 +104,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::Location location)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, 2);
 
         serialize(location.begin);
@@ -103,11 +116,14 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstName& name)
     {
+        lua_rawcheckstack(L, 1);
         lua_pushstring(L, name.value);
     }
 
     void serialize(Luau::AstLocal* local)
     {
+        lua_rawcheckstack(L, 2);
+
         lua_pushlightuserdata(L, local);
         lua_gettable(L, localTableIndex);
 
@@ -138,6 +154,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprTable::Item& item)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, 3);
 
         switch (item.kind)
@@ -228,6 +245,8 @@ struct AstSerialize : public Luau::AstVisitor
     static const size_t preambleSize = 2;
     void serializeNodePreamble(Luau::AstNode* node, const char* tag)
     {
+        lua_rawcheckstack(L, 2);
+        
         lua_pushstring(L, tag);
         lua_setfield(L, -2, "tag");
 
@@ -236,6 +255,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeLocals(Luau::AstArray<Luau::AstLocal*>& locals, size_t nrec = 0)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, locals.size, nrec);
 
         for (size_t i = 0; i < locals.size; i++)
@@ -247,6 +267,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeExprs(Luau::AstArray<Luau::AstExpr*>& exprs, size_t nrec = 0)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, exprs.size, nrec);
 
         for (size_t i = 0; i < exprs.size; i++)
@@ -258,6 +279,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStats(Luau::AstArray<Luau::AstStat*>& stats, size_t nrec = 0)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, stats.size, nrec);
 
         for (size_t i = 0; i < stats.size; i++)
@@ -269,6 +291,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprGroup* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 1);
 
         serializeNodePreamble(node, "group");
@@ -279,6 +302,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprConstantNil* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize);
 
         serializeNodePreamble(node, "nil");
@@ -286,6 +310,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprConstantBool* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 1);
 
         serializeNodePreamble(node, "boolean");
@@ -296,6 +321,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprConstantNumber* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 1);
 
         serializeNodePreamble(node, "number");
@@ -306,6 +332,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprConstantString* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 1);
 
         serializeNodePreamble(node, "number");
@@ -316,6 +343,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprLocal* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "local");
@@ -329,6 +357,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprGlobal* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 1);
 
         serializeNodePreamble(node, "global");
@@ -339,6 +368,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprVarargs* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize);
 
         serializeNodePreamble(node, "vararg");
@@ -346,6 +376,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprCall* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "call");
@@ -360,6 +391,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprIndexName* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
         serializeNodePreamble(node, "indexname");
@@ -368,8 +400,9 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "expr");
 
         serialize(node->index);
-        withLocation(node->indexLocation);
         lua_setfield(L, -2, "index");
+        serialize(node->indexLocation);
+        lua_setfield(L, -2, "indexLocation");
 
         lua_createtable(L, 0, 2);
         lua_pushlstring(L, &node->op, 1);
@@ -381,6 +414,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprIndexExpr* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "index");
@@ -394,6 +428,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprFunction* node)
     {
+        lua_rawcheckstack(L, 3);
         lua_createtable(L, 0, preambleSize);
 
         serializeNodePreamble(node, "function");
@@ -425,6 +460,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprTable* node)
     {
+        lua_rawcheckstack(L, 3);
         lua_createtable(L, 0, preambleSize + 1);
 
         serializeNodePreamble(node, "table");
@@ -440,6 +476,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprUnary* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "unary");
@@ -464,6 +501,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprBinary* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
         serializeNodePreamble(node, "binary");
@@ -480,6 +518,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprTypeAssertion* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "cast");
@@ -493,6 +532,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprIfElse* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
         serializeNodePreamble(node, "conditional");
@@ -515,6 +555,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprInterpString* node)
     {
+        lua_rawcheckstack(L, 3);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "interpolatedstring");
@@ -533,6 +574,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprError* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "error");
@@ -545,6 +587,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatBlock* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 1);
 
         serializeNodePreamble(node, "block");
@@ -555,6 +598,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatIf* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 5);
 
         serializeNodePreamble(node, "conditional");
@@ -565,7 +609,10 @@ struct AstSerialize : public Luau::AstVisitor
         node->thenbody->visit(this);
         lua_setfield(L, -2, "consequent");
 
-        node->elsebody->visit(this);
+        if (node->elsebody)
+            node->elsebody->visit(this);
+        else
+            lua_pushnil(L);
         lua_setfield(L, -2, "antecedent");
 
         if (node->thenLocation)
@@ -583,6 +630,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatWhile* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 4);
 
         serializeNodePreamble(node, "while");
@@ -602,6 +650,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatRepeat* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "repeat");
@@ -615,6 +664,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatBreak* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize);
 
         serializeNodePreamble(node, "break");
@@ -622,6 +672,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatContinue* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize);
 
         serializeNodePreamble(node, "continue");
@@ -629,6 +680,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatReturn* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 1);
 
         serializeNodePreamble(node, "return");
@@ -639,6 +691,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatExpr* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 1);
 
         serializeNodePreamble(node, "expression");
@@ -649,6 +702,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatLocal* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
         serializeNodePreamble(node, "local");
@@ -668,6 +722,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatFor* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 6);
 
         serializeNodePreamble(node, "for");
@@ -696,6 +751,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatForIn* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 5);
 
         serializeNodePreamble(node, "forin");
@@ -724,6 +780,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatAssign* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "assign");
@@ -737,6 +794,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatCompoundAssign* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
         serializeNodePreamble(node, "compoundassign");
@@ -753,6 +811,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatFunction* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "function");
@@ -766,6 +825,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatLocalFunction* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "localfunction");
@@ -799,6 +859,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatError* node)
     {
+        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
         serializeNodePreamble(node, "error");
@@ -1193,15 +1254,17 @@ static int luau_parse(lua_State* L)
 {
     std::string source = luaL_checkstring(L, 1);
 
-    Luau::ParseResult result = parse(source);
+    StatResult result = parse(source);
 
-    if (!result.errors.empty())
+    auto& errors = result.parseResult.errors;
+
+    if (!errors.empty())
     {
         std::vector<std::string> locationStrings{};
-        locationStrings.reserve(result.errors.size());
+        locationStrings.reserve(errors.size());
 
         size_t size = 0;
-        for (auto error : result.errors)
+        for (auto error : errors)
         {
             locationStrings.emplace_back(Luau::toString(error.getLocation()));
             size += locationStrings.back().size() + 2 + error.getMessage().size() + 1;
@@ -1210,24 +1273,26 @@ static int luau_parse(lua_State* L)
         std::string fullError;
         fullError.reserve(size);
 
-        for (size_t i = 0; i < result.errors.size(); i++)
+        for (size_t i = 0; i < errors.size(); i++)
         {
             fullError += locationStrings[i];
             fullError += ": ";
-            fullError += result.errors[i].getMessage();
+            fullError += errors[i].getMessage();
             fullError += "\n";
         }
 
         luaL_error(L, "parsing failed:\n%s", fullError.c_str());
     }
 
+    lua_rawcheckstack(L, 3);
+
     lua_createtable(L, 0, 2);
 
     AstSerialize serializer{L};
-    serializer.visit(result.root);
+    serializer.visit(result.parseResult.root);
     lua_setfield(L, -2, "root");
 
-    lua_pushnumber(L, result.lines);
+    lua_pushnumber(L, result.parseResult.lines);
     lua_setfield(L, -2, "lines");
 
     return 1;

--- a/std/pp.luau
+++ b/std/pp.luau
@@ -54,7 +54,7 @@ local typeSortOrder = {
 local function traverseTable(dataTable, seen, indent)
     local output = ""
 
-    local indentStr = string.rep("\t", indent)
+    local indentStr = string.rep("  ", indent)
 
     local keys = {}
 


### PR DESCRIPTION
Allocator was going out of scope so we operated on dead AST.

Added Luau stack checks to not run out of limited minimal space provided.

Fixed `indexLocation` trying to apply to `index` AstName which is no longer a table.
Fixed crash on missing `else` in 'if' statement.

Pretty print will use indent of 2 spaces for easier viewing.