### PR TITLE
Enable IPO for Release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,17 @@ include(get_version.cmake)
 
 project(Lute LANGUAGES CXX C VERSION ${LUTE_VERSION})
 
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT ipo_supported)
+    if(ipo_supported)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+        message(STATUS "IPO enabled for Release build.")
+    else()
+        message(WARNING "IPO not supported by the compiler.")
+    endif()
+endif()
+
 add_library(Lute.Runtime STATIC)
 add_library(Lute.Fs STATIC)
 add_library(Lute.Luau STATIC)


### PR DESCRIPTION
Adds extra optimization and creates smaller binaries. Understood if we want to wait on this until we have a test suite to make sure the final build still functions as expected.