### PR TITLE
Fix argument parsing: Properly handle `--` to separate files and script arguments

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -201,7 +201,28 @@ int main(int argc, char** argv)
     program_argc = argc - program_args;
     program_argv = &argv[program_args];
 
-    const std::vector<std::string> files = getSourceFiles(argc, argv);
+    std::vector<std::string> files;
+
+    bool parsingFiles = true;
+
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "--") == 0)
+        {
+            parsingFiles = false; // stop collecting files
+            program_argc = argc - (i + 1);
+            program_argv = &argv[i + 1];
+            break;
+        }
+
+        if (parsingFiles)
+            files.push_back(std::string(argv[i])); // fix: Explicit conversion
+    }
+
+    if (program_argc == 0) // default to just running the script if no args are passed
+    {
+        program_argv = nullptr;
+    }
 
     // Given the source files, perform a typecheck here
     if (runTypecheck)

--- a/extern/luau/CMakeLists.txt
+++ b/extern/luau/CMakeLists.txt
@@ -4,7 +4,7 @@ if(EXT_PLATFORM_STRING)
     return()
 endif()
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 option(LUAU_BUILD_CLI "Build CLI" ON)
 option(LUAU_BUILD_TESTS "Build tests" ON)


### PR DESCRIPTION
Previously, lute treated arguments after -- as files instead of script arguments. This caused errors like:
```sh
Error opening ./1  
Error opening ./2  
Error opening ./3  
``` 
since ```1 2 3``` were misinterpreted as file paths.

This PR does the following:
- Ensures -- properly marks the transition between files and arguments.
- Converts argv[i] from char* to std::string before pushing it into files. (Misc)

Closes #86