### PR TITLE
TLS on net.serve

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,18 @@ set(LIBUV_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/libuv/include)
 add_subdirectory(extern/boringssl)
 set(BORINGSSL_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/boringssl/include)
 
+# boringssl is openssl
+set(OPENSSL_FOUND TRUE CACHE INTERNAL "Force found status for OpenSSL")
+set(OPENSSL_INCLUDE_DIR ${BORINGSSL_INCLUDE_DIR} CACHE INTERNAL "Include dir for BoringSSL")
+
+add_library(OpenSSL::SSL INTERFACE IMPORTED GLOBAL)
+target_link_libraries(OpenSSL::SSL INTERFACE ssl)
+target_include_directories(OpenSSL::SSL INTERFACE ${BORINGSSL_INCLUDE_DIR})
+
+add_library(OpenSSL::Crypto INTERFACE IMPORTED GLOBAL)
+target_link_libraries(OpenSSL::Crypto INTERFACE crypto)
+target_include_directories(OpenSSL::Crypto INTERFACE ${BORINGSSL_INCLUDE_DIR})
+
 # curl setup
 set(USE_LIBIDN2 OFF)
 set(USE_NGHTTP2 OFF)
@@ -52,30 +64,6 @@ set(BUILD_SHARED_LIBS OFF)
 set(BUILD_STATIC_LIBS ON)
 
 set(HAVE_BORINGSSL ON)
-if(HAVE_BORINGSSL)
-    set(OPENSSL_FOUND TRUE CACHE INTERNAL "Force found status for OpenSSL")
-    set(OPENSSL_INCLUDE_DIR ${BORINGSSL_INCLUDE_DIR} CACHE INTERNAL "Include dir for BoringSSL")
-
-    if(NOT TARGET crypto OR NOT TARGET ssl)
-      message(FATAL_ERROR "BoringSSL targets 'crypto' and 'ssl' not found. Check extern/boringssl/CMakeLists.txt")
-    endif()
-
-    if(NOT TARGET OpenSSL::SSL)
-      add_library(OpenSSL::SSL INTERFACE IMPORTED GLOBAL)
-      target_link_libraries(OpenSSL::SSL INTERFACE ssl)
-      target_include_directories(OpenSSL::SSL INTERFACE ${BORINGSSL_INCLUDE_DIR})
-    endif()
-
-    if(NOT TARGET OpenSSL::Crypto)
-      add_library(OpenSSL::Crypto INTERFACE IMPORTED GLOBAL)
-      target_link_libraries(OpenSSL::Crypto INTERFACE crypto)
-      target_include_directories(OpenSSL::Crypto INTERFACE ${BORINGSSL_INCLUDE_DIR})
-    endif()
-
-    set(OPENSSL_LIBRARIES OpenSSL::Crypto OpenSSL::SSL CACHE INTERNAL "Libraries for BoringSSL")
-    set(OPENSSL_CRYPTO_LIBRARY OpenSSL::Crypto CACHE INTERNAL "Crypto library for BoringSSL")
-    set(OPENSSL_SSL_LIBRARY OpenSSL::SSL CACHE INTERNAL "SSL library for BoringSSL")
-endif()
 add_subdirectory(extern/curl)
 
 # uWebSockets setup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,8 +36,8 @@ add_subdirectory(extern/libuv)
 set(LIBUV_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/libuv/include)
 
 # boringssl setup
-add_subdirectory(extern/uWebSockets/uSockets/boringssl)
-set(BORINGSSL_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/uWebSockets/uSockets/boringssl/include)
+add_subdirectory(extern/boringssl)
+set(BORINGSSL_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/boringssl/include)
 
 # curl setup
 set(USE_LIBIDN2 OFF)
@@ -52,6 +52,30 @@ set(BUILD_SHARED_LIBS OFF)
 set(BUILD_STATIC_LIBS ON)
 
 set(HAVE_BORINGSSL ON)
