### PR TITLE
Add initial `std/time` library with a `duration` type.

### DIFF
--- a/examples/time_example.luau
+++ b/examples/time_example.luau
@@ -1,7 +1,7 @@
 local time = require("@std/time")
-local Duration = time.Duration
+local duration = time.duration
 
-local fiveSeconds = Duration.fromSecs(5)
+local fiveSeconds = duration.seconds(5)
 local tenSeconds = fiveSeconds * 2
 local fifteenSeconds = fiveSeconds + tenSeconds
 
@@ -12,10 +12,10 @@ print(fifteenSeconds)
 print(fiveSeconds < tenSeconds)
 print (fifteenSeconds > tenSeconds)
 
-local randomNanos = Duration.fromNanos(25038)
+local randomNanos = duration.nanoseconds(25038)
 print(randomNanos)
 
-local randomMillis = Duration.fromMillis(25038)
+local randomMillis = duration.milliseconds(25038)
 print(randomMillis)
 
 print(randomMillis < randomNanos)

--- a/examples/time_example.luau
+++ b/examples/time_example.luau
@@ -1,0 +1,22 @@
+local time = require("@std/time")
+local Duration = time.Duration
+
+local fiveSeconds = Duration.fromSecs(5)
+local tenSeconds = fiveSeconds * 2
+local fifteenSeconds = fiveSeconds + tenSeconds
+
+print(fiveSeconds)
+print(tenSeconds)
+print(fifteenSeconds)
+
+print(fiveSeconds < tenSeconds)
+print (fifteenSeconds > tenSeconds)
+
+local randomNanos = Duration.fromNanos(25038)
+print(randomNanos)
+
+local randomMillis = Duration.fromMillis(25038)
+print(randomMillis)
+
+print(randomMillis < randomNanos)
+print(randomMillis + randomNanos > fiveSeconds)

