### PR TITLE
Add process.exit() function with error code feedback

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "luau-lsp.fflags.enableNewSolver": true,
     "luau-lsp.sourcemap.enabled": false,
-    "luau-lsp.platform.type": "standard"
+    "luau-lsp.platform.type": "standard",
 }

--- a/process/include/lute/process.h
+++ b/process/include/lute/process.h
@@ -16,10 +16,13 @@ int run(lua_State* L);
 int homedir(lua_State* L);
 int cwd(lua_State* L);
 
+int exitFunc(lua_State* L);
+
 static const luaL_Reg lib[] = {
     {"run", run},
     {"homedir", homedir},
     {"cwd", cwd},
+    {"exit", exitFunc},
 
     {nullptr, nullptr}
 };

--- a/process/src/process.cpp
+++ b/process/src/process.cpp
@@ -6,7 +6,7 @@
 #include <memory>
 #include <functional>
 #include <map>
-#include <Common.h>
+#include "Luau/Common.h"
 
 #include "lua.h"
 #include "lualib.h"

--- a/process/src/process.cpp
+++ b/process/src/process.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <functional>
 #include <map>
+#include <Common.h>
 
 #include "lua.h"
 #include "lualib.h"

--- a/process/src/process.cpp
+++ b/process/src/process.cpp
@@ -439,21 +439,11 @@ int exitFunc(lua_State* L)
 {
     int exitCode = luaL_optinteger(L, 1, 0);
 
-    if (exitCode == 0)
-    {
-        fprintf(stderr, "Process exiting normally with code: %d\n", exitCode);
-    }
-    else
-    {
-        fprintf(stderr, "Process exiting with error code: %d\n", exitCode);
-    }
-
-    fflush(stderr);
 
     // Exit with the provided code
     std::exit(exitCode);
 
-    return 0; // This line will never be reached
+    LUAU_UNREACHABLE();
 }
 
 int cwd(lua_State* L)

--- a/process/src/process.cpp
+++ b/process/src/process.cpp
@@ -435,6 +435,27 @@ int homedir(lua_State* L)
     return 1;
 }
 
+int exitFunc(lua_State* L)
+{
+    int exitCode = luaL_optinteger(L, 1, 0);
+
+    if (exitCode == 0)
+    {
+        fprintf(stderr, "Process exiting normally with code: %d\n", exitCode);
+    }
+    else
+    {
+        fprintf(stderr, "Process exiting with error code: %d\n", exitCode);
+    }
+
+    fflush(stderr);
+
+    // Exit with the provided code
+    std::exit(exitCode);
+
+    return 0; // This line will never be reached
+}
+
 int cwd(lua_State* L)
 {
     std::string buffer;


### PR DESCRIPTION
Adds a new process.exit() function to the process module that allows scripts to terminate execution with a specified exit code. Includes diagnostic output to stderr indicating the exit code for debugging purposes.

Closes #228 