### PR TITLE
Clean up `@lrt/fs`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,13 +77,6 @@ target_link_libraries(Queijo.Net PRIVATE Queijo.Runtime Luau.VM uv_a ${WOLFSSL_L
 target_link_libraries(Queijo.Task PRIVATE Queijo.Runtime Luau.VM uv_a)
 target_link_libraries(Queijo.CLI PRIVATE Luau.CLI.lib Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Queijo.Runtime Queijo.Fs Queijo.Luau Queijo.Net Queijo.Task)
 
-target_compile_options(Queijo.Runtime PRIVATE ${QUEIJO_OPTIONS})
-target_compile_options(Queijo.Fs PRIVATE ${QUEIJO_OPTIONS})
-target_compile_options(Queijo.Luau PRIVATE ${QUEIJO_OPTIONS})
-target_compile_options(Queijo.Net PRIVATE ${QUEIJO_OPTIONS})
-target_compile_options(Queijo.Task PRIVATE ${QUEIJO_OPTIONS})
-target_compile_options(Queijo.CLI PRIVATE ${QUEIJO_OPTIONS})
-
 set(QUEIJO_OPTIONS)
 
 if(MSVC)
@@ -98,3 +91,10 @@ else()
     list(APPEND QUEIJO_OPTIONS -Wsign-compare) # This looks to be included in -Wall for GCC but not clang
     list(APPEND QUEIJO_OPTIONS -Werror) # Warnings are errors
 endif()
+
+target_compile_options(Queijo.Runtime PRIVATE ${QUEIJO_OPTIONS})
+target_compile_options(Queijo.Fs PRIVATE ${QUEIJO_OPTIONS})
+target_compile_options(Queijo.Luau PRIVATE ${QUEIJO_OPTIONS})
+target_compile_options(Queijo.Net PRIVATE ${QUEIJO_OPTIONS})
+target_compile_options(Queijo.Task PRIVATE ${QUEIJO_OPTIONS})
+target_compile_options(Queijo.CLI PRIVATE ${QUEIJO_OPTIONS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ if(MSVC)
     list(APPEND QUEIJO_OPTIONS /D_CRT_SECURE_NO_WARNINGS) # We need to use the portable CRT functions.
     list(APPEND QUEIJO_OPTIONS "/we4018") # Signed/unsigned mismatch
     list(APPEND QUEIJO_OPTIONS "/we4388") # Also signed/unsigned mismatch
-    list(APPEND QUEIJO_OPTIONS /WX) # Warnings are errors
+    # FIXME: list(APPEND QUEIJO_OPTIONS /WX) # Warnings are errors
 else()
     list(APPEND QUEIJO_OPTIONS -Wall) # All warnings
     list(APPEND QUEIJO_OPTIONS -Wimplicit-fallthrough)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ target_compile_options(Queijo.CLI PRIVATE ${QUEIJO_OPTIONS})
 set(QUEIJO_OPTIONS)
 
 if(MSVC)
+    list(APPEND QUEIJO_OPTIONS NOMINMAX)
     list(APPEND QUEIJO_OPTIONS /D_CRT_SECURE_NO_WARNINGS) # We need to use the portable CRT functions.
     list(APPEND QUEIJO_OPTIONS "/we4018") # Signed/unsigned mismatch
     list(APPEND QUEIJO_OPTIONS "/we4388") # Also signed/unsigned mismatch

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ target_link_libraries(Queijo.CLI PRIVATE Luau.CLI.lib Luau.Compiler Luau.Config 
 set(QUEIJO_OPTIONS)
 
 if(MSVC)
-    list(APPEND QUEIJO_OPTIONS NOMINMAX)
+    list(APPEND QUEIJO_OPTIONS /DNOMINMAX)
     list(APPEND QUEIJO_OPTIONS /D_CRT_SECURE_NO_WARNINGS) # We need to use the portable CRT functions.
     list(APPEND QUEIJO_OPTIONS "/we4018") # Signed/unsigned mismatch
     list(APPEND QUEIJO_OPTIONS "/we4388") # Also signed/unsigned mismatch

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -228,7 +228,6 @@ int main(int argc, char** argv)
 
     for (size_t i = 0; i < files.size(); ++i)
     {
-        bool isLastFile = i == files.size() - 1;
         failed += !runFile(runtime, files[i].c_str(), L);
     }
 

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -21,7 +21,6 @@
 #include "uv.h"
 
 #ifdef _WIN32
-#define NOMINMAX // prevent windows.h from defining min/max macros
 #include <Windows.h>
 #endif
 

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -21,6 +21,7 @@
 #include "uv.h"
 
 #ifdef _WIN32
+#define NOMINMAX // prevent windows.h from defining min/max macros
 #include <Windows.h>
 #endif
 

--- a/cli/spawn.cpp
+++ b/cli/spawn.cpp
@@ -161,8 +161,6 @@ int lua_spawn(lua_State* L)
 {
     const char* file = luaL_checkstring(L, 1);
 
-    Runtime* runtime = getRuntime(L);
-
     auto child = std::make_shared<Runtime>();
 
     setupState(*child);

--- a/cli/tc.cpp
+++ b/cli/tc.cpp
@@ -183,7 +183,6 @@ int typecheck(const std::vector<std::string> sourceFiles)
 {
     Luau::Mode mode = Luau::Mode::Strict;
     bool annotate = true;
-    int threadCount = 0;
     std::string basePath = "";
 
     Luau::FrontendOptions frontendOptions;

--- a/examples/writeFile.luau
+++ b/examples/writeFile.luau
@@ -1,4 +1,6 @@
---  Open a file if it doesn't exist, truncate it, 
+local fs = require("@lrt/fs")
+
+--  Open a file if it doesn't exist, truncate it,
 local file = fs.open("dest", "w+")
 if file == nil then
     print("Error opening file")

--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -136,7 +136,7 @@ int read(lua_State* L)
 
         if (numBytesRead < 0)
         {
-            printf("Error reading: %s. Closing file.\n", uv_err_name(numBytesRead));
+            luaL_errorL(L, "Error reading: %s. Closing file.\n", uv_err_name(numBytesRead));
             memset(readBuffer, 0, sizeof(readBuffer));
             return 0;
         }
@@ -182,7 +182,7 @@ int write(lua_State* L)
         if (bytesWritten < 0)
         {
             // Error case.
-            printf("Error writing to file with descriptor %zu\n", file.fileDescriptor);
+            luaL_errorL(L, "Error writing to file with descriptor %zu\n", file.fileDescriptor);
             memset(writeBuffer, 0, sizeof(writeBuffer));
             return 0;
         }
@@ -206,7 +206,7 @@ std::optional<FileHandle> openHelper(lua_State* L, const char* path, const char*
     int errcode = uv_fs_open(uv_default_loop(), &openReq, path, *openFlags, modeFlags, nullptr);
     if (openReq.result < 0)
     {
-        printf("Error opening file %s\n", path);
+        luaL_errorL(L, "Error opening file %s\n", path);
         return std::nullopt;
     }
 
@@ -222,7 +222,7 @@ int open(lua_State* L)
     // When the number of arguments is less 2
     if (nArgs < 1)
     {
-        printf("Error: no file supplied\n");
+        luaL_errorL(L, "Error: no file supplied\n");
         return 0;
     }
 
@@ -256,7 +256,7 @@ int readfiletostring(lua_State* L)
     std::optional<FileHandle> handle = openHelper(L, path, openMode, &openFlags);
     if (!handle)
     {
-        printf("Error opening file for reading at %s\n", path);
+        luaL_errorL(L, "Error opening file for reading at %s\n", path);
         return 0;
     }
 
@@ -279,7 +279,7 @@ int readfiletostring(lua_State* L)
 
         if (numBytesRead < 0)
         {
-            printf("Error reading: %s. Closing file.\n", uv_err_name(numBytesRead));
+            luaL_errorL(L, "Error reading: %s. Closing file.\n", uv_err_name(numBytesRead));
             cleanup(readBuffer, sizeof(readBuffer), *handle);
             return 0;
         }
@@ -306,7 +306,7 @@ int writestringtofile(lua_State* L)
     std::optional<FileHandle> handle = openHelper(L, path, openMode, &openFlags);
     if (!handle)
     {
-        printf("Error opening file for reading at %s\n", path);
+        luaL_errorL(L, "Error opening file for reading at %s\n", path);
         return 0;
     }
 
@@ -334,7 +334,7 @@ int writestringtofile(lua_State* L)
         if (bytesWritten < 0)
         {
             // Error case.
-            printf("Error writing to file with descriptor %zu\n", handle->fileDescriptor);
+            luaL_errorL(L, "Error writing to file with descriptor %zu\n", handle->fileDescriptor);
             cleanup(writeBuffer, sizeof(writeBuffer), *handle);
             return 0;
         }

--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -8,7 +8,7 @@
 #include "queijo/runtime.h"
 
 #include <cstdio>
-#include <string>
+#include <cstring>
 #include <map>
 #include <memory>
 #include <optional>

--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -1,11 +1,15 @@
 #include "queijo/fs.h"
+
 #include "lua.h"
 #include "lualib.h"
+#include "uv.h"
+
 #include "queijo/ref.h"
 #include "queijo/runtime.h"
-#include "uv.h"
+
 #include <cstdio>
 #include <cstring>
+#include <map>
 #include <memory>
 #ifdef _WIN32
 #include <direct.h>
@@ -15,8 +19,6 @@
 #include <sys/stat.h>
 #include <string>
 #include <stdlib.h>
-#include <map>
-using namespace std;
 
 namespace fs
 {
@@ -29,28 +31,19 @@ int setFlags(const char* c, int* openFlags, int* modeFlags)
         switch (c)
         {
         case 'r':
-        {
             *openFlags |= O_RDONLY;
             break;
-        }
         case 'w':
-        {
             *openFlags |= O_WRONLY | O_TRUNC;
             break;
-        }
         case 'x':
-        {
             *openFlags |= O_CREAT | O_EXCL;
             *modeFlags = 0700;
             break;
-        }
         case 'a':
-        {
             *openFlags |= O_WRONLY | O_APPEND;
-        }
+            break;
         case '+':
-        {
-
             // If we have not set the truncate bit in 'w' mode,
             *openFlags &= ~O_RDONLY;
             *openFlags &= ~O_WRONLY;
@@ -62,12 +55,9 @@ int setFlags(const char* c, int* openFlags, int* modeFlags)
                 *modeFlags = 0000700 | 0000070 | 0000007;
             }
             break;
-        }
         default:
-        {
             printf("Unsupported mode %c\n", c);
             return 1;
-        }
         }
     }
 
@@ -179,7 +169,7 @@ int write(lua_State* L)
     {
         // copy stringToWrite[0], numBytesLeftToWrite into write buffer
 
-        int sizeToWrite = min(wbSize, numBytesLeftToWrite);
+        int sizeToWrite = std::min(wbSize, numBytesLeftToWrite);
         memcpy(writeBuffer, stringToWrite + offset, sizeToWrite);
         uv_buf_t iov = uv_buf_init(writeBuffer, sizeToWrite);
 
@@ -335,7 +325,7 @@ int writestringtofile(lua_State* L)
     {
         // copy stringToWrite[0], numBytesLeftToWrite into write buffer
 
-        int sizeToWrite = min(wbSize, numBytesLeftToWrite);
+        int sizeToWrite = std::min(wbSize, numBytesLeftToWrite);
         memcpy(writeBuffer, stringToWrite + offset, sizeToWrite);
         iov = uv_buf_init(writeBuffer, sizeToWrite);
 

--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -123,7 +123,6 @@ int read(lua_State* L)
     FileHandle file = unpackFileHandle(L);
 
     int numBytesRead = 0;
-    int totalBytesRead = 0;
     uv_fs_t readReq;
     uv_buf_t iov = uv_buf_init(readBuffer, sizeof(readBuffer));
     luaL_Strbuf resultBuf;
@@ -133,7 +132,6 @@ int read(lua_State* L)
         uv_fs_read(uv_default_loop(), &readReq, file.fileDescriptor, &iov, 1, -1, nullptr);
 
         numBytesRead = readReq.result;
-        totalBytesRead += numBytesRead;
 
         if (numBytesRead < 0)
         {
@@ -218,7 +216,6 @@ int open(lua_State* L)
     int nArgs = lua_gettop(L);
     const char* path = luaL_checkstring(L, 1);
     int openFlags = 0x0000;
-    int modeFlags = 0x0000;
     // When the number of arguments is less 2
     if (nArgs < 1)
     {
@@ -265,7 +262,6 @@ int readfiletostring(lua_State* L)
     lua_settop(L, 1);
 
     int numBytesRead = 0;
-    int totalBytesRead = 0;
     uv_fs_t readReq;
     uv_buf_t iov = uv_buf_init(readBuffer, sizeof(readBuffer));
     luaL_Strbuf resultBuf;
@@ -275,7 +271,6 @@ int readfiletostring(lua_State* L)
         uv_fs_read(uv_default_loop(), &readReq, handle->fileDescriptor, &iov, 1, -1, nullptr);
 
         numBytesRead = readReq.result;
-        totalBytesRead += numBytesRead;
 
         if (numBytesRead < 0)
         {
@@ -403,7 +398,6 @@ int readasync(lua_State* L)
             uv_buf_t iov = uv_buf_init(readBuffer, sizeof(readBuffer));
             // Read data
             int numBytesRead = 0;
-            int totalBytesRead = 0;
             uv_fs_t readReq;
             // Output data
             std::vector<char> resultData;
@@ -412,7 +406,6 @@ int readasync(lua_State* L)
             {
                 uv_fs_read(uv_default_loop(), &readReq, fd, &iov, 1, -1, nullptr);
                 numBytesRead = readReq.result;
-                totalBytesRead += numBytesRead;
 
                 if (numBytesRead < 0)
                 {

--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <map>
 #include <memory>
+#include <optional>
 #ifdef _WIN32
 #include <direct.h>
 #else


### PR DESCRIPTION
The initial implementation of `@lrt/fs` is really hacky, and could do with a lot of clean up both in terms of the code quality, and the actual provided API. I'm starting by cleaning up the code itself, especially helper functions which were written in a very C-style, and can be rewritten to be much more natural C++ code.

There's definitely other stuff to clean up as well though, some of which might reasonably be done in their own follow-up PRs. All of the printing in the code should probably be replaced with luau runtime errors. I'll probably do at least that before calling this draft ready, but other suggestions are welcome as well.