--- a/std/time.luau
+++ b/std/time.luau
@@ -16,6 +16,9 @@ type DurationData = {
 local Duration = {}
 Duration.__index = Duration
 
+type DurationInterface = typeof(Duration)
+export type Duration = typeof(setmetatable({} :: DurationData, {} :: DurationInterface))
+
 function Duration.new(seconds: number, nanoseconds: number): Duration
     local self = {
         seconds = seconds,
@@ -160,9 +163,6 @@ end
 function Duration.__tostring(self: Duration): string
     return string.format("%d.%09d", self.seconds, self.nanoseconds)
 end
-
-type DurationInterface = typeof(Duration)
-export type Duration = typeof(setmetatable({} :: DurationData, {} :: DurationInterface))
 
 return {
     Duration = Duration,

--- a/std/time.luau
+++ b/std/time.luau
@@ -1,0 +1,169 @@
+local NANOS_PER_SEC = 1_000_000_000
+local NANOS_PER_MILLI = 1_000_000
+local NANOS_PER_MICRO = 1_000
+local MILLIS_PER_SEC = 1_000
+local MICROS_PER_SEC = 1_000_000
+local SECS_PER_MINUTE = 60
+local MINS_PER_HOUR = 60
+local HOURS_PER_DAY = 24
+local DAYS_PER_WEEK = 7
+
+type DurationData = {
+    seconds: number,
+    nanoseconds: number,
+}
+
+local Duration = {}
+Duration.__index = Duration
+
+function Duration.new(seconds: number, nanoseconds: number): Duration
+    local self = {
+        seconds = seconds,
+        nanoseconds = nanoseconds,
+    }
+
+    return setmetatable(self, Duration)
+end
+
+function Duration.fromSecs(seconds: number): Duration
+    return Duration.new(seconds, 0)
+end
+
+function Duration.fromMillis(milliseconds: number): Duration
+    local seconds = math.floor(milliseconds / MILLIS_PER_SEC)
+    local nanoseconds = (milliseconds % MILLIS_PER_SEC) * NANOS_PER_MILLI
+
+    return Duration.new(seconds, nanoseconds)
+end
+
+function Duration.fromMicros(microseconds: number): Duration
+    local seconds = math.floor(microseconds / MICROS_PER_SEC)
+    local nanoseconds = (microseconds % MICROS_PER_SEC) * NANOS_PER_MICRO
+
+    return Duration.new(seconds, nanoseconds)
+end
+
+function Duration.fromNanos(nanoseconds: number): Duration
+    local seconds = math.floor(nanoseconds / NANOS_PER_SEC)
+    local nanosecondsRemaining = nanoseconds % NANOS_PER_SEC
+
+    return Duration.new(seconds, nanosecondsRemaining)
+end
+
+function Duration.fromMinutes(minutes: number): Duration
+    return Duration.new(minutes * SECS_PER_MINUTE, 0)
+end
+
+function Duration.fromHours(hours: number): Duration
+    return Duration.new(hours * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
+end
+
+function Duration.fromDays(days: number): Duration
+    return Duration.new(days * HOURS_PER_DAY * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
+end
+
+function Duration.fromWeeks(weeks: number): Duration
+    return Duration.new(weeks * DAYS_PER_WEEK * HOURS_PER_DAY * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
+end
+
+function Duration.subsecMillis(self: Duration): number
+    return math.floor(self.nanoseconds / NANOS_PER_MILLI)
+end
+
+function Duration.subsecMicros(self: Duration): number
+    return math.floor(self.nanoseconds / NANOS_PER_MICRO)
+end
+
+function Duration.subsecNanos(self: Duration): number
+    return self.nanoseconds
+end
+
+function Duration.asSecs(self: Duration): number
+    return self.seconds + self.nanoseconds / NANOS_PER_SEC
+end
+
+function Duration.asMillis(self: Duration): number
+    return self.seconds * MILLIS_PER_SEC + self:subsecMillis()
+end
+
+function Duration.asMicros(self: Duration): number
+    return self.seconds * MICROS_PER_SEC + self:subsecMicros()
+end
+
+function Duration.asNanos(self: Duration): number
+    return self.seconds * NANOS_PER_SEC + self:subsecNanos()
+end
+
+function Duration.__add(a: Duration, b: Duration): Duration
+    local seconds = a.seconds + b.seconds
+    local nanoseconds = a.nanoseconds + b.nanoseconds
+
+    if nanoseconds >= NANOS_PER_SEC then
+        seconds += 1
+        nanoseconds -= NANOS_PER_SEC
+    end
+
+    return Duration.new(seconds, nanoseconds)
+end
+
+function Duration.__sub(a: Duration, b: Duration): Duration
+    local seconds = a.seconds - b.seconds
+    local nanoseconds = a.nanoseconds - b.nanoseconds
+
+    if nanoseconds < 0 then
+        seconds -= 1
+        nanoseconds += NANOS_PER_SEC
+    end
+
+    return Duration.new(seconds, nanoseconds)
+end
+
+function Duration.__mul(a: Duration, b: number): Duration
+    local seconds = a.seconds * b
+    local nanoseconds = a.nanoseconds * b
+
+    seconds += math.floor(nanoseconds / NANOS_PER_SEC)
+    nanoseconds %= NANOS_PER_SEC
+
+    return Duration.new(seconds, nanoseconds)
+end
+
+function Duration.__div(a: Duration, b: number): Duration
+    local seconds, extraSeconds = a.seconds / b, a.seconds % b
+    local nanoseconds, extraNanos = a.nanoseconds / b, a.nanoseconds % b
+
+    nanoseconds += (extraSeconds * NANOS_PER_SEC + extraNanos) / b
+
+    return Duration.new(seconds, nanoseconds)
+end
+
+function Duration.__eq(a: Duration, b: Duration): boolean
+    return a.seconds == b.seconds and a.nanoseconds == b.nanoseconds
+end
+
+function Duration.__lt(a: Duration, b: Duration): boolean
+    if a.seconds == b.seconds then
+        return a.nanoseconds < b.nanoseconds
+    end
+
+    return a.seconds < b.seconds
+end
+
+function Duration.__le(a: Duration, b: Duration): boolean
+    if a.seconds == b.seconds then
+        return a.nanoseconds <= b.nanoseconds
+    end
+
+    return a.seconds <= b.seconds
+end
+
+function Duration.__tostring(self: Duration): string
+    return string.format("%d.%09d", self.seconds, self.nanoseconds)
+end
+
+type DurationInterface = typeof(Duration)
+export type Duration = typeof(setmetatable({} :: DurationData, {} :: DurationInterface))
+
+return {
+    Duration = Duration,
+}

--- a/std/time.luau
+++ b/std/time.luau
@@ -8,7 +8,7 @@ local MINS_PER_HOUR = 60
 local HOURS_PER_DAY = 24
 local DAYS_PER_WEEK = 7
 
-type DurationData = {
+type durationdata = {
     seconds: number,
     nanoseconds: number,
 }
@@ -16,10 +16,10 @@ type DurationData = {
 local duration = {}
 duration.__index = duration
 
-type DurationInterface = typeof(duration)
-export type Duration = typeof(setmetatable({} :: DurationData, {} :: DurationInterface))
+type durationinterface = typeof(duration)
+export type duration = typeof(setmetatable({} :: durationdata, {} :: durationinterface))
 
-function duration.create(seconds: number, nanoseconds: number): Duration
+function duration.create(seconds: number, nanoseconds: number): duration
     local self = {
         seconds = seconds,
         nanoseconds = nanoseconds,
@@ -28,76 +28,76 @@ function duration.create(seconds: number, nanoseconds: number): Duration
     return setmetatable(self, duration)
 end
 
-function duration.seconds(seconds: number): Duration
+function duration.seconds(seconds: number): duration
     return duration.create(seconds, 0)
 end
 
-function duration.milliseconds(milliseconds: number): Duration
+function duration.milliseconds(milliseconds: number): duration
     local seconds = math.floor(milliseconds / MILLIS_PER_SEC)
     local nanoseconds = (milliseconds % MILLIS_PER_SEC) * NANOS_PER_MILLI
 
     return duration.create(seconds, nanoseconds)
 end
 
-function duration.microseconds(microseconds: number): Duration
+function duration.microseconds(microseconds: number): duration
     local seconds = math.floor(microseconds / MICROS_PER_SEC)
     local nanoseconds = (microseconds % MICROS_PER_SEC) * NANOS_PER_MICRO
 
     return duration.create(seconds, nanoseconds)
 end
 
-function duration.nanoseconds(nanoseconds: number): Duration
+function duration.nanoseconds(nanoseconds: number): duration
     local seconds = math.floor(nanoseconds / NANOS_PER_SEC)
     local nanosecondsRemaining = nanoseconds % NANOS_PER_SEC
 
     return duration.create(seconds, nanosecondsRemaining)
 end
 
-function duration.minutes(minutes: number): Duration
+function duration.minutes(minutes: number): duration
     return duration.create(minutes * SECS_PER_MINUTE, 0)
 end
 
-function duration.hours(hours: number): Duration
+function duration.hours(hours: number): duration
     return duration.create(hours * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
 end
 
-function duration.days(days: number): Duration
+function duration.days(days: number): duration
     return duration.create(days * HOURS_PER_DAY * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
 end
 
-function duration.weeks(weeks: number): Duration
+function duration.weeks(weeks: number): duration
     return duration.create(weeks * DAYS_PER_WEEK * HOURS_PER_DAY * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
 end
 
-function duration.subsecmillis(self: Duration): number
+function duration.subsecmillis(self: duration): number
     return math.floor(self.nanoseconds / NANOS_PER_MILLI)
 end
 
-function duration.subsecmicros(self: Duration): number
+function duration.subsecmicros(self: duration): number
     return math.floor(self.nanoseconds / NANOS_PER_MICRO)
 end
 
-function duration.subsecnanos(self: Duration): number
+function duration.subsecnanos(self: duration): number
     return self.nanoseconds
 end
 
-function duration.toseconds(self: Duration): number
+function duration.toseconds(self: duration): number
     return self.seconds + self.nanoseconds / NANOS_PER_SEC
 end
 
-function duration.tomilliseconds(self: Duration): number
+function duration.tomilliseconds(self: duration): number
     return self.seconds * MILLIS_PER_SEC + self:subsecmillis()
 end
 
-function duration.tomicroseconds(self: Duration): number
+function duration.tomicroseconds(self: duration): number
     return self.seconds * MICROS_PER_SEC + self:subsecmicros()
 end
 
-function duration.tonanoseconds(self: Duration): number
+function duration.tonanoseconds(self: duration): number
     return self.seconds * NANOS_PER_SEC + self:subsecnanos()
 end
 
-function duration.__add(a: Duration, b: Duration): Duration
+function duration.__add(a: duration, b: duration): duration
     local seconds = a.seconds + b.seconds
     local nanoseconds = a.nanoseconds + b.nanoseconds
 
@@ -109,7 +109,7 @@ function duration.__add(a: Duration, b: Duration): Duration
     return duration.create(seconds, nanoseconds)
 end
 
-function duration.__sub(a: Duration, b: Duration): Duration
+function duration.__sub(a: duration, b: duration): duration
     local seconds = a.seconds - b.seconds
     local nanoseconds = a.nanoseconds - b.nanoseconds
 
@@ -121,7 +121,7 @@ function duration.__sub(a: Duration, b: Duration): Duration
     return duration.create(seconds, nanoseconds)
 end
 
-function duration.__mul(a: Duration, b: number): Duration
+function duration.__mul(a: duration, b: number): duration
     local seconds = a.seconds * b
     local nanoseconds = a.nanoseconds * b
 
@@ -131,7 +131,7 @@ function duration.__mul(a: Duration, b: number): Duration
     return duration.create(seconds, nanoseconds)
 end
 
-function duration.__div(a: Duration, b: number): Duration
+function duration.__div(a: duration, b: number): duration
     local seconds, extraSeconds = a.seconds / b, a.seconds % b
     local nanoseconds, extraNanos = a.nanoseconds / b, a.nanoseconds % b
 
@@ -140,11 +140,11 @@ function duration.__div(a: Duration, b: number): Duration
     return duration.create(seconds, nanoseconds)
 end
 
-function duration.__eq(a: Duration, b: Duration): boolean
+function duration.__eq(a: duration, b: duration): boolean
     return a.seconds == b.seconds and a.nanoseconds == b.nanoseconds
 end
 
-function duration.__lt(a: Duration, b: Duration): boolean
+function duration.__lt(a: duration, b: duration): boolean
     if a.seconds == b.seconds then
         return a.nanoseconds < b.nanoseconds
     end
@@ -152,7 +152,7 @@ function duration.__lt(a: Duration, b: Duration): boolean
     return a.seconds < b.seconds
 end
 
-function duration.__le(a: Duration, b: Duration): boolean
+function duration.__le(a: duration, b: duration): boolean
     if a.seconds == b.seconds then
         return a.nanoseconds <= b.nanoseconds
     end
@@ -160,7 +160,7 @@ function duration.__le(a: Duration, b: Duration): boolean
     return a.seconds <= b.seconds
 end
 
-function duration.__tostring(self: Duration): string
+function duration.__tostring(self: duration): string
     return string.format("%d.%09d", self.seconds, self.nanoseconds)
 end
 

--- a/std/time.luau
+++ b/std/time.luau
@@ -13,91 +13,91 @@ type DurationData = {
     nanoseconds: number,
 }
 
-local Duration = {}
-Duration.__index = Duration
+local duration = {}
+duration.__index = duration
 
-type DurationInterface = typeof(Duration)
+type DurationInterface = typeof(duration)
 export type Duration = typeof(setmetatable({} :: DurationData, {} :: DurationInterface))
 
-function Duration.new(seconds: number, nanoseconds: number): Duration
+function duration.create(seconds: number, nanoseconds: number): Duration
     local self = {
         seconds = seconds,
         nanoseconds = nanoseconds,
     }
 
-    return setmetatable(self, Duration)
+    return setmetatable(self, duration)
 end
 
-function Duration.fromSecs(seconds: number): Duration
-    return Duration.new(seconds, 0)
+function duration.seconds(seconds: number): Duration
+    return duration.create(seconds, 0)
 end
 
-function Duration.fromMillis(milliseconds: number): Duration
+function duration.milliseconds(milliseconds: number): Duration
     local seconds = math.floor(milliseconds / MILLIS_PER_SEC)
     local nanoseconds = (milliseconds % MILLIS_PER_SEC) * NANOS_PER_MILLI
 
-    return Duration.new(seconds, nanoseconds)
+    return duration.create(seconds, nanoseconds)
 end
 
-function Duration.fromMicros(microseconds: number): Duration
+function duration.microseconds(microseconds: number): Duration
     local seconds = math.floor(microseconds / MICROS_PER_SEC)
     local nanoseconds = (microseconds % MICROS_PER_SEC) * NANOS_PER_MICRO
 
-    return Duration.new(seconds, nanoseconds)
+    return duration.create(seconds, nanoseconds)
 end
 
-function Duration.fromNanos(nanoseconds: number): Duration
+function duration.nanoseconds(nanoseconds: number): Duration
     local seconds = math.floor(nanoseconds / NANOS_PER_SEC)
     local nanosecondsRemaining = nanoseconds % NANOS_PER_SEC
 
-    return Duration.new(seconds, nanosecondsRemaining)
+    return duration.create(seconds, nanosecondsRemaining)
 end
 
-function Duration.fromMinutes(minutes: number): Duration
-    return Duration.new(minutes * SECS_PER_MINUTE, 0)
+function duration.minutes(minutes: number): Duration
+    return duration.create(minutes * SECS_PER_MINUTE, 0)
 end
 
-function Duration.fromHours(hours: number): Duration
-    return Duration.new(hours * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
+function duration.hours(hours: number): Duration
+    return duration.create(hours * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
 end
 
-function Duration.fromDays(days: number): Duration
-    return Duration.new(days * HOURS_PER_DAY * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
+function duration.days(days: number): Duration
+    return duration.create(days * HOURS_PER_DAY * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
 end
 
-function Duration.fromWeeks(weeks: number): Duration
-    return Duration.new(weeks * DAYS_PER_WEEK * HOURS_PER_DAY * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
+function duration.weeks(weeks: number): Duration
+    return duration.create(weeks * DAYS_PER_WEEK * HOURS_PER_DAY * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
 end
 
-function Duration.subsecMillis(self: Duration): number
+function duration.subsecmillis(self: Duration): number
     return math.floor(self.nanoseconds / NANOS_PER_MILLI)
 end
 
-function Duration.subsecMicros(self: Duration): number
+function duration.subsecmicros(self: Duration): number
     return math.floor(self.nanoseconds / NANOS_PER_MICRO)
 end
 
-function Duration.subsecNanos(self: Duration): number
+function duration.subsecnanos(self: Duration): number
     return self.nanoseconds
 end
 
-function Duration.asSecs(self: Duration): number
+function duration.toseconds(self: Duration): number
     return self.seconds + self.nanoseconds / NANOS_PER_SEC
 end
 
-function Duration.asMillis(self: Duration): number
-    return self.seconds * MILLIS_PER_SEC + self:subsecMillis()
+function duration.tomilliseconds(self: Duration): number
+    return self.seconds * MILLIS_PER_SEC + self:subsecmillis()
 end
 
-function Duration.asMicros(self: Duration): number
-    return self.seconds * MICROS_PER_SEC + self:subsecMicros()
+function duration.tomicroseconds(self: Duration): number
+    return self.seconds * MICROS_PER_SEC + self:subsecmicros()
 end
 
-function Duration.asNanos(self: Duration): number
-    return self.seconds * NANOS_PER_SEC + self:subsecNanos()
+function duration.tonanoseconds(self: Duration): number
+    return self.seconds * NANOS_PER_SEC + self:subsecnanos()
 end
 
-function Duration.__add(a: Duration, b: Duration): Duration
+function duration.__add(a: Duration, b: Duration): Duration
     local seconds = a.seconds + b.seconds
     local nanoseconds = a.nanoseconds + b.nanoseconds
 
@@ -106,10 +106,10 @@ function Duration.__add(a: Duration, b: Duration): Duration
         nanoseconds -= NANOS_PER_SEC
     end
 
-    return Duration.new(seconds, nanoseconds)
+    return duration.create(seconds, nanoseconds)
 end
 
-function Duration.__sub(a: Duration, b: Duration): Duration
+function duration.__sub(a: Duration, b: Duration): Duration
     local seconds = a.seconds - b.seconds
     local nanoseconds = a.nanoseconds - b.nanoseconds
 
@@ -118,33 +118,33 @@ function Duration.__sub(a: Duration, b: Duration): Duration
         nanoseconds += NANOS_PER_SEC
     end
 
-    return Duration.new(seconds, nanoseconds)
+    return duration.create(seconds, nanoseconds)
 end
 
-function Duration.__mul(a: Duration, b: number): Duration
+function duration.__mul(a: Duration, b: number): Duration
     local seconds = a.seconds * b
     local nanoseconds = a.nanoseconds * b
 
     seconds += math.floor(nanoseconds / NANOS_PER_SEC)
     nanoseconds %= NANOS_PER_SEC
 
-    return Duration.new(seconds, nanoseconds)
+    return duration.create(seconds, nanoseconds)
 end
 
-function Duration.__div(a: Duration, b: number): Duration
+function duration.__div(a: Duration, b: number): Duration
     local seconds, extraSeconds = a.seconds / b, a.seconds % b
     local nanoseconds, extraNanos = a.nanoseconds / b, a.nanoseconds % b
 
     nanoseconds += (extraSeconds * NANOS_PER_SEC + extraNanos) / b
 
-    return Duration.new(seconds, nanoseconds)
+    return duration.create(seconds, nanoseconds)
 end
 
-function Duration.__eq(a: Duration, b: Duration): boolean
+function duration.__eq(a: Duration, b: Duration): boolean
     return a.seconds == b.seconds and a.nanoseconds == b.nanoseconds
 end
 
-function Duration.__lt(a: Duration, b: Duration): boolean
+function duration.__lt(a: Duration, b: Duration): boolean
     if a.seconds == b.seconds then
         return a.nanoseconds < b.nanoseconds
     end
@@ -152,7 +152,7 @@ function Duration.__lt(a: Duration, b: Duration): boolean
     return a.seconds < b.seconds
 end
 
-function Duration.__le(a: Duration, b: Duration): boolean
+function duration.__le(a: Duration, b: Duration): boolean
     if a.seconds == b.seconds then
         return a.nanoseconds <= b.nanoseconds
     end
@@ -160,10 +160,10 @@ function Duration.__le(a: Duration, b: Duration): boolean
     return a.seconds <= b.seconds
 end
 
-function Duration.__tostring(self: Duration): string
+function duration.__tostring(self: Duration): string
     return string.format("%d.%09d", self.seconds, self.nanoseconds)
 end
 
 return {
-    Duration = Duration,
+    duration = duration,
 }


### PR DESCRIPTION
This PR adds an initial version of a `std/time` library for lrt. It currently features a `duration` data type with some useful functionality for manipulating `durations` including via overloaded operators. Future additions to this library should include wrapping builtin time functionality in a type-safe interface and allowing it to interact with `duration` properly. We should probably also deal with overflow cases directly and produce errors (either with `error`, or we should adopt a result type convention).