### PR TITLE
Split run and check commands

### DIFF
--- a/cli/tc.cpp
+++ b/cli/tc.cpp
@@ -226,7 +226,7 @@ int typecheck(const std::vector<std::string>& sourceFilesInput)
 
     if (sourceFiles.empty())
     {
-        fprintf(stderr, "Error: lute --check expects a file to type check.\n\n");
+        fprintf(stderr, "Error: lute check expects a file to type check.\n\n");
         return 1;
     }
 


### PR DESCRIPTION
This splits lute into two subcommands. `run` and `check`. The motivation is to support a more ergonomic `run` command while not compromising on the existing `--check` ability to process multiple files.

```
Usage: lute <command> [options] [arguments...]

Commands:
  run (default)   Run a Luau script.
  check           Type check Luau files.

Run Options (when using 'run' or no command):
  lute [run] <script.luau> [args...]
    Executes the script, passing [args...] to it.

Check Options:
  lute check <file1.luau> [file2.luau...]
    Performs a type check on the specified files.

General Options:
  -h, --help    Display this usage message.
```

If run/check is not provided, run is inferred, and the unrecognized command is passed to run as if it's the script.

Closes #174 