### PR TITLE
Expose previously private stuff in lute

### DIFF
--- a/runtime/include/lute/runtime.h
+++ b/runtime/include/lute/runtime.h
@@ -60,7 +60,6 @@ struct Runtime
 
     std::vector<ThreadToContinue> runningThreads;
 
-private:
     std::mutex continuationMutex;
     std::vector<std::function<void()>> continuations;
 


### PR DESCRIPTION
For lutes scheduler to play nicely with mlua (im working on a mlua lute integration thing), these runtime internals need to be public so tokio can do its thing and then call into luteexts scheduler apis to progress with lute stuff