### PR TITLE
Improve luthier's git version extraction on macOS

### DIFF
--- a/tools/luthier.py
+++ b/tools/luthier.py
@@ -12,7 +12,7 @@ cwd = os.getcwd()
 
 def gitVersion():
     gitVersionString = sp.check_output(['git', '--version'])
-    gitVersion = gitVersionString.decode('utf-8').strip().split()[-1]
+    gitVersion = gitVersionString.decode('utf-8').strip().split()[2]
     components = gitVersion.split('.')
     return { 'major': int(components[0]), 'minor': int(components[1]), 'patch': int(components[2]) }
 


### PR DESCRIPTION
Apple Git's `git --version` output on my machine, which broke luthier: `git version 2.39.3 (Apple Git-145)`.

I tested on a few different platforms, and the beginning of the output of `git --version` is always consistent: `git version X.Y.Z`.