### PR TITLE
Improve stack trace when debugging required modules

### DIFF
--- a/runtime/src/require.cpp
+++ b/runtime/src/require.cpp
@@ -269,22 +269,26 @@ static int load(lua_State* L, void* ctx, const char* chunkname, const char* cont
             const std::string prefix = "module " + std::string(chunknameView.substr(1)) + " must";
 
             if (lua_gettop(ML) == 0)
-                lua_pushstring(ML, (prefix + " return a value, if it has no return value, you should explicitly return `nil`").c_str());
+                lua_pushstring(ML, (prefix + " return a value, if it has no return value, you should explicitly return `nil`\n").c_str());
         }
         else if (status == LUA_YIELD)
         {
-            lua_pushstring(ML, "module can not yield");
+            lua_pushstring(ML, "module can not yield\n");
         }
         else if (!lua_isstring(ML, -1))
         {
-            lua_pushstring(ML, "unknown error while running module");
+            lua_pushstring(ML, "unknown error while running module\n");
         }
     }
 
     // add ML result to L stack
     lua_xmove(ML, L, 1);
     if (lua_isstring(L, -1))
+    {
+        lua_pushstring(L, lua_debugtrace(ML));
+        lua_concat(L, 2);
         lua_error(L);
+    }
 
     // remove ML thread from L stack
     lua_remove(L, -2);


### PR DESCRIPTION
Required modules run in their own threads in Lute, and there isn't an easy way to automatically "inherit" a stack trace across a thread boundary. To make it more user-friendly to debug where an issue is coming from in required modules, each module thread now stores its stack trace in its error message in the case of an error, appended to the actual error message.

---

To demonstrate, I have five Luau files that require each other in a chain: `a.luau`, `b.luau`, `c.luau`, `d.luau`, and `e.luau`. At the end of the chain, `e.luau` attempts to (illegally) yield.

Prior to this change, Lute outputted this:
```
module can not yield
stacktrace:
[C] function require
a:1
```

This is what Lute outputs now:
```
module can not yield
[C] function yield
./e:1
[C] function require
./d:1
[C] function require
./c:1
[C] function require
./b:1

stacktrace:
[C] function require
a:1
```

Fixes #131.