### PR TITLE
Maintain a ref for the new thread created in net.serve request handling

### DIFF
--- a/net/src/net.cpp
+++ b/net/src/net.cpp
@@ -238,6 +238,7 @@ static void processRequest(
 )
 {
     lua_State* L = lua_newthread(state->runtime->GL);
+    luaL_sandboxthread(L);
     std::shared_ptr<Ref> threadRef = getRefForThread(L);
     lua_pop(state->runtime->GL, 1);
 

--- a/net/src/net.cpp
+++ b/net/src/net.cpp
@@ -238,6 +238,8 @@ static void processRequest(
 )
 {
     lua_State* L = lua_newthread(state->runtime->GL);
+    std::shared_ptr<Ref> threadRef = getRefForThread(L);
+    lua_pop(state->runtime->GL, 1);
 
     lua_createtable(L, 0, 5);
 


### PR DESCRIPTION
With high amounts of requests it seems like the GC is cleaning in-flight threads causing the process to exit. Holding onto a ref is fixing this behavior for me.