### PR TITLE
CST: Handle AstExprTable and AstExprConstantBool

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -43,6 +43,9 @@ export type AstLocal = {
 	name: Token<string>,
 }
 
+export type AstExprConstantBool = Token<"true" | "false"> & { tag: "boolean", value: boolean }
+
+
 export type AstExprConstantString = Token<string> & {
 	tag: "string",
 	quoteStyle: "single" | "double" | "block" | "interp",
@@ -83,6 +86,29 @@ export type AstExprIndexExpr = {
 	index: AstExpr,
 }
 
+export type AstExprTableItem = | { kind: "list", value: AstExpr, separator: Token<"," | ";">? } | {
+	kind: "record",
+	key: Token<string>,
+	equals: Token<"=">,
+	value: AstExpr,
+	separator: Token<"," | ";">?,
+} | {
+	kind: "general",
+	indexerOpen: Token<"[">,
+	key: AstExpr,
+	indexerClose: Token<"]">,
+	equals: Token<"=">,
+	value: AstExpr,
+	separator: Token<"," | ";">?,
+}
+
+export type AstExprTable = {
+	tag: "table",
+	openBrace: Token<"{">,
+	entries: { AstExprTableItem },
+	closeBrace: Token<"}">,
+}
+
 export type AstExprBinary = {
 	tag: "binary",
 	lhsoperand: AstExpr,
@@ -90,27 +116,16 @@ export type AstExprBinary = {
 	rhsoperand: AstExpr,
 }
 
-export type AstExprTableItem =
-	| { kind: "list", value: AstExpr }
-	| { kind: "record", key: string, equals: Token<"=">, value: AstExpr }
-	| { kind: "general", key: string, equals: Token<"=">, value: AstExpr }
-
-export type AstExprTable = {
-	tag: "table",
-	openBrace: Token<"{">,
-	entries: { never },
-	closeBrace: Token<"}">,
-}
-
 export type AstExpr =
+	| AstExprConstantBool
 	| AstExprConstantString
 	| AstExprLocal
 	| AstExprGlobal
 	| AstExprCall
 	| AstExprIndexName
 	| AstExprIndexExpr
-	| AstExprBinary
 	| AstExprTable
+	| AstExprBinary
 
 export type AstStatBlock = {
 	tag: "block",

--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -45,7 +45,6 @@ export type AstLocal = {
 
 export type AstExprConstantBool = Token<"true" | "false"> & { tag: "boolean", value: boolean }
 
-
 export type AstExprConstantString = Token<string> & {
 	tag: "string",
 	quoteStyle: "single" | "double" | "block" | "interp",

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -11,11 +11,13 @@ type Visitor = {
 	visitGlobal: (T.AstExprGlobal) -> boolean,
 	visitCall: (T.AstExprCall) -> boolean,
 	visitBinary: (T.AstExprBinary) -> boolean,
+	visitTableItem: (T.AstExprTableItem) -> boolean,
 	visitTable: (T.AstExprTable) -> boolean,
 	visitIndexName: (T.AstExprIndexName) -> boolean,
 
 	visitToken: (T.Token) -> boolean,
 	visitString: (T.AstExprConstantString) -> boolean,
+	visitBoolean: (T.AstExprConstantBool) -> boolean,
 	visitLocal: (T.AstLocal) -> boolean,
 }
 
@@ -32,11 +34,13 @@ local defaultVisitor: Visitor = {
 	visitGlobal = alwaysVisit :: any,
 	visitCall = alwaysVisit :: any,
 	visitBinary = alwaysVisit :: any,
+	visitTableItem = alwaysVisit :: any,
 	visitTable = alwaysVisit :: any,
 	visitIndexName = alwaysVisit :: any,
 
 	visitToken = alwaysVisit :: any,
 	visitString = alwaysVisit :: any,
+	visitBoolean = alwaysVisit :: any,
 	visitLocal = alwaysVisit :: any,
 }
 
@@ -95,6 +99,12 @@ local function visitString(node: T.AstExprConstantString, visitor: Visitor)
 	end
 end
 
+local function visitBoolean(node: T.AstExprConstantBool, visitor: Visitor)
+	if visitor.visitBoolean(node) then
+		visitToken(node, visitor)
+	end
+end
+
 local function visitLocalReference(node: T.AstExprLocal, visitor: Visitor)
 	if visitor.visitLocalReference(node) then
 		visitor.visitToken(node.token)
@@ -128,10 +138,36 @@ local function visitBinary(node: T.AstExprBinary, visitor: Visitor)
 	end
 end
 
+local function visitTableItem(node: T.AstExprTableItem, visitor: Visitor)
+	if visitor.visitTableItem(node) then
+		if node.kind == "list" then
+			visitExpression(node.value, visitor)
+		elseif node.kind == "record" then
+			visitToken(node.key, visitor)
+			visitToken(node.equals, visitor)
+			visitExpression(node.value, visitor)
+		elseif node.kind == "general" then
+			visitToken(node.indexerOpen, visitor)
+			visitExpression(node.key, visitor)
+			visitToken(node.indexerClose, visitor)
+			visitToken(node.equals, visitor)
+			visitExpression(node.value, visitor)
+		else
+			exhaustiveMatch(node.kind)
+		end
+
+		if node.separator then
+			visitToken(node.separator, visitor)
+		end
+	end
+end
+
 local function visitTable(node: T.AstExprTable, visitor: Visitor)
 	if visitor.visitTable(node) then
 		visitToken(node.openBrace, visitor)
-		-- TODO: visit entries
+		for _, item in node.entries do
+			visitTableItem(item, visitor)
+		end
 		visitToken(node.closeBrace, visitor)
 	end
 end
@@ -145,7 +181,9 @@ local function visitIndexName(node: T.AstExprIndexName, visitor: Visitor)
 end
 
 function visitExpression(expression: T.AstExpr, visitor: Visitor)
-	if expression.tag == "string" then
+	if expression.tag == "boolean" then
+		visitBoolean(expression, visitor)
+	elseif expression.tag == "string" then
 		visitString(expression, visitor)
 	elseif expression.tag == "local" then
 		visitLocalReference(expression, visitor)

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -121,6 +121,7 @@ local function test_roundtrippableAst()
 	local files = {
 		"examples/a.luau",
 		"examples/b.luau",
+		"examples/json.luau",
 	}
 
 	for _, path in files do


### PR DESCRIPTION
Adds support for tables and booleans as part of the CST.

Tables are serialized as a list of separate table items, split by a separator (either a comma or a semicolon)

Booleans are serialized directly as a single token, with extra data representing their real value.