### PR TITLE
Fix release builds by marking assert variable with maybe_unused

### DIFF
--- a/time/src/time.cpp
+++ b/time/src/time.cpp
@@ -360,7 +360,7 @@ int lua_now(lua_State* L)
 {
     uv_timespec64_t now;
 
-    int status = uv_clock_gettime(UV_CLOCK_MONOTONIC, &now);
+    [[maybe_unused]] int status = uv_clock_gettime(UV_CLOCK_MONOTONIC, &now);
     assert(status == 0);
 
     uv_timespec64_t* timespec = static_cast<uv_timespec64_t*>(lua_newuserdatatagged(L, sizeof(uv_timespec64_t), kInstantTag));


### PR DESCRIPTION
In a release build asserts are compiled out, so we get an unused variable error. We can use the C++17 feature of marking variables as `maybe_unused` to fix this.