### PR TITLE
Refactor runtime libraries to be explicitly required.

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -58,14 +58,16 @@ lua_State* setupState(Runtime& runtime)
     // register the builtin tables
     luaL_openlibs(L);
 
-    luaopen_fs(L);
-    lua_pop(L, 1);
+    luaL_findtable(L, LUA_REGISTRYINDEX, "_MODULES", 1);
 
-    luaopen_net(L);
-    lua_pop(L, 1);
+    lrtopen_fs(L);
+    lua_setfield(L, -2, "@lrt/fs");
 
-    luaopen_luau(L);
-    lua_pop(L, 1);
+    lrtopen_net(L);
+    lua_setfield(L, -2, "@lrt/net");
+
+    lrtopen_luau(L);
+    lua_setfield(L, -2, "@lrt/luau");
 
     static const luaL_Reg funcs[] = {
         {"require", lua_require},

--- a/examples/async_read.luau
+++ b/examples/async_read.luau
@@ -1,5 +1,7 @@
+local fs = require("@lrt/fs")
 local task = require("@std/task")
--- blocking 
+
+-- blocking
 local f = fs.open("temp", "w+")
 local x = "This is a string I am writing to a file"
 fs.write(f, x)
@@ -12,5 +14,3 @@ end)
 local t2 = task.await(t)
 print(t2)
 print(t2 == x)
-
-

--- a/examples/linter.luau
+++ b/examples/linter.luau
@@ -1,3 +1,6 @@
+local fs = require("@lrt/fs")
+local luau = require("@lrt/luau")
+
 local pp = require("@std/pp")
 
 local function select<T>(node, predicate: ({[string]: any}) -> T?): { T }

--- a/examples/net_example.luau
+++ b/examples/net_example.luau
@@ -1,3 +1,5 @@
+local net = require("@lrt/net")
+
 local task = require("@std/task")
 
 local t = task.create(function()

--- a/examples/parsing.luau
+++ b/examples/parsing.luau
@@ -1,3 +1,6 @@
+local luau = require("@lrt/luau")
+
 local pretty = require("@std/pp")
+
 local foo = luau.parseexpr("5")
 print(pretty(foo))

--- a/fs/include/queijo/fs.h
+++ b/fs/include/queijo/fs.h
@@ -3,6 +3,11 @@
 #include "lua.h"
 #include "lualib.h"
 
+int luaopen_fs(lua_State* L);
+
+namespace fs
+{
+
 // TODO: add the ability to open as bytes
 /* Takes  path: string, a mode: 'r|a|w|x|+' (defaulting to r when omitted)
    Returns a table representing a handle to the file the state of a file {fd : number, error : ...}
@@ -26,7 +31,7 @@ int writestringtofile(lua_State* L);
 /* Reads a file without blocking */
 int readasync(lua_State* L);
 
-static const luaL_Reg fslib[] = {
+static const luaL_Reg lib[] = {
     /* Manual control apis - you are responsible for calling close / open*/
     {"open", open},
     {"read", read},
@@ -39,4 +44,4 @@ static const luaL_Reg fslib[] = {
     {NULL, NULL},
 };
 
-int luaopen_fs(lua_State* L);
+} // namespace fs

--- a/fs/include/queijo/fs.h
+++ b/fs/include/queijo/fs.h
@@ -3,7 +3,10 @@
 #include "lua.h"
 #include "lualib.h"
 
+// open the library as a standard global luau library
 int luaopen_fs(lua_State* L);
+// open the library as a table on top of the stack
+int lrtopen_fs(lua_State* L);
 
 namespace fs
 {

--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -470,3 +470,19 @@ int luaopen_fs(lua_State* L)
     luaL_register(L, "fs", fs::lib);
     return 1;
 }
+
+int lrtopen_fs(lua_State* L)
+{
+    lua_createtable(L, 0, std::size(fs::lib));
+
+    for (auto& [name, func] : fs::lib)
+    {
+        if (!name || !func)
+            break;
+
+        lua_pushcfunction(L, func, name);
+        lua_setfield(L, -2, name);
+    }
+
+    return 1;
+}

--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -17,6 +17,9 @@
 #include <map>
 using namespace std;
 
+namespace fs
+{
+
 int setFlags(const char* c, int* openFlags, int* modeFlags)
 {
     for (const char* it = c; *it != '\0'; it++)
@@ -441,7 +444,7 @@ int readasync(lua_State* L)
 
             // Push the result buffer onto the stack
             info->token->complete(
-                [data = std::move(resultData)](lua_State* L) 
+                [data = std::move(resultData)](lua_State* L)
                 {
                     lua_pushlstring(L, data.data(), data.size());
                     return 1;
@@ -460,8 +463,10 @@ int readasync(lua_State* L)
     return lua_yield(L, 0);
 }
 
+} // namespace fs
+
 int luaopen_fs(lua_State* L)
 {
-    luaL_register(L, "fs", fslib);
+    luaL_register(L, "fs", fs::lib);
     return 1;
 }

--- a/luau/include/queijo/luau.h
+++ b/luau/include/queijo/luau.h
@@ -1,5 +1,20 @@
 #pragma once
 
-struct lua_State;
+#include "lua.h"
+#include "lualib.h"
 
 int luaopen_luau(lua_State* L);
+
+namespace luau {
+
+int luau_parse(lua_State* L);
+
+int luau_parseexpr(lua_State* L);
+
+static const luaL_Reg lib[] = {
+    {"parse", luau_parse},
+    {"parseexpr", luau_parseexpr},
+    {nullptr, nullptr},
+};
+
+} // namespace luau

--- a/luau/include/queijo/luau.h
+++ b/luau/include/queijo/luau.h
@@ -3,7 +3,10 @@
 #include "lua.h"
 #include "lualib.h"
 
+// open the library as a standard global luau library
 int luaopen_luau(lua_State* L);
+// open the library as a table on top of the stack
+int lrtopen_luau(lua_State* L);
 
 namespace luau {
 

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -246,7 +246,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeNodePreamble(Luau::AstNode* node, const char* tag)
     {
         lua_rawcheckstack(L, 2);
-        
+
         lua_pushstring(L, tag);
         lua_setfield(L, -2, "tag");
 
@@ -1250,7 +1250,7 @@ struct AstSerialize : public Luau::AstVisitor
     }
 };
 
-static int luau_parse(lua_State* L)
+int luau_parse(lua_State* L)
 {
     std::string source = luaL_checkstring(L, 1);
 
@@ -1298,7 +1298,7 @@ static int luau_parse(lua_State* L)
     return 1;
 }
 
-static int luau_parseexpr(lua_State* L)
+int luau_parseexpr(lua_State* L)
 {
     std::string source = luaL_checkstring(L, 1);
 
@@ -1335,12 +1335,6 @@ static int luau_parseexpr(lua_State* L)
 
     return 1;
 }
-
-static const luaL_Reg lib[] = {
-    {"parse", luau_parse},
-    {"parseexpr", luau_parseexpr},
-    {nullptr, nullptr},
-};
 
 } // namespace luau
 

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1344,3 +1344,19 @@ int luaopen_luau(lua_State* L)
 
     return 1;
 }
+
+int lrtopen_luau(lua_State* L)
+{
+    lua_createtable(L, 0, std::size(luau::lib));
+
+    for (auto& [name, func] : luau::lib)
+    {
+        if (!name || !func)
+            break;
+
+        lua_pushcfunction(L, func, name);
+        lua_setfield(L, -2, name);
+    }
+
+    return 1;
+}

--- a/net/include/queijo/net.h
+++ b/net/include/queijo/net.h
@@ -3,8 +3,10 @@
 #include "lua.h"
 #include "lualib.h"
 
-int luainit_net(lua_State* L);
+// open the library as a standard global luau library
 int luaopen_net(lua_State* L);
+// open the library as a table on top of the stack
+int lrtopen_net(lua_State* L);
 
 namespace net
 {
@@ -19,4 +21,4 @@ static const luaL_Reg lib[] = {
     {nullptr, nullptr},
 };
 
-}
+} // namespace net

--- a/net/include/queijo/net.h
+++ b/net/include/queijo/net.h
@@ -1,6 +1,22 @@
 #pragma once
 
-struct lua_State;
+#include "lua.h"
+#include "lualib.h"
 
+int luainit_net(lua_State* L);
 int luaopen_net(lua_State* L);
 
+namespace net
+{
+
+int get(lua_State* L);
+
+int getAsync(lua_State* L);
+
+static const luaL_Reg lib[] = {
+    {"get", get},
+    {"getAsync", getAsync},
+    {nullptr, nullptr},
+};
+
+}

--- a/net/src/net.cpp
+++ b/net/src/net.cpp
@@ -110,17 +110,29 @@ static CurlHolder& globalCurlInit()
     return holder;
 }
 
-int luainit_net(lua_State* L)
+int luaopen_net(lua_State* L)
 {
     globalCurlInit();
 
-    return 0;
+    luaL_register(L, "net", net::lib);
+
+    return 1;
 }
 
-int luaopen_net(lua_State* L)
+int lrtopen_net(lua_State* L)
 {
-    luainit_net(L);
-    luaL_register(L, "net", net::lib);
+    globalCurlInit();
+
+    lua_createtable(L, 0, std::size(net::lib));
+
+    for (auto& [name, func] : net::lib)
+    {
+        if (!name || !func)
+            break;
+
+        lua_pushcfunction(L, func, name);
+        lua_setfield(L, -2, name);
+    }
 
     return 1;
 }

--- a/net/src/net.cpp
+++ b/net/src/net.cpp
@@ -50,7 +50,7 @@ static std::pair<std::string, std::vector<char>> requestData(const std::string& 
     return { "", data };
 }
 
-static int get(lua_State* L)
+int get(lua_State* L)
 {
     std::string url = luaL_checkstring(L, 1);
 
@@ -63,7 +63,7 @@ static int get(lua_State* L)
     return 1;
 }
 
-static int getAsync(lua_State* L)
+int getAsync(lua_State* L)
 {
     std::string url = luaL_checkstring(L, 1);
 
@@ -89,12 +89,7 @@ static int getAsync(lua_State* L)
     return lua_yield(L, 0);
 }
 
-static const luaL_Reg lib[] = {
-    {"get", get},
-    {"getAsync", getAsync},
-    {nullptr, nullptr},
-};
-}
+} // namespace net
 
 struct CurlHolder
 {
@@ -115,10 +110,16 @@ static CurlHolder& globalCurlInit()
     return holder;
 }
 
-int luaopen_net(lua_State* L)
+int luainit_net(lua_State* L)
 {
     globalCurlInit();
 
+    return 0;
+}
+
+int luaopen_net(lua_State* L)
+{
+    luainit_net(L);
     luaL_register(L, "net", net::lib);
 
     return 1;


### PR DESCRIPTION
This change refactors lrt's provided runtime libraries to function not as globals, but as special requirable modules provided under the `@lrt` alias. The libraries still provide the standard flow to open them as globals if embedders want to use lrt. In follow-up work, we should figure out a common interface for this functionality in luau-land and put it all under `@std`. That way alternative runtimes can use a sort of `std-runtime` library with a similar structure that runtime-agnostic code can target, rather than forcing the runtime's API surface to comply with ours if people want compatibility.