### PR TITLE
CST: Improve support for conditionals

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -168,6 +168,24 @@ export type AstExprTypeAssertion = {
 	annotation: AstType,
 }
 
+export type AstExprIfElseIfs = {
+	["elseif"]: Token<"elseif">,
+	condition: AstExpr,
+	["then"]: Token<"then">,
+	consequent: AstExpr,
+}
+
+export type AstExprIfElse = {
+	tag: "conditional",
+	["if"]: Token<"if">,
+	condition: AstExpr,
+	["then"]: Token<"then">,
+	consequent: AstExpr,
+	elseifs: { AstExprIfElseIfs },
+	["else"]: Token<"else">,
+	antecedent: AstExpr,
+}
+
 export type AstExpr =
 	| AstExprGroup
 	| AstExprConstantNil
@@ -186,6 +204,7 @@ export type AstExpr =
 	| AstExprBinary
 	| AstExprInterpString
 	| AstExprTypeAssertion
+	| AstExprIfElse
 
 export type AstStatBlock = {
 	tag: "block",

--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -192,12 +192,20 @@ export type AstStatBlock = {
 	statements: { AstStat },
 }
 
+export type AstStatElseIf = {
+	["elseif"]: Token<"elseif">,
+	condition: AstExpr,
+	["then"]: Token<"then">,
+	consequent: AstStatBlock,
+}
+
 export type AstStatIf = {
 	tag: "conditional",
 	["if"]: Token<"if">,
 	condition: AstExpr,
 	["then"]: Token<"then">,
 	consequent: AstStatBlock,
+	elseifs: { AstStatElseIf },
 	["else"]: Token<"else">, -- TODO: this could be elseif!
 	antecedent: AstStatBlock,
 	["end"]: Token<"end">,

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -139,7 +139,12 @@ local function visitIf(node: T.AstStatIf, visitor: Visitor)
 		visitExpression(node.condition, visitor)
 		visitToken(node["then"], visitor)
 		visitBlock(node.consequent, visitor)
-		-- TODO: special handling for elseif?
+		for _, elseifNode in node.elseifs do
+			visitToken(elseifNode["elseif"], visitor)
+			visitExpression(elseifNode.condition, visitor)
+			visitToken(elseifNode["then"], visitor)
+			visitBlock(elseifNode.consequent, visitor)
+		end
 		if node["else"] then
 			visitToken(node["else"], visitor)
 		end

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -33,6 +33,7 @@ export type Visitor = {
 	visitGroup: (T.AstExprGroup) -> boolean,
 	visitInterpolatedString: (T.AstExprInterpString) -> boolean,
 	visitTypeAssertion: (T.AstExprTypeAssertion) -> boolean,
+	visitIfExpression: (T.AstExprIfElse) -> boolean,
 
 	visitTypeReference: (T.AstTypeReference) -> boolean,
 	visitTypeBoolean: (T.AstTypeSingletonBool) -> boolean,
@@ -84,6 +85,7 @@ local defaultVisitor: Visitor = {
 	visitGroup = alwaysVisit :: any,
 	visitInterpolatedString = alwaysVisit,
 	visitTypeAssertion = alwaysVisit,
+	visitIfExpression = alwaysVisit,
 
 	visitTypeReference = alwaysVisit :: any,
 	visitTypeBoolean = alwaysVisit :: any,
@@ -432,6 +434,23 @@ local function visitTypeAssertion(node: T.AstExprTypeAssertion, visitor: Visitor
 	end
 end
 
+local function visitIfExpression(node: T.AstExprIfElse, visitor: Visitor)
+	if visitor.visitIfExpression(node) then
+		visitToken(node["if"], visitor)
+		visitExpression(node.condition, visitor)
+		visitToken(node["then"], visitor)
+		visitExpression(node.consequent, visitor)
+		for _, elseifs in node["elseifs"] do
+			visitToken(elseifs["elseif"], visitor)
+			visitExpression(elseifs.condition, visitor)
+			visitToken(elseifs["then"], visitor)
+			visitExpression(elseifs.consequent, visitor)
+		end
+		visitToken(node["else"], visitor)
+		visitExpression(node.antecedent, visitor)
+	end
+end
+
 local function visitTypeReference(node: T.AstTypeReference, visitor: Visitor)
 	if visitor.visitTypeReference(node) then
 		if node.prefix then
@@ -518,6 +537,8 @@ function visitExpression(expression: T.AstExpr, visitor: Visitor)
 			visitInterpolatedString(expression, visitor)
 		elseif expression.tag == "cast" then
 			visitTypeAssertion(expression, visitor)
+		elseif expression.tag == "conditional" then
+			visitIfExpression(expression, visitor)
 		else
 			exhaustiveMatch(expression.tag)
 		end

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -973,22 +973,76 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprIfElse* node)
     {
+        const auto* cstNode = lookupCstNode<Luau::CstExprIfElse>(node);
+
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 3);
+        lua_createtable(L, 0, preambleSize + 7);
 
         serializeNodePreamble(node, "conditional");
+
+        serializeToken(node->location.begin, "if");
+        lua_setfield(L, -2, "if");
 
         node->condition->visit(this);
         lua_setfield(L, -2, "condition");
 
         if (node->hasThen)
+        {
+            if (cstNode)
+            {
+                serializeToken(cstNode->thenPosition, "then");
+                lua_setfield(L, -2, "then");
+            }
+
             node->trueExpr->visit(this);
+        }
         else
             lua_pushnil(L);
         lua_setfield(L, -2, "consequent");
 
+        lua_createtable(L, 0, preambleSize + 4);
+        int i = 0;
+        while (node->hasElse && node->falseExpr->is<Luau::AstExprIfElse>())
+        {
+            lua_createtable(L, 0, 4);
+
+            node = node->falseExpr->as<Luau::AstExprIfElse>();
+            cstNode = lookupCstNode<Luau::CstExprIfElse>(node);
+
+            serializeToken(node->location.begin, "elseif");
+            lua_setfield(L, -2, "elseif");
+
+            node->condition->visit(this);
+            lua_setfield(L, -2, "condition");
+
+            if (node->hasThen)
+            {
+                if (cstNode)
+                {
+                    serializeToken(cstNode->thenPosition, "then");
+                    lua_setfield(L, -2, "then");
+                }
+
+                node->trueExpr->visit(this);
+            }
+            else
+                lua_pushnil(L);
+            lua_setfield(L, -2, "consequent");
+
+            lua_rawseti(L, -2, i + 1);
+            i++;
+        }
+        lua_setfield(L, -2, "elseifs");
+
         if (node->hasElse)
+        {
+            if (cstNode)
+            {
+                serializeToken(cstNode->elsePosition, "else");
+                lua_setfield(L, -2, "else");
+            }
             node->falseExpr->visit(this);
+        }
         else
             lua_pushnil(L);
         lua_setfield(L, -2, "antecedent");

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1079,6 +1079,31 @@ struct AstSerialize : public Luau::AstVisitor
         node->thenbody->visit(this);
         lua_setfield(L, -2, "consequent");
 
+        lua_createtable(L, 0, preambleSize + 4);
+        int i = 0;
+        while (node->elsebody && node->elsebody->is<Luau::AstStatIf>())
+        {
+            lua_createtable(L, 0, 4);
+
+            auto elseif = node->elsebody->as<Luau::AstStatIf>();
+            serializeToken(elseif->location.begin, "elseif");
+            lua_setfield(L, -2, "elseif");
+
+            elseif->condition->visit(this);
+            lua_setfield(L, -2, "condition");
+
+            serializeToken(elseif->thenLocation->begin, "then");
+            lua_setfield(L, -2, "then");
+
+            elseif->thenbody->visit(this);
+            lua_setfield(L, -2, "consequent");
+
+            lua_rawseti(L, -2, i + 1);
+            node = elseif;
+            i++;
+        }
+        lua_setfield(L, -2, "elseifs");
+
         if (node->elsebody)
         {
             LUAU_ASSERT(node->elseLocation);

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1002,7 +1002,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         lua_createtable(L, 0, preambleSize + 4);
         int i = 0;
-        while (node->hasElse && node->falseExpr->is<Luau::AstExprIfElse>())
+        while (node->hasElse && node->falseExpr->is<Luau::AstExprIfElse>() && (!cstNode || cstNode->isElseIf))
         {
             lua_createtable(L, 0, 4);
 

--- a/tests/astSerializerTests/if-expression-1.luau
+++ b/tests/astSerializerTests/if-expression-1.luau
@@ -1,0 +1,2 @@
+local x = if true then 1 else 2
+local y = if true then 1 elseif false then 2 else 3

--- a/tests/astSerializerTests/if-expression-2.luau
+++ b/tests/astSerializerTests/if-expression-2.luau
@@ -1,3 +1,4 @@
+-- stylua: ignore
 local x = if true
 	then call()
 	else if false

--- a/tests/astSerializerTests/if-expression-2.luau
+++ b/tests/astSerializerTests/if-expression-2.luau
@@ -1,0 +1,5 @@
+local x = if true
+	then call()
+	else if false
+		then call()
+		else call()

--- a/tests/astSerializerTests/if-statement-1.luau
+++ b/tests/astSerializerTests/if-statement-1.luau
@@ -1,0 +1,17 @@
+if true then
+	print()
+end
+
+if true then
+	print()
+else
+	print()
+end
+
+if true then
+	print()
+elseif false then
+	print()
+else
+	print()
+end

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -150,6 +150,7 @@ local function test_roundtrippableAst()
 		"tests/astSerializerTests/function-declaration-2.luau",
 		"tests/astSerializerTests/generic-for-loop-1.luau",
 		"tests/astSerializerTests/if-expression-1.luau",
+		"tests/astSerializerTests/if-expression-2.luau",
 		"tests/astSerializerTests/if-statement-1.luau",
 		"tests/astSerializerTests/interpolated-string-1.luau",
 		"tests/astSerializerTests/interpolated-string-2.luau",

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -145,6 +145,7 @@ local function test_roundtrippableAst()
 		"tests/astSerializerTests/function-declaration-1.luau",
 		"tests/astSerializerTests/function-declaration-2.luau",
 		"tests/astSerializerTests/generic-for-loop-1.luau",
+		"tests/astSerializerTests/if-statement-1.luau",
 		"tests/astSerializerTests/interpolated-string-1.luau",
 		"tests/astSerializerTests/interpolated-string-2.luau",
 		"tests/astSerializerTests/local-function-declaration-1.luau",

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -124,6 +124,7 @@ local function test_roundtrippableAst()
 		"examples/async_read.luau",
 		"examples/b.luau",
 		"examples/badisnan.luau",
+		-- "examples/cliargs.luau", genuine failure
 		"examples/compile.luau",
 		"examples/directories.luau",
 		"examples/json.luau",
@@ -135,9 +136,12 @@ local function test_roundtrippableAst()
 		"examples/parallel_sort.luau",
 		"examples/parsing.luau",
 		"examples/process_env.luau",
+		-- "examples/process.luau", genuine failure (table?)
+		-- "examples/serve_html.luau", genuine failure (advancing)
 		"examples/serve.luau",
 		"examples/spawn_example.luau",
 		"examples/time_example.luau",
+		-- "examples/toml.luau", genuine failure
 		"examples/writeFile.luau",
 		"tests/astSerializerTests/assignment-1.luau",
 		"tests/astSerializerTests/break-continue-1.luau",
@@ -145,6 +149,7 @@ local function test_roundtrippableAst()
 		"tests/astSerializerTests/function-declaration-1.luau",
 		"tests/astSerializerTests/function-declaration-2.luau",
 		"tests/astSerializerTests/generic-for-loop-1.luau",
+		"tests/astSerializerTests/if-expression-1.luau",
 		"tests/astSerializerTests/if-statement-1.luau",
 		"tests/astSerializerTests/interpolated-string-1.luau",
 		"tests/astSerializerTests/interpolated-string-2.luau",
@@ -163,6 +168,7 @@ local function test_roundtrippableAst()
 		local source = fs.readfiletostring(path)
 		local result = printer.printfile(parser.parsefile(source))
 
+		print(result)
 		assert(source == result)
 	end
 end


### PR DESCRIPTION
This PR:
- Fixes the handling of `elseif` clauses in conditional statements; and
- Introduces serialization for if-expressions

When serializing elseifs to Luau (both in the statement and expression case), we store it as an array of specific elseif nodes. Note that such an elseif node does not exist in the C++ representation of the AST: instead the C++ AST stores elseif chains in a "linked list" format: for `AstStatIf`, if `elsebody` is another `AstStatIf`, then it is actually an elseif.

However, the array representation is a simpler representation in Luau, allows us to differentiate between the `if` and `elseif` token correctly, and makes it easier to post-process in downstream consumers.