### PR TITLE
CST: Handle AstExprUnary

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -136,6 +136,12 @@ export type AstExprTable = {
 	closeBrace: Token<"}">,
 }
 
+export type AstExprUnary = {
+	tag: "unary",
+	operator: Token<"not" | "-" | "#">,
+	operand: AstExpr,
+}
+
 export type AstExprBinary = {
 	tag: "binary",
 	lhsoperand: AstExpr,
@@ -156,6 +162,7 @@ export type AstExpr =
 	| AstExprIndexExpr
 	| AstExprAnonymousFunction
 	| AstExprTable
+	| AstExprUnary
 	| AstExprBinary
 
 export type AstStatBlock = {

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -11,6 +11,7 @@ type Visitor = {
 	visitLocalReference: (T.AstExprLocal) -> boolean,
 	visitGlobal: (T.AstExprGlobal) -> boolean,
 	visitCall: (T.AstExprCall) -> boolean,
+	visitUnary: (T.AstExprUnary) -> boolean,
 	visitBinary: (T.AstExprBinary) -> boolean,
 	visitAnonymousFunction: (T.AstExprAnonymousFunction) -> boolean,
 	visitTableItem: (T.AstExprTableItem) -> boolean,
@@ -39,6 +40,7 @@ local defaultVisitor: Visitor = {
 	visitLocalReference = alwaysVisit :: any,
 	visitGlobal = alwaysVisit :: any,
 	visitCall = alwaysVisit :: any,
+	visitUnary = alwaysVisit :: any,
 	visitBinary = alwaysVisit :: any,
 	visitAnonymousFunction = alwaysVisit :: any,
 	visitTableItem = alwaysVisit :: any,
@@ -169,6 +171,13 @@ local function visitCall(node: T.AstExprCall, visitor: Visitor)
 	end
 end
 
+local function visitUnary(node: T.AstExprUnary, visitor: Visitor)
+	if visitor.visitUnary(node) then
+		visitToken(node.operator, visitor)
+		visitExpression(node.operand, visitor)
+	end
+end
+
 local function visitBinary(node: T.AstExprBinary, visitor: Visitor)
 	if visitor.visitBinary(node) then
 		visitExpression(node.lhsoperand, visitor)
@@ -257,6 +266,8 @@ function visitExpression(expression: T.AstExpr, visitor: Visitor)
 		visitGlobal(expression, visitor)
 	elseif expression.tag == "call" then
 		visitCall(expression, visitor)
+	elseif expression.tag == "unary" then
+		visitUnary(expression, visitor)
 	elseif expression.tag == "binary" then
 		visitBinary(expression, visitor)
 	elseif expression.tag == "function" then

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -864,18 +864,10 @@ struct AstSerialize : public Luau::AstVisitor
 
         serializeNodePreamble(node, "unary");
 
-        switch (node->op)
-        {
-        case Luau::AstExprUnary::Op::Not:
-            lua_pushstring(L, "not");
-            break;
-        case Luau::AstExprUnary::Op::Minus:
-            lua_pushstring(L, "-");
-            break;
-        case Luau::AstExprUnary::Op::Len:
-            lua_pushstring(L, "#");
-            break;
-        }
+        if (const auto cstNode = lookupCstNode<Luau::CstExprOp>(node))
+            serializeToken(cstNode->opPosition, toString(node->op).data());
+        else
+            lua_pushstring(L, Luau::toString(node->op).data());
         lua_setfield(L, -2, "operator");
 
         node->expr->visit(this);


### PR DESCRIPTION
Serializes the unary AST node with a token representing the operator and the expression representing the operand.