### PR TITLE
Remove errors immediately killing the process

### DIFF
--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -95,7 +95,7 @@ bool Runtime::runToCompletion()
             error += lua_debugtrace(L);
 
             fprintf(stderr, "%s", error.c_str());
-            return false;
+            continue;
         }
 
         if (next.cont)


### PR DESCRIPTION
Fixes issue #162 by switching the `return false;` upon encountering LUA_ERR to be a `continue;`