### PR TITLE
Update tags to count back from 128.

### DIFF
--- a/runtime/include/lute/userdatas.h
+++ b/runtime/include/lute/userdatas.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// all tags start from 800 arbitrarily.
-const int kDurationTag       = 801;
-const int kInstantTag        = 802;
-const int kCompilerResultTag = 803;
+// all tags count down from 128
+const int kDurationTag       = 127;
+const int kInstantTag        = 126;
+const int kCompilerResultTag = 125;

--- a/runtime/include/lute/userdatas.h
+++ b/runtime/include/lute/userdatas.h
@@ -1,5 +1,6 @@
 #pragma once
 
-const int kDurationTag = 1;
-const int kInstantTag = 2;
-const int kCompilerResultTag = 3;
+// all tags start from 800 arbitrarily.
+const int kDurationTag       = 801;
+const int kInstantTag        = 802;
+const int kCompilerResultTag = 803;


### PR DESCRIPTION
There may be conflicts with VM tags, so we can just start at 800. I don't think the VM will ever use the first 799.