### PR TITLE
Reorganize system library to match ordering in other libraries.

### DIFF
--- a/system/include/lute/system.h
+++ b/system/include/lute/system.h
@@ -9,11 +9,11 @@ int luaopen_system(lua_State* L);
 // open the library as a table on top of the stack
 int luteopen_system(lua_State* L);
 
-static const char kArchitectureProperty[] = "arch";
-static const char kOperatingSystemProperty[] = "os";
-
 namespace libsystem
 {
+
+static const char kArchitectureProperty[] = "arch";
+static const char kOperatingSystemProperty[] = "os";
 
 int lua_cpus(lua_State* L);
 int lua_threadcount(lua_State* L);

--- a/system/include/lute/system.h
+++ b/system/include/lute/system.h
@@ -12,8 +12,9 @@ int luteopen_system(lua_State* L);
 static const char kArchitectureProperty[] = "arch";
 static const char kOperatingSystemProperty[] = "os";
 
-namespace system_lib
+namespace libsystem
 {
+
 int lua_cpus(lua_State* L);
 int lua_threadcount(lua_State* L);
 
@@ -29,4 +30,4 @@ static const std::string properties[] = {
     kOperatingSystemProperty,
 };
 
-} // namespace system_lib
+} // namespace libsystem

--- a/system/src/system.cpp
+++ b/system/src/system.cpp
@@ -94,10 +94,10 @@ int luteopen_system(lua_State* L)
     uv_os_uname(&sysinfo);
 
     lua_pushstring(L, sysinfo.sysname);
-    lua_setfield(L, -2, kOperatingSystemProperty);
+    lua_setfield(L, -2, libsystem::kOperatingSystemProperty);
 
     lua_pushstring(L, sysinfo.machine);
-    lua_setfield(L, -2, kArchitectureProperty);
+    lua_setfield(L, -2, libsystem::kArchitectureProperty);
 
     lua_setreadonly(L, -1, 1);
 

--- a/system/src/system.cpp
+++ b/system/src/system.cpp
@@ -5,43 +5,7 @@
 #include <string>
 #include <vector>
 
-int luaopen_system(lua_State* L)
-{
-    luteopen_system(L);
-    lua_setglobal(L, "system");
-
-    return 1;
-}
-
-int luteopen_system(lua_State* L)
-{
-    lua_createtable(L, 0, std::size(system_lib::lib) + std::size(system_lib::properties));
-
-    for (auto& [name, func] : system_lib::lib)
-    {
-        if (!name || !func)
-            break;
-
-        lua_pushcfunction(L, func, name);
-        lua_setfield(L, -2, name);
-    }
-
-    // os
-    uv_utsname_t sysinfo;
-    uv_os_uname(&sysinfo);
-
-    lua_pushstring(L, sysinfo.sysname);
-    lua_setfield(L, -2, kOperatingSystemProperty);
-
-    lua_pushstring(L, sysinfo.machine);
-    lua_setfield(L, -2, kArchitectureProperty);
-
-    lua_setreadonly(L, -1, 1);
-
-    return 1;
-}
-
-namespace system_lib
+namespace libsystem
 {
 int lua_cpus(lua_State* L)
 {
@@ -102,4 +66,40 @@ int lua_threadcount(lua_State* L)
     return 1;
 }
 
-} // namespace system_lib
+} // namespace libsystem
+
+int luaopen_system(lua_State* L)
+{
+    luteopen_system(L);
+    lua_setglobal(L, "system");
+
+    return 1;
+}
+
+int luteopen_system(lua_State* L)
+{
+    lua_createtable(L, 0, std::size(libsystem::lib) + std::size(libsystem::properties));
+
+    for (auto& [name, func] : libsystem::lib)
+    {
+        if (!name || !func)
+            break;
+
+        lua_pushcfunction(L, func, name);
+        lua_setfield(L, -2, name);
+    }
+
+    // os
+    uv_utsname_t sysinfo;
+    uv_os_uname(&sysinfo);
+
+    lua_pushstring(L, sysinfo.sysname);
+    lua_setfield(L, -2, kOperatingSystemProperty);
+
+    lua_pushstring(L, sysinfo.machine);
+    lua_setfield(L, -2, kArchitectureProperty);
+
+    lua_setreadonly(L, -1, 1);
+
+    return 1;
+}


### PR DESCRIPTION
A little bit of cleanup work, making the system library mimic the ordering of the other libraries.