### PR TITLE
CST: Handle table types

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -412,6 +412,49 @@ export type AstTypeIntersection = {
 	types: Punctuated<AstType, "&">,
 }
 
+export type AstTypeArray = {
+	tag: "array",
+	openBrace: Token<"{">,
+	access: Token<"read" | "write">?,
+	type: AstType,
+	closeBrace: Token<"}">,
+}
+
+export type AstTypeTableItem = {
+	kind: "indexer",
+	access: Token<"read" | "write">?,
+	indexerOpen: Token<"[">,
+	key: AstType,
+	indexerClose: Token<"]">,
+	colon: Token<":">,
+	value: AstType,
+	separator: Token<"," | ";">?,
+} | {
+	kind: "stringproperty",
+	access: Token<"read" | "write">?,
+	indexerOpen: Token<"[">,
+	key: AstTypeSingletonString,
+	indexerClose: Token<"]">,
+	colon: Token<":">,
+	value: AstType,
+	separator: Token<"," | ";">?,
+} | {
+	kind: "property",
+	access: Token<"read" | "write">?,
+	key: AstTypeSingletonString,
+	indexerClose: Token<"]">,
+	colon: Token<":">,
+	value: AstType,
+	separator: Token<"," | ";">?,
+}
+
+export type AstTypeTable = {
+	tag: "table",
+	openBrace: Token<"{">,
+	entries: { AstTypeTableItem },
+	closeBrace: Token<"}">,
+}
+
 export type AstType =
 	| AstTypeReference
 	| AstTypeSingletonBool
@@ -421,5 +464,7 @@ export type AstType =
 	| AstTypeUnion
 	| AstTypeIntersection
 	| AstTypeOptional