+if(HAVE_BORINGSSL)
+    set(OPENSSL_FOUND TRUE CACHE INTERNAL "Force found status for OpenSSL")
+    set(OPENSSL_INCLUDE_DIR ${BORINGSSL_INCLUDE_DIR} CACHE INTERNAL "Include dir for BoringSSL")
+
+    if(NOT TARGET crypto OR NOT TARGET ssl)
+      message(FATAL_ERROR "BoringSSL targets 'crypto' and 'ssl' not found. Check extern/boringssl/CMakeLists.txt")
+    endif()
+
+    if(NOT TARGET OpenSSL::SSL)
+      add_library(OpenSSL::SSL INTERFACE IMPORTED GLOBAL)
+      target_link_libraries(OpenSSL::SSL INTERFACE ssl)
+      target_include_directories(OpenSSL::SSL INTERFACE ${BORINGSSL_INCLUDE_DIR})
+    endif()
+
+    if(NOT TARGET OpenSSL::Crypto)
+      add_library(OpenSSL::Crypto INTERFACE IMPORTED GLOBAL)
+      target_link_libraries(OpenSSL::Crypto INTERFACE crypto)
+      target_include_directories(OpenSSL::Crypto INTERFACE ${BORINGSSL_INCLUDE_DIR})
+    endif()
+
+    set(OPENSSL_LIBRARIES OpenSSL::Crypto OpenSSL::SSL CACHE INTERNAL "Libraries for BoringSSL")
+    set(OPENSSL_CRYPTO_LIBRARY OpenSSL::Crypto CACHE INTERNAL "Crypto library for BoringSSL")
+    set(OPENSSL_SSL_LIBRARY OpenSSL::SSL CACHE INTERNAL "SSL library for BoringSSL")
+endif()
 add_subdirectory(extern/curl)
 
 # uWebSockets setup

