### PR TITLE
CST: Handle for loops

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -226,6 +226,31 @@ export type AstStatLocal = {
 	values: Punctuated<AstExpr>,
 }
 
+export type AstStatFor = {
+	tag: "for",
+	["for"]: Token<"for">,
+	variable: Token<string>,
+	equals: Token<"=">,
+	from: AstExpr,
+	toComma: Token<",">,
+	to: AstExpr,
+	stepComma: Token<",">?,
+	step: AstExpr?,
+	["do"]: Token<"do">,
+	body: AstStatBlock,
+	["end"]: Token<"end">,
+}
+
+export type AstStatForIn = {
+	tag: "forin",
+	["for"]: Token<"for">,
+	variables: Punctuated<Token<string>>,
+	["in"]: Token<"in">,
+	values: Punctuated<Token<string>>,
+	["do"]: Token<"do">,
+	body: AstStatBlock,
+	["end"]: Token<"end">,
+}
 export type AstStat =
 	| AstStatBlock
 	| AstStatIf
@@ -236,5 +261,7 @@ export type AstStat =
 	| AstStatReturn
 	| AstStatExpr
 	| AstStatLocal
+	| AstStatFor
+	| AstStatForIn
 
 return {}

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -9,6 +9,8 @@ type Visitor = {
 	visitRepeat: (T.AstStatRepeat) -> boolean,
 	visitReturn: (T.AstStatReturn) -> boolean,
 	visitLocalDeclaration: (T.AstStatLocal) -> boolean,
+	visitFor: (T.AstStatFor) -> boolean,
+	visitForIn: (T.AstStatForIn) -> boolean,
 
 	visitLocalReference: (T.AstExprLocal) -> boolean,
 	visitGlobal: (T.AstExprGlobal) -> boolean,
@@ -42,6 +44,8 @@ local defaultVisitor: Visitor = {
 	visitRepeat = alwaysVisit :: any,
 	visitReturn = alwaysVisit :: any,
 	visitLocalDeclaration = alwaysVisit :: any,
+	visitFor = alwaysVisit :: any,
+	visitForIn = alwaysVisit :: any,
 
 	visitLocalReference = alwaysVisit :: any,
 	visitGlobal = alwaysVisit :: any,
@@ -146,6 +150,38 @@ local function visitLocalStatement(node: T.AstStatLocal, visitor: Visitor)
 			visitToken(node.equals, visitor)
 		end
 		visitPunctuated(node.values, visitor, visitExpression)
+	end
+end
+
+local function visitFor(node: T.AstStatFor, visitor: Visitor)
+	if visitor.visitFor(node) then
+		visitToken(node["for"], visitor)
+		visitLocal(node.variable, visitor)
+		visitToken(node.equals, visitor)
+		visitExpression(node.from, visitor)
+		visitToken(node.toComma, visitor)
+		visitExpression(node.to, visitor)
+		if node.stepComma then
+			visitToken(node.stepComma, visitor)
+		end
+		if node.step then
+			visitExpression(node.step, visitor)
+		end
+		visitToken(node["do"], visitor)
+		visitBlock(node.body, visitor)
+		visitToken(node["end"], visitor)
+	end
+end
+
+local function visitForIn(node: T.AstStatForIn, visitor: Visitor)
+	if visitor.visitForIn(node) then
+		visitToken(node["for"], visitor)
+		visitPunctuated(node.variables, visitor, visitLocal)
+		visitToken(node["in"], visitor)
+		visitPunctuated(node.values, visitor, visitExpression)
+		visitToken(node["do"], visitor)
+		visitBlock(node.body, visitor)
+		visitToken(node["end"], visitor)
 	end
 end
 
@@ -348,6 +384,10 @@ function visitStatement(statement: T.AstStat, visitor: Visitor)
 		visitToken(statement, visitor)
 	elseif statement.tag == "repeat" then
 		visitRepeat(statement, visitor)
+	elseif statement.tag == "for" then
+		visitFor(statement, visitor)
+	elseif statement.tag == "forin" then
+		visitForIn(statement, visitor)
 	else
 		exhaustiveMatch(statement.tag)
 	end

--- a/tests/astSerializerTests/generic-for-loop-1.luau
+++ b/tests/astSerializerTests/generic-for-loop-1.luau
@@ -1,0 +1,11 @@
+for index, value in pairs(list) do
+	call(index, value)
+end
+
+for index, value in next, list do
+	call(index, value)
+end
+
+for index, value in list do
+	call(index, value)
+end

--- a/tests/astSerializerTests/numeric-for-loop-1.luau
+++ b/tests/astSerializerTests/numeric-for-loop-1.luau
@@ -1,0 +1,7 @@
+for index = 1, 10 do
+	call(index)
+end
+for _ = start, final do
+end
+for _ = 1, 10, 2 do
+end

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -130,6 +130,8 @@ local function test_roundtrippableAst()
 		"examples/time_example.luau",
 		"examples/writeFile.luau",
 		"tests/astSerializerTests/break-continue-1.luau",
+		"tests/astSerializerTests/generic-for-loop-1.luau",
+		"tests/astSerializerTests/numeric-for-loop-1.luau",
 		"tests/astSerializerTests/while-1.luau",
 		"tests/astSerializerTests/repeat-until-1.luau",
 	}


### PR DESCRIPTION
This PR extends the CST support to include all the necessary tokens in numeric (`for i = 1, 10, 2 do`) and for-in (`for ... in ... do`) loops.

As mentioned previously, a future change will standardise the AST property names to switch away from using keywords