### PR TITLE
Re-enable Linux arm releases

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -26,6 +26,7 @@ runs:
       uses: Roblox/setup-foreman@v3
       with:
         token: ${{ inputs.token }}
+        allow-external-github-orgs: true
 
     - name: Install dependencies (Linux)
       if: runner.os == 'Linux'

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -23,7 +23,7 @@ runs:
   using: "composite"
   steps:
     - name: Install tools
-      uses: Roblox/setup-foreman@v1
+      uses: Roblox/setup-foreman@v3
       with:
         token: ${{ inputs.token }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install tools
-        uses: Roblox/setup-foreman@v1
+        uses: Roblox/setup-foreman@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         uses: Roblox/setup-foreman@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          allow-external-github-orgs: true
 
       - name: Run StyLua
         run: stylua --check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,9 @@ jobs:
           - os: ubuntu-latest
             artifact_name: lute-linux-x86_64
             options: --c-compiler clang --cxx-compiler clang++
-          # TODO: Re-enable once foreman works on linux arm64
-          # - os: ubuntu-24.04-arm
-          #   artifact_name: lute-linux-aarch64
-          #   options: --c-compiler clang --cxx-compiler clang++
+          - os: ubuntu-24.04-arm
+            artifact_name: lute-linux-aarch64
+            options: --c-compiler clang --cxx-compiler clang++
           - os: macos-latest
             artifact_name: lute-macos-aarch64
           - os: windows-latest


### PR DESCRIPTION
Foreman 1.6.4 with Linux arm support was released today: https://github.com/Roblox/foreman/releases