### PR TITLE
CST: Handle type packs

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -368,7 +368,7 @@ export type AstTypeReference = {
 	prefixPoint: Token<".">?,
 	name: Token<string>,
 	openParameters: Token<"<">?,
-	parameters: Punctuated<AstType>?,
+	parameters: Punctuated<AstType | AstTypePack>?,
 	closeParameters: Token<">">?,
 }
 

--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -467,4 +467,26 @@ export type AstType =
 	| AstTypeArray
 	| AstTypeTable
 
+export type AstTypePackExplicit = {
+	tag: "explicit",
+	openParens: Token<"(">,
+	types: Punctuated<AstType>,
+	tailType: AstTypePack?,
+	closeParens: Token<")">,
+}
+
+export type AstTypePackGeneric = {
+	tag: "generic",
+	name: Token,
+	ellipsis: Token<"...">,
+}
+
+export type AstTypePackVariadic = {
+	tag: "variadic",
+	ellipsis: Token<"...">,
+	type: AstType,
+}
+
+export type AstTypePack = AstTypePackExplicit | AstTypePackGeneric | AstTypePackVariadic
+
 return {}

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -481,6 +481,14 @@ local function visitIfExpression(node: T.AstExprIfElse, visitor: Visitor)
 	end
 end
 
+local function visitTypeOrPack(node: T.AstType | T.AstTypePack, visitor: Visitor)
+	if node.tag == "explicit" or node.tag == "generic" or node.tag == "variadic" then
+		visitTypePack(node, visitor)
+	else
+		visitType(node, visitor)
+	end
+end
+
 local function visitTypeReference(node: T.AstTypeReference, visitor: Visitor)
 	if visitor.visitTypeReference(node) then
 		if node.prefix then
@@ -494,7 +502,7 @@ local function visitTypeReference(node: T.AstTypeReference, visitor: Visitor)
 			visitToken(node.openParameters, visitor)
 		end
 		if node.parameters then
-			visitPunctuated(node.parameters, visitor, visitType)
+			visitPunctuated(node.parameters, visitor, visitTypeOrPack)
 		end
 		if node.closeParameters then
 			visitToken(node.closeParameters, visitor)

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -46,6 +46,10 @@ export type Visitor = {
 	visitTypeArray: (T.AstTypeArray) -> boolean,
 	visitTypeTable: (T.AstTypeTable) -> boolean,
 
+	visitTypePackExplicit: (T.AstTypePackExplicit) -> boolean,
+	visitTypePackGeneric: (T.AstTypePackGeneric) -> boolean,
+	visitTypePackVariadic: (T.AstTypePackVariadic) -> boolean,
+
 	visitToken: (T.Token) -> boolean,
 	visitNil: (T.AstExprConstantNil) -> boolean,
 	visitString: (T.AstExprConstantString) -> boolean,
@@ -102,6 +106,10 @@ local defaultVisitor: Visitor = {
 	visitTypeIntersection = alwaysVisit :: any,
 	visitTypeArray = alwaysVisit :: any,
 	visitTypeTable = alwaysVisit :: any,
+
+	visitTypePackExplicit = alwaysVisit,
+	visitTypePackGeneric = alwaysVisit,
+	visitTypePackVariadic = alwaysVisit,
 
 	visitToken = alwaysVisit :: any,
 	visitNil = alwaysVisit :: any,
@@ -580,6 +588,31 @@ local function visitTypeTable(node: T.AstTypeTable, visitor: Visitor)
 	end
 end
 
+local function visitTypePackExplicit(node: T.AstTypePackExplicit, visitor: Visitor)
+	if visitor.visitTypePackExplicit(node) then
+		visitToken(node.openParens, visitor)
+		visitPunctuated(node.types, visitor, visitType)
+		if node.tailType then
+			visitTypePack(node.tailType, visitor)
+		end
+		visitToken(node.closeParens, visitor)
+	end
+end
+
+local function visitTypePackGeneric(node: T.AstTypePackGeneric, visitor: Visitor)
+	if visitor.visitTypePackGeneric(node) then
+		visitToken(node.name, visitor)
+		visitToken(node.ellipsis, visitor)
+	end
+end
+
+local function visitTypePackVariadic(node: T.AstTypePackVariadic, visitor: Visitor)
+	if visitor.visitTypePackVariadic(node) then
+		visitToken(node.ellipsis, visitor)
+		visitType(node.type, visitor)
+	end
+end
+
 function visitExpression(expression: T.AstExpr, visitor: Visitor)
 	if visitor.visitExpression(expression) then
 		if expression.tag == "nil" then
@@ -692,6 +725,18 @@ function visitType(type: T.AstType, visitor: Visitor)
 	end
 end
 
+function visitTypePack(type: T.AstTypePack, visitor: Visitor)
+	if type.tag == "explicit" then
+		visitTypePackExplicit(type, visitor)
+	elseif type.tag == "generic" then
+		visitTypePackGeneric(type, visitor)
+	elseif type.tag == "variadic" then
+		visitTypePackVariadic(type, visitor)
+	else
+		exhaustiveMatch(type.tag)
+	end
+end
+
 local function createVisitor()
 	return table.clone(defaultVisitor)
 end
@@ -702,5 +747,6 @@ return {
 	visitStatement = visitStatement,
 	visitExpression = visitExpression,
 	visitType = visitType,
+	visitTypePack = visitTypePack,
 	visitToken = visitToken,
 }


### PR DESCRIPTION
This PR adds support for serializing type packs as part of the CST. They are all fairly straightforward, serializing the exact tokens that show up in each pack kind