### PR TITLE
Implement `Runtime::runOnce()` and use it in the internal scheduler loop

### DIFF
--- a/runtime/include/lute/runtime.h
+++ b/runtime/include/lute/runtime.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Luau/Variant.h"
 #include "lua.h"
 #include "lute/ref.h"
 
@@ -10,7 +11,6 @@
 #include <mutex>
 #include <string>
 #include <thread>
-#include <variant>
 #include <vector>
 
 struct ThreadToContinue
@@ -35,7 +35,7 @@ struct StepEmpty
 {
 };
 
-typedef std::variant<StepSuccess, StepErr, StepEmpty> RuntimeStep;
+typedef Luau::Variant<StepSuccess, StepErr, StepEmpty> RuntimeStep;
 
 struct Runtime
 {

--- a/runtime/include/lute/runtime.h
+++ b/runtime/include/lute/runtime.h
@@ -28,9 +28,14 @@ struct StepErr
 
 struct StepSuccess
 {
+    lua_State* L;
 };
 
-typedef std::variant<StepSuccess, StepErr> RuntimeStep;
+struct StepEmpty
+{
+};
+
+typedef std::variant<StepSuccess, StepErr, StepEmpty> RuntimeStep;
 
 struct Runtime
 {

--- a/runtime/include/lute/runtime.h
+++ b/runtime/include/lute/runtime.h
@@ -35,7 +35,7 @@ struct StepEmpty
 {
 };
 
-typedef Luau::Variant<StepSuccess, StepErr, StepEmpty> RuntimeStep;
+using RuntimeStep = Luau::Variant<StepSuccess, StepErr, StepEmpty>;
 
 struct Runtime
 {

--- a/runtime/include/lute/runtime.h
+++ b/runtime/include/lute/runtime.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "lua.h"
 #include "lute/ref.h"
 
 #include <atomic>
@@ -9,6 +10,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <variant>
 #include <vector>
 
 struct ThreadToContinue
@@ -19,12 +21,24 @@ struct ThreadToContinue
     std::function<void()> cont;
 };
 
+struct StepErr
+{
+    lua_State* L;
+};
+
+struct StepSuccess
+{
+};
+
+typedef std::variant<StepSuccess, StepErr> RuntimeStep;
+
 struct Runtime
 {
     Runtime();
     ~Runtime();
 
     bool runToCompletion();
+    RuntimeStep runOnce();
 
     // For child runtimes, run a thread waiting for work
     void runContinuously();
@@ -32,6 +46,7 @@ struct Runtime
     // Reports an error for a specified lua state.
     void reportError(lua_State* L);
 
+    bool hasWork();
     bool hasContinuations();
     bool hasThreads();
 

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -58,7 +58,7 @@ RuntimeStep Runtime::runOnce()
         continuation();
 
     if (runningThreads.empty())
-        return StepSuccess{};
+        return StepEmpty{};
 
     auto next = std::move(runningThreads.front());
     runningThreads.erase(runningThreads.begin());
@@ -84,7 +84,7 @@ RuntimeStep Runtime::runOnce()
 
     if (status == LUA_YIELD)
     {
-        return StepSuccess{};
+        return StepSuccess{L};
     }
 
     if (status != LUA_OK)
@@ -95,7 +95,7 @@ RuntimeStep Runtime::runOnce()
     if (next.cont)
         next.cont();
 
-    return StepSuccess{};
+    return StepSuccess{L};
 }
 
 bool Runtime::runToCompletion()
@@ -121,6 +121,10 @@ bool Runtime::runToCompletion()
                 return false;
         }
         else if (std::holds_alternative<StepSuccess>(step))
+        {
+            continue;
+        }
+        else if (std::holds_alternative<StepEmpty>(step))
         {
             continue;
         };

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -6,7 +6,6 @@
 
 #include <string>
 #include <assert.h>
-#include <variant>
 
 static void lua_close_checked(lua_State* L)
 {
@@ -104,30 +103,24 @@ bool Runtime::runToCompletion()
     {
         auto step = runOnce();
 
-        if (std::holds_alternative<StepErr>(step))
+        if (auto err = Luau::get_if<StepErr>(&step))
         {
-            StepErr err = std::get<StepErr>(step);
-
-            if (err.L == nullptr)
+            if (err->L == nullptr)
             {
                 fprintf(stderr, "lua_State* L is nullptr");
                 return false;
             }
 
-            reportError(err.L);
+            reportError(err->L);
 
             // ensure we exit the process with error code properly
             if (!hasWork())
                 return false;
         }
-        else if (std::holds_alternative<StepSuccess>(step))
+        else
         {
             continue;
         }
-        else if (std::holds_alternative<StepEmpty>(step))
-        {
-            continue;
-        };
     };
 
     return true;

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <assert.h>
+#include <variant>
 
 static void lua_close_checked(lua_State* L)
 {
@@ -35,72 +36,99 @@ Runtime::~Runtime()
         runLoopThread.join();
 }
 
+bool Runtime::hasWork()
+{
+    return hasContinuations() || hasThreads() || activeTokens.load() != 0;
+}
+
+RuntimeStep Runtime::runOnce()
+{
+    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+
+    // Complete all C++ continuations
+    std::vector<std::function<void()>> copy;
+
+    {
+        std::unique_lock lock(continuationMutex);
+        copy = std::move(continuations);
+        continuations.clear();
+    }
+
+    for (auto&& continuation : copy)
+        continuation();
+
+    if (runningThreads.empty())
+        return StepSuccess{};
+
+    auto next = std::move(runningThreads.front());
+    runningThreads.erase(runningThreads.begin());
+
+    next.ref->push(GL);
+    lua_State* L = lua_tothread(GL, -1);
+
+    if (L == nullptr)
+    {
+        fprintf(stderr, "Cannot resume a non-thread reference");
+        return StepErr{L};
+    }
+
+    // We still have 'next' on stack to hold on to thread we are about to run
+    lua_pop(GL, 1);
+
+    int status = LUA_OK;
+
+    if (!next.success)
+        status = lua_resumeerror(L, nullptr);
+    else
+        status = lua_resume(L, nullptr, next.argumentCount);
+
+    if (status == LUA_YIELD)
+    {
+        return StepSuccess{};
+    }
+
+    if (status != LUA_OK)
+    {
+        return StepErr{L};
+    };
+
+    if (next.cont)
+        next.cont();
+
+    return StepSuccess{};
+}
+
 bool Runtime::runToCompletion()
 {
-    // While there is some C++ or Luau code left to run (waiting for something to happen?)
-    while (!runningThreads.empty() || hasContinuations() || activeTokens.load() != 0)
+    while (hasWork())
     {
-        uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+        auto step = runOnce();
 
-        // Complete all C++ continuations
-        std::vector<std::function<void()>> copy;
-
+        if (std::holds_alternative<StepErr>(step))
         {
-            std::unique_lock lock(continuationMutex);
-            copy = std::move(continuations);
-            continuations.clear();
-        }
+            StepErr err = std::get<StepErr>(step);
 
-        for (auto&& continuation : copy)
-            continuation();
-
-        if (runningThreads.empty())
-            continue;
-
-        auto next = std::move(runningThreads.front());
-        runningThreads.erase(runningThreads.begin());
-
-        next.ref->push(GL);
-        lua_State* L = lua_tothread(GL, -1);
-
-        if (L == nullptr)
-        {
-            fprintf(stderr, "Cannot resume a non-thread reference");
-            return false;
-        }
-
-        // We still have 'next' on stack to hold on to thread we are about to run
-        lua_pop(GL, 1);
-
-        int status = LUA_OK;
-
-        if (!next.success)
-            status = lua_resumeerror(L, nullptr);
-        else
-            status = lua_resume(L, nullptr, next.argumentCount);
-
-        if (status == LUA_YIELD)
-        {
-            continue;
-        }
-
-        if (status != LUA_OK)
-        {
-            reportError(L);
-
-            // If we have no work to do, then exit the process.
-            if (!hasThreads() && !hasContinuations())
+            if (err.L == nullptr)
+            {
+                fprintf(stderr, "lua_State* L is nullptr");
                 return false;
-            else
-                continue;
-        }
+            }
 
-        if (next.cont)
-            next.cont();
-    }
+            reportError(err.L);
+
+            // ensure we exit the process with error code properly
+            if (!hasWork())
+                return false;
+        }
+        else if (std::holds_alternative<StepSuccess>(step))
+        {
+            continue;
+        };
+    };
 
     return true;
 }
+
 
 void Runtime::reportError(lua_State* L)
 {

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -126,7 +126,6 @@ bool Runtime::runToCompletion()
     return true;
 }
 
-
 void Runtime::reportError(lua_State* L)
 {
     std::string error;


### PR DESCRIPTION
This PR implements a C-sided API `Runtime::runOnce()` to run a singular iteration of the scheduler loop. This returns an `std::variant` between `StepErr` and `StepSuccess`, returning the `lua_State* L` which errored if the variant is a `StepErr`. This is then utilized in `Runtime::runToCompletion`, which simplifies some logic regarding exiting the runtime loop.

Fixes #272