### PR TITLE
CST: Handle parsing expressions directly

### DIFF
--- a/batteries/syntax/parser.luau
+++ b/batteries/syntax/parser.luau
@@ -8,6 +8,11 @@ local function parse(source: string): T.AstStatBlock
 	return luau.parse(source).root
 end
 
+local function parseexpr(source: string): T.AstExpr
+	return luau.parseexpr(source)
+end
+
 return {
 	parse = parse,
+	parseexpr = parseexpr,
 }

--- a/batteries/syntax/printer.luau
+++ b/batteries/syntax/printer.luau
@@ -46,31 +46,47 @@ local function printString(expr: T.AstExprConstantString): string
 	return result
 end
 
---- Returns a string representation of an AstStatBlock
-local function printBlock(block: T.AstStatBlock): string
-	local printer = visitor.createVisitor()
-	local result = ""
+type PrintVisitor = visitor.Visitor & {
+	result: string,
+}
+
+local function printVisitor()
+	local printer = visitor.createVisitor() :: PrintVisitor
+	printer.result = ""
 
 	printer.visitToken = function(node: T.Token)
-		result ..= printToken(node)
+		printer.result ..= printToken(node)
 		return false
 	end
 
 	printer.visitString = function(node: T.AstExprConstantString)
-		result ..= printString(node)
+		printer.result ..= printString(node)
 		return false
 	end
 
 	printer.visitTypeString = function(node: T.AstTypeSingletonString)
-		result ..= printString(node)
+		printer.result ..= printString(node)
 		return false
 	end
 
-	visitor.visitBlock(block, printer)
+	return printer
+end
 
-	return result
+--- Returns a string representation of an AstStatBlock
+local function printBlock(block: T.AstStatBlock): string
+	local printer = printVisitor()
+	visitor.visitBlock(block, printer)
+	return printer.result
+end
+
+--- Returns a string representation of an AstExpr
+function printExpr(block: T.AstExpr): string
+	local printer = printVisitor()
+	visitor.visitExpression(block, printer)
+	return printer.result
 end
 
 return {
 	print = printBlock,
+	printexpr = printExpr,
 }

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -2,8 +2,9 @@
 
 local T = require("./ast_types")
 
-type Visitor = {
+export type Visitor = {
 	visitBlock: (T.AstStatBlock) -> boolean,
+	visitBlockEnd: (T.AstStatBlock) -> (),
 	visitIf: (T.AstStatIf) -> boolean,
 	visitWhile: (T.AstStatWhile) -> boolean,
 	visitRepeat: (T.AstStatRepeat) -> boolean,
@@ -17,6 +18,8 @@ type Visitor = {
 	visitLocalFunction: (T.AstStatLocalFunction) -> boolean,
 	visitTypeAlias: (T.AstStatTypeAlias) -> boolean,
 
+	visitExpression: (T.AstExpr) -> boolean,
+	visitExpressionEnd: (T.AstExpr) -> (),
 	visitLocalReference: (T.AstExprLocal) -> boolean,
 	visitGlobal: (T.AstExprGlobal) -> boolean,
 	visitCall: (T.AstExprCall) -> boolean,
@@ -28,6 +31,7 @@ type Visitor = {
 	visitIndexName: (T.AstExprIndexName) -> boolean,
 	visitIndexExpr: (T.AstExprIndexExpr) -> boolean,
 	visitGroup: (T.AstExprGroup) -> boolean,
+	visitInterpolatedString: (T.AstExprInterpString) -> boolean,
 
 	visitTypeReference: (T.AstTypeReference) -> boolean,
 	visitTypeBoolean: (T.AstTypeSingletonBool) -> boolean,
@@ -50,6 +54,7 @@ end
 
 local defaultVisitor: Visitor = {
 	visitBlock = alwaysVisit :: any,
+	visitBlockEnd = alwaysVisit :: any,
 	visitIf = alwaysVisit :: any,
 	visitWhile = alwaysVisit :: any,
 	visitRepeat = alwaysVisit :: any,
@@ -63,6 +68,8 @@ local defaultVisitor: Visitor = {
 	visitLocalFunction = alwaysVisit :: any,
 	visitTypeAlias = alwaysVisit :: any,
 
+	visitExpression = alwaysVisit :: any,
+	visitExpressionEnd = alwaysVisit :: any,
 	visitLocalReference = alwaysVisit :: any,
 	visitGlobal = alwaysVisit :: any,
 	visitCall = alwaysVisit :: any,
@@ -74,6 +81,7 @@ local defaultVisitor: Visitor = {
 	visitIndexName = alwaysVisit :: any,
 	visitIndexExpr = alwaysVisit :: any,
 	visitGroup = alwaysVisit :: any,
+	visitInterpolatedString = alwaysVisit :: any,
 
 	visitTypeReference = alwaysVisit :: any,
 	visitTypeBoolean = alwaysVisit :: any,
@@ -118,6 +126,8 @@ local function visitBlock(block: T.AstStatBlock, visitor: Visitor)
 		for _, statement in block.statements do
 			visitStatement(statement, visitor)
 		end
+
+		visitor.visitBlockEnd(block)
 	end
 end
 
@@ -447,38 +457,42 @@ local function visitTypeGroup(node: T.AstTypeGroup, visitor: Visitor)
 end
 
 function visitExpression(expression: T.AstExpr, visitor: Visitor)
-	if expression.tag == "nil" then
-		visitNil(expression, visitor)
-	elseif expression.tag == "boolean" then
-		visitBoolean(expression, visitor)
-	elseif expression.tag == "number" then
-		visitNumber(expression, visitor)
-	elseif expression.tag == "string" then
-		visitString(expression, visitor)
-	elseif expression.tag == "local" then
-		visitLocalReference(expression, visitor)
-	elseif expression.tag == "global" then
-		visitGlobal(expression, visitor)
-	elseif expression.tag == "vararg" then
-		visitVarargs(expression, visitor)
-	elseif expression.tag == "call" then
-		visitCall(expression, visitor)
-	elseif expression.tag == "unary" then
-		visitUnary(expression, visitor)
-	elseif expression.tag == "binary" then
-		visitBinary(expression, visitor)
-	elseif expression.tag == "function" then
-		visitAnonymousFunction(expression, visitor)
-	elseif expression.tag == "table" then
-		visitTable(expression, visitor)
-	elseif expression.tag == "indexname" then
-		visitIndexName(expression, visitor)
-	elseif expression.tag == "index" then
-		visitIndexExpr(expression, visitor)
-	elseif expression.tag == "group" then
-		visitGroup(expression, visitor)
-	else
-		exhaustiveMatch(expression.tag)
+	if visitor.visitExpression(expression) then
+		if expression.tag == "nil" then
+			visitNil(expression, visitor)
+		elseif expression.tag == "boolean" then
+			visitBoolean(expression, visitor)
+		elseif expression.tag == "number" then
+			visitNumber(expression, visitor)
+		elseif expression.tag == "string" then
+			visitString(expression, visitor)
+		elseif expression.tag == "local" then
+			visitLocalReference(expression, visitor)
+		elseif expression.tag == "global" then
+			visitGlobal(expression, visitor)
+		elseif expression.tag == "vararg" then
+			visitVarargs(expression, visitor)
+		elseif expression.tag == "call" then
+			visitCall(expression, visitor)
+		elseif expression.tag == "unary" then
+			visitUnary(expression, visitor)
+		elseif expression.tag == "binary" then
+			visitBinary(expression, visitor)
+		elseif expression.tag == "function" then
+			visitAnonymousFunction(expression, visitor)
+		elseif expression.tag == "table" then
+			visitTable(expression, visitor)
+		elseif expression.tag == "indexname" then
+			visitIndexName(expression, visitor)
+		elseif expression.tag == "index" then
+			visitIndexExpr(expression, visitor)
+		elseif expression.tag == "group" then
+			visitGroup(expression, visitor)
+		else
+			exhaustiveMatch(expression.tag)
+		end
+
+		visitor.visitExpressionEnd(expression)
 	end
 end
 
@@ -543,4 +557,7 @@ end
 return {
 	createVisitor = createVisitor,
 	visitBlock = visitBlock,
+	visitStatement = visitStatement,
+	visitExpression = visitExpression,
+	visitType = visitType,
 }

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -31,7 +31,6 @@ export type Visitor = {
 	visitIndexName: (T.AstExprIndexName) -> boolean,
 	visitIndexExpr: (T.AstExprIndexExpr) -> boolean,
 	visitGroup: (T.AstExprGroup) -> boolean,
-	visitInterpolatedString: (T.AstExprInterpString) -> boolean,
 
 	visitTypeReference: (T.AstTypeReference) -> boolean,
 	visitTypeBoolean: (T.AstTypeSingletonBool) -> boolean,
@@ -81,7 +80,6 @@ local defaultVisitor: Visitor = {
 	visitIndexName = alwaysVisit :: any,
 	visitIndexExpr = alwaysVisit :: any,
 	visitGroup = alwaysVisit :: any,
-	visitInterpolatedString = alwaysVisit :: any,
 
 	visitTypeReference = alwaysVisit :: any,
 	visitTypeBoolean = alwaysVisit :: any,

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -57,12 +57,16 @@ struct ExprResult
 
 static ExprResult parseExpr(std::string& source)
 {
+    // TODO: this is very bad, fix it!
+    FFlag::LuauStoreCSTData2.value = true;
+
     auto allocator = std::make_shared<Luau::Allocator>();
     auto names = std::make_shared<Luau::AstNameTable>(*allocator);
 
     Luau::ParseOptions options;
     options.captureComments = true;
     options.allowDeclarationSyntax = false;
+    options.storeCstData = true;
 
     auto parseResult = Luau::Parser::parseExpr(source.data(), source.size(), *names, *allocator, options);
 


### PR DESCRIPTION
To help make writing tests easier, we want to support returning a CST when parsing expressions directly. This PR adds CST support to the parseexpr function (as well as adding a wrapper around it in the batteries syntax package).

We extend the visitor set up to allow visiting an overall expression. We also add "end" visitors. For now, this is only for expression and blocks (as necessary for codemod tooling), however we may want to add "end" visitors for other nodes in the future.

The printer logic is also modified to support printing expressions directly.