+	| AstTypeArray
+	| AstTypeTable
 
 return {}

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -43,6 +43,8 @@ export type Visitor = {
 	visitTypeGroup: (T.AstTypeGroup) -> boolean,
 	visitTypeUnion: (T.AstTypeUnion) -> boolean,
 	visitTypeIntersection: (T.AstTypeIntersection) -> boolean,
+	visitTypeArray: (T.AstTypeArray) -> boolean,
+	visitTypeTable: (T.AstTypeTable) -> boolean,
 
 	visitToken: (T.Token) -> boolean,
 	visitNil: (T.AstExprConstantNil) -> boolean,
@@ -98,6 +100,8 @@ local defaultVisitor: Visitor = {
 	visitTypeGroup = alwaysVisit :: any,
 	visitTypeUnion = alwaysVisit :: any,
 	visitTypeIntersection = alwaysVisit :: any,
+	visitTypeArray = alwaysVisit :: any,
+	visitTypeTable = alwaysVisit :: any,
 
 	visitToken = alwaysVisit :: any,
 	visitNil = alwaysVisit :: any,
@@ -537,6 +541,45 @@ local function visitTypeIntersection(node: T.AstTypeIntersection, visitor: Visit
 	end
 end
 
+local function visitTypeArray(node: T.AstTypeArray, visitor: Visitor)
+	if visitor.visitTypeArray(node) then
+		visitToken(node.openBrace, visitor)
+		if node.access then
+			visitToken(node.access, visitor)
+		end
+		visitType(node.type, visitor)
+		visitToken(node.closeBrace, visitor)
+	end
+end
+
+local function visitTypeTable(node: T.AstTypeTable, visitor: Visitor)
+	if visitor.visitTypeTable(node) then
+		visitToken(node.openBrace, visitor)
+		for _, entry in node.entries do
+			if entry.access then
+				visitToken(entry.access, visitor)
+			end
+			if entry.kind == "indexer" then
+				visitToken(entry.indexerOpen, visitor)
+				visitType(entry.key, visitor)
+				visitToken(entry.indexerClose, visitor)
+			elseif entry.kind == "stringproperty" then
+				visitToken(entry.indexerOpen, visitor)
+				visitTypeString(entry.key, visitor)
+				visitToken(entry.indexerClose, visitor)
+			else
+				visitToken(entry.key, visitor)
+			end
+			visitToken(entry.colon, visitor)
+			visitType(entry.value, visitor)
+			if entry.separator then
+				visitToken(entry.separator, visitor)
+			end
+		end
+		visitToken(node.closeBrace, visitor)
+	end
+end
+
 function visitExpression(expression: T.AstExpr, visitor: Visitor)
 	if visitor.visitExpression(expression) then
 		if expression.tag == "nil" then
@@ -640,6 +683,10 @@ function visitType(type: T.AstType, visitor: Visitor)
 		visitTypeIntersection(type, visitor)
 	elseif type.tag == "optional" then
 		visitToken(type, visitor)
+	elseif type.tag == "array" then
+		visitTypeArray(type, visitor)
+	elseif type.tag == "table" then
+		visitTypeTable(type, visitor)
 	else
 		exhaustiveMatch(type.tag)
 	end

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1733,9 +1733,8 @@ struct AstSerialize : public Luau::AstVisitor
                     lua_setfield(L, -2, "indexerOpen");
 
                     {
-                        // TODO: fix start position
-                        auto initialPosition = currentPosition;
-                        serializeToken(initialPosition, item.stringInfo->sourceString.data);
+                        auto initialPosition = item.stringPosition;
+                        serializeToken(item.stringPosition, item.stringInfo->sourceString.data);
 
                         switch (item.stringInfo->quoteStyle)
                         {

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -1619,7 +1619,177 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeType(Luau::AstTypeTable* node)
     {
-        // TODO: types
+        const auto cstNode = lookupCstNode<Luau::CstTypeTable>(node);
+
+        LUAU_ASSERT(cstNode); // TODO: handle non cst node
+
+        if (cstNode->isArray)
+        {
+            lua_rawcheckstack(L, 2);
+            lua_createtable(L, 0, preambleSize + 4);
+
+            serializeNodePreamble(node, "array");
+
+            serializeToken(node->location.begin, "{");
+            lua_setfield(L, -2, "openBrace");
+
+            if (node->indexer->accessLocation)
+            {
+                LUAU_ASSERT(node->indexer->access != Luau::AstTableAccess::ReadWrite);
+                serializeToken(node->indexer->accessLocation->begin, node->indexer->access == Luau::AstTableAccess::Read ? "read" : "write");
+            }
+            else
+                lua_pushnil(L);
+            lua_setfield(L, -2, "access");
+
+            node->indexer->resultType->visit(this);
+            lua_setfield(L, -2, "type");
+
+            serializeToken(Luau::Position{node->location.end.line, node->location.end.column - 1}, "}");
+            lua_setfield(L, -2, "closeBrace");
+
+            return;
+        }
+
+        lua_rawcheckstack(L, 2);
+        lua_createtable(L, 0, preambleSize + 4);
+
+        serializeNodePreamble(node, "table");
+
+        serializeToken(node->location.begin, "{");
+        lua_setfield(L, -2, "openBrace");
+
+        lua_createtable(L, cstNode->items.size, 0);
+        const Luau::AstTableProp* prop = node->props.begin();
+        for (size_t i = 0; i < cstNode->items.size; i++)
+        {
+            lua_rawcheckstack(L, 2);
+            lua_createtable(L, 0, 8);
+
+            Luau::CstTypeTable::Item item = cstNode->items.data[i];
+
+            if (item.kind == Luau::CstTypeTable::Item::Kind::Indexer)
+            {
+                LUAU_ASSERT(node->indexer);
+
+                lua_pushstring(L, "indexer");
+                lua_setfield(L, -2, "kind");
+
+                if (node->indexer->accessLocation)
+                {
+                    LUAU_ASSERT(node->indexer->access != Luau::AstTableAccess::ReadWrite);
+                    serializeToken(node->indexer->accessLocation->begin, node->indexer->access == Luau::AstTableAccess::Read ? "read" : "write");
+                }
+                else
+                    lua_pushnil(L);
+                lua_setfield(L, -2, "access");
+
+                serializeToken(item.indexerOpenPosition, "[");
+                lua_setfield(L, -2, "indexerOpen");
+
+                node->indexer->indexType->visit(this);
+                lua_setfield(L, -2, "key");
+
+                serializeToken(item.indexerClosePosition, "]");
+                lua_setfield(L, -2, "indexerClose");
+
+                serializeToken(item.colonPosition, ":");
+                lua_setfield(L, -2, "colon");
+
+                node->indexer->resultType->visit(this);
+                lua_setfield(L, -2, "value");
+
+                if (item.separator)
+                    serializeToken(*item.separatorPosition, item.separator == Luau::CstExprTable::Comma ? "," : ";");
+                else
+                    lua_pushnil(L);
+                lua_setfield(L, -2, "separator");
+            }
+            else
+            {
+                if (item.kind == Luau::CstTypeTable::Item::Kind::StringProperty)
+                {
+                    lua_pushstring(L, "stringproperty");
+                    lua_setfield(L, -2, "kind");
+                }
+                else
+                {
+                    lua_pushstring(L, "property");
+                    lua_setfield(L, -2, "kind");
+                }
+
+                if (prop->accessLocation)
+                {
+                    LUAU_ASSERT(prop->access != Luau::AstTableAccess::ReadWrite);
+                    serializeToken(prop->accessLocation->begin, prop->access == Luau::AstTableAccess::Read ? "read" : "write");
+                }
+                else
+                    lua_pushnil(L);
+                lua_setfield(L, -2, "access");
+
+                if (item.kind == Luau::CstTypeTable::Item::Kind::StringProperty)
+                {
+                    serializeToken(item.indexerOpenPosition, "[");
+                    lua_setfield(L, -2, "indexerOpen");
+
+                    {
+                        // TODO: fix start position
+                        auto initialPosition = currentPosition;
+                        serializeToken(initialPosition, item.stringInfo->sourceString.data);
+
+                        switch (item.stringInfo->quoteStyle)
+                        {
+                        case Luau::CstExprConstantString::QuotedSingle:
+                            lua_pushstring(L, "single");
+                            break;
+                        case Luau::CstExprConstantString::QuotedDouble:
+                            lua_pushstring(L, "double");
+                            break;
+                        default:
+                            LUAU_ASSERT(false);
+                        }
+                        lua_setfield(L, -2, "quoteStyle");
+
+                        // Unlike normal tokens, string content contains quotation marks that were not included during advancement
+                        // For simplicity, lets set the current position manually
+                        // If string part was single line, end position = current position + 2 (start and end character)
+                        // If string parts was multi line, end position = current position + 1 (just end character)
+                        if (initialPosition.line == currentPosition.line)
+                            currentPosition.column += 2;
+                        else
+                            currentPosition.column += 1;
+                    }
+                    lua_setfield(L, -2, "key");
+
+                    serializeToken(item.indexerClosePosition, "]");
+                    lua_setfield(L, -2, "indexerClose");
+                }
+                else
+                {
+                    serializeToken(prop->location.begin, prop->name.value);
+                    lua_setfield(L, -2, "key");
+                }
+
+                serializeToken(item.colonPosition, ":");
+                lua_setfield(L, -2, "colon");
+
+                prop->type->visit(this);
+                lua_setfield(L, -2, "value");
+
+                if (item.separator)
+                    serializeToken(*item.separatorPosition, item.separator == Luau::CstExprTable::Comma ? "," : ";");
+                else
+                    lua_pushnil(L);
+                lua_setfield(L, -2, "separator");
+
+                ++prop;
+            }
+            lua_rawseti(L, -2, i + 1);
+        }
+        lua_setfield(L, -2, "entries");
+
+        serializeToken(Luau::Position{node->location.end.line, node->location.end.column - 1}, "}");
+        lua_setfield(L, -2, "closeBrace");
     }
 
     void serializeType(Luau::AstTypeFunction* node)
@@ -2071,7 +2241,8 @@ struct AstSerialize : public Luau::AstVisitor
 
     bool visit(Luau::AstTypeTable* node) override
     {
-        return true;
+        serializeType(node);
+        return false;
     }
 
     bool visit(Luau::AstTypeFunction* node) override

--- a/tests/astSerializerTests/type-tables-1.luau
+++ b/tests/astSerializerTests/type-tables-1.luau
@@ -1,0 +1,5 @@
+type A = { string }
+type B = { foo: string }
+type C = { [string]: number }
+type D = { foo: string, [string]: number, bar: string }
+type E = { ["a type"]: string }

--- a/tests/astSerializerTests/type-tables-2.luau
+++ b/tests/astSerializerTests/type-tables-2.luau
@@ -1,0 +1,2 @@
+-- stylua: ignore
+type A = { [  "a type"]: string }

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -164,6 +164,7 @@ local function test_roundtrippableAst()
 		"tests/astSerializerTests/type-assertion-1.luau",
 		"tests/astSerializerTests/type-function-1.luau",
 		"tests/astSerializerTests/type-singletons-1.luau",
+		"tests/astSerializerTests/type-tables-1.luau",
 		"tests/astSerializerTests/while-1.luau",
 		"tests/astSerializerTests/repeat-until-1.luau",
 	}

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -165,6 +165,7 @@ local function test_roundtrippableAst()
 		"tests/astSerializerTests/type-function-1.luau",
 		"tests/astSerializerTests/type-singletons-1.luau",
 		"tests/astSerializerTests/type-tables-1.luau",
+		"tests/astSerializerTests/type-tables-2.luau",
 		"tests/astSerializerTests/while-1.luau",
 		"tests/astSerializerTests/repeat-until-1.luau",
 	}


### PR DESCRIPTION
This PR adds support for handling table types as part of the CST.

Type tables are serialized as a list of separate table items, split by a separator (either a comma or a semicolon). The separator is included as part of the item node.

We add a special case node `AstTypeArray` to handle the `{ number }` case. Although this node does not exist on the C++ side, we serialize it independently in Luau for easier ergonomics, given that an array type cannot be mixed with a general table type.