### PR TITLE
CST: Handle AstStatWhile

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -174,6 +174,15 @@ export type AstStatIf = {
 	["end"]: Token<"end">,
 }
 
+export type AstStatWhile = {
+	tag: "while",
+	["while"]: Token<"while">,
+	condition: AstExpr,
+	["do"]: Token<"do">,
+	body: AstStatBlock,
+	["end"]: Token<"end">,
+}
+
 export type AstStatReturn = {
 	tag: "return",
 	["return"]: Token<"return">,
@@ -193,6 +202,6 @@ export type AstStatLocal = {
 	values: Punctuated<AstExpr>,
 }
 
-export type AstStat = AstStatBlock | AstStatIf | AstStatReturn | AstStatExpr | AstStatLocal
+export type AstStat = AstStatBlock | AstStatIf | AstStatWhile | AstStatReturn | AstStatExpr | AstStatLocal
 
 return {}

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -5,6 +5,7 @@ local T = require("./ast_types")
 type Visitor = {
 	visitBlock: (T.AstStatBlock) -> boolean,
 	visitIf: (T.AstStatIf) -> boolean,
+	visitWhile: (T.AstStatWhile) -> boolean,
 	visitReturn: (T.AstStatReturn) -> boolean,
 	visitLocalDeclaration: (T.AstStatLocal) -> boolean,
 
@@ -33,6 +34,7 @@ end
 local defaultVisitor: Visitor = {
 	visitBlock = alwaysVisit :: any,
 	visitIf = alwaysVisit :: any,
+	visitWhile = alwaysVisit :: any,
 	visitReturn = alwaysVisit :: any,
 	visitLocalDeclaration = alwaysVisit :: any,
 
@@ -98,6 +100,16 @@ local function visitIf(node: T.AstStatIf, visitor: Visitor)
 		if node.antecedent then
 			visitBlock(node.antecedent, visitor)
 		end
+		visitToken(node["end"], visitor)
+	end
+end
+
+local function visitWhile(node: T.AstStatWhile, visitor: Visitor)
+	if visitor.visitWhile(node) then
+		visitToken(node["while"], visitor)
+		visitExpression(node.condition, visitor)
+		visitToken(node["do"], visitor)
+		visitBlock(node.body, visitor)
 		visitToken(node["end"], visitor)
 	end
 end
@@ -283,6 +295,8 @@ function visitStatement(statement: T.AstStat, visitor: Visitor)
 		visitLocalStatement(statement, visitor)
 	elseif statement.tag == "return" then
 		visitReturn(statement, visitor)
+	elseif statement.tag == "while" then
+		visitWhile(statement, visitor)
 	else
 		exhaustiveMatch(statement.tag)
 	end

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1033,17 +1033,23 @@ struct AstSerialize : public Luau::AstVisitor
 
         serializeNodePreamble(node, "while");
 
+        serializeToken(node->location.begin, "while");
+        lua_setfield(L, -2, "while");
+
         node->condition->visit(this);
         lua_setfield(L, -2, "condition");
+
+        if (node->hasDo)
+            serializeToken(node->doLocation.begin, "do");
+        else
+            lua_pushnil(L);
+        lua_setfield(L, -2, "do");
 
         node->body->visit(this);
         lua_setfield(L, -2, "body");
 
-        if (node->hasDo)
-            serialize(node->doLocation);
-        else
-            lua_pushnil(L);
-        lua_setfield(L, -2, "doLocation");
+        serializeToken(node->body->location.end, "end");
+        lua_setfield(L, -2, "end");
     }
 
     void serializeStat(Luau::AstStatRepeat* node)

--- a/tests/astSerializerTests/while-1.luau
+++ b/tests/astSerializerTests/while-1.luau
@@ -1,0 +1,3 @@
+while condition do
+	call()
+end

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -129,6 +129,7 @@ local function test_roundtrippableAst()
 		"examples/parsing.luau",
 		"examples/time_example.luau",
 		"examples/writeFile.luau",
+		"tests/astSerializerTests/while-1.luau",
 	}
 
 	for _, path in files do


### PR DESCRIPTION
Serializes the full AstStatWhile node, including all its tokens `while` / `do` / `end`.

At the moment, the keys are still keywords. In a follow up we intend to clean up the overall AST structure for standardisation