### PR TITLE
Improve luthier to check out by revision when possible.

### DIFF
--- a/extern/curl.tune
+++ b/extern/curl.tune
@@ -1,4 +1,5 @@
 [dependency]
 name = "curl"
 remote = "https://github.com/curl/curl.git"
-branch = "curl-8_12_1"
+branch = "curl-8_13_0"
+revision = "1c3149881769e7bd79b072e48374e4c2b3678b2f"

--- a/extern/libuv.tune
+++ b/extern/libuv.tune
@@ -2,3 +2,4 @@
 name = "libuv"
 remote = "https://github.com/libuv/libuv.git"
 branch = "v1.50.0"
+revision = "8fb9cb919489a48880680a56efecff6a7dfb4504"

--- a/extern/luau.tune
+++ b/extern/luau.tune
@@ -1,4 +1,5 @@
 [dependency]
 name = "luau"
 remote = "https://github.com/luau-lang/luau.git"
-branch = "0.665"
+branch = "0.668"
+revision = "ee1c6bf0db9948b5e89e2ee66be72f6235bf0696"

--- a/extern/uWebSockets.tune
+++ b/extern/uWebSockets.tune
@@ -2,3 +2,4 @@
 name = "uWebSockets"
 remote = "https://github.com/uNetworking/uWebSockets.git"
 branch = "v20.74.0"
+revision = "c445faa38125bf782eed3fec97f83b4733c7fb91"

--- a/extern/wolfssl.tune
+++ b/extern/wolfssl.tune
@@ -2,3 +2,4 @@
 name = "wolfssl"
 remote = "https://github.com/wolfSSL/wolfssl.git"
 branch = "v5.7.6-stable"
+revision = "239b85c80438bf60d9a5b9e0ebe9ff097a760d0d"

--- a/tools/luthier.py
+++ b/tools/luthier.py
@@ -293,7 +293,7 @@ def fetchDependency(dependencyInfo):
         os.chdir(getSourceRoot())
         return result
 
-    if gitVersionInfo['major'] >= 2 and gitVersionInfo['minor'] >= 49:
+    if (gitVersionInfo['major'], gitVersionInfo['minor']) >= (2, 49):
         # if it doesn't exist, we'll do a shallow clone
         return call(['git', 'clone', '--depth=1', '--recurse-submodules', '--revision', dependency['revision'], dependency['remote'], "extern/" + dependency['name']])
     else:

--- a/tools/luthier.py
+++ b/tools/luthier.py
@@ -10,6 +10,14 @@ from os import path
 
 cwd = os.getcwd()
 
+def gitVersion():
+    gitVersionString = sp.check_output(['git', '--version'])
+    gitVersion = gitVersionString.decode('utf-8').strip().split()[-1]
+    components = gitVersion.split('.')
+    return { 'major': int(components[0]), 'minor': int(components[1]), 'patch': int(components[2]) }
+
+gitVersionInfo = gitVersion()
+
 class ReportableError(Exception):
     """This error object is used to indicate an error should be reported to the user
        without a full stack trace."""
@@ -279,15 +287,18 @@ def fetchDependency(dependencyInfo):
     # if the directory already exists, update that directory to `branch`
     if os.path.isdir(os.path.join('extern', dependency['name'])):
         os.chdir(os.path.join('extern', dependency['name']))
-        check(call(['git', 'fetch', '--depth=1', 'origin', dependency['branch']]))
-        result = call(['git', 'checkout', dependency['branch']])
+        check(call(['git', 'fetch', '--depth=1', 'origin', dependency['revision']]))
+        result = call(['git', 'checkout', dependency['revision']])
         check(call(['git', 'submodule', 'update', '--init', '--recursive', '--depth=1']))
         os.chdir(getSourceRoot())
         return result
 
-
-    # if it doesn't exist, we'll do a shallow clone
-    return call(['git', 'clone', '--depth=1', '--recurse-submodules', '--branch', dependency['branch'], dependency['remote'], "extern/" + dependency['name']])
+    if gitVersionInfo['major'] >= 2 and gitVersionInfo['minor'] >= 49:
+        # if it doesn't exist, we'll do a shallow clone
+        return call(['git', 'clone', '--depth=1', '--recurse-submodules', '--revision', dependency['revision'], dependency['remote'], "extern/" + dependency['name']])
+    else:
+        # if it doesn't exist, we'll do a shallow clone
+        return call(['git', 'clone', '--depth=1', '--recurse-submodules', '--branch', dependency['branch'], dependency['remote'], "extern/" + dependency['name']])
 
 def fetchDependencies(args):
     for _, _, files in os.walk('extern'):


### PR DESCRIPTION
While we currently have a pretty sane set of dependencies, we're technically vulnerable to a possible supply chain attack right now relying solely on git tags. As it turns out, very conveniently, git has _finally_ added support for checking out a single revision directly in the latest git version, `git 2.49.0`. So, we're now able to use revisions instead for anyone with the latest `git` installed.