### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: Build and Release
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: lute-linux-x86_64
+            options: --c-compiler=clang --cxx-compiler=clang++
+          - os: ubuntu-24.04-arm
+            artifact_name: lute-linux-aarch64
+            options: --c-compiler=clang --cxx-compiler=clang++
+          - os: macos-latest
+            artifact_name: lute-macos-aarch64
+          - os: windows-latest
+            artifact_name: lute-windows-x86_64
+      fail-fast: false
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y ninja-build clang
+
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew update
+        brew install cmake ninja
+
+    - name: Install dependencies (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        choco install ninja
+
+    - if: runner.os == 'Windows'
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Configure
+      run: python ./tools/luthier.py configure lute --config release ${{ matrix.options }}
+
+    - name: Build
+      run: python ./tools/luthier.py build lute --config release ${{ matrix.options }}
+
+    - name: Get Artifact Path
+      id: artifact_path
+      shell: bash
+      run: |
+        exe_path=$(python ./tools/luthier.py build lute --config release --which)
+        echo "Executable path: $exe_path"  # Debug print
+        echo "exe_path=$exe_path" >> "$GITHUB_OUTPUT"
+    
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        path: ${{ steps.artifact_path.outputs.exe_path }}
+        name: ${{ matrix.artifact_name }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: get_version.cmake
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - run: |
+          mkdir release
+          for dir in ./artifacts/*; do
+            base_name=$(basename "$dir")
+            zip -rj release/"${base_name}.zip" "$dir"/*
+          done
+
+      - name: Get project version
+        id: get_version
+        run: |
+          VERSION=$(cmake -P get_version.cmake 2>&1)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create Nightly Tag
+        id: tag_step
+        if: github.event_name == 'schedule'
+        run: |
+          DATE=$(date +%Y%m%d)
+          TAG="-nightly.$DATE"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Create Release Tag
+        id: tag_release
+        run: |
+          VERSION=${{ steps.get_version.outputs.version }}
+          NIGHTLY_TAG=${{ steps.tag_step.outputs.tag }}
+          RELEASE_TAG="$VERSION$NIGHTLY_TAG"
+          echo "tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag_release.outputs.tag }}
+          name: ${{ steps.tag_release.outputs.tag }}
+          draft: false
+          prerelease: ${{ github.event_name == 'schedule' }}
+          files: release/*.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,9 @@ set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-project(Lute LANGUAGES CXX C)
+include(get_version.cmake)
+
+project(Lute LANGUAGES CXX C VERSION ${LUTE_VERSION})
 
 add_library(Lute.Runtime STATIC)
 add_library(Lute.Fs STATIC)

--- a/get_version.cmake
+++ b/get_version.cmake
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.13)
+
+set(LUTE_VERSION 0.1.0)
+message("${LUTE_VERSION}")

--- a/tools/luthier.py
+++ b/tools/luthier.py
@@ -63,6 +63,16 @@ argParser.add_argument(
     help='print out the path to the compiled binary and exit'
 )
 
+argParser.add_argument(
+    '--cxx-compiler', dest='cxx_compiler', action='store',
+    help='C++ compiler to use',
+)
+
+argParser.add_argument(
+    '--c-compiler', dest='c_compiler', action='store',
+    help='C compiler to use',
+)
+
 if isWindows:
     vsVersionGroup = argParser.add_mutually_exclusive_group()
 
@@ -150,7 +160,10 @@ def getProjectPath(args):
 
     config = getConfig(args).lower()
 
-    return os.path.join(buildDir, getCompiler(args), config)
+    if isLinux:
+        return os.path.join(buildDir, config)
+    else:
+        return os.path.join(buildDir, getCompiler(args), config)
 
 def projectPathExists(args):
     projectPath = getProjectPath(args)
@@ -176,7 +189,6 @@ def getExePath(args):
         return os.path.join(
             buildDir,
             config.lower(),
-            container,
             exeName
         )
 
@@ -205,6 +217,9 @@ def call(*args):
 def build(args):
     targetName = args.target
     projectPath = getProjectPath(args)
+
+    if isWindows:
+        targetName = targetName + '.exe'
 
     if args.clean:
         call(['ninja', '-C', projectPath, 'clean'])
@@ -238,6 +253,12 @@ def getConfigureArguments(args):
         '-DCMAKE_BUILD_TYPE=' + config,
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=1',
     ]
+
+    if args.cxx_compiler:
+        configArgs.append('-DCMAKE_CXX_COMPILER=' + args.cxx_compiler)
+
+    if args.c_compiler:
+        configArgs.append('-DCMAKE_C_COMPILER=' + args.c_compiler)
 
     return configArgs
 


### PR DESCRIPTION
This adds a release workflow that can either be run manually to create a new release based on the version in `get_version.cmake` or will be run nightly and will produce pre-releases with the format of `0.1.0-nightly.20250314`. 

See the example run [here](https://github.com/Nicell/lute/actions/runs/13851701027) and the resulting release [here](https://github.com/Nicell/lute/releases/tag/0.1.0-nightly.20250314). (Two slight adjustments made after this run happened, no longer installing cmake on macos since it's already there and changed `-nightly-20250314` to `-nightly.20250314`.

The output is confirmed working with foreman and rokit.

Closes #93

Note: For nightly releases, with foreman you can just put `0.1.0-nightly`, but on rokit, you need to have the full tag written including date.