### PR TITLE
Use upload-pages-artifact

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,15 +25,15 @@ jobs:
         working-directory: docs
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: github-pages
-          path: docs/.vitepress/dist
+          path: docs/.vitepress/dist/
   
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    
+
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
The existing upload artifact doesn't produce a single tar that's gzipped, which deploy-pages requires... because of course it does