### PR TITLE
Fix terminating/aborting on Linux when attempting to run a directory

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -129,6 +129,12 @@ bool setupArguments(lua_State* L, int argc, char** argv)
 
 static bool runFile(Runtime& runtime, const char* name, lua_State* GL)
 {
+    if (isDirectory(name))
+    {
+        fprintf(stderr, "Error: %s is a directory\n", name);
+        return false;
+    }
+
     std::optional<std::string> source = readFile(name);
     if (!source)
     {


### PR DESCRIPTION
Fixes #214

The termination/abort seems to be happening because `std::string` would error from an invalid size, attempting to allocate a really large string buffer in `readFile`

https://github.com/luau-lang/luau/blob/c51743268bcbe5c5af1bd78bcacaefe7f6fe3391/CLI/src/FileUtils.cpp#L188-L196

`fopen` with a directory would work on Linux, and apparently using `ftell` on a directory is undefined behavior.