### PR TITLE
Remove the misinformation in @batteries/pp's FIXME comments.

### DIFF
--- a/batteries/pp.luau
+++ b/batteries/pp.luau
@@ -80,6 +80,7 @@ local function isEmpty(t: { [unknown]: unknown }): boolean
 	return true
 end
 
+-- FIXME(luau): mark `dataTable` indexer as read-only
 local function traverseTable(
 	dataTable: { [unknown]: unknown },
 	seen: { [unknown]: boolean },
@@ -141,7 +142,6 @@ local function traverseTable(
 			continue
 		end
 
-		-- FIXME(luau): `{[unknown]: unknown} should be treated identically to `table`
 		if isPrimitiveArray(value :: { [unknown]: unknown }) then -- collapse primitive arrays
 			local outputConcatTbl = table.create(#value) :: { string }
 
@@ -182,6 +182,5 @@ return function(data: unknown, options: ExistingOptions?): string
 		return formatValue(data, options)
 	end
 
-	-- FIXME(luau): `{[unknown]: unknown} should be treated identically to `table`
 	return `\{\n{traverseTable(data :: { [unknown]: unknown }, { [data] = true }, 1, options)}\}`
 end


### PR DESCRIPTION
Someone tried to cite this incorrect comment as an indication that Luau would eventually do something unsound, which will not happen. When I wrote the comment, I was thinking about read-only indexers specifically, but we don't have syntax or support for read-only indexers yet, and the relationship implied by the comment doesn't even really hold for a read-only `unknown` indexer, but is at least _safe_ (hence why the cast we have today is alright because we don't mutate the table, we're just reading it).