### PR TITLE
Add explicit support to `pp` for primitives.

### DIFF
--- a/std/pp.luau
+++ b/std/pp.luau
@@ -147,6 +147,11 @@ local function traverseTable(dataTable, seen, indent)
     return output
 end
 
-return function(dataTable)
-    return "{\n" .. traverseTable(dataTable, {[dataTable]=true}, 1) .. "}"
+return function(data)
+    -- if it's not a primitive, we'll pretty print it as a value
+    if typeof(data) ~= "table" then
+        return formatValue(data)
+    end
+
+    return "{\n" .. traverseTable(data, {[data]=true}, 1) .. "}"
 end


### PR DESCRIPTION
This PR adds a little check to `pp` to make it more useful for running on non-tables as well.