### PR TITLE
Rename `process.create` to `process.run`

### DIFF
--- a/docs/reference/process.md
+++ b/docs/reference/process.md
@@ -4,7 +4,7 @@
 local process = require("@lute/process")
 ```
 
-## create <Badge type="warning" text="yields" />
+## run <Badge type="warning" text="yields" />
 ```luau
 (args: { string }, options: ProcessOptions) -> ProcessResult
 ```

--- a/examples/process.luau
+++ b/examples/process.luau
@@ -1,14 +1,14 @@
 local process = require("@lute/process")
 local task = require("@std/task")
 
-local result = process.create({ "echo", "Hello, lute!" })
+local result = process.run({ "echo", "Hello, lute!" })
 
 print(result.exitcode)
 print(result.stdout)
 
-local t1 = task.create(process.create, { "echo", "-n", "One" })
-local t2 = task.create(process.create, { "echo", "-n", "Two" })
-local t3 = task.create(process.create, { "echo", "-n", "Three" })
+local t1 = task.create(process.run, { "echo", "-n", "One" })
+local t2 = task.create(process.run, { "echo", "-n", "Two" })
+local t3 = task.create(process.run, { "echo", "-n", "Three" })
 
 local r1, r2, r3 = task.awaitall(t1, t2, t3)
 
@@ -16,17 +16,17 @@ print(r1.stdout)
 print(r2.stdout)
 print(r3.stdout)
 
-local r4 = process.create("echo Hello, lute!", { shell = true })
+local r4 = process.run("echo Hello, lute!", { shell = true })
 print(r4.stdout)
 
-local r5 = process.create({ "echo", "$HOME" }, { env = { HOME = "/home/lute" }, shell = true })
+local r5 = process.run({ "echo", "$HOME" }, { env = { HOME = "/home/lute" }, shell = true })
 print(r5.stdout)
 
-local r6 = process.create({ "pwd" }, { cwd = "/" })
+local r6 = process.run({ "pwd" }, { cwd = "/" })
 print(r6.stdout)
 
-local r7 = process.create("echo $0", { shell = true })
+local r7 = process.run("echo $0", { shell = true })
 print(r7.stdout)
 
-local r8 = process.create("echo $0", { shell = "/bin/sh" })
+local r8 = process.run("echo $0", { shell = "/bin/sh" })
 print(r8.stdout)

--- a/process/include/lute/process.h
+++ b/process/include/lute/process.h
@@ -11,13 +11,13 @@ int luteopen_process(lua_State* L);
 namespace process
 {
 
-int create(lua_State* L);
+int run(lua_State* L);
 
 int homedir(lua_State* L);
 int cwd(lua_State* L);
 
 static const luaL_Reg lib[] = {
-    {"create", create},
+    {"run", run},
     {"homedir", homedir},
     {"cwd", cwd},
 

--- a/process/src/process.cpp
+++ b/process/src/process.cpp
@@ -183,7 +183,7 @@ static void allocBuffer(uv_handle_t* handle, size_t suggestedSize, uv_buf_t* buf
     }
 }
 
-int create(lua_State* L)
+int run(lua_State* L)
 {
     std::vector<std::string> args;
     if (lua_istable(L, 1))


### PR DESCRIPTION
`process.create` will create a long-lived process. Our current `process.create` does not fit this, so we should rename it so that we don't have to swap things around when we eventually implement long-lived process creation.