### PR TITLE
CST: Handle AstExprIndexExpr

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -93,7 +93,9 @@ export type AstExprIndexName = {
 export type AstExprIndexExpr = {
 	tag: "index",
 	expr: AstExpr,
+	openBrackets: Token<"[">,
 	index: AstExpr,
+	closeBrackets: Token<"]">,
 }
 
 export type AstFunctionBody = {

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -16,6 +16,7 @@ type Visitor = {
 	visitTableItem: (T.AstExprTableItem) -> boolean,
 	visitTable: (T.AstExprTable) -> boolean,
 	visitIndexName: (T.AstExprIndexName) -> boolean,
+	visitIndexExpr: (T.AstExprIndexExpr) -> boolean,
 	visitGroup: (T.AstExprGroup) -> boolean,
 
 	visitToken: (T.Token) -> boolean,
@@ -44,6 +45,7 @@ local defaultVisitor: Visitor = {
 	visitTableItem = alwaysVisit :: any,
 	visitTable = alwaysVisit :: any,
 	visitIndexName = alwaysVisit :: any,
+	visitIndexExpr = alwaysVisit :: any,
 	visitGroup = alwaysVisit :: any,
 
 	visitToken = alwaysVisit :: any,
@@ -234,6 +236,15 @@ local function visitIndexName(node: T.AstExprIndexName, visitor: Visitor)
 	end
 end
 
+local function visitIndexExpr(node: T.AstExprIndexExpr, visitor: Visitor)
+	if visitor.visitIndexExpr(node) then
+		visitExpression(node.expr, visitor)
+		visitToken(node.openBrackets, visitor)
+		visitExpression(node.index, visitor)
+		visitToken(node.closeBrackets, visitor)
+	end
+end
+
 local function visitGroup(node: T.AstExprGroup, visitor: Visitor)
 	if visitor.visitGroup(node) then
 		visitToken(node.openParens, visitor)
@@ -265,6 +276,8 @@ function visitExpression(expression: T.AstExpr, visitor: Visitor)
 		visitTable(expression, visitor)
 	elseif expression.tag == "indexname" then
 		visitIndexName(expression, visitor)
+	elseif expression.tag == "index" then
+		visitIndexExpr(expression, visitor)
 	elseif expression.tag == "group" then
 		visitGroup(expression, visitor)
 	else

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -763,6 +763,8 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprIndexExpr* node)
     {
+        const auto* cstNode = lookupCstNode<Luau::CstExprIndexExpr>(node);
+
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
@@ -771,8 +773,20 @@ struct AstSerialize : public Luau::AstVisitor
         node->expr->visit(this);
         lua_setfield(L, -2, "expr");
 
+        if (cstNode)
+        {
+            serializeToken(cstNode->openBracketPosition, "[");
+            lua_setfield(L, -2, "openBrackets");
+        }
+
         node->index->visit(this);
         lua_setfield(L, -2, "index");
+
+        if (cstNode)
+        {
+            serializeToken(cstNode->closeBracketPosition, "]");
+            lua_setfield(L, -2, "closeBrackets");
+        }
     }
 
     void serializeFunctionBody(Luau::AstExprFunction* node)


### PR DESCRIPTION
Store the extra information about the `[` and `]` tokens in an expression index node (`e.g. foo["testing"]`), to allow full recreation of the original node.