### PR TITLE
Add various filesystem operations

### DIFF
--- a/examples/directories.luau
+++ b/examples/directories.luau
@@ -1,0 +1,5 @@
+local fs = require("@lute/fs")
+
+for _, file in fs.listdir("./examples") do
+    print(`Example {file.name} is a {file.type}`)
+end

--- a/fs/include/lute/fs.h
+++ b/fs/include/lute/fs.h
@@ -62,6 +62,7 @@ static const luaL_Reg lib[] = {
 
     {"mkdir", fs_mkdir},
     {"listdir", listdir},
+    {"rmdir", fs_rmdir},
 
     {"readfiletostring", readfiletostring},
     {"writestringtofile", writestringtofile},

--- a/fs/include/lute/fs.h
+++ b/fs/include/lute/fs.h
@@ -34,6 +34,15 @@ int writestringtofile(lua_State* L);
 /* Reads a file without blocking */
 int readasync(lua_State* L);
 
+/* Removes a file */
+int fs_remove(lua_State* L);
+
+/* Creates a folder */
+int fs_mkdir(lua_State* L);
+
+/* Removes a directory */
+int fs_rmdir(lua_State* L);
+
 /* Gets the type of a file entry */
 int type(lua_State* L);
 
@@ -47,8 +56,11 @@ static const luaL_Reg lib[] = {
     {"write", write},
     {"close", close},
 
+    {"remove", fs_remove},
+
     {"type", type},
 
+    {"mkdir", fs_mkdir},
     {"listdir", listdir},
 
     {"readfiletostring", readfiletostring},

--- a/fs/include/lute/fs.h
+++ b/fs/include/lute/fs.h
@@ -34,12 +34,22 @@ int writestringtofile(lua_State* L);
 /* Reads a file without blocking */
 int readasync(lua_State* L);
 
+/* Gets the type of a file entry */
+int type(lua_State* L);
+
+/* Lists the contents of a directory */
+int listdir(lua_State* L);
+
 static const luaL_Reg lib[] = {
     /* Manual control apis - you are responsible for calling close / open*/
     {"open", open},
     {"read", read},
     {"write", write},
     {"close", close},
+
+    {"type", type},
+
+    {"listdir", listdir},
 
     {"readfiletostring", readfiletostring},
     {"writestringtofile", writestringtofile},

--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -290,7 +290,11 @@ void cleanup(char* buffer, int size, const FileHandle& handle)
 
 int fs_remove(lua_State* L)
 {
-    std::filesystem::remove(luaL_checkstring(L, 1));
+    uv_fs_t unlink_req;
+    int err = uv_fs_unlink(uv_default_loop(), &unlink_req, luaL_checkstring(L, 1), nullptr);
+
+    if (err)
+        luaL_errorL(L, "%s", uv_strerror(err));
 
     return 0;
 }
@@ -302,6 +306,18 @@ int fs_mkdir(lua_State* L)
 
     uv_fs_t req;
     int err = uv_fs_mkdir(uv_default_loop(), &req, path, mode, nullptr);
+
+    if (err)
+        luaL_errorL(L, "%s", uv_strerror(err));
+
+    return 0;
+}
+
+int fs_rmdir(lua_State* L) {
+    const char* path = luaL_checkstring(L, 1);
+
+    uv_fs_t rmdir_req;
+    int err = uv_fs_rmdir(uv_default_loop(), &rmdir_req, path, nullptr);
 
     if (err)
         luaL_errorL(L, "%s", uv_strerror(err));

--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstring>
 #include <fcntl.h>
+#include <filesystem>
 #include <map>
 #include <memory>
 #include <optional>
@@ -263,6 +264,25 @@ void cleanup(char* buffer, int size, const FileHandle& handle)
     memset(buffer, 0, size);
     uv_fs_t closeReq;
     uv_fs_close(uv_default_loop(), &closeReq, handle.fileDescriptor, nullptr);
+}
+
+int fs_remove(lua_State *L) {
+    std::filesystem::remove(luaL_checkstring(L, 1));
+    
+    return 0;
+}
+
+int fs_mkdir(lua_State *L) {
+    const char *path = luaL_checkstring(L, 1);
+    int mode = luaL_optinteger(L, 2, 0777);
+
+    uv_fs_t req;
+    int err = uv_fs_mkdir(uv_default_loop(), &req, path, mode, nullptr);
+
+    if (err)
+        luaL_errorL(L, "%s", uv_strerror(err));
+
+    return 0;   
 }
 
 int type(lua_State* L)

--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -22,6 +22,28 @@
 #include <string>
 #include <stdlib.h>
 
+
+#if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#endif
+
+#if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#endif
+
+#if !defined(S_ISCHR) && defined(S_IFMT) && defined(S_IFCHR)
+#define S_ISCHR(m) (((m) & S_IFMT) == S_IFCHR)
+#endif
+
+#if !defined(S_ISLNK) && defined(S_IFMT) && defined(S_IFLNK)
+#define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
+#endif
+
+#if !defined(S_ISFIFO) && defined(S_IFMT) && defined(S_IFIFO)
+#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
+#endif
+
+
 namespace fs
 {
 
@@ -266,14 +288,16 @@ void cleanup(char* buffer, int size, const FileHandle& handle)
     uv_fs_close(uv_default_loop(), &closeReq, handle.fileDescriptor, nullptr);
 }
 
-int fs_remove(lua_State *L) {
+int fs_remove(lua_State* L)
+{
     std::filesystem::remove(luaL_checkstring(L, 1));
-    
+
     return 0;
 }
 
-int fs_mkdir(lua_State *L) {
-    const char *path = luaL_checkstring(L, 1);
+int fs_mkdir(lua_State* L)
+{
+    const char* path = luaL_checkstring(L, 1);
     int mode = luaL_optinteger(L, 2, 0777);
 
     uv_fs_t req;
@@ -282,7 +306,7 @@ int fs_mkdir(lua_State *L) {
     if (err)
         luaL_errorL(L, "%s", uv_strerror(err));
 
-    return 0;   
+    return 0;
 }
 
 int type(lua_State* L)

--- a/fs/src/fs.cpp
+++ b/fs/src/fs.cpp
@@ -332,22 +332,28 @@ int type(lua_State* L)
     {
         lua_pushstring(L, UV_TYPENAME_CHAR);
     }
-    else if (S_ISBLK(req.statbuf.st_mode))
-    {
-        lua_pushstring(L, UV_TYPENAME_BLOCK);
-    }
-    else if (S_ISFIFO(req.statbuf.st_mode))
-    {
-        lua_pushstring(L, UV_TYPENAME_FIFO);
-    }
     else if (S_ISLNK(req.statbuf.st_mode))
     {
         lua_pushstring(L, UV_TYPENAME_LINK);
     }
+#ifdef S_ISBLK
+    else if (S_ISBLK(req.statbuf.st_mode))
+    {
+        lua_pushstring(L, UV_TYPENAME_BLOCK);
+    }
+#endif
+#ifdef S_ISFIFO
+    else if (S_ISFIFO(req.statbuf.st_mode))
+    {
+        lua_pushstring(L, UV_TYPENAME_FIFO);
+    }
+#endif
+#ifdef S_ISSOCK
     else if (S_ISSOCK(req.statbuf.st_mode))
     {
         lua_pushstring(L, UV_TYPENAME_SOCKET);
     }
+#endif
     else
     {
         lua_pushstring(L, UV_TYPENAME_UNKNOWN);


### PR DESCRIPTION
Adds `fs.listdir` which produces a table that has the name and type of folder entries, `fs.remove` which removes files and empty directories, and `fs.type` which returns the type of a file.

Closes #82 