### PR TITLE
Enable new solver in VSCode configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
-     "luau-lsp.sourcemap.enabled": false,
-     "luau-lsp.platform.type": "standard"
+    "luau-lsp.fflags.enableNewSolver": true,
+    "luau-lsp.sourcemap.enabled": false,
+    "luau-lsp.platform.type": "standard"
 }


### PR DESCRIPTION
Not really sure we should be committing `.vscode/settings.json` to the repo, since it blocks others from using their own config. But given that it was added in https://github.com/aatxe/lute/pull/154, lets extend it to force enable the new solver