### PR TITLE
Remove restriction on the type of require results.

### DIFF
--- a/runtime/src/require.cpp
+++ b/runtime/src/require.cpp
@@ -269,7 +269,7 @@ static int load(lua_State* L, void* ctx, const char* chunkname, const char* cont
             const std::string prefix = "module " + std::string(chunknameView.substr(1)) + " must";
 
             if (lua_gettop(ML) == 0)
-                lua_pushstring(ML, (prefix + " return a value").c_str());
+                lua_pushstring(ML, (prefix + " return a value, if it has no return value, you should explicitly return `nil`").c_str());
         }
         else if (status == LUA_YIELD)
         {

--- a/runtime/src/require.cpp
+++ b/runtime/src/require.cpp
@@ -270,8 +270,6 @@ static int load(lua_State* L, void* ctx, const char* chunkname, const char* cont
 
             if (lua_gettop(ML) == 0)
                 lua_pushstring(ML, (prefix + " return a value").c_str());
-            else if (!lua_istable(ML, -1) && !lua_isfunction(ML, -1))
-                lua_pushstring(ML, (prefix + " return a table or function").c_str());
         }
         else if (status == LUA_YIELD)
         {


### PR DESCRIPTION
We originally implemented a restriction on require results being a table or function so that scripts would intrinsically be forwards-compatible as they evolve. To my surprise, this is a controversial choice. As part of the as-of-yet-unwritten style guide of Lute, we'll never return anything that is not a table or function, but users are free to do how they see fit.