### PR TITLE
CST: Handle repeat, break and continue

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -195,6 +195,14 @@ export type AstStatWhile = {
 	["end"]: Token<"end">,
 }
 
+export type AstStatRepeat = {
+	tag: "repeat",
+	["repeat"]: Token<"repeat">,
+	body: AstStatBlock,
+	["until"]: Token<"until">,
+	condition: AstExpr,
+}
+
 export type AstStatReturn = {
 	tag: "return",
 	["return"]: Token<"return">,
@@ -214,6 +222,6 @@ export type AstStatLocal = {
 	values: Punctuated<AstExpr>,
 }
 
-export type AstStat = AstStatBlock | AstStatIf | AstStatWhile | AstStatReturn | AstStatExpr | AstStatLocal
+export type AstStat = AstStatBlock | AstStatIf | AstStatWhile | AstStatRepeat | AstStatReturn | AstStatExpr | AstStatLocal
 
 return {}

--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -203,6 +203,10 @@ export type AstStatRepeat = {
 	condition: AstExpr,
 }
 
+export type AstStatBreak = Token<"break"> & { tag: "break" }
+
+export type AstStatContinue = Token<"continue"> & { tag: "continue" }
+
 export type AstStatReturn = {
 	tag: "return",
 	["return"]: Token<"return">,
@@ -222,6 +226,15 @@ export type AstStatLocal = {
 	values: Punctuated<AstExpr>,
 }
 
-export type AstStat = AstStatBlock | AstStatIf | AstStatWhile | AstStatRepeat | AstStatReturn | AstStatExpr | AstStatLocal
+export type AstStat =
+	| AstStatBlock
+	| AstStatIf
+	| AstStatWhile
+	| AstStatRepeat
+	| AstStatBreak
+	| AstStatContinue
+	| AstStatReturn
+	| AstStatExpr
+	| AstStatLocal
 
 return {}

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -6,6 +6,7 @@ type Visitor = {
 	visitBlock: (T.AstStatBlock) -> boolean,
 	visitIf: (T.AstStatIf) -> boolean,
 	visitWhile: (T.AstStatWhile) -> boolean,
+	visitRepeat: (T.AstStatRepeat) -> boolean,
 	visitReturn: (T.AstStatReturn) -> boolean,
 	visitLocalDeclaration: (T.AstStatLocal) -> boolean,
 
@@ -38,6 +39,7 @@ local defaultVisitor: Visitor = {
 	visitBlock = alwaysVisit :: any,
 	visitIf = alwaysVisit :: any,
 	visitWhile = alwaysVisit :: any,
+	visitRepeat = alwaysVisit :: any,
 	visitReturn = alwaysVisit :: any,
 	visitLocalDeclaration = alwaysVisit :: any,
 
@@ -117,6 +119,15 @@ local function visitWhile(node: T.AstStatWhile, visitor: Visitor)
 		visitToken(node["do"], visitor)
 		visitBlock(node.body, visitor)
 		visitToken(node["end"], visitor)
+	end
+end
+
+local function visitRepeat(node: T.AstStatRepeat, visitor: Visitor)
+	if visitor.visitRepeat(node) then
+		visitToken(node["repeat"], visitor)
+		visitBlock(node.body, visitor)
+		visitToken(node["until"], visitor)
+		visitExpression(node.condition, visitor)
 	end
 end
 
@@ -331,6 +342,8 @@ function visitStatement(statement: T.AstStat, visitor: Visitor)
 		visitReturn(statement, visitor)
 	elseif statement.tag == "while" then
 		visitWhile(statement, visitor)
+	elseif statement.tag == "repeat" then
+		visitRepeat(statement, visitor)
 	else
 		exhaustiveMatch(statement.tag)
 	end

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -342,6 +342,10 @@ function visitStatement(statement: T.AstStat, visitor: Visitor)
 		visitReturn(statement, visitor)
 	elseif statement.tag == "while" then
 		visitWhile(statement, visitor)
+	elseif statement.tag == "break" then
+		visitToken(statement, visitor)
+	elseif statement.tag == "continue" then
+		visitToken(statement, visitor)
 	elseif statement.tag == "repeat" then
 		visitRepeat(statement, visitor)
 	else

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1082,16 +1082,14 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeStat(Luau::AstStatBreak* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize);
-
+        serializeToken(node->location.begin, "break", preambleSize);
         serializeNodePreamble(node, "break");
     }
 
     void serializeStat(Luau::AstStatContinue* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize);
-
+        serializeToken(node->location.begin, "continue", preambleSize);
         serializeNodePreamble(node, "continue");
     }
 

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1063,11 +1063,20 @@ struct AstSerialize : public Luau::AstVisitor
 
         serializeNodePreamble(node, "repeat");
 
-        node->condition->visit(this);
-        lua_setfield(L, -2, "condition");
+        serializeToken(node->location.begin, "repeat");
+        lua_setfield(L, -2, "repeat");
 
         node->body->visit(this);
         lua_setfield(L, -2, "body");
+
+        if (const auto cstNode = lookupCstNode<Luau::CstStatRepeat>(node))
+        {
+            serializeToken(cstNode->untilPosition, "until");
+            lua_setfield(L, -2, "until");
+        }
+
+        node->condition->visit(this);
+        lua_setfield(L, -2, "condition");
     }
 
     void serializeStat(Luau::AstStatBreak* node)

--- a/tests/astSerializerTests/break-continue-1.luau
+++ b/tests/astSerializerTests/break-continue-1.luau
@@ -1,0 +1,7 @@
+while true do
+	break
+end
+
+while true do
+	continue
+end

--- a/tests/astSerializerTests/repeat-until-1.luau
+++ b/tests/astSerializerTests/repeat-until-1.luau
@@ -1,0 +1,3 @@
+repeat
+	call()
+until condition

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -130,6 +130,7 @@ local function test_roundtrippableAst()
 		"examples/time_example.luau",
 		"examples/writeFile.luau",
 		"tests/astSerializerTests/while-1.luau",
+		"tests/astSerializerTests/repeat-until-1.luau",
 	}
 
 	for _, path in files do

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -129,6 +129,7 @@ local function test_roundtrippableAst()
 		"examples/parsing.luau",
 		"examples/time_example.luau",
 		"examples/writeFile.luau",
+		"tests/astSerializerTests/break-continue-1.luau",
 		"tests/astSerializerTests/while-1.luau",
 		"tests/astSerializerTests/repeat-until-1.luau",
 	}


### PR DESCRIPTION
This PR adds support for serializing all the the repeat stmt node, as well as `break` and `continue` last stmt

For break and continue, it is fairly simple - we serialize the tokens directly.

For repeat, we serialize the `repeat` and `until` tokens using the CST data, alongside the condition and body.

