### PR TITLE
Don't parse flags as files

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -214,7 +214,7 @@ int main(int argc, char** argv)
             program_argv = &argv[i + 1];
             break;
         }
-        else if (argv[i][0] == '-')
+        else if (argv[i][0] == '-' && argv[i][1] != '\0')
             continue;
 
         if (parsingFiles)

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -214,6 +214,8 @@ int main(int argc, char** argv)
             program_argv = &argv[i + 1];
             break;
         }
+        else if (argv[i][0] == '-')
+            continue;
 
         if (parsingFiles)
             files.push_back(std::string(argv[i])); // fix: Explicit conversion


### PR DESCRIPTION
Right now `lute --check .` will parse the files as `["--check", "."]`.

Let's not do that

