### PR TITLE
Fix build on Linux.

### DIFF
--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -13,6 +13,7 @@
 #include <sys/fcntl.h> // on mac we do this
 #endif
 #include <sys/stat.h>
+#include <string>
 #include <stdlib.h>
 #include <map>
 using namespace std;

--- a/runtime/include/queijo/runtime.h
+++ b/runtime/include/queijo/runtime.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <vector>
 

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -4,6 +4,7 @@
 
 #include "uv.h"
 
+#include <string>
 #include <assert.h>
 
 static void lua_close_checked(lua_State* L)


### PR DESCRIPTION
Looks like something updated in the Linux builds such that we need to explicitly include the string header.