### PR TITLE
CST: Handle AstExprConstantNumber

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -45,6 +45,8 @@ export type AstLocal = {
 
 export type AstExprConstantBool = Token<"true" | "false"> & { tag: "boolean", value: boolean }
 
+export type AstExprConstantNumber = Token<string> & { tag: "number", value: number }
+
 export type AstExprConstantString = Token<string> & {
 	tag: "string",
 	quoteStyle: "single" | "double" | "block" | "interp",
@@ -117,6 +119,7 @@ export type AstExprBinary = {
 
 export type AstExpr =
 	| AstExprConstantBool
+	| AstExprConstantNumber
 	| AstExprConstantString
 	| AstExprLocal
 	| AstExprGlobal

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -18,6 +18,7 @@ type Visitor = {
 	visitToken: (T.Token) -> boolean,
 	visitString: (T.AstExprConstantString) -> boolean,
 	visitBoolean: (T.AstExprConstantBool) -> boolean,
+	visitNumber: (T.AstExprConstantNumber) -> boolean,
 	visitLocal: (T.AstLocal) -> boolean,
 }
 
@@ -41,6 +42,7 @@ local defaultVisitor: Visitor = {
 	visitToken = alwaysVisit :: any,
 	visitString = alwaysVisit :: any,
 	visitBoolean = alwaysVisit :: any,
+	visitNumber = alwaysVisit :: any,
 	visitLocal = alwaysVisit :: any,
 }
 
@@ -101,6 +103,12 @@ end
 
 local function visitBoolean(node: T.AstExprConstantBool, visitor: Visitor)
 	if visitor.visitBoolean(node) then
+		visitToken(node, visitor)
+	end
+end
+
+local function visitNumber(node: T.AstExprConstantNumber, visitor: Visitor)
+	if visitor.visitNumber(node) then
 		visitToken(node, visitor)
 	end
 end
@@ -183,6 +191,8 @@ end
 function visitExpression(expression: T.AstExpr, visitor: Visitor)
 	if expression.tag == "boolean" then
 		visitBoolean(expression, visitor)
+	elseif expression.tag == "number" then
+		visitNumber(expression, visitor)
 	elseif expression.tag == "string" then
 		visitString(expression, visitor)
 	elseif expression.tag == "local" then

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -623,9 +623,9 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprConstantNumber* node)
     {
-        lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 1);
+        const auto cstNode = lookupCstNode<Luau::CstExprConstantNumber>(node);
 
+        serializeToken(node->location.begin, cstNode ? cstNode->value.data : std::to_string(node->value).data(), preambleSize + 1);
         serializeNodePreamble(node, "number");
 
         lua_pushnumber(L, node->value);

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -122,6 +122,9 @@ local function test_roundtrippableAst()
 		"examples/a.luau",
 		"examples/b.luau",
 		"examples/json.luau",
+		"examples/main.luau",
+		"examples/parsing.luau",
+		"examples/time_example.luau",
 	}
 
 	for _, path in files do


### PR DESCRIPTION
Serialize numbers directly as tokens with their real string representation. Alongside this, we serialize the real value of the number that was determined during parsing.