### PR TITLE
CST: Serialize and print EOF trivia properly

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -36,6 +36,8 @@ export type Token<Kind = string> = {
 	read trailingTrivia: { Trivia },
 }
 
+export type Eof = Token<nil> & { tag: "eof" }
+
 export type Pair<T, Separator> = { node: T, separator: Token<Separator>? }
 export type Punctuated<T, Separator = ","> = { Pair<T, Separator> }
 

--- a/batteries/syntax/parser.luau
+++ b/batteries/syntax/parser.luau
@@ -12,7 +12,18 @@ local function parseexpr(source: string): T.AstExpr
 	return luau.parseexpr(source)
 end
 
+export type ParseResult = {
+	root: T.AstStatBlock,
+	eof: T.Eof,
+}
+
+local function parsefile(source: string): ParseResult
+	local result = luau.parse(source)
+	return { root = result.root, eof = result.eof }
+end
+
 return {
 	parse = parse,
 	parseexpr = parseexpr,
+	parsefile = parsefile,
 }

--- a/batteries/syntax/printer.luau
+++ b/batteries/syntax/printer.luau
@@ -116,7 +116,15 @@ function printExpr(block: T.AstExpr): string
 	return printer.result
 end
 
+function printFile(result: { root: T.AstStatBlock, eof: T.Eof }): string
+	local printer = printVisitor()
+	visitor.visitBlock(result.root, printer)
+	visitor.visitToken(result.eof, printer)
+	return printer.result
+end
+
 return {
 	print = printBlock,
 	printexpr = printExpr,
+	printfile = printFile,
 }

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -585,4 +585,5 @@ return {
 	visitStatement = visitStatement,
 	visitExpression = visitExpression,
 	visitType = visitType,
+	visitToken = visitToken,
 }

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -626,6 +626,14 @@ struct AstSerialize : public Luau::AstVisitor
         }
     }
 
+    void serializeEof(Luau::Position eofPosition)
+    {
+        serializeToken(eofPosition, "");
+
+        lua_pushstring(L, "eof");
+        lua_setfield(L, -2, "tag");
+    }
+
     void serialize(Luau::AstExprGroup* node)
     {
         lua_rawcheckstack(L, 2);
@@ -1980,11 +1988,14 @@ int luau_parse(lua_State* L)
 
     lua_rawcheckstack(L, 3);
 
-    lua_createtable(L, 0, 2);
+    lua_createtable(L, 0, 3);
 
     AstSerialize serializer{L, source, result.parseResult.cstNodeMap, result.parseResult.commentLocations};
     serializer.visit(result.parseResult.root);
     lua_setfield(L, -2, "root");
+
+    serializer.serializeEof(result.parseResult.root->location.end);
+    lua_setfield(L, -2, "eof");
 
     lua_pushnumber(L, result.parseResult.lines);
     lua_setfield(L, -2, "lines");

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -124,6 +124,7 @@ local function test_roundtrippableAst()
 		"examples/async_read.luau",
 		"examples/b.luau",
 		"examples/badisnan.luau",
+		"examples/compile.luau",
 		"examples/directories.luau",
 		"examples/json.luau",
 		"examples/main.luau",
@@ -134,6 +135,7 @@ local function test_roundtrippableAst()
 		"examples/parallel_sort.luau",
 		"examples/parsing.luau",
 		"examples/process_env.luau",
+		"examples/serve.luau",
 		"examples/spawn_example.luau",
 		"examples/time_example.luau",
 		"examples/writeFile.luau",
@@ -154,11 +156,9 @@ local function test_roundtrippableAst()
 	}
 
 	for _, path in files do
+		print(path)
 		local source = fs.readfiletostring(path)
-		local result = printer.print(parser.parse(source))
-
-		-- FIXME: we currently don't handle the EOF character (and its trivia) in the CST
-		result ..= "\n"
+		local result = printer.printfile(parser.parsefile(source))
 
 		assert(source == result)
 	end


### PR DESCRIPTION
The CST works by attaching trivia between tokens as trailing trivia of the previous token or leading trivia of the currently processed token. However, right now the CST does not serialize any trailing trivia of the file properly (e.g. whitespace such as newline at EOF, or files composed solely of comments). This is because we do not process a final token to attach leading trivia to.

This PR introduces a final "EOF" token that is composed solely of leading trivia at the end of the file. This is not a concept in the Luau AST itself, so we need to extend our parse result to carry the "eof" token separately, independent of the AstStatBlock.

An alternative approach could be to attach all trivia at the end of the file as trailing trivia of the last processed token. However, this ends up special casing this particular token and breaks the guarantee that the trailing trivia will only consist of trivia up to and including a single newline character. As such, downstream tooling would potentially need to handle final statement / expressions in files separately to all other statements / expressions if they cared about trivia processing (e.g., formatters). Also, this would not work for files consisting solely of trivia, as there is no token present.