--- a/net/src/net.cpp
+++ b/net/src/net.cpp
@@ -13,7 +13,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <variant>
 
 namespace net
 {

--- a/net/src/net.cpp
+++ b/net/src/net.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <variant>
 
 namespace net
 {
@@ -98,13 +99,13 @@ int getAsync(lua_State* L)
 }
 
 static const int kEmptyServerKey = 0;
-static Luau::DenseHashMap<int, std::unique_ptr<uWS::App>> serverInstances(kEmptyServerKey);
+static Luau::DenseHashMap<int, std::variant<std::unique_ptr<uWS::App>, std::unique_ptr<uWS::SSLApp>>> serverInstances(kEmptyServerKey);
 static Luau::DenseHashMap<int, std::shared_ptr<struct ServerLoopState>> serverStates(kEmptyServerKey);
 static int nextServerId = 1;
 
 struct ServerLoopState
 {
-    uWS::App* app;
+    std::variant<uWS::App*, uWS::SSLApp*> app;
     Runtime* runtime;
     bool running = true;
     std::function<void()> loopFunction;
@@ -244,7 +245,7 @@ static void processRequest(
     const std::string& method,
     const std::string& path,
     const std::string& query,
-    const std::string_view& body
+    const std::string& body
 )
 {
     lua_State* L = state->runtime->GL;
@@ -268,7 +269,7 @@ static void processRequest(
     lua_settable(L, -3);
 
     lua_pushstring(L, "body");
-    lua_pushlstring(L, body.data(), body.size());
+    lua_pushstring(L, body.c_str());
     lua_settable(L, -3);
 
     state->handlerRef->push(L);
@@ -291,79 +292,12 @@ static void processRequest(
     lua_pop(L, 1);
 }
 
-bool closeServer(int serverId)
-{
-    if (!serverInstances.contains(serverId) || !serverStates.contains(serverId))
-    {
-        return false;
-    }
-
-    auto& app = serverInstances[serverId];
-    app->close();
-    serverStates[serverId]->running = false;
-
-    serverInstances[serverId].reset();
-    serverStates[serverId] = nullptr;
-
-    return true;
-}
-
-int serve(lua_State* L)
-{
-    std::string hostname = "0.0.0.0";
-    int port = 3000;
-    int handlerIndex = 1;
-
-    // Check if first argument is a table (config) or function (handler)
-    if (lua_istable(L, 1))
-    {
-        lua_getfield(L, 1, "hostname");
-        if (lua_isstring(L, -1))
-        {
-            hostname = lua_tostring(L, -1);
-        }
-        lua_pop(L, 1);
-
-        lua_getfield(L, 1, "port");
-        if (lua_isnumber(L, -1))
-        {
-            port = lua_tointeger(L, -1);
-        }
-        lua_pop(L, 1);
-
-        lua_getfield(L, 1, "handler");
-        if (!lua_isfunction(L, -1))
-        {
-            lua_pop(L, 1);
-            luaL_errorL(L, "handler function is required in config table");
-            return 0;
-        }
-        lua_insert(L, -1);
-        handlerIndex = lua_gettop(L);
-    }
-    else if (!lua_isfunction(L, 1))
-    {
-        luaL_errorL(L, "serve requires a handler function or config table");
-        return 0;
-    }
-
-    Runtime* runtime = getRuntime(L);
-
-    auto app = std::make_unique<uWS::App>();
-
-    int serverId = nextServerId++;
-
-    auto state = std::make_shared<ServerLoopState>();
-    state->app = app.get();
-    state->runtime = runtime;
-    state->hostname = hostname;
-    state->port = port;
-
-    lua_pushvalue(L, handlerIndex);
-    state->handlerRef = std::make_shared<Ref>(L, -1);
-    lua_pop(L, 1);
-
-    state->app->any(
+void setupAppAndListen(
+    auto* app,
+    std::shared_ptr<ServerLoopState> state,
+    bool& success
+) {
+    app->any(
         "/*",
         [state](auto* res, auto* req)
         {
@@ -388,27 +322,150 @@ int serve(lua_State* L)
                 }
             );
 
+            std::string bodyBuffer;
             res->onData(
-                [state, res, req, method, path, query](std::string_view data, bool last)
-                {
-                    if (!last)
-                        return;
-                    processRequest(state, res, req, method, path, query, data);
+                [state, res, req, method, path, query, bodyBuffer = std::move(bodyBuffer)]
+                (std::string_view data, bool last) mutable {
+                    bodyBuffer.append(data);
+                    if (last) {
+                        processRequest(state, res, req, method, path, query, bodyBuffer);
+                    }
                 }
             );
         }
     );
 
-    bool success = false;
-
-    state->app->listen(
-        hostname,
-        port,
-        [&success](auto* listen_socket)
-        {
+    app->listen(
+        state->hostname,
+        state->port,
+        [&success](auto* listen_socket) {
             success = (listen_socket != nullptr);
         }
     );
+}
+
+bool closeServer(int serverId)
+{
+    if (!serverInstances.contains(serverId) || !serverStates.contains(serverId))
+    {
+        return false;
+    }
+
+    std::visit([](auto* appPtr){ if (appPtr) appPtr->close(); }, serverStates[serverId]->app);
+    serverStates[serverId]->running = false;
+
+    std::visit([](auto& ptr){ if(ptr) ptr.reset(); }, serverInstances[serverId]);
+    serverStates[serverId] = nullptr;
+
+    return true;
+}
+
+int serve(lua_State* L)
+{
+    std::string hostname = "0.0.0.0";
+    int port = 3000;
+    std::optional<uWS::SocketContextOptions> tlsOptions;
+    int handlerIndex = 1;
+
+    // Check if first argument is a table (config) or function (handler)
+    if (lua_istable(L, 1))
+    {
+        lua_getfield(L, 1, "hostname");
+        if (lua_isstring(L, -1))
+        {
+            hostname = lua_tostring(L, -1);
+        }
+        lua_pop(L, 1);
+
+        lua_getfield(L, 1, "port");
+        if (lua_isnumber(L, -1))
+        {
+            port = lua_tointeger(L, -1);
+        }
+        lua_pop(L, 1);
+
+        lua_getfield(L, 1, "tls");
+        if (lua_istable(L, -1))
+        {
+            tlsOptions.emplace();
+
+            lua_getfield(L, -1, "cert_file_name");
+            if (!lua_isstring(L, -1))
+            {
+                luaL_errorL(L, "tls config requires 'cert_file_name' (string)");
+                return 0;
+            }
+            tlsOptions->cert_file_name = lua_tostring(L, -1);
+            lua_pop(L, 1);
+
+            lua_getfield(L, -1, "key_file_name");
+            if (!lua_isstring(L, -1))
+            {
+                luaL_errorL(L, "tls config requires 'key_file_name' (string)");
+                return 0;
+            }
+            tlsOptions->key_file_name = lua_tostring(L, -1);
+            lua_pop(L, 1);
+
+            lua_getfield(L, -1, "passphrase");
+            if (lua_isstring(L, -1))
+            {
+                tlsOptions->passphrase = lua_tostring(L, -1);
+            }
+            lua_pop(L, 1);
+
+            lua_getfield(L, -1, "ca_file_name");
+            if (lua_isstring(L, -1))
+            {
+                tlsOptions->ca_file_name = lua_tostring(L, -1);
+            }
+            lua_pop(L, 1);
+        }
+        lua_pop(L, 1);
+
+        lua_getfield(L, 1, "handler");
+        if (!lua_isfunction(L, -1))
+        {
+            lua_pop(L, 1);
+            luaL_errorL(L, "handler function is required in config table");
+            return 0;
+        }
+        lua_insert(L, -1);
+        handlerIndex = lua_gettop(L);
+    }
+    else if (!lua_isfunction(L, 1))
+    {
+        luaL_errorL(L, "serve requires a handler function or config table");
+        return 0;
+    }
+
+    Runtime* runtime = getRuntime(L);
+
+    int serverId = nextServerId++;
+
+    auto state = std::make_shared<ServerLoopState>();
+    state->runtime = runtime;
+    state->hostname = hostname;
+    state->port = port;
+
+    lua_pushvalue(L, handlerIndex);
+    state->handlerRef = std::make_shared<Ref>(L, -1);
+    lua_pop(L, 1);
+
+    std::variant<std::unique_ptr<uWS::App>, std::unique_ptr<uWS::SSLApp>> app;
+    bool success = false;
+
+    if (tlsOptions) {
+        auto ssl_app = std::make_unique<uWS::SSLApp>(*tlsOptions);
+        state->app = ssl_app.get();
+        setupAppAndListen(ssl_app.get(), state, success);
+        app = std::move(ssl_app);
+    } else {
+        auto plain_app = std::make_unique<uWS::App>();
+        state->app = plain_app.get();
+        setupAppAndListen(plain_app.get(), state, success);
+        app = std::move(plain_app);
+    }
 
     if (!success)
     {
@@ -422,7 +479,7 @@ int serve(lua_State* L)
         {
             return;
         }
-        state->app->run();
+        std::visit([](auto* appPtr){ if(appPtr) appPtr->run(); }, state->app);
         state->runtime->schedule(state->loopFunction);
     };
 

--- a/net/src/net.cpp
+++ b/net/src/net.cpp
@@ -5,6 +5,7 @@
 #include "curl/curl.h"
 #include "App.h"
 #include "Luau/DenseHash.h"
+#include "Luau/Variant.h"
 
 #include "lua.h"
 #include "lualib.h"
@@ -98,14 +99,16 @@ int getAsync(lua_State* L)
     return lua_yield(L, 0);
 }
 
+using uWSApp = Luau::Variant<std::unique_ptr<uWS::App>, std::unique_ptr<uWS::SSLApp>>;
+
 static const int kEmptyServerKey = 0;
-static Luau::DenseHashMap<int, std::variant<std::unique_ptr<uWS::App>, std::unique_ptr<uWS::SSLApp>>> serverInstances(kEmptyServerKey);
+static Luau::DenseHashMap<int, uWSApp> serverInstances(kEmptyServerKey);
 static Luau::DenseHashMap<int, std::shared_ptr<struct ServerLoopState>> serverStates(kEmptyServerKey);
 static int nextServerId = 1;
 
 struct ServerLoopState
 {
-    std::variant<uWS::App*, uWS::SSLApp*> app;
+    Luau::Variant<uWS::App*, uWS::SSLApp*> app;
     Runtime* runtime;
     bool running = true;
     std::function<void()> loopFunction;
@@ -351,10 +354,10 @@ bool closeServer(int serverId)
         return false;
     }
 
-    std::visit([](auto* appPtr){ if (appPtr) appPtr->close(); }, serverStates[serverId]->app);
+    Luau::visit([](auto* appPtr){ if (appPtr) appPtr->close(); }, serverStates[serverId]->app);
     serverStates[serverId]->running = false;
 
-    std::visit([](auto& ptr){ if(ptr) ptr.reset(); }, serverInstances[serverId]);
+    Luau::visit([](auto& ptr){ if(ptr) ptr.reset(); }, serverInstances[serverId]);
     serverStates[serverId] = nullptr;
 
     return true;
@@ -452,7 +455,7 @@ int serve(lua_State* L)
     state->handlerRef = std::make_shared<Ref>(L, -1);
     lua_pop(L, 1);
 
-    std::variant<std::unique_ptr<uWS::App>, std::unique_ptr<uWS::SSLApp>> app;
+    uWSApp app;
     bool success = false;
 
     if (tlsOptions) {
@@ -479,7 +482,7 @@ int serve(lua_State* L)
         {
             return;
         }
-        std::visit([](auto* appPtr){ if(appPtr) appPtr->run(); }, state->app);
+        Luau::visit([](auto* appPtr){ if(appPtr) appPtr->run(); }, state->app);
         state->runtime->schedule(state->loopFunction);
     };
 

--- a/net/src/net.cpp
+++ b/net/src/net.cpp
@@ -294,11 +294,8 @@ static void processRequest(
     lua_pop(L, 1);
 }
 
-void setupAppAndListen(
-    auto* app,
-    std::shared_ptr<ServerLoopState> state,
-    bool& success
-) {
+void setupAppAndListen(auto* app, std::shared_ptr<ServerLoopState> state, bool& success)
+{
     app->any(
         "/*",
         [state](auto* res, auto* req)
@@ -326,10 +323,11 @@ void setupAppAndListen(
 
             std::string bodyBuffer;
             res->onData(
-                [state, res, req, method, path, query, bodyBuffer = std::move(bodyBuffer)]
-                (std::string_view data, bool last) mutable {
+                [state, res, req, method, path, query, bodyBuffer = std::move(bodyBuffer)](std::string_view data, bool last) mutable
+                {
                     bodyBuffer.append(data);
-                    if (last) {
+                    if (last)
+                    {
                         processRequest(state, res, req, method, path, query, bodyBuffer);
                     }
                 }
@@ -340,7 +338,8 @@ void setupAppAndListen(
     app->listen(
         state->hostname,
         state->port,
-        [&success](auto* listen_socket) {
+        [&success](auto* listen_socket)
+        {
             success = (listen_socket != nullptr);
         }
     );
@@ -353,10 +352,24 @@ bool closeServer(int serverId)
         return false;
     }
 
-    Luau::visit([](auto* appPtr){ if (appPtr) appPtr->close(); }, serverStates[serverId]->app);
+    Luau::visit(
+        [](auto* appPtr)
+        {
+            if (appPtr)
+                appPtr->close();
+        },
+        serverStates[serverId]->app
+    );
     serverStates[serverId]->running = false;
 
-    Luau::visit([](auto& ptr){ if(ptr) ptr.reset(); }, serverInstances[serverId]);
+    Luau::visit(
+        [](auto& ptr)
+        {
+            if (ptr)
+                ptr.reset();
+        },
+        serverInstances[serverId]
+    );
     serverStates[serverId] = nullptr;
 
     return true;
@@ -457,12 +470,15 @@ int serve(lua_State* L)
     uWSApp app;
     bool success = false;
 
-    if (tlsOptions) {
+    if (tlsOptions)
+    {
         auto ssl_app = std::make_unique<uWS::SSLApp>(*tlsOptions);
         state->app = ssl_app.get();
         setupAppAndListen(ssl_app.get(), state, success);
         app = std::move(ssl_app);
-    } else {
+    }
+    else
+    {
         auto plain_app = std::make_unique<uWS::App>();
         state->app = plain_app.get();
         setupAppAndListen(plain_app.get(), state, success);
@@ -481,7 +497,14 @@ int serve(lua_State* L)
         {
             return;
         }
-        Luau::visit([](auto* appPtr){ if(appPtr) appPtr->run(); }, state->app);
+        Luau::visit(
+            [](auto* appPtr)
+            {
+                if (appPtr)
+                    appPtr->run();
+            },
+            state->app
+        );
         state->runtime->schedule(state->loopFunction);
     };
 


### PR DESCRIPTION
Implements TLS on `net.serve` using `SSLApp`. `App` and `SSLApp` are unique templated classes. We can support both by storing them in a variant when required.

```luau
type TLS = {
  cert_file_name: string, -- fullchain certificate file path
  key_file_name: string, -- key file path
  passphrase: string?, -- optional passphrase for cert and key
  ca_file_name: string?, -- optional certificate authority file path for mTLS, defaults to no mTLS
}
```

Tested locally, seems to work as expected 😎 closes #125 