### PR TITLE
Add an initial collections library.

### DIFF
--- a/std/collections.luau
+++ b/std/collections.luau
@@ -1,0 +1,37 @@
+local function map<K, A, B>(table: {[K]: A}, f: (A) -> B): {[K]: B}
+    local new = {}
+
+    for k, v in table do
+        new[k] = f(v)
+    end
+
+    return new
+end
+
+local function filter<K, V>(table: {[K]: V}, predicate: (V) -> boolean): {[K]: V}
+    local new = {}
+
+    for k, v in table do
+        if predicate(v) then
+            new[k] = v
+        end
+    end
+
+    return new
+end
+
+local function fold<K, V, A>(table: {[K]: V}, f: (A, V) -> A, initial: A): A
+    local acc = initial
+
+    for _, v in table do
+        acc = f(acc, v)
+    end
+
+    return acc
+end
+
+return {
+    map = map,
+    filter = filter,
+    fold = fold,
+}

--- a/std/task.luau
+++ b/std/task.luau
@@ -5,7 +5,7 @@ export type Task = {
 }
 
 local function create(f, ...): Task
-    local data: Task = {}
+    local data = {}
 
     data.co = coroutine.create(function(...)
         local success, result = pcall(f, ...)


### PR DESCRIPTION
Adds an initial collections library to `std` with iterative implementations of `map`, `filter`, and `fold`. I imagine there'll be more useful things to add here in the future, but I figure putting down something simple with the obvious bits is a good starting point, and helps people get a sense of scope for lrt.