### PR TITLE
CST: Handle if statements (excluding elseif) and nils

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -43,6 +43,8 @@ export type AstLocal = {
 	name: Token<string>,
 }
 
+export type AstExprConstantNil = Token<"nil"> & { tag: "nil" }
+
 export type AstExprConstantBool = Token<"true" | "false"> & { tag: "boolean", value: boolean }
 
 export type AstExprConstantNumber = Token<string> & { tag: "number", value: number }
@@ -118,6 +120,7 @@ export type AstExprBinary = {
 }
 
 export type AstExpr =
+	| AstExprConstantNil
 	| AstExprConstantBool
 	| AstExprConstantNumber
 	| AstExprConstantString
@@ -132,6 +135,17 @@ export type AstExpr =
 export type AstStatBlock = {
 	tag: "block",
 	statements: { AstStat },
+}
+
+export type AstStatIf = {
+	tag: "conditional",
+	["if"]: Token<"if">,
+	condition: AstExpr,
+	["then"]: Token<"then">,
+	consequent: AstStatBlock,
+	["else"]: Token<"else">, -- TODO: this could be elseif!
+	antecedent: AstStatBlock,
+	["end"]: Token<"end">,
 }
 
 export type AstStatReturn = {
@@ -153,6 +167,6 @@ export type AstStatLocal = {
 	values: Punctuated<AstExpr>,
 }
 
-export type AstStat = AstStatBlock | AstStatReturn | AstStatExpr | AstStatLocal
+export type AstStat = AstStatBlock | AstStatIf | AstStatReturn | AstStatExpr | AstStatLocal
 
 return {}

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -4,6 +4,7 @@ local T = require("./ast_types")
 
 type Visitor = {
 	visitBlock: (T.AstStatBlock) -> boolean,
+	visitIf: (T.AstStatIf) -> boolean,
 	visitReturn: (T.AstStatReturn) -> boolean,
 	visitLocalDeclaration: (T.AstStatLocal) -> boolean,
 
@@ -16,6 +17,7 @@ type Visitor = {
 	visitIndexName: (T.AstExprIndexName) -> boolean,
 
 	visitToken: (T.Token) -> boolean,
+	visitNil: (T.AstExprConstantNil) -> boolean,
 	visitString: (T.AstExprConstantString) -> boolean,
 	visitBoolean: (T.AstExprConstantBool) -> boolean,
 	visitNumber: (T.AstExprConstantNumber) -> boolean,
@@ -28,6 +30,7 @@ end
 
 local defaultVisitor: Visitor = {
 	visitBlock = alwaysVisit :: any,
+	visitIf = alwaysVisit :: any,
 	visitReturn = alwaysVisit :: any,
 	visitLocalDeclaration = alwaysVisit :: any,
 
@@ -40,6 +43,7 @@ local defaultVisitor: Visitor = {
 	visitIndexName = alwaysVisit :: any,
 
 	visitToken = alwaysVisit :: any,
+	visitNil = alwaysVisit :: any,
 	visitString = alwaysVisit :: any,
 	visitBoolean = alwaysVisit :: any,
 	visitNumber = alwaysVisit :: any,
@@ -77,6 +81,23 @@ local function visitBlock(block: T.AstStatBlock, visitor: Visitor)
 	end
 end
 
+local function visitIf(node: T.AstStatIf, visitor: Visitor)
+	if visitor.visitIf(node) then
+		visitToken(node["if"], visitor)
+		visitExpression(node.condition, visitor)
+		visitToken(node["then"], visitor)
+		visitBlock(node.consequent, visitor)
+		-- TODO: special handling for elseif?
+		if node["else"] then
+			visitToken(node["else"], visitor)
+		end
+		if node.antecedent then
+			visitBlock(node.antecedent, visitor)
+		end
+		visitToken(node["end"], visitor)
+	end
+end
+
 local function visitReturn(node: T.AstStatReturn, visitor: Visitor)
 	if visitor.visitReturn(node) then
 		visitToken(node["return"], visitor)
@@ -98,6 +119,12 @@ end
 local function visitString(node: T.AstExprConstantString, visitor: Visitor)
 	if visitor.visitString(node) then
 		visitor.visitToken(node)
+	end
+end
+
+local function visitNil(node: T.AstExprConstantNil, visitor: Visitor)
+	if visitor.visitNil(node) then
+		visitToken(node, visitor)
 	end
 end
 
@@ -189,7 +216,9 @@ local function visitIndexName(node: T.AstExprIndexName, visitor: Visitor)
 end
 
 function visitExpression(expression: T.AstExpr, visitor: Visitor)
-	if expression.tag == "boolean" then
+	if expression.tag == "nil" then
+		visitNil(expression, visitor)
+	elseif expression.tag == "boolean" then
 		visitBoolean(expression, visitor)
 	elseif expression.tag == "number" then
 		visitNumber(expression, visitor)
@@ -215,6 +244,8 @@ end
 function visitStatement(statement: T.AstStat, visitor: Visitor)
 	if statement.tag == "block" then
 		visitBlock(statement, visitor)
+	elseif statement.tag == "conditional" then
+		visitIf(statement, visitor)
 	elseif statement.tag == "expression" then
 		visitExpression(statement.expression, visitor)
 	elseif statement.tag == "local" then

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -125,6 +125,7 @@ local function test_roundtrippableAst()
 		"examples/main.luau",
 		"examples/parsing.luau",
 		"examples/time_example.luau",
+		"examples/writeFile.luau",
 	}
 
 	for _, path in files do


### PR DESCRIPTION
This PR adds support for serializing a full if statement as a CST node. For now, we exclude special handling of elseif blocks within if statements, this will be added in a future change.

Alongside this, we serialize `nil` expressions directly as a token. This allows us to successfully roundtrip the `writeFile.luau` example.