### PR TITLE
Make Lute a single-folder VS Code workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /cmake[.-]*/
 /coverage/
 /.vs/
+/.vscode/
 /fuzz/luau.pb.*
 /crash-*
 /default.prof*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "luau-lsp.fflags.enableNewSolver": true,
-    "luau-lsp.sourcemap.enabled": false,
-    "luau-lsp.platform.type": "standard",
-}

--- a/lute.code-workspace
+++ b/lute.code-workspace
@@ -1,0 +1,19 @@
+{
+    "folders": [
+        {
+            "path": ".",
+        }
+    ],
+    "launch": {
+        "configurations": [],
+        "compounds": []
+    },
+    "tasks": {
+        "version": "2.0.0",
+    },
+    "settings": {
+        "luau-lsp.fflags.enableNewSolver": true,
+        "luau-lsp.sourcemap.enabled": false,
+        "luau-lsp.platform.type": "standard",
+    },
+}


### PR DESCRIPTION
VS Code has varying levels of settings overrides. The most basic is user settings, then workspace settings, followed by project folder settings. Currently, we store project settings in `.vscode/settings.json`, which means that we can't add the `.vscode` directory to `.gitignore`.

This PR creates a [multi-root workspace](https://code.visualstudio.com/docs/editing/workspaces/multi-root-workspaces) containing only the root folder of this repository, which allows us to store these settings in `lute.code-workspace` instead. Now, `.vscode` is added to `.gitignore` and can be used for defining local-only launch and task configurations.

This also means that we can add workspace-level launch and task configurations (which would run luthier) that come packaged with this repository by default in `lute.code-workspace`.

As long as the repository is opened in VS Code as a workspace, this should behave the same as before.