### PR TITLE
Add result to @batteries

### DIFF
--- a/batteries/result.luau
+++ b/batteries/result.luau
@@ -1,6 +1,4 @@
-type T<Value> =
-    | { success: true, value: Value }
-    | { success: false, traceback: string, err: string }
+type T<Value> = | { success: true, value: Value } | { success: false, traceback: string, err: string }
 
 local result = {}
 
@@ -21,6 +19,18 @@ function result.fail<Value>(err: string): T<Value>
 		traceback = traceback,
 		err = err,
 	}
+end
+
+function result.pcall<R, T...>(f: (T...) -> R, ...: T...): T<R>
+	local success, value = pcall(f, ...)
+
+	if success then
+		return result.ok(value)
+	else
+		local err = value :: any
+
+		return result.fail(err)
+	end
 end
 
 return result

--- a/batteries/result.luau
+++ b/batteries/result.luau
@@ -1,0 +1,31 @@
+type T<Value> = {
+	success: true,
+	value: Value,
+} | {
+	success: false,
+	traceback: string,
+	err: string,
+}
+
+local result = {}
+
+function result.ok<Value>(value: Value): T<Value>
+	return {
+		success = true,
+		value = value,
+	}
+end
+
+function result.fail<Value>(err: string): T<Value>
+	-- Ignore the current call to debug.traceback, and the call to fail.
+	local traceback = debug.traceback(nil, 2)
+
+	return {
+		success = false,
+
+		traceback = traceback,
+		err = err,
+	}
+end
+
+return result

--- a/batteries/result.luau
+++ b/batteries/result.luau
@@ -1,11 +1,6 @@
-type T<Value> = {
-	success: true,
-	value: Value,
-} | {
-	success: false,
-	traceback: string,
-	err: string,
-}
+type T<Value> =
+    | { success: true, value: Value }
+    | { success: false, traceback: string, err: string }
 
 local result = {}
 


### PR DESCRIPTION
Many operations involving the file system & networking can fail. One of the most common ways of handling this is pcall, but this is not type safe.

A common idiom is to have a Result type, somewhat similar to Rust's Result type. It's an extremely common and useful idiom. Any project written in Lute interacting with APIs which could error will end up encountering the problem of gracefully handling failure; the result battery significantly helps with that.