### PR TITLE
Fix API casing inconsistencies

### DIFF
--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1784,9 +1784,9 @@ int compile_luau(lua_State* L)
 
     if (lua_type(L, 2) == LUA_TTABLE)
     {
-        opts.optimizationLevel = check_int_field(L, 2, "optimization_level", 1);
-        opts.debugLevel = check_int_field(L, 2, "debug_level", 1);
-        opts.coverageLevel = check_int_field(L, 2, "coverage_level", 1);
+        opts.optimizationLevel = check_int_field(L, 2, "optimizationlevel", 1);
+        opts.debugLevel = check_int_field(L, 2, "debuglevel", 1);
+        opts.coverageLevel = check_int_field(L, 2, "coveragelevel", 1);
     }
 
     std::string bytecode = Luau::compile(std::string(source, source_size), opts);

--- a/net/include/lute/net.h
+++ b/net/include/lute/net.h
@@ -13,14 +13,11 @@ namespace net
 
 int get(lua_State* L);
 
-int getAsync(lua_State* L);
-
-int serve(lua_State* L);
+int lua_serve(lua_State* L);
 
 static const luaL_Reg lib[] = {
     {"get", get},
-    {"getAsync", getAsync},
-    {"serve", serve},
+    {"serve", lua_serve},
     {nullptr, nullptr},
 };
 

--- a/net/src/net.cpp
+++ b/net/src/net.cpp
@@ -57,19 +57,6 @@ int get(lua_State* L)
 {
     std::string url = luaL_checkstring(L, 1);
 
-    auto [error, data] = requestData(url);
-
-    if (!error.empty())
-        luaL_errorL(L, "network request failed: %s", error.c_str());
-
-    lua_pushlstring(L, data.data(), data.size());
-    return 1;
-}
-
-int getAsync(lua_State* L)
-{
-    std::string url = luaL_checkstring(L, 1);
-
     auto token = getResumeToken(L);
 
     // TODO: add cancellations
@@ -375,7 +362,7 @@ bool closeServer(int serverId)
     return true;
 }
 
-int serve(lua_State* L)
+int lua_serve(lua_State* L)
 {
     std::string hostname = "0.0.0.0";
     int port = 3000;


### PR DESCRIPTION
Contributes partial fixes to #181 by renaming `debug_level`, `coverage_level`, `optimization_level` to their luacase counterparts. Also removes `net.get` and renames `net.getAsync` to `net.get`. Internally, renames `int getAsync()` to `int lua_get`, making it consistent with other lute functions.