### PR TITLE
Fix net.serve not being yieldable

### DIFF
--- a/net/src/net.cpp
+++ b/net/src/net.cpp
@@ -250,7 +250,7 @@ static void processRequest(
     const std::string& body
 )
 {
-    lua_State* L = state->runtime->GL;
+    lua_State* L = lua_newthread(state->runtime->GL);
 
     lua_createtable(L, 0, 5);
 
@@ -279,7 +279,8 @@ static void processRequest(
     lua_pushvalue(L, -2);
     lua_remove(L, -3);
 
-    if (lua_pcall(L, 1, 1, 0) != 0)
+    int status = lua_resume(L, nullptr, 1);
+    if ((status != LUA_OK) && (status != LUA_YIELD))
     {
         std::string error = lua_tostring(L, -1);
         lua_pop(L, 1);

--- a/net/src/net.cpp
+++ b/net/src/net.cpp
@@ -280,7 +280,7 @@ static void processRequest(
     lua_remove(L, -3);
 
     int status = lua_resume(L, nullptr, 1);
-    if ((status != LUA_OK) && (status != LUA_YIELD))
+    if (status != LUA_OK && status != LUA_YIELD)
     {
         std::string error = lua_tostring(L, -1);
         lua_pop(L, 1);


### PR DESCRIPTION
Fixes #169 by deriving a lua_State from the runtime global lua_State, and then resuming it with the handler function.