### PR TITLE
Add type definitions for array and dictionary types to std/collections.

### DIFF
--- a/std/collections.luau
+++ b/std/collections.luau
@@ -1,3 +1,6 @@
+export type Array<T> = {T}
+export type Dictionary<T> = {[string]: T}
+
 local function map<K, A, B>(table: {[K]: A}, f: (A) -> B): {[K]: B}
     local new = {}
 


### PR DESCRIPTION
This PR makes a minor addition to std/collections to add `Array<T>` and `Dictionary<T>` type definitions.