### PR TITLE
Freeze the `@batteries/toml` module.

### DIFF
--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -168,4 +168,4 @@ end
 toml.serialize = serialize
 toml.deserialize = deserialize
 
-return toml
+return table.freeze(toml)


### PR DESCRIPTION
We should consistently call `table.freeze` on our modules.