### PR TITLE
CST: Fix colon positions and minor improvements

### DIFF
--- a/batteries/syntax/ast_types.luau
+++ b/batteries/syntax/ast_types.luau
@@ -86,6 +86,7 @@ export type AstExprCall = {
 	openParens: Token<"(">?,
 	arguments: Punctuated<AstExpr>,
 	closeParens: Token<")">?,
+	self: boolean,
 }
 
 export type AstExprIndexName = {

--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -10,6 +10,7 @@ export type Visitor = {
 	visitRepeat: (T.AstStatRepeat) -> boolean,
 	visitReturn: (T.AstStatReturn) -> boolean,
 	visitLocalDeclaration: (T.AstStatLocal) -> boolean,
+	visitLocalDeclarationEnd: (T.AstStatLocal) -> (),
 	visitFor: (T.AstStatFor) -> boolean,
 	visitForIn: (T.AstStatForIn) -> boolean,
 	visitAssign: (T.AstStatAssign) -> boolean,
@@ -72,6 +73,7 @@ local defaultVisitor: Visitor = {
 	visitRepeat = alwaysVisit :: any,
 	visitReturn = alwaysVisit :: any,
 	visitLocalDeclaration = alwaysVisit :: any,
+	visitLocalDeclarationEnd = alwaysVisit :: any,
 	visitFor = alwaysVisit :: any,
 	visitForIn = alwaysVisit :: any,
 	visitAssign = alwaysVisit :: any,
@@ -217,6 +219,8 @@ local function visitLocalStatement(node: T.AstStatLocal, visitor: Visitor)
 			visitToken(node.equals, visitor)
 		end
 		visitPunctuated(node.values, visitor, visitExpression)
+
+		visitor.visitLocalDeclarationEnd(node)
 	end
 end
 

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -333,7 +333,7 @@ struct AstSerialize : public Luau::AstVisitor
         if (lua_isnil(L, -1))
         {
             lua_pop(L, 1);
-            lua_createtable(L, 0, 3);
+            lua_createtable(L, 0, 4);
 
             // set up reference for this local into the local table
             lua_pushlightuserdata(L, local);
@@ -467,12 +467,11 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeTrivia(const std::vector<Trivia>& trivia)
     {
-        lua_rawcheckstack(L, 2);
+        lua_rawcheckstack(L, 3);
         lua_createtable(L, trivia.size(), 0);
 
         for (size_t i = 0; i < trivia.size(); i++)
         {
-            lua_rawcheckstack(L, 2);
             lua_createtable(L, 0, 3);
 
             switch (trivia[i].kind)
@@ -502,7 +501,7 @@ struct AstSerialize : public Luau::AstVisitor
     // For correct trivia computation, everything must end up going through serializeToken
     void serializeToken(Luau::Position position, const char* text, int nrec = 0)
     {
-        lua_rawcheckstack(L, 2);
+        lua_rawcheckstack(L, 3);
         lua_createtable(L, 0, nrec + 3);
 
         const auto trivia = extractTrivia(position);
@@ -535,7 +534,6 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "text");
         advancePosition(text);
 
-        lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, 0);
         lua_setfield(L, -2, "trailingTrivia");
 
@@ -593,12 +591,11 @@ struct AstSerialize : public Luau::AstVisitor
     template<typename T>
     void serializePunctuated(Luau::AstArray<T> nodes, Luau::AstArray<Luau::Position> separators, const char* separatorText)
     {
-        lua_rawcheckstack(L, 2);
+        lua_rawcheckstack(L, 3);
         lua_createtable(L, nodes.size, 0);
 
         for (size_t i = 0; i < nodes.size; i++)
         {
-            lua_rawcheckstack(L, 2);
             lua_createtable(L, 0, 2);
 
             nodes.data[i]->visit(this);
@@ -642,12 +639,11 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializePunctuated(Luau::AstArray<Luau::AstLocal*> nodes, Luau::AstArray<Luau::Position> separators, const char* separatorText)
     {
-        lua_rawcheckstack(L, 2);
+        lua_rawcheckstack(L, 3);
         lua_createtable(L, nodes.size, 0);
 
         for (size_t i = 0; i < nodes.size; i++)
         {
-            lua_rawcheckstack(L, 2);
             lua_createtable(L, 0, 2);
 
             serialize(nodes.data[i]);
@@ -887,7 +883,7 @@ struct AstSerialize : public Luau::AstVisitor
         const auto* cstNode = lookupCstNode<Luau::CstExprFunction>(node);
 
         lua_rawcheckstack(L, 3);
-        lua_createtable(L, 0, 9);
+        lua_createtable(L, 0, 14);
 
         if (node->generics.size > 0 || node->genericPacks.size > 0)
         {

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -323,7 +323,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_pushstring(L, name.value);
     }
 
-    void serialize(Luau::AstLocal* local, bool createToken = true)
+    void serialize(Luau::AstLocal* local, bool createToken = true, std::optional<Luau::Position> colonPosition = std::nullopt)
     {
         lua_rawcheckstack(L, 2);
 
@@ -347,7 +347,10 @@ struct AstSerialize : public Luau::AstVisitor
 
                 // TODO: get position of colon properly
                 if (local->annotation)
-                    serializeToken(currentPosition, ":");
+                {
+                    LUAU_ASSERT(colonPosition);
+                    serializeToken(*colonPosition, ":");
+                }
                 else
                     lua_pushnil(L);
                 lua_setfield(L, -2, "colon");
@@ -637,7 +640,7 @@ struct AstSerialize : public Luau::AstVisitor
         }
     }
 
-    void serializePunctuated(Luau::AstArray<Luau::AstLocal*> nodes, Luau::AstArray<Luau::Position> separators, const char* separatorText)
+    void serializePunctuated(Luau::AstArray<Luau::AstLocal*> nodes, Luau::AstArray<Luau::Position> separators, const char* separatorText, Luau::AstArray<Luau::Position> colonPositions)
     {
         lua_rawcheckstack(L, 3);
         lua_createtable(L, nodes.size, 0);
@@ -646,7 +649,7 @@ struct AstSerialize : public Luau::AstVisitor
         {
             lua_createtable(L, 0, 2);
 
-            serialize(nodes.data[i]);
+            serialize(nodes.data[i], /* createToken=*/ true, colonPositions.data[i]);
             lua_setfield(L, -2, "node");
 
             if (i < separators.size)
@@ -776,7 +779,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeToken(node->location.begin, node->local->name.value);
         lua_setfield(L, -2, "token"),
 
-            serialize(node->local);
+        serialize(node->local);
         lua_setfield(L, -2, "local");
 
         lua_pushboolean(L, node->upvalue);
@@ -922,7 +925,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "openParens");
         }
 
-        serializePunctuated(node->args, cstNode ? cstNode->argsCommaPositions : Luau::AstArray<Luau::Position>{}, ",");
+        serializePunctuated(node->args, cstNode ? cstNode->argsCommaPositions : Luau::AstArray<Luau::Position>{}, ",", cstNode ? cstNode->argsAnnotationColonPositions : Luau::AstArray<Luau::Position>{});
         lua_setfield(L, -2, "parameters");
 
         if (node->vararg)
@@ -931,9 +934,8 @@ struct AstSerialize : public Luau::AstVisitor
             lua_pushnil(L);
         lua_setfield(L, -2, "vararg");
 
-        // TODO: get proper position of colon
-        if (node->varargAnnotation)
-            serializeToken(currentPosition, ":");
+        if (cstNode && node->varargAnnotation)
+            serializeToken(cstNode->varargAnnotationColonPosition, ":");
         else
             lua_pushnil(L);
         lua_setfield(L, -2, "varargColon");
@@ -1386,7 +1388,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "local");
 
         const auto cstNode = lookupCstNode<Luau::CstStatLocal>(node);
-        serializePunctuated(node->vars, cstNode ? cstNode->varsCommaPositions : Luau::AstArray<Luau::Position>{}, ",");
+        serializePunctuated(node->vars, cstNode ? cstNode->varsCommaPositions : Luau::AstArray<Luau::Position>{}, ",", cstNode ? cstNode->varsAnnotationColonPositions : Luau::AstArray<Luau::Position>{});
         lua_setfield(L, -2, "variables");
 
         if (node->equalsSignLocation)
@@ -1411,7 +1413,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeToken(node->location.begin, "for");
         lua_setfield(L, -2, "for");
 
-        serialize(node->var);
+        serialize(node->var, /* createToken= */ true, cstNode ? std::make_optional(cstNode->annotationColonPosition) : std::nullopt);
         lua_setfield(L, -2, "variable");
 
         if (cstNode)
@@ -1469,7 +1471,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeToken(node->location.begin, "for");
         lua_setfield(L, -2, "for");
 
-        serializePunctuated(node->vars, cstNode ? cstNode->varsCommaPositions : Luau::AstArray<Luau::Position>{}, ",");
+        serializePunctuated(node->vars, cstNode ? cstNode->varsCommaPositions : Luau::AstArray<Luau::Position>{}, ",", cstNode ? cstNode->varsAnnotationColonPositions : Luau::AstArray<Luau::Position>{});
         lua_setfield(L, -2, "variables");
 
         if (node->hasIn)

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -22,6 +22,7 @@ const char* COMPILE_RESULT_TYPE = "CompileResult";
 LUAU_FASTFLAG(LuauStoreCSTData2)
 LUAU_FASTFLAG(LuauFixFunctionWithAttributesStartLocation)
 LUAU_FASTFLAG(LuauStoreReturnTypesAsPackOnAst)
+LUAU_FASTFLAG(LuauStoreLocalAnnotationColonPositions)
 
 namespace luau
 {
@@ -40,6 +41,7 @@ static StatResult parse(std::string& source)
     FFlag::LuauStoreCSTData2.value = true;
     FFlag::LuauFixFunctionWithAttributesStartLocation.value = true;
     FFlag::LuauStoreReturnTypesAsPackOnAst.value = true;
+    FFlag::LuauStoreLocalAnnotationColonPositions.value = true;
 
     auto allocator = std::make_shared<Luau::Allocator>();
     auto names = std::make_shared<Luau::AstNameTable>(*allocator);
@@ -68,6 +70,7 @@ static ExprResult parseExpr(std::string& source)
     FFlag::LuauStoreCSTData2.value = true;
     FFlag::LuauFixFunctionWithAttributesStartLocation.value = true;
     FFlag::LuauStoreReturnTypesAsPackOnAst.value = true;
+    FFlag::LuauStoreLocalAnnotationColonPositions.value = true;
 
     auto allocator = std::make_shared<Luau::Allocator>();
     auto names = std::make_shared<Luau::AstNameTable>(*allocator);
@@ -646,7 +649,7 @@ struct AstSerialize : public Luau::AstVisitor
         {
             lua_createtable(L, 0, 2);
 
-            serialize(nodes.data[i], /* createToken=*/ true, colonPositions.data[i]);
+            serialize(nodes.data[i], /* createToken=*/ true, colonPositions.size > i ? std::make_optional(colonPositions.data[i]): std::nullopt);
             lua_setfield(L, -2, "node");
 
             if (i < separators.size)

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -821,6 +821,9 @@ struct AstSerialize : public Luau::AstVisitor
         serializePunctuated(node->args, cstNode ? cstNode->commaPositions : Luau::AstArray<Luau::Position>{}, ",");
         lua_setfield(L, -2, "arguments");
 
+        lua_pushboolean(L, node->self);
+        lua_setfield(L, -2, "self");
+
         serialize(node->argLocation);
         lua_setfield(L, -2, "argLocation");
 

--- a/tests/astSerializerTests/local-assignment-1.luau
+++ b/tests/astSerializerTests/local-assignment-1.luau
@@ -1,0 +1,3 @@
+local a = 1
+local b, c = 2, nil
+local d: string = ""

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -118,72 +118,20 @@ local function test_triviaSplitBetweenLeadingAndTrailing()
 end
 
 local function test_roundtrippableAst()
-	local files = {
-		"examples/a.luau",
-		-- "examples/ansi.luau",
-		"examples/async_read.luau",
-		"examples/b.luau",
-		"examples/badisnan.luau",
-		"examples/cliargs.luau",
-		"examples/compile.luau",
-		"examples/directories.luau",
-		"examples/json.luau",
-		"examples/main.luau",
-		"examples/net_example.luau",
-		"examples/parallel_serve_helper.luau",
-		"examples/parallel_serve.luau",
-		"examples/parallel_sort_helper.luau",
-		"examples/parallel_sort.luau",
-		"examples/parsing.luau",
-		"examples/process_env.luau",
-		"examples/process.luau",
-		"examples/serve_html.luau",
-		"examples/serve.luau",
-		"examples/spawn_example.luau",
-		"examples/time_example.luau",
-		"examples/toml.luau",
-		"examples/writeFile.luau",
-		"tests/astSerializerTests/assignment-1.luau",
-		"tests/astSerializerTests/attributes-1.luau",
-		"tests/astSerializerTests/break-continue-1.luau",
-		"tests/astSerializerTests/compound-assignment-1.luau",
-		"tests/astSerializerTests/compound-types-1.luau",
-		"tests/astSerializerTests/compound-types-2.luau",
-		"tests/astSerializerTests/compound-types-3.luau",
-		"tests/astSerializerTests/function-declaration-1.luau",
-		"tests/astSerializerTests/function-declaration-2.luau",
-		"tests/astSerializerTests/function-declaration-3.luau",
-		"tests/astSerializerTests/function-declaration-4.luau",
-		"tests/astSerializerTests/function-type-1.luau",
-		"tests/astSerializerTests/function-type-2.luau",
-		"tests/astSerializerTests/generic-for-loop-1.luau",
-		"tests/astSerializerTests/if-expression-1.luau",
-		"tests/astSerializerTests/if-expression-2.luau",
-		"tests/astSerializerTests/if-statement-1.luau",
-		"tests/astSerializerTests/interpolated-string-1.luau",
-		"tests/astSerializerTests/interpolated-string-2.luau",
-		"tests/astSerializerTests/local-function-declaration-1.luau",
-		"tests/astSerializerTests/numeric-for-loop-1.luau",
-		"tests/astSerializerTests/table-1.luau",
-		"tests/astSerializerTests/table-2.luau",
-		"tests/astSerializerTests/type-alias-1.luau",
-		"tests/astSerializerTests/type-assertion-1.luau",
-		"tests/astSerializerTests/type-function-1.luau",
-		"tests/astSerializerTests/type-singletons-1.luau",
-		"tests/astSerializerTests/type-tables-1.luau",
-		"tests/astSerializerTests/type-tables-2.luau",
-		"tests/astSerializerTests/while-1.luau",
-		"tests/astSerializerTests/repeat-until-1.luau",
-	}
+	local function visitDirectory(directory: string)
+		for _, entry in fs.listdir(directory) do
+			local path = `{directory}/{entry.name}`
+			print(path)
+			local source = fs.readfiletostring(path)
+			local result = printer.printfile(parser.parsefile(source))
 
-	for _, path in files do
-		print(path)
-		local source = fs.readfiletostring(path)
-		local result = printer.printfile(parser.parsefile(source))
-
-		print(result)
-		assert(source == result)
+			print(result)
+			assert(source == result)
+		end
 	end
+
+	visitDirectory("examples")
+	visitDirectory("tests/astSerializerTests")
 end
 
 test_tokenContainsLeadingSpaces()

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -120,11 +120,11 @@ end
 local function test_roundtrippableAst()
 	local files = {
 		"examples/a.luau",
-		"examples/ansi.luau",
+		-- "examples/ansi.luau",
 		"examples/async_read.luau",
 		"examples/b.luau",
 		"examples/badisnan.luau",
-		-- "examples/cliargs.luau", genuine failure
+		"examples/cliargs.luau",
 		"examples/compile.luau",
 		"examples/directories.luau",
 		"examples/json.luau",
@@ -136,12 +136,12 @@ local function test_roundtrippableAst()
 		"examples/parallel_sort.luau",
 		"examples/parsing.luau",
 		"examples/process_env.luau",
-		-- "examples/process.luau", genuine failure (table?)
-		-- "examples/serve_html.luau", genuine failure (advancing)
+		"examples/process.luau",
+		"examples/serve_html.luau",
 		"examples/serve.luau",
 		"examples/spawn_example.luau",
 		"examples/time_example.luau",
-		-- "examples/toml.luau", genuine failure
+		"examples/toml.luau",
 		"examples/writeFile.luau",
 		"tests/astSerializerTests/assignment-1.luau",
 		"tests/astSerializerTests/attributes-1.luau",


### PR DESCRIPTION
- Use the real positions of colons (now available from new Luau version)
- Serialize value of `self` on an AstExprCall
- Fix some size expectations in `lua_rawcheckstack` and `lua_createtable`
- Add a visitor for end of a local declaration
- Simplify testing structure and run more tests