### PR TITLE
Implement task.resume

### DIFF
--- a/examples/resume.luau
+++ b/examples/resume.luau
@@ -1,0 +1,11 @@
+local task = require("@lute/task")
+
+local c = coroutine.create(function()
+	print("hi")
+	coroutine.yield()
+	print("hi2")
+	error("hello world")
+end)
+
+task.resume(c)
+task.resume(c)

--- a/runtime/include/lute/runtime.h
+++ b/runtime/include/lute/runtime.h
@@ -32,13 +32,15 @@ struct Runtime
     bool hasContinuations();
 
     void schedule(std::function<void()> f);
-
+    
     // Resume thread with the specified error
     void scheduleLuauError(std::shared_ptr<Ref> ref, std::string error);
 
     // Resume thread with the results computed by the continuation
     void scheduleLuauResume(std::shared_ptr<Ref> ref, std::function<int(lua_State*)> cont);
-
+    
+    void reportError(lua_State* L);
+    
     // Run 'f' in a libuv work queue
     void runInWorkQueue(std::function<void()> f);
 

--- a/runtime/include/lute/runtime.h
+++ b/runtime/include/lute/runtime.h
@@ -32,7 +32,6 @@ struct Runtime
     bool hasContinuations();
 
     void schedule(std::function<void()> f);
-    
     // Resume thread with the specified error
     void scheduleLuauError(std::shared_ptr<Ref> ref, std::string error);
 

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -66,6 +66,7 @@ bool Runtime::runToCompletion()
         if (L == nullptr)
         {
             fprintf(stderr, "Cannot resume a non-thread reference");
+            return false;
         }
 
         // We still have 'next' on stack to hold on to thread we are about to run

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -66,7 +66,6 @@ bool Runtime::runToCompletion()
         if (L == nullptr)
         {
             fprintf(stderr, "Cannot resume a non-thread reference");
-            return false;
         }
 
         // We still have 'next' on stack to hold on to thread we are about to run
@@ -89,7 +88,6 @@ bool Runtime::runToCompletion()
                 error += "\nstacktrace:\n";
                 error += lua_debugtrace(L);
                 fprintf(stderr, "%s", error.c_str());
-                return false;
             }
 
             continue;
@@ -97,16 +95,7 @@ bool Runtime::runToCompletion()
 
         if (status != LUA_OK)
         {
-            std::string error;
-
-            if (const char* str = lua_tostring(L, -1))
-                error = str;
-
-            error += "\nstacktrace:\n";
-            error += lua_debugtrace(L);
-
-            fprintf(stderr, "%s", error.c_str());
-            return false;
+            reportError(L);
         }
 
         if (next.cont)
@@ -149,6 +138,19 @@ void Runtime::schedule(std::function<void()> f)
     continuations.push_back(std::move(f));
 
     runLoopCv.notify_one();
+}
+
+void Runtime::reportError(lua_State* L)
+{
+    std::string error;
+
+    if (const char* str = lua_tostring(L, -1))
+        error = str;
+
+    error += "\nstacktrace:\n";
+    error += lua_debugtrace(L);
+
+    fprintf(stderr, "%s", error.c_str());
 }
 
 void Runtime::scheduleLuauError(std::shared_ptr<Ref> ref, std::string error)

--- a/task/include/lute/task.h
+++ b/task/include/lute/task.h
@@ -12,9 +12,12 @@ namespace task
 {
 
 int lua_defer(lua_State* L);
+int lua_resume(lua_State* L);
 
 static const luaL_Reg lib[] = {
     {"defer", lua_defer},
+    {"resume", lua_resume},
+    
     {nullptr, nullptr},
 };
 

--- a/task/src/task.cpp
+++ b/task/src/task.cpp
@@ -1,5 +1,8 @@
 #include "lute/task.h"
 
+#include "lua.h"
+#include "lualib.h"
+#include "lute/ref.h"
 #include "lute/runtime.h"
 
 namespace task
@@ -10,6 +13,19 @@ namespace task
 
         runtime->runningThreads.push_back({ true, getRefForThread(L), 0 });
         return lua_yield(L, 0);
+    };
+    
+    int lua_resume(lua_State* L)
+    {
+        Runtime* runtime = getRuntime(L);
+        lua_State* thread = lua_tothread(L, 1);
+        luaL_argexpected(L, thread, 1, "thread");
+        
+        auto ref = getRefForThread(thread);
+        
+        runtime->scheduleLuauResume(ref, [](lua_State* L) { return 0; });
+        
+        return 0;
     }
 } // namespace task
 

--- a/task/src/task.cpp
+++ b/task/src/task.cpp
@@ -5,6 +5,9 @@
 #include "lute/ref.h"
 #include "lute/runtime.h"
 
+// taken from extern/luau/VM/lcorolib.cpp
+static const char* const statnames[] = {"running", "suspended", "normal", "dead", "dead"};
+
 namespace task
 {
     int lua_defer(lua_State* L)
@@ -18,12 +21,29 @@ namespace task
     int lua_resume(lua_State* L)
     {
         Runtime* runtime = getRuntime(L);
+        
         lua_State* thread = lua_tothread(L, 1);
         luaL_argexpected(L, thread, 1, "thread");
         
-        auto ref = getRefForThread(thread);
+        int currentThreadStatus = lua_costatus(L, thread);
+        if (currentThreadStatus != LUA_COSUS)
+        {
+            auto ref = getRefForThread(L);
+            luaL_errorL(L, "cannot resume %s coroutine", statnames[currentThreadStatus]);
+            
+            return 1;
+        };
         
-        runtime->scheduleLuauResume(ref, [](lua_State* L) { return 0; });
+        lua_remove(L, 1);
+        
+        int args = lua_gettop(L);
+        lua_xmove(L, thread, args);
+        
+        int status = lua_resume(thread, L, args);
+        
+        if ((status != LUA_OK) && (status != LUA_YIELD) && (status != LUA_BREAK)) {
+            runtime->reportError(thread);
+        }
         
         return 0;
     }


### PR DESCRIPTION
Closes issue #144 

This PR:
- Changes the scheduler to close the process when all threads are dead
  - It does this by not returning in `Runtime::runToCompletion()`. These returns have been removed.
- Abstracts error handling logic into `Runtime::reportError(lua_State* L)`
- Implements `task.resume<T...>(thread, T...)`. This propagates errors to the output.