### PR TITLE
CST: Add initial support for types

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -328,6 +328,14 @@ export type AstTypeSingletonString = Token<string> & {
 	quoteStyle: "single" | "double",
 }
 
-export type AstType = | AstTypeReference | AstTypeSingletonBool | AstTypeSingletonString
+export type AstTypeTypeof = {
+	tag: "typeof",
+	typeof: Token<"typeof">,
+	openParens: Token<"(">,
+	expr: AstExpr,
+	closeParens: Token<")">,
+}
+
+export type AstType = | AstTypeReference | AstTypeSingletonBool | AstTypeSingletonString | AstTypeTypeof
 
 return {}

--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -298,4 +298,16 @@ export type AstStat =
 	| AstStatFunction
 	| AstStatLocalFunction
 
+export type AstTypeSingletonBool = Token<"true" | "false"> & {
+	tag: "boolean",
+	value: boolean,
+}
+
+export type AstTypeSingletonString = Token<string> & {
+	tag: "string",
+	quoteStyle: "single" | "double",
+}
+
+export type AstType = | AstTypeSingletonBool | AstTypeSingletonString
+
 return {}

--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -281,6 +281,15 @@ export type AstStatLocalFunction = {
 	body: AstFunctionBody,
 }
 
+export type AstStatTypeAlias = {
+	tag: "typealias",
+	["export"]: Token<"export">?,
+	typeToken: Token<"type">,
+	name: Token,
+	equals: Token<"=">,
+	type: AstType,
+}
+
 export type AstStat =
 	| AstStatBlock
 	| AstStatIf
@@ -297,6 +306,7 @@ export type AstStat =
 	| AstStatCompoundAssign
 	| AstStatFunction
 	| AstStatLocalFunction
+	| AstStatTypeAlias
 
 export type AstTypeSingletonBool = Token<"true" | "false"> & {
 	tag: "boolean",

--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -336,6 +336,13 @@ export type AstTypeTypeof = {
 	closeParens: Token<")">,
 }
 
-export type AstType = | AstTypeReference | AstTypeSingletonBool | AstTypeSingletonString | AstTypeTypeof
+export type AstTypeGroup = {
+	tag: "group",
+	openParens: Token<"(">,
+	type: AstType,
+	closeParens: Token<">">,
+}
+
+export type AstType = | AstTypeReference | AstTypeSingletonBool | AstTypeSingletonString | AstTypeTypeof | AstTypeGroup
 
 return {}

--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -308,6 +308,16 @@ export type AstStat =
 	| AstStatLocalFunction
 	| AstStatTypeAlias
 
+export type AstTypeReference = {
+	tag: "reference",
+	prefix: Token<string>?,
+	prefixPoint: Token<".">?,
+	name: Token<string>,
+	openParameters: Token<"<">?,
+	parameters: Punctuated<AstType>?,
+	closeParameters: Token<">">?,
+}
+
 export type AstTypeSingletonBool = Token<"true" | "false"> & {
 	tag: "boolean",
 	value: boolean,
@@ -318,6 +328,6 @@ export type AstTypeSingletonString = Token<string> & {
 	quoteStyle: "single" | "double",
 }
 
-export type AstType = | AstTypeSingletonBool | AstTypeSingletonString
+export type AstType = | AstTypeReference | AstTypeSingletonBool | AstTypeSingletonString
 
 return {}

--- a/batteries/syntax/printer.luau
+++ b/batteries/syntax/printer.luau
@@ -61,6 +61,11 @@ local function printBlock(block: T.AstStatBlock): string
 		return false
 	end
 
+	printer.visitTypeString = function(node: T.AstTypeSingletonString)
+		result ..= printString(node)
+		return false
+	end
+
 	visitor.visitBlock(block, printer)
 
 	return result

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -29,6 +29,7 @@ type Visitor = {
 	visitIndexExpr: (T.AstExprIndexExpr) -> boolean,
 	visitGroup: (T.AstExprGroup) -> boolean,
 
+	visitTypeReference: (T.AstTypeReference) -> boolean,
 	visitTypeBoolean: (T.AstTypeSingletonBool) -> boolean,
 	visitTypeString: (T.AstTypeSingletonString) -> boolean,
 
@@ -72,8 +73,9 @@ local defaultVisitor: Visitor = {
 	visitIndexExpr = alwaysVisit :: any,
 	visitGroup = alwaysVisit :: any,
 
-	visitTypeBoolean = alwaysVisit() :: any,
-	visitTypeString = alwaysVisit() :: any,
+	visitTypeReference = alwaysVisit :: any,
+	visitTypeBoolean = alwaysVisit :: any,
+	visitTypeString = alwaysVisit :: any,
 
 	visitToken = alwaysVisit :: any,
 	visitNil = alwaysVisit :: any,
@@ -390,6 +392,27 @@ local function visitGroup(node: T.AstExprGroup, visitor: Visitor)
 	end
 end
 
+local function visitTypeReference(node: T.AstTypeReference, visitor: Visitor)
+	if visitor.visitTypeReference(node) then
+		if node.prefix then
+			visitToken(node.prefix, visitor)
+		end
+		if node.prefixPoint then
+			visitToken(node.prefixPoint, visitor)
+		end
+		visitToken(node.name, visitor)
+		if node.openParameters then
+			visitToken(node.openParameters, visitor)
+		end
+		if node.parameters then
+			visitPunctuated(node.parameters, visitor, visitType)
+		end
+		if node.closeParameters then
+			visitToken(node.closeParameters, visitor)
+		end
+	end
+end
+
 local function visitTypeBoolean(node: T.AstTypeSingletonBool, visitor: Visitor)
 	if visitor.visitTypeBoolean(node) then
 		visitToken(node, visitor)
@@ -477,7 +500,9 @@ function visitStatement(statement: T.AstStat, visitor: Visitor)
 end
 
 function visitType(type: T.AstType, visitor: Visitor)
-	if type.tag == "boolean" then
+	if type.tag == "reference" then
+		visitTypeReference(type, visitor)
+	elseif type.tag == "boolean" then
 		visitTypeBoolean(type, visitor)
 	elseif type.tag == "string" then
 		visitTypeString(type, visitor)

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -15,6 +15,7 @@ type Visitor = {
 	visitCompoundAssign: (T.AstStatCompoundAssign) -> boolean,
 	visitFunction: (T.AstStatFunction) -> boolean,
 	visitLocalFunction: (T.AstStatLocalFunction) -> boolean,
+	visitTypeAlias: (T.AstStatTypeAlias) -> boolean,
 
 	visitLocalReference: (T.AstExprLocal) -> boolean,
 	visitGlobal: (T.AstExprGlobal) -> boolean,
@@ -57,6 +58,7 @@ local defaultVisitor: Visitor = {
 	visitCompoundAssign = alwaysVisit :: any,
 	visitFunction = alwaysVisit :: any,
 	visitLocalFunction = alwaysVisit :: any,
+	visitTypeAlias = alwaysVisit :: any,
 
 	visitLocalReference = alwaysVisit :: any,
 	visitGlobal = alwaysVisit :: any,
@@ -212,6 +214,18 @@ local function visitCompoundAssign(node: T.AstStatCompoundAssign, visitor: Visit
 		visitExpression(node.variable, visitor)
 		visitToken(node.operand, visitor)
 		visitExpression(node.value, visitor)
+	end
+end
+
+local function visitTypeAlias(node: T.AstStatTypeAlias, visitor: Visitor)
+	if visitor.visitTypeAlias(node) then
+		if node.export then
+			visitToken(node.export, visitor)
+		end
+		visitToken(node.typeToken, visitor)
+		visitToken(node.name, visitor)
+		visitToken(node.equals, visitor)
+		visitType(node.type, visitor)
 	end
 end
 
@@ -455,18 +469,20 @@ function visitStatement(statement: T.AstStat, visitor: Visitor)
 		visitFunction(statement, visitor)
 	elseif statement.tag == "localfunction" then
 		visitLocalFunction(statement, visitor)
+	elseif statement.tag == "typealias" then
+		visitTypeAlias(statement, visitor)
 	else
 		exhaustiveMatch(statement.tag)
 	end
 end
 
-function visitType(ty: T.AstType, visitor: Visitor)
-	if ty.tag == "boolean" then
-		visitTypeBoolean(ty, visitor)
-	elseif ty.tag == "string" then
-		visitTypeString(ty, visitor)
+function visitType(type: T.AstType, visitor: Visitor)
+	if type.tag == "boolean" then
+		visitTypeBoolean(type, visitor)
+	elseif type.tag == "string" then
+		visitTypeString(type, visitor)
 	else
-		exhaustiveMatch(ty.tag)
+		exhaustiveMatch(type.tag)
 	end
 end
 

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -33,6 +33,7 @@ type Visitor = {
 	visitTypeBoolean: (T.AstTypeSingletonBool) -> boolean,
 	visitTypeString: (T.AstTypeSingletonString) -> boolean,
 	visitTypeTypeof: (T.AstTypeTypeof) -> boolean,
+	visitTypeGroup: (T.AstTypeGroup) -> boolean,
 
 	visitToken: (T.Token) -> boolean,
 	visitNil: (T.AstExprConstantNil) -> boolean,
@@ -78,6 +79,7 @@ local defaultVisitor: Visitor = {
 	visitTypeBoolean = alwaysVisit :: any,
 	visitTypeString = alwaysVisit :: any,
 	visitTypeTypeof = alwaysVisit :: any,
+	visitTypeGroup = alwaysVisit :: any,
 
 	visitToken = alwaysVisit :: any,
 	visitNil = alwaysVisit :: any,
@@ -436,6 +438,14 @@ local function visitTypeTypeof(node: T.AstTypeTypeof, visitor: Visitor)
 	end
 end
 
+local function visitTypeGroup(node: T.AstTypeGroup, visitor: Visitor)
+	if visitor.visitTypeGroup(node) then
+		visitToken(node.openParens, visitor)
+		visitType(node.type, visitor)
+		visitToken(node.closeParens, visitor)
+	end
+end
+
 function visitExpression(expression: T.AstExpr, visitor: Visitor)
 	if expression.tag == "nil" then
 		visitNil(expression, visitor)
@@ -519,6 +529,8 @@ function visitType(type: T.AstType, visitor: Visitor)
 		visitTypeString(type, visitor)
 	elseif type.tag == "typeof" then
 		visitTypeTypeof(type, visitor)
+	elseif type.tag == "group" then
+		visitTypeGroup(type, visitor)
 	else
 		exhaustiveMatch(type.tag)
 	end

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -32,6 +32,7 @@ type Visitor = {
 	visitTypeReference: (T.AstTypeReference) -> boolean,
 	visitTypeBoolean: (T.AstTypeSingletonBool) -> boolean,
 	visitTypeString: (T.AstTypeSingletonString) -> boolean,
+	visitTypeTypeof: (T.AstTypeTypeof) -> boolean,
 
 	visitToken: (T.Token) -> boolean,
 	visitNil: (T.AstExprConstantNil) -> boolean,
@@ -76,6 +77,7 @@ local defaultVisitor: Visitor = {
 	visitTypeReference = alwaysVisit :: any,
 	visitTypeBoolean = alwaysVisit :: any,
 	visitTypeString = alwaysVisit :: any,
+	visitTypeTypeof = alwaysVisit :: any,
 
 	visitToken = alwaysVisit :: any,
 	visitNil = alwaysVisit :: any,
@@ -425,6 +427,15 @@ local function visitTypeString(node: T.AstTypeSingletonString, visitor: Visitor)
 	end
 end
 
+local function visitTypeTypeof(node: T.AstTypeTypeof, visitor: Visitor)
+	if visitor.visitTypeTypeof(node) then
+		visitToken(node.typeof, visitor)
+		visitToken(node.openParens, visitor)
+		visitExpression(node.expr, visitor)
+		visitToken(node.closeParens, visitor)
+	end
+end
+
 function visitExpression(expression: T.AstExpr, visitor: Visitor)
 	if expression.tag == "nil" then
 		visitNil(expression, visitor)
@@ -506,6 +517,8 @@ function visitType(type: T.AstType, visitor: Visitor)
 		visitTypeBoolean(type, visitor)
 	elseif type.tag == "string" then
 		visitTypeString(type, visitor)
+	elseif type.tag == "typeof" then
+		visitTypeTypeof(type, visitor)
 	else
 		exhaustiveMatch(type.tag)
 	end

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -28,6 +28,9 @@ type Visitor = {
 	visitIndexExpr: (T.AstExprIndexExpr) -> boolean,
 	visitGroup: (T.AstExprGroup) -> boolean,
 
+	visitTypeBoolean: (T.AstTypeSingletonBool) -> boolean,
+	visitTypeString: (T.AstTypeSingletonString) -> boolean,
+
 	visitToken: (T.Token) -> boolean,
 	visitNil: (T.AstExprConstantNil) -> boolean,
 	visitString: (T.AstExprConstantString) -> boolean,
@@ -66,6 +69,9 @@ local defaultVisitor: Visitor = {
 	visitIndexName = alwaysVisit :: any,
 	visitIndexExpr = alwaysVisit :: any,
 	visitGroup = alwaysVisit :: any,
+
+	visitTypeBoolean = alwaysVisit() :: any,
+	visitTypeString = alwaysVisit() :: any,
 
 	visitToken = alwaysVisit :: any,
 	visitNil = alwaysVisit :: any,
@@ -370,6 +376,18 @@ local function visitGroup(node: T.AstExprGroup, visitor: Visitor)
 	end
 end
 
+local function visitTypeBoolean(node: T.AstTypeSingletonBool, visitor: Visitor)
+	if visitor.visitTypeBoolean(node) then
+		visitToken(node, visitor)
+	end
+end
+
+local function visitTypeString(node: T.AstTypeSingletonString, visitor: Visitor)
+	if visitor.visitTypeString(node) then
+		visitToken(node, visitor)
+	end
+end
+
 function visitExpression(expression: T.AstExpr, visitor: Visitor)
 	if expression.tag == "nil" then
 		visitNil(expression, visitor)
@@ -439,6 +457,16 @@ function visitStatement(statement: T.AstStat, visitor: Visitor)
 		visitLocalFunction(statement, visitor)
 	else
 		exhaustiveMatch(statement.tag)
+	end
+end
+
+function visitType(ty: T.AstType, visitor: Visitor)
+	if ty.tag == "boolean" then
+		visitTypeBoolean(ty, visitor)
+	elseif ty.tag == "string" then
+		visitTypeString(ty, visitor)
+	else
+		exhaustiveMatch(ty.tag)
 	end
 end
 

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -635,7 +635,7 @@ struct AstSerialize : public Luau::AstVisitor
         node->expr->visit(this);
         lua_setfield(L, -2, "expression");
 
-        serializeToken(Luau::Position{node->location.end.line, node->location.end.column - 1}, "}");
+        serializeToken(Luau::Position{node->location.end.line, node->location.end.column - 1}, ")");
         lua_setfield(L, -2, "closeParens");
     }
 
@@ -1542,6 +1542,23 @@ struct AstSerialize : public Luau::AstVisitor
         currentPosition = node->location.end;
     }
 
+    void serializeType(Luau::AstTypeGroup* node)
+    {
+        lua_rawcheckstack(L, 2);
+        lua_createtable(L, 0, preambleSize + 3);
+
+        serializeNodePreamble(node, "group");
+
+        serializeToken(node->location.begin, "(");
+        lua_setfield(L, -2, "openParens");
+
+        node->type->visit(this);
+        lua_setfield(L, -2, "type");
+
+        serializeToken(Luau::Position{node->location.end.line, node->location.end.column -1}, ")");
+        lua_setfield(L, -2, "closeParens");
+    }
+
     void serializeType(Luau::AstTypeError* node)
     {
         // TODO: types
@@ -1885,6 +1902,12 @@ struct AstSerialize : public Luau::AstVisitor
     bool visit(Luau::AstTypePackGeneric* node) override
     {
         return true;
+    }
+
+    bool visit(Luau::AstTypeGroup* node) override
+    {
+        serializeType(node);
+        return false;
     }
 };
 

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1387,12 +1387,43 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeType(Luau::AstTypeSingletonBool* node)
     {
-        // TODO: types
+        serializeToken(node->location.begin, node->value ? "true" : "false", preambleSize + 1);
+        serializeNodePreamble(node, "boolean");
+
+        lua_pushboolean(L, node->value);
+        lua_setfield(L, -2, "value");
     }
 
     void serializeType(Luau::AstTypeSingletonString* node)
     {
-        // TODO: types
+        if (const auto cstNode = lookupCstNode<Luau::CstTypeSingletonString>(node))
+        {
+            serializeToken(node->location.begin, cstNode->sourceString.data, preambleSize);
+
+            switch (cstNode->quoteStyle)
+            {
+            case Luau::CstExprConstantString::QuotedSingle:
+                lua_pushstring(L, "single");
+                break;
+            case Luau::CstExprConstantString::QuotedDouble:
+                lua_pushstring(L, "double");
+                break;
+            default:
+                LUAU_ASSERT(false);
+            }
+            lua_setfield(L, -2, "quoteStyle");
+        }
+        else
+        {
+            serializeToken(node->location.begin, node->value.data, preambleSize);
+        }
+
+        serializeNodePreamble(node, "string");
+
+        // Unlike normal tokens, string content contains quotation marks that were not included during advancement
+        // For simplicity, lets set the current position manually
+        LUAU_ASSERT(currentPosition <= node->location.end);
+        currentPosition = node->location.end;
     }
 
     void serializeType(Luau::AstTypeError* node)

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -573,6 +573,32 @@ struct AstSerialize : public Luau::AstVisitor
         }
     }
 
+    void serializePunctuated(Luau::AstArray<Luau::AstTypeOrPack> nodes, Luau::AstArray<Luau::Position> separators, const char* separatorText)
+    {
+        lua_rawcheckstack(L, 2);
+        lua_createtable(L, nodes.size, 0);
+
+        for (size_t i = 0; i < nodes.size; i++)
+        {
+            lua_rawcheckstack(L, 2);
+            lua_createtable(L, 0, 2);
+
+            if (nodes.data[i].type)
+                nodes.data[i].type->visit(this);
+            else
+                nodes.data[i].typePack->visit(this);
+            lua_setfield(L, -2, "node");
+
+            if (i < separators.size)
+                serializeToken(separators.data[i], separatorText);
+            else
+                lua_pushnil(L);
+            lua_setfield(L, -2, "separator");
+
+            lua_rawseti(L, -2, i + 1);
+        }
+    }
+
     void serializePunctuated(Luau::AstArray<Luau::AstLocal*> nodes, Luau::AstArray<Luau::Position> separators, const char* separatorText)
     {
         lua_rawcheckstack(L, 2);
@@ -1390,7 +1416,47 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeType(Luau::AstTypeReference* node)
     {
-        // TODO: types
+        lua_rawcheckstack(L, 2);
+        lua_createtable(L, 0, preambleSize + 6);
+
+        serializeNodePreamble(node, "reference");
+
+        const auto cstNode = lookupCstNode<Luau::CstTypeReference>(node);
+
+        if (node->prefix)
+        {
+            LUAU_ASSERT(node->prefixLocation);
+            serializeToken(node->prefixLocation->begin, node->prefix->value);
+            lua_setfield(L, -2, "prefix");
+
+            if (cstNode)
+            {
+                LUAU_ASSERT(cstNode->prefixPointPosition);
+                serializeToken(*cstNode->prefixPointPosition, ".");
+                lua_setfield(L, -2, "prefixPoint");
+            }
+        }
+
+        serializeToken(node->nameLocation.begin, node->name.value);
+        lua_setfield(L, -2, "name");
+
+        if (node->hasParameterList)
+        {
+            if (cstNode)
+            {
+                serializeToken(cstNode->openParametersPosition, "<");
+                lua_setfield(L, -2, "openParameters");
+            }
+
+            serializePunctuated(node->parameters, cstNode ? cstNode->parametersCommaPositions : Luau::AstArray<Luau::Position>{}, ",");
+            lua_setfield(L, -2, "parameters");
+
+            if (cstNode)
+            {
+                serializeToken(cstNode->closeParametersPosition, ">");
+                lua_setfield(L, -2, "closeParameters");
+            }
+        }
     }
 
     void serializeType(Luau::AstTypeTable* node)
@@ -1732,7 +1798,8 @@ struct AstSerialize : public Luau::AstVisitor
 
     bool visit(Luau::AstTypeReference* node) override
     {
-        return true;
+        serializeType(node);
+        return false;
     }
 
     bool visit(Luau::AstTypeTable* node) override

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1471,7 +1471,29 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeType(Luau::AstTypeTypeof* node)
     {
-        // TODO: types
+        lua_rawcheckstack(L, 2);
+        lua_createtable(L, 0, preambleSize + 4);
+
+        serializeNodePreamble(node, "typeof");
+
+        serializeToken(node->location.begin, "typeof");
+        lua_setfield(L, -2, "typeof");
+
+        const auto cstNode = lookupCstNode<Luau::CstTypeTypeof>(node);
+        if (cstNode)
+        {
+            serializeToken(cstNode->openPosition, "(");
+            lua_setfield(L, -2, "openParens");
+        }
+
+        node->expr->visit(this);
+        lua_setfield(L, -2, "expr");
+
+        if (cstNode)
+        {
+            serializeToken(cstNode->closePosition, ")");
+            lua_setfield(L, -2, "closeParens");
+        }
     }
 
     void serializeType(Luau::AstTypeIntersection* node)
@@ -1814,7 +1836,8 @@ struct AstSerialize : public Luau::AstVisitor
 
     bool visit(Luau::AstTypeTypeof* node) override
     {
-        return true;
+        serializeType(node);
+        return false;
     }
 
     bool visit(Luau::AstTypeUnion* node) override

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1326,7 +1326,35 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatTypeAlias* node)
     {
-        // TODO: types
+        lua_rawcheckstack(L, 2);
+        lua_createtable(L, 0, preambleSize + 5);
+
+        serializeNodePreamble(node, "typealias");
+
+        const auto cstNode = lookupCstNode<Luau::CstStatTypeAlias>(node);
+
+        if (node->exported)
+            serializeToken(node->location.begin, "export");
+        else
+            lua_pushnil(L);
+        lua_setfield(L, -2, "export");
+
+        serializeToken(cstNode ? cstNode->typeKeywordPosition : node->location.begin, "type");
+        lua_setfield(L, -2, "typeToken");
+
+        serializeToken(node->nameLocation.begin, node->name.value);
+        lua_setfield(L, -2, "name");
+
+        // TODO: generics
+
+        if (cstNode)
+        {
+            serializeToken(cstNode->equalsPosition, "=");
+            lua_setfield(L, -2, "equals");
+        }
+
+        node->type->visit(this);
+        lua_setfield(L, -2, "type");
     }
 
     void serializeStat(Luau::AstStatDeclareFunction* node)

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1734,12 +1734,14 @@ struct AstSerialize : public Luau::AstVisitor
 
     bool visit(Luau::AstTypeSingletonBool* node) override
     {
-        return true;
+        serializeType(node);
+        return false;
     }
 
     bool visit(Luau::AstTypeSingletonString* node) override
     {
-        return true;
+        serializeType(node);
+        return false;
     }
 
     bool visit(Luau::AstTypeError* node) override

--- a/tests/astSerializerTests/type-singletons-1.luau
+++ b/tests/astSerializerTests/type-singletons-1.luau
@@ -1,0 +1,2 @@
+type A = "string"
+type B = true

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -137,6 +137,7 @@ local function test_roundtrippableAst()
 		"tests/astSerializerTests/generic-for-loop-1.luau",
 		"tests/astSerializerTests/local-function-declaration-1.luau",
 		"tests/astSerializerTests/numeric-for-loop-1.luau",
+		"tests/astSerializerTests/type-singletons-1.luau",
 		"tests/astSerializerTests/while-1.luau",
 		"tests/astSerializerTests/repeat-until-1.luau",
 	}


### PR DESCRIPTION
This PR adds initial support for serializing types as part of the CST. This includes serializing type references, singleton strings and booleans, types wrapped in parentheses (type group) and typeof. We also serialize type alias statements (for now, excluding generics. We will introduce generic declarations in a follow up commit)