### PR TITLE
Traverse directories for files when type checking

### DIFF
--- a/cli/tc.h
+++ b/cli/tc.h
@@ -4,4 +4,4 @@
 #include "Luau/Frontend.h"
 #include "Luau/FileUtils.h"
 
-int typecheck(const std::vector<std::string> sourceFiles);
+int typecheck(const std::vector<std::string>& sourceFiles);


### PR DESCRIPTION
The change in https://github.com/aatxe/lute/pull/90 stopped directories from being traversed.

We re-introduce that in this change. `getExtension` is a static method in Luau FileUtils so we have to copy it over.

I decided to do this only for typechecking instead of for main `lute`, since I'm not sure if we want to support running a directory of luau scripts at once