### PR TITLE
Exit the process when the last thread errors and there is no work to do

### DIFF
--- a/runtime/include/lute/runtime.h
+++ b/runtime/include/lute/runtime.h
@@ -30,6 +30,7 @@ struct Runtime
     void runContinuously();
 
     bool hasContinuations();
+    bool hasThreads();
 
     void schedule(std::function<void()> f);
 

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -95,7 +95,12 @@ bool Runtime::runToCompletion()
             error += lua_debugtrace(L);
 
             fprintf(stderr, "%s", error.c_str());
-            continue;
+
+            // If we have no work to do, then exit the process.
+            if (!hasThreads() && !hasContinuations())
+                return false;
+            else
+                continue;
         }
 
         if (next.cont)
@@ -136,6 +141,11 @@ bool Runtime::hasContinuations()
 {
     std::unique_lock lock(continuationMutex);
     return !continuations.empty();
+}
+
+bool Runtime::hasThreads()
+{
+    return !runningThreads.empty();
 }
 
 void Runtime::schedule(std::function<void()> f)


### PR DESCRIPTION
In PR #195, a regression was accidentally introduced. When the process exits due to an error, it would return 0. This fixes that regression by checking if there is any work left to do. If the last thread was halted by an error, the process will exit.