### PR TITLE
Rename `@batteries/cliargs` to `@batteries/cli` and clean up the code.

### DIFF
--- a/batteries/cli.luau
+++ b/batteries/cli.luau
@@ -21,67 +21,87 @@ type ParseResult = {
 	fwdArgs: { string },
 }
 
-type ParseData = {
+type ParserData = {
 	arguments: { [number]: ArgData },
 	positional: { [number] : ArgData},
 	parsed: { [number]: ParseResult },
 }
 
-type ParseInterface = typeof(cli)
-export type Parser = setmetatable<ParseData, ParseInterface>
+type ParserInterface = typeof(cli)
+export type Parser = setmetatable<ParserData, ParserInterface>
 
 function cli.parser(): Parser
-	local self = setmetatable({}, cli) :: Parser
-	self.arguments = {}
-	self.positional = {}
-	self.parsed = { values = {}, flags = {}, fwdArgs = {} }
-	return self
+	local self = {
+        arguments = {},
+        positional = {},
+        parsed = { values = {}, flags = {}, fwdArgs = {} },
+	}
+
+	return setmetatable(self, cli)
 end
 
-function cli.add(self: Parser, name: string, kind: ArgKind, options: ArgOptions)
+function cli.add(self: Parser, name: string, kind: ArgKind, options: ArgOptions): ()
 	local argument = {
 		name = name,
 		kind = kind,
 		options = options or { aliases = {}, required = false },
 	}
-	table.insert(self.arguments, argument)
 
+	table.insert(self.arguments, argument)
 	if kind == "positional" then
 		table.insert(self.positional, argument)
 	end
 end
 
 function cli.parse(self: Parser, args: {string}): ()
-	local i = 1
+	local i = 0
 	local pos_index = 1
-	while i <= #args do
+
+    while i < #args do
+       	i += 1
+
 		local arg = args[i]
 
+		-- if the argument is exactly "--", we pass everything along
 		if arg == "--" then
 			table.move(args, i + 1, #args, 1, self.parsed.fwdArgs)
 			break
 		end
 
+		-- if the argument starts with two dashes, we're parsing either a flag or an option
 		if string.sub(arg, 1, 2) == "--" then
 			local name = string.sub(arg, 3)
 			local found = false
+
 			for _, argument in self.arguments do
 				local aliases = argument.options.aliases or {}
+
 				if argument.name == name or table.find(aliases, name) then
 					found = true
+
 					if argument.kind == "option" then
-						i += 1
+    					-- advance past the argument
+    					i += 1
+
 						assert(i <= #args, "Missing value for argument: " .. argument.name)
 						self.parsed.values[argument.name] = args[i]
-					else
-						self.parsed.flags[argument.name] = true
+
+						break
 					end
+
+					self.parsed.flags[argument.name] = true
 					break
 				end
 			end
+
 			assert(found, "Unknown argument: " .. name)
-		elseif string.sub(arg, 1, 1) == "-" then
+			continue
+		end
+
+		-- if the argument starts with a single dash, we're parsing a flag
+		if string.sub(arg, 1, 1) == "-" then
 			local flags = string.sub(arg, 2)
+
 			for j = 1, #flags do
 				local name = string.sub(flags, j, j)
 				local found = false
@@ -99,24 +119,32 @@ function cli.parse(self: Parser, args: {string}): ()
 						break
 					end
 				end
+
 				assert(found, "Unknown argument: " .. name)
 			end
-		else
-			if pos_index <= #self.positional then
-				self.parsed.values[self.positional[pos_index].name] = arg
-				pos_index += 1
-			else
-				table.insert(self.parsed.fwdArgs, arg)
-			end
+
+			continue
 		end
-		i += 1
+
+		-- if we have positional arguments left, we can take this argument as one
+		if pos_index <= #self.positional then
+    		self.parsed.values[self.positional[pos_index].name] = arg
+    		pos_index += 1
+            continue
+		end
+
+		-- otherwise, the argument is forwarded on
+		table.insert(self.parsed.fwdArgs, arg)
 	end
 
+	-- check that all required arguments are present, and set any default values as needed
 	for _, argument in self.arguments do
 		assert(argument)
+
 		if argument.options.required and self.parsed.values[argument.name] == nil then
 			assert(self.parsed.values[argument.name], "Missing required argument: " .. argument.name)
 		end
+
 		if self.parsed.values[argument.name] == nil and argument.options.default then
 			self.parsed.values[argument.name] = argument.options.default
 		end
@@ -131,7 +159,7 @@ function cli.has(self: Parser, name: string): boolean
 	return self.parsed.flags[name] ~= nil
 end
 
-function cli.getFwdArgs(): { string } | nil
+function cli.forwaded(): { string }?
 	return self.parsed.fwdArgs
 end
 

--- a/batteries/cli.luau
+++ b/batteries/cli.luau
@@ -24,7 +24,7 @@ type ParseResult = {
 type ParserData = {
     arguments: { [number]: ArgData },
     positional: { [number] : ArgData},
-    parsed: { [number]: ParseResult },
+    parsed: ParseResult,
 }
 
 type ParserInterface = typeof(cli)

--- a/batteries/cli.luau
+++ b/batteries/cli.luau
@@ -3,173 +3,173 @@ cli.__index = cli
 
 type ArgKind = "positional" | "flag" | "option"
 type ArgOptions = {
-	help: string?,
-	aliases: { string }?,
-	default: string?,
-	required: boolean?,
+    help: string?,
+    aliases: { string }?,
+    default: string?,
+    required: boolean?,
 }
 
 type ArgData = {
-	name: string,
-	kind: ArgKind,
-	options: ArgOptions,
+    name: string,
+    kind: ArgKind,
+    options: ArgOptions,
 }
 
 type ParseResult = {
-	values: { [string]: string },
-	flags: { [string]: boolean },
-	fwdArgs: { string },
+    values: { [string]: string },
+    flags: { [string]: boolean },
+    fwdArgs: { string },
 }
 
 type ParserData = {
-	arguments: { [number]: ArgData },
-	positional: { [number] : ArgData},
-	parsed: { [number]: ParseResult },
+    arguments: { [number]: ArgData },
+    positional: { [number] : ArgData},
+    parsed: { [number]: ParseResult },
 }
 
 type ParserInterface = typeof(cli)
 export type Parser = setmetatable<ParserData, ParserInterface>
 
 function cli.parser(): Parser
-	local self = {
+    local self = {
         arguments = {},
         positional = {},
         parsed = { values = {}, flags = {}, fwdArgs = {} },
-	}
+    }
 
-	return setmetatable(self, cli)
+    return setmetatable(self, cli)
 end
 
 function cli.add(self: Parser, name: string, kind: ArgKind, options: ArgOptions): ()
-	local argument = {
-		name = name,
-		kind = kind,
-		options = options or { aliases = {}, required = false },
-	}
+    local argument = {
+        name = name,
+        kind = kind,
+        options = options or { aliases = {}, required = false },
+    }
 
-	table.insert(self.arguments, argument)
-	if kind == "positional" then
-		table.insert(self.positional, argument)
-	end
+    table.insert(self.arguments, argument)
+    if kind == "positional" then
+        table.insert(self.positional, argument)
+    end
 end
 
 function cli.parse(self: Parser, args: {string}): ()
-	local i = 0
-	local pos_index = 1
+    local i = 0
+    local pos_index = 1
 
     while i < #args do
-       	i += 1
+        i += 1
 
-		local arg = args[i]
+        local arg = args[i]
 
-		-- if the argument is exactly "--", we pass everything along
-		if arg == "--" then
-			table.move(args, i + 1, #args, 1, self.parsed.fwdArgs)
-			break
-		end
+        -- if the argument is exactly "--", we pass everything along
+        if arg == "--" then
+            table.move(args, i + 1, #args, 1, self.parsed.fwdArgs)
+            break
+        end
 
-		-- if the argument starts with two dashes, we're parsing either a flag or an option
-		if string.sub(arg, 1, 2) == "--" then
-			local name = string.sub(arg, 3)
-			local found = false
+        -- if the argument starts with two dashes, we're parsing either a flag or an option
+        if string.sub(arg, 1, 2) == "--" then
+            local name = string.sub(arg, 3)
+            local found = false
 
-			for _, argument in self.arguments do
-				local aliases = argument.options.aliases or {}
+            for _, argument in self.arguments do
+                local aliases = argument.options.aliases or {}
 
-				if argument.name == name or table.find(aliases, name) then
-					found = true
+                if argument.name == name or table.find(aliases, name) then
+                    found = true
 
-					if argument.kind == "option" then
-    					-- advance past the argument
-    					i += 1
+                    if argument.kind == "option" then
+                        -- advance past the argument
+                        i += 1
 
-						assert(i <= #args, "Missing value for argument: " .. argument.name)
-						self.parsed.values[argument.name] = args[i]
+                        assert(i <= #args, "Missing value for argument: " .. argument.name)
+                        self.parsed.values[argument.name] = args[i]
 
-						break
-					end
+                        break
+                    end
 
-					self.parsed.flags[argument.name] = true
-					break
-				end
-			end
+                    self.parsed.flags[argument.name] = true
+                    break
+                end
+            end
 
-			assert(found, "Unknown argument: " .. name)
-			continue
-		end
-
-		-- if the argument starts with a single dash, we're parsing a flag
-		if string.sub(arg, 1, 1) == "-" then
-			local flags = string.sub(arg, 2)
-
-			for j = 1, #flags do
-				local name = string.sub(flags, j, j)
-				local found = false
-				for _, argument in self.arguments do
-					local aliases = argument.options.aliases or {}
-					if argument.name == name or table.find(aliases, name) then
-						found = true
-						if argument.kind == "option" then
-							i += 1
-							assert(i <= #args, "Missing value for argument: " .. argument.name)
-							self.parsed.values[argument.name] = args[i]
-						else
-							self.parsed.flags[argument.name] = true
-						end
-						break
-					end
-				end
-
-				assert(found, "Unknown argument: " .. name)
-			end
-
-			continue
-		end
-
-		-- if we have positional arguments left, we can take this argument as one
-		if pos_index <= #self.positional then
-    		self.parsed.values[self.positional[pos_index].name] = arg
-    		pos_index += 1
+            assert(found, "Unknown argument: " .. name)
             continue
-		end
+        end
 
-		-- otherwise, the argument is forwarded on
-		table.insert(self.parsed.fwdArgs, arg)
-	end
+        -- if the argument starts with a single dash, we're parsing a flag
+        if string.sub(arg, 1, 1) == "-" then
+            local flags = string.sub(arg, 2)
 
-	-- check that all required arguments are present, and set any default values as needed
-	for _, argument in self.arguments do
-		assert(argument)
+            for j = 1, #flags do
+                local name = string.sub(flags, j, j)
+                local found = false
+                for _, argument in self.arguments do
+                    local aliases = argument.options.aliases or {}
+                    if argument.name == name or table.find(aliases, name) then
+                        found = true
+                        if argument.kind == "option" then
+                            i += 1
+                            assert(i <= #args, "Missing value for argument: " .. argument.name)
+                            self.parsed.values[argument.name] = args[i]
+                        else
+                            self.parsed.flags[argument.name] = true
+                        end
+                        break
+                    end
+                end
 
-		if argument.options.required and self.parsed.values[argument.name] == nil then
-			assert(self.parsed.values[argument.name], "Missing required argument: " .. argument.name)
-		end
+                assert(found, "Unknown argument: " .. name)
+            end
 
-		if self.parsed.values[argument.name] == nil and argument.options.default then
-			self.parsed.values[argument.name] = argument.options.default
-		end
-	end
+            continue
+        end
+
+        -- if we have positional arguments left, we can take this argument as one
+        if pos_index <= #self.positional then
+            self.parsed.values[self.positional[pos_index].name] = arg
+            pos_index += 1
+            continue
+        end
+
+        -- otherwise, the argument is forwarded on
+        table.insert(self.parsed.fwdArgs, arg)
+    end
+
+    -- check that all required arguments are present, and set any default values as needed
+    for _, argument in self.arguments do
+        assert(argument)
+
+        if argument.options.required and self.parsed.values[argument.name] == nil then
+            assert(self.parsed.values[argument.name], "Missing required argument: " .. argument.name)
+        end
+
+        if self.parsed.values[argument.name] == nil and argument.options.default then
+            self.parsed.values[argument.name] = argument.options.default
+        end
+    end
 end
 
 function cli.get(self: Parser, name: string): boolean
-	return self.parsed.values[name]
+    return self.parsed.values[name]
 end
 
 function cli.has(self: Parser, name: string): boolean
-	return self.parsed.flags[name] ~= nil
+    return self.parsed.flags[name] ~= nil
 end
 
 function cli.forwaded(): { string }?
-	return self.parsed.fwdArgs
+    return self.parsed.fwdArgs
 end
 
 function cli.help(self: Parser): ()
-	print("Usage:")
-	for _, argument in self.arguments do
-		local aliasStr = table.concat(argument.options.aliases or {}, ", ")
-		local reqStr = if argument.options.required then "(required) " else ""
-		print(string.format("  --%s (-%s) - %s%s", argument.name, aliasStr, reqStr, argument.options.help or ""))
-	end
+    print("Usage:")
+    for _, argument in self.arguments do
+        local aliasStr = table.concat(argument.options.aliases or {}, ", ")
+        local reqStr = if argument.options.required then "(required) " else ""
+        print(string.format("  --%s (-%s) - %s%s", argument.name, aliasStr, reqStr, argument.options.help or ""))
+    end
 end
 
 return cli

--- a/batteries/cli.luau
+++ b/batteries/cli.luau
@@ -1,5 +1,5 @@
-local cliargs = {}
-cliargs.__index = cliargs
+local cli = {}
+cli.__index = cli
 
 type ArgKind = "positional" | "flag" | "option"
 type ArgOptions = {
@@ -27,18 +27,18 @@ type ParseData = {
 	parsed: { [number]: ParseResult },
 }
 
-type ParseInterface = typeof(cliargs)
-export type ParserType = setmetatable<ParseData, ParseInterface>
+type ParseInterface = typeof(cli)
+export type Parser = setmetatable<ParseData, ParseInterface>
 
-function cliargs.new(): ParserType
-	local self = setmetatable({}, cliargs) :: ParserType
+function cli.parser(): Parser
+	local self = setmetatable({}, cli) :: Parser
 	self.arguments = {}
 	self.positional = {}
 	self.parsed = { values = {}, flags = {}, fwdArgs = {} }
 	return self
 end
 
-function cliargs.add(self: ParserType, name: string, kind: ArgKind, options: ArgOptions)
+function cli.add(self: Parser, name: string, kind: ArgKind, options: ArgOptions)
 	local argument = {
 		name = name,
 		kind = kind,
@@ -51,17 +51,17 @@ function cliargs.add(self: ParserType, name: string, kind: ArgKind, options: Arg
 	end
 end
 
-function cliargs.parse(self: ParserType, args: {string}): ()
+function cli.parse(self: Parser, args: {string}): ()
 	local i = 1
 	local pos_index = 1
 	while i <= #args do
 		local arg = args[i]
-		
+
 		if arg == "--" then
 			table.move(args, i + 1, #args, 1, self.parsed.fwdArgs)
 			break
 		end
-		
+
 		if string.sub(arg, 1, 2) == "--" then
 			local name = string.sub(arg, 3)
 			local found = false
@@ -123,19 +123,19 @@ function cliargs.parse(self: ParserType, args: {string}): ()
 	end
 end
 
-function cliargs.get(self: ParserType, name: string): boolean
+function cli.get(self: Parser, name: string): boolean
 	return self.parsed.values[name]
 end
 
-function cliargs.has(self:ParserType, name: string): boolean
+function cli.has(self: Parser, name: string): boolean
 	return self.parsed.flags[name] ~= nil
 end
 
-function cliargs.getFwdArgs(): { string } | nil
+function cli.getFwdArgs(): { string } | nil
 	return self.parsed.fwdArgs
 end
 
-function cliargs.help(self: ParserType): ()
+function cli.help(self: Parser): ()
 	print("Usage:")
 	for _, argument in self.arguments do
 		local aliasStr = table.concat(argument.options.aliases or {}, ", ")
@@ -144,4 +144,4 @@ function cliargs.help(self: ParserType): ()
 	end
 end
 
-return cliargs
+return cli

--- a/examples/cliargs.luau
+++ b/examples/cliargs.luau
@@ -1,15 +1,13 @@
 local cli = require("@batteries/cli")
 
-local parser = cli.parser()
+local args = cli.parser()
 
-parser:add("input", "positional", { help = "Input file" })
-parser:add("verbose", "flag", { help = "Enable verbose mode", aliases = { "v" } })
-parser:add("output", "option", { help = "Output file", aliases = { "o" }, default = "default.txt" })
+args:add("input", "positional", { help = "Input file" })
+args:add("verbose", "flag", { help = "Enable verbose mode", aliases = { "v" } })
+args:add("output", "option", { help = "Output file", aliases = { "o" }, default = "default.txt" })
 
-local args = { ... }
+args:parse({ ... })
 
-parser:parse(args)
-
-print("Input File:", parser:get("input"))        -- "input.txt"
-print("Verbose Mode:", parser:has("verbose"))   -- true
-print("Output File:", parser:get("output"))     -- "result.txt"
+print("Input File:", args:get("input"))        -- "input.txt"
+print("Verbose Mode:", args:has("verbose"))   -- true
+print("Output File:", args:get("output"))     -- "result.txt"

--- a/examples/cliargs.luau
+++ b/examples/cliargs.luau
@@ -1,6 +1,6 @@
-local cliargs = require("@batteries/cliargs")
+local cli = require("@batteries/cli")
 
-local parser = cliargs.new()
+local parser = cli.parser()
 
 parser:add("input", "positional", { help = "Input file" })
 parser:add("verbose", "flag", { help = "Enable verbose mode", aliases = { "v" } })


### PR DESCRIPTION
This PR does some basic tidying of `@batteries/cli` (after renaming it from `@batteries/cliargs`). Clean up includes some minor changes to the name of the interface, cleaning up some of the parsing code itself to have easier to follow control flow, and fixing some of the incorrect type info in the library.