### PR TITLE
CST: Improve parse API

### DIFF
--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -507,7 +507,7 @@ end
 
 local function visitIndexName(node: luau.AstExprIndexName, visitor: Visitor)
 	if visitor.visitIndexName(node) then
-		visitExpression(node.expr, visitor)
+		visitExpression(node.expression, visitor)
 		visitToken(node.accessor, visitor)
 		visitToken(node.index, visitor)
 	end
@@ -515,7 +515,7 @@ end
 
 local function visitIndexExpr(node: luau.AstExprIndexExpr, visitor: Visitor)
 	if visitor.visitIndexExpr(node) then
-		visitExpression(node.expr, visitor)
+		visitExpression(node.expression, visitor)
 		visitToken(node.openBrackets, visitor)
 		visitExpression(node.index, visitor)
 		visitToken(node.closeBrackets, visitor)
@@ -611,7 +611,7 @@ local function visitTypeTypeof(node: luau.AstTypeTypeof, visitor: Visitor)
 	if visitor.visitTypeTypeof(node) then
 		visitToken(node.typeof, visitor)
 		visitToken(node.openParens, visitor)
-		visitExpression(node.expr, visitor)
+		visitExpression(node.expression, visitor)
 		visitToken(node.closeParens, visitor)
 	end
 end

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -124,13 +124,13 @@ export type AstFunctionBody = {
 	returnSpecifier: Token<":">?,
 	returnAnnotation: AstTypePack?,
 	body: AstStatBlock,
-	["end"]: Token<"end">,
+	endKeyword: Token<"end">,
 }
 
 export type AstExprAnonymousFunction = {
 	tag: "function",
 	attributes: { AstAttribute },
-	["function"]: Token<"function">,
+	functionKeyword: Token<"function">,
 	body: AstFunctionBody,
 }
 
@@ -184,20 +184,20 @@ export type AstExprTypeAssertion = {
 }
 
 export type AstExprIfElseIfs = {
-	["elseif"]: Token<"elseif">,
+	elseifKeyword: Token<"elseif">,
 	condition: AstExpr,
-	["then"]: Token<"then">,
+	thenKeyword: Token<"then">,
 	consequent: AstExpr,
 }
 
 export type AstExprIfElse = {
 	tag: "conditional",
-	["if"]: Token<"if">,
+	ifKeyword: Token<"if">,
 	condition: AstExpr,
-	["then"]: Token<"then">,
+	thenKeyword: Token<"then">,
 	consequent: AstExpr,
 	elseifs: { AstExprIfElseIfs },
-	["else"]: Token<"else">,
+	elseKeyword: Token<"else">,
 	antecedent: AstExpr,
 }
 
@@ -227,38 +227,38 @@ export type AstStatBlock = {
 }
 
 export type AstStatElseIf = {
-	["elseif"]: Token<"elseif">,
+	elseifKeyword: Token<"elseif">,
 	condition: AstExpr,
-	["then"]: Token<"then">,
+	thenKeyword: Token<"then">,
 	consequent: AstStatBlock,
 }
 
 export type AstStatIf = {
 	tag: "conditional",
-	["if"]: Token<"if">,
+	ifKeyword: Token<"if">,
 	condition: AstExpr,
-	["then"]: Token<"then">,
+	thenKeyword: Token<"then">,
 	consequent: AstStatBlock,
 	elseifs: { AstStatElseIf },
-	["else"]: Token<"else">?, -- TODO: this could be elseif!
+	elseKeyword: Token<"else">?, -- TODO: this could be elseif!
 	antecedent: AstStatBlock?,
-	["end"]: Token<"end">,
+	endKeyword: Token<"end">,
 }
 
 export type AstStatWhile = {
 	tag: "while",
-	["while"]: Token<"while">,
+	whileKeyword: Token<"while">,
 	condition: AstExpr,
-	["do"]: Token<"do">,
+	doKeyword: Token<"do">,
 	body: AstStatBlock,
-	["end"]: Token<"end">,
+	endKeyword: Token<"end">,
 }
 
 export type AstStatRepeat = {
 	tag: "repeat",
-	["repeat"]: Token<"repeat">,
+	repeatKeyword: Token<"repeat">,
 	body: AstStatBlock,
-	["until"]: Token<"until">,
+	untilKeyword: Token<"until">,
 	condition: AstExpr,
 }
 
@@ -268,7 +268,7 @@ export type AstStatContinue = Token<"continue"> & { tag: "continue" }
 
 export type AstStatReturn = {
 	tag: "return",
-	["return"]: Token<"return">,
+	returnKeyword: Token<"return">,
 	expressions: Punctuated<AstExpr>,
 }
 
@@ -279,7 +279,7 @@ export type AstStatExpr = {
 
 export type AstStatLocal = {
 	tag: "local",
-	["local"]: Token<"local">,
+	localKeyword: Token<"local">,
 	variables: Punctuated<AstLocal>,
 	equals: Token<"=">?,
 	values: Punctuated<AstExpr>,
@@ -287,7 +287,7 @@ export type AstStatLocal = {
 
 export type AstStatFor = {
 	tag: "for",
-	["for"]: Token<"for">,
+	forKeyword: Token<"for">,
 	variable: AstLocal,
 	equals: Token<"=">,
 	from: AstExpr,
@@ -295,20 +295,20 @@ export type AstStatFor = {
 	to: AstExpr,
 	stepComma: Token<",">?,
 	step: AstExpr?,
-	["do"]: Token<"do">,
+	doKeyword: Token<"do">,
 	body: AstStatBlock,
-	["end"]: Token<"end">,
+	endKeyword: Token<"end">,
 }
 
 export type AstStatForIn = {
 	tag: "forin",
-	["for"]: Token<"for">,
+	forKeyword: Token<"for">,
 	variables: Punctuated<Token<string>>,
-	["in"]: Token<"in">,
+	inKeyword: Token<"in">,
 	values: Punctuated<AstExpr>,
-	["do"]: Token<"do">,
+	doKeyword: Token<"do">,
 	body: AstStatBlock,
-	["end"]: Token<"end">,
+	endKeyword: Token<"end">,
 }
 
 export type AstStatAssign = {
@@ -330,7 +330,7 @@ export type AstAttribute = Token<"@checked" | "@native" | "@deprecated"> & { tag
 export type AstStatFunction = {
 	tag: "function",
 	attributes: { AstAttribute },
-	["function"]: Token<"function">,
+	functionKeyword: Token<"function">,
 	name: AstExpr,
 	body: AstFunctionBody,
 }
@@ -338,8 +338,8 @@ export type AstStatFunction = {
 export type AstStatLocalFunction = {
 	tag: "localfunction",
 	attributes: { AstAttribute },
-	["local"]: Token<"local">,
-	["function"]: Token<"function">,
+	localKeyword: Token<"local">,
+	functionKeyword: Token<"function">,
 	name: AstLocal,
 	body: AstFunctionBody,
 }
@@ -361,7 +361,7 @@ export type AstStatTypeFunction = {
 	tag: "typefunction",
 	export: Token<"export">?,
 	type: Token<"type">,
-	["function"]: Token<"function">,
+	functionKeyword: Token<"function">,
 	name: Token,
 	body: AstFunctionBody,
 }

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -32,13 +32,13 @@ export type MultiLineComment = {
 export type Trivia = Whitespace | SingleLineComment | MultiLineComment
 
 export type Token<Kind = string> = {
-	read leadingTrivia: { Trivia },
-	read position: Position,
-	read text: Kind,
-	read trailingTrivia: { Trivia },
+	leadingTrivia: { Trivia },
+	position: Position,
+	text: Kind,
+	trailingTrivia: { Trivia },
 }
 
-export type Eof = Token<nil> & { tag: "eof" }
+export type Eof = Token<""> & { tag: "eof" }
 
 export type Pair<T, Separator> = { node: T, separator: Token<Separator>? }
 export type Punctuated<T, Separator = ","> = { Pair<T, Separator> }
@@ -47,6 +47,7 @@ export type AstLocal = {
 	name: Token<string>,
 	colon: Token<":">?,
 	annotation: AstType?,
+	shadows: AstLocal?,
 }
 
 export type AstExprGroup = {
@@ -84,16 +85,17 @@ export type AstExprVarargs = Token<"..."> & { tag: "vararg" }
 
 export type AstExprCall = {
 	tag: "call",
-	func: AstExpr, -- TODO: stricter?
+	func: AstExpr,
 	openParens: Token<"(">?,
 	arguments: Punctuated<AstExpr>,
 	closeParens: Token<")">?,
 	self: boolean,
+	argLocation: Location,
 }
 
 export type AstExprIndexName = {
 	tag: "indexname",
-	expr: AstExpr,
+	expression: AstExpr,
 	accessor: Token<"." | ":">,
 	index: Token<string>,
 	indexLocation: Location,
@@ -101,7 +103,7 @@ export type AstExprIndexName = {
 
 export type AstExprIndexExpr = {
 	tag: "index",
-	expr: AstExpr,
+	expression: AstExpr,
 	openBrackets: Token<"[">,
 	index: AstExpr,
 	closeBrackets: Token<"]">,
@@ -112,6 +114,7 @@ export type AstFunctionBody = {
 	generics: Punctuated<AstGenericType>?,
 	genericPacks: Punctuated<AstGenericTypePack>?,
 	closeGenerics: Token<">">?,
+	self: AstLocal?,
 	openParens: Token<"(">,
 	parameters: Punctuated<AstLocal>,
 	vararg: Token<"...">?,
@@ -237,8 +240,8 @@ export type AstStatIf = {
 	["then"]: Token<"then">,
 	consequent: AstStatBlock,
 	elseifs: { AstStatElseIf },
-	["else"]: Token<"else">, -- TODO: this could be elseif!
-	antecedent: AstStatBlock,
+	["else"]: Token<"else">?, -- TODO: this could be elseif!
+	antecedent: AstStatBlock?,
 	["end"]: Token<"end">,
 }
 
@@ -343,7 +346,7 @@ export type AstStatLocalFunction = {
 
 export type AstStatTypeAlias = {
 	tag: "typealias",
-	["export"]: Token<"export">?,
+	export: Token<"export">?,
 	typeToken: Token<"type">,
 	name: Token,
 	openGenerics: Token<"<">?,
@@ -356,7 +359,7 @@ export type AstStatTypeAlias = {
 
 export type AstStatTypeFunction = {
 	tag: "typefunction",
-	["export"]: Token<"export">?,
+	export: Token<"export">?,
 	type: Token<"type">,
 	["function"]: Token<"function">,
 	name: Token,
@@ -421,7 +424,7 @@ export type AstTypeTypeof = {
 	tag: "typeof",
 	typeof: Token<"typeof">,
 	openParens: Token<"(">,
-	expr: AstExpr,
+	expression: AstExpr,
 	closeParens: Token<")">,
 }
 

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -934,7 +934,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "body");
 
         serializeToken(node->body->location.end, "end");
-        lua_setfield(L, -2, "end");
+        lua_setfield(L, -2, "endKeyword");
     }
 
     void serialize(Luau::AstExprFunction* node)
@@ -950,7 +950,7 @@ struct AstSerialize : public Luau::AstVisitor
         const auto cstNode = lookupCstNode<Luau::CstExprFunction>(node);
 
         serializeToken(cstNode->functionKeywordPosition, "function");
-        lua_setfield(L, -2, "function");
+        lua_setfield(L, -2, "functionKeyword");
 
         serializeFunctionBody(node);
         lua_setfield(L, -2, "body");
@@ -1041,7 +1041,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "conditional");
 
         serializeToken(node->location.begin, "if");
-        lua_setfield(L, -2, "if");
+        lua_setfield(L, -2, "ifKeyword");
 
         node->condition->visit(this);
         lua_setfield(L, -2, "condition");
@@ -1049,7 +1049,7 @@ struct AstSerialize : public Luau::AstVisitor
         if (node->hasThen)
         {
             serializeToken(cstNode->thenPosition, "then");
-            lua_setfield(L, -2, "then");
+            lua_setfield(L, -2, "thenKeyword");
 
             node->trueExpr->visit(this);
         }
@@ -1067,7 +1067,7 @@ struct AstSerialize : public Luau::AstVisitor
             cstNode = lookupCstNode<Luau::CstExprIfElse>(node);
 
             serializeToken(node->location.begin, "elseif");
-            lua_setfield(L, -2, "elseif");
+            lua_setfield(L, -2, "elseifKeyword");
 
             node->condition->visit(this);
             lua_setfield(L, -2, "condition");
@@ -1075,7 +1075,7 @@ struct AstSerialize : public Luau::AstVisitor
             if (node->hasThen)
             {
                 serializeToken(cstNode->thenPosition, "then");
-                lua_setfield(L, -2, "then");
+                lua_setfield(L, -2, "thenKeyword");
                 node->trueExpr->visit(this);
             }
             else
@@ -1090,7 +1090,7 @@ struct AstSerialize : public Luau::AstVisitor
         if (node->hasElse)
         {
             serializeToken(cstNode->elsePosition, "else");
-            lua_setfield(L, -2, "else");
+            lua_setfield(L, -2, "elseKeyword");
             node->falseExpr->visit(this);
         }
         else
@@ -1167,13 +1167,13 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "conditional");
 
         serializeToken(node->location.begin, "if");
-        lua_setfield(L, -2, "if");
+        lua_setfield(L, -2, "ifKeyword");
 
         node->condition->visit(this);
         lua_setfield(L, -2, "condition");
 
         serializeToken(node->thenLocation->begin, "then");
-        lua_setfield(L, -2, "then");
+        lua_setfield(L, -2, "thenKeyword");
 
         node->thenbody->visit(this);
         lua_setfield(L, -2, "consequent");
@@ -1186,13 +1186,13 @@ struct AstSerialize : public Luau::AstVisitor
 
             auto elseif = node->elsebody->as<Luau::AstStatIf>();
             serializeToken(elseif->location.begin, "elseif");
-            lua_setfield(L, -2, "elseif");
+            lua_setfield(L, -2, "elseifKeyword");
 
             elseif->condition->visit(this);
             lua_setfield(L, -2, "condition");
 
             serializeToken(elseif->thenLocation->begin, "then");
-            lua_setfield(L, -2, "then");
+            lua_setfield(L, -2, "thenKeyword");
 
             elseif->thenbody->visit(this);
             lua_setfield(L, -2, "consequent");
@@ -1207,24 +1207,24 @@ struct AstSerialize : public Luau::AstVisitor
         {
             LUAU_ASSERT(node->elseLocation);
             serializeToken(node->elseLocation->begin, "else");
-            lua_setfield(L, -2, "else");
+            lua_setfield(L, -2, "elseKeyword");
 
             node->elsebody->visit(this);
             lua_setfield(L, -2, "antecedent");
 
             serializeToken(node->elsebody->location.end, "end");
-            lua_setfield(L, -2, "end");
+            lua_setfield(L, -2, "endKeyword");
         }
         else
         {
             lua_pushnil(L);
-            lua_setfield(L, -2, "else");
+            lua_setfield(L, -2, "elseKeyword");
 
             lua_pushnil(L);
             lua_setfield(L, -2, "antecedent");
 
             serializeToken(node->thenbody->location.end, "end");
-            lua_setfield(L, -2, "end");
+            lua_setfield(L, -2, "endKeyword");
         }
     }
 
@@ -1236,7 +1236,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "while");
 
         serializeToken(node->location.begin, "while");
-        lua_setfield(L, -2, "while");
+        lua_setfield(L, -2, "whileKeyword");
 
         node->condition->visit(this);
         lua_setfield(L, -2, "condition");
@@ -1245,13 +1245,13 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(node->doLocation.begin, "do");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "do");
+        lua_setfield(L, -2, "doKeyword");
 
         node->body->visit(this);
         lua_setfield(L, -2, "body");
 
         serializeToken(node->body->location.end, "end");
-        lua_setfield(L, -2, "end");
+        lua_setfield(L, -2, "endKeyword");
     }
 
     void serializeStat(Luau::AstStatRepeat* node)
@@ -1262,14 +1262,14 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "repeat");
 
         serializeToken(node->location.begin, "repeat");
-        lua_setfield(L, -2, "repeat");
+        lua_setfield(L, -2, "repeatKeyword");
 
         node->body->visit(this);
         lua_setfield(L, -2, "body");
 
         auto cstNode = lookupCstNode<Luau::CstStatRepeat>(node);
         serializeToken(cstNode->untilPosition, "until");
-        lua_setfield(L, -2, "until");
+        lua_setfield(L, -2, "untilKeyword");
 
         node->condition->visit(this);
         lua_setfield(L, -2, "condition");
@@ -1297,7 +1297,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "return");
 
         serializeToken(node->location.begin, "return");
-        lua_setfield(L, -2, "return");
+        lua_setfield(L, -2, "returnKeyword");
 
         const auto cstNode = lookupCstNode<Luau::CstStatReturn>(node);
         serializePunctuated(node->list, cstNode->commaPositions, ",");
@@ -1323,7 +1323,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "local");
 
         serializeToken(node->location.begin, "local");
-        lua_setfield(L, -2, "local");
+        lua_setfield(L, -2, "localKeyword");
 
         const auto cstNode = lookupCstNode<Luau::CstStatLocal>(node);
         serializePunctuated(node->vars, cstNode->varsCommaPositions, ",", cstNode->varsAnnotationColonPositions);
@@ -1349,7 +1349,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "for");
 
         serializeToken(node->location.begin, "for");
-        lua_setfield(L, -2, "for");
+        lua_setfield(L, -2, "forKeyword");
 
         serialize(node->var, /* createToken= */ true, std::make_optional(cstNode->annotationColonPosition));
         lua_setfield(L, -2, "variable");
@@ -1382,13 +1382,13 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(node->doLocation.begin, "do");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "do");
+        lua_setfield(L, -2, "doKeyword");
 
         node->body->visit(this);
         lua_setfield(L, -2, "body");
 
         serializeToken(node->body->location.end, "end");
-        lua_setfield(L, -2, "end");
+        lua_setfield(L, -2, "endKeyword");
     }
 
     void serializeStat(Luau::AstStatForIn* node)
@@ -1401,7 +1401,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "forin");
 
         serializeToken(node->location.begin, "for");
-        lua_setfield(L, -2, "for");
+        lua_setfield(L, -2, "forKeyword");
 
         serializePunctuated(node->vars, cstNode->varsCommaPositions, ",", cstNode->varsAnnotationColonPositions);
         lua_setfield(L, -2, "variables");
@@ -1410,7 +1410,7 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(node->inLocation.begin, "in");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "in");
+        lua_setfield(L, -2, "inKeyword");
 
         serializePunctuated(node->values, cstNode->valuesCommaPositions, ",");
         lua_setfield(L, -2, "values");
@@ -1419,13 +1419,13 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(node->doLocation.begin, "do");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "do");
+        lua_setfield(L, -2, "doKeyword");
 
         node->body->visit(this);
         lua_setfield(L, -2, "body");
 
         serializeToken(node->body->location.end, "end");
-        lua_setfield(L, -2, "end");
+        lua_setfield(L, -2, "endKeyword");
     }
 
     void serializeStat(Luau::AstStatAssign* node)
@@ -1478,7 +1478,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "attributes");
 
         serializeToken(cstNode->functionKeywordPosition, "function");
-        lua_setfield(L, -2, "function");
+        lua_setfield(L, -2, "functionKeyword");
 
         node->name->visit(this);
         lua_setfield(L, -2, "name");
@@ -1500,10 +1500,10 @@ struct AstSerialize : public Luau::AstVisitor
         const auto cstNode = lookupCstNode<Luau::CstStatLocalFunction>(node);
 
         serializeToken(cstNode->localKeywordPosition, "local");
-        lua_setfield(L, -2, "local");
+        lua_setfield(L, -2, "localKeyword");
 
         serializeToken(cstNode->functionKeywordPosition, "function");
-        lua_setfield(L, -2, "function");
+        lua_setfield(L, -2, "functionKeyword");
 
         serialize(node->name);
         lua_setfield(L, -2, "name");
@@ -1582,7 +1582,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "type");
 
         serializeToken(cstNode->functionKeywordPosition, "function");
-        lua_setfield(L, -2, "function");
+        lua_setfield(L, -2, "functionKeyword");
 
         serializeToken(node->nameLocation.begin, node->name.value);
         lua_setfield(L, -2, "name");

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -345,7 +345,6 @@ struct AstSerialize : public Luau::AstVisitor
                 serializeToken(local->location.begin, local->name.value);
                 lua_setfield(L, -2, "name");
 
-                // TODO: get position of colon properly
                 if (local->annotation)
                 {
                     LUAU_ASSERT(colonPosition);
@@ -373,11 +372,13 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprTable::Item& item, Luau::CstExprTable::Item* cstNode)
     {
+        LUAU_ASSERT(cstNode);
+
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, 7);
 
         if (item.kind == Luau::AstExprTable::Item::List)
         {
+            lua_createtable(L, 0, 3);
             lua_pushstring(L, "list");
             lua_setfield(L, -2, "kind");
 
@@ -386,6 +387,7 @@ struct AstSerialize : public Luau::AstVisitor
         }
         else if (item.kind == Luau::AstExprTable::Item::Record)
         {
+            lua_createtable(L, 0, 5);
             lua_pushstring(L, "record");
             lua_setfield(L, -2, "kind");
 
@@ -393,50 +395,40 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(item.key->location.begin, std::string(value.data, value.size).data());
             lua_setfield(L, -2, "key");
 
-            if (cstNode && cstNode->equalsPosition)
-            {
-                serializeToken(cstNode->equalsPosition.value(), "=");
-                lua_setfield(L, -2, "equals");
-            }
+            LUAU_ASSERT(cstNode->equalsPosition);
+            serializeToken(*cstNode->equalsPosition, "=");
+            lua_setfield(L, -2, "equals");
 
             visit(item.value);
             lua_setfield(L, -2, "value");
         }
         else if (item.kind == Luau::AstExprTable::Item::General)
         {
+            lua_createtable(L, 0, 7);
             lua_pushstring(L, "general");
             lua_setfield(L, -2, "kind");
 
-            if (cstNode && cstNode->indexerOpenPosition)
-            {
-                serializeToken(cstNode->indexerOpenPosition.value(), "[");
-                lua_setfield(L, -2, "indexerOpen");
-            }
+            LUAU_ASSERT(cstNode->indexerOpenPosition);
+            serializeToken(*cstNode->indexerOpenPosition, "[");
+            lua_setfield(L, -2, "indexerOpen");
 
             visit(item.key);
             lua_setfield(L, -2, "key");
 
-            if (cstNode)
-            {
-                if (cstNode->indexerClosePosition)
-                {
-                    serializeToken(cstNode->indexerClosePosition.value(), "]");
-                    lua_setfield(L, -2, "indexerClose");
-                }
+            LUAU_ASSERT(cstNode->indexerClosePosition);
+            serializeToken(*cstNode->indexerClosePosition, "]");
+            lua_setfield(L, -2, "indexerClose");
 
-                if (cstNode->equalsPosition)
-                {
-                    serializeToken(cstNode->equalsPosition.value(), "=");
-                    lua_setfield(L, -2, "equals");
-                }
-            }
+            LUAU_ASSERT(cstNode->equalsPosition);
+            serializeToken(*cstNode->equalsPosition, "=");
+            lua_setfield(L, -2, "equals");
 
             visit(item.value);
             lua_setfield(L, -2, "value");
         }
 
-        if (cstNode && cstNode->separator)
-            serializeToken(cstNode->separatorPosition.value(), cstNode->separator.value() == Luau::CstExprTable::Comma ? "," : ";");
+        if (cstNode->separator)
+            serializeToken(*cstNode->separatorPosition, *cstNode->separator == Luau::CstExprTable::Comma ? "," : ";");
         else
             lua_pushnil(L);
         lua_setfield(L, -2, "separator");
@@ -505,7 +497,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeToken(Luau::Position position, const char* text, int nrec = 0)
     {
         lua_rawcheckstack(L, 3);
-        lua_createtable(L, 0, nrec + 3);
+        lua_createtable(L, 0, nrec + 4);
 
         const auto trivia = extractTrivia(position);
         if (lastTokenRef != LUA_NOREF)
@@ -541,18 +533,6 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "trailingTrivia");
 
         lastTokenRef = lua_ref(L, -1);
-    }
-
-    void serializeLocals(Luau::AstArray<Luau::AstLocal*>& locals, size_t nrec = 0)
-    {
-        lua_rawcheckstack(L, 2);
-        lua_createtable(L, locals.size, nrec);
-
-        for (size_t i = 0; i < locals.size; i++)
-        {
-            serialize(locals.data[i]);
-            lua_rawseti(L, -2, i + 1);
-        }
     }
 
     void serializeExprs(Luau::AstArray<Luau::AstExpr*>& exprs, size_t nrec = 0)
@@ -733,7 +713,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serialize(Luau::AstExprConstantString* node)
     {
         const auto cstNode = lookupCstNode<Luau::CstExprConstantString>(node);
-        serializeToken(node->location.begin, cstNode->sourceString.data, preambleSize);
+        serializeToken(node->location.begin, cstNode->sourceString.data, preambleSize + 2);
         serializeNodePreamble(node, "string");
 
         switch (cstNode->quoteStyle)
@@ -765,7 +745,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serialize(Luau::AstExprLocal* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 2);
+        lua_createtable(L, 0, preambleSize + 3);
 
         serializeNodePreamble(node, "local");
 
@@ -801,7 +781,7 @@ struct AstSerialize : public Luau::AstVisitor
         const auto cstNode = lookupCstNode<Luau::CstExprCall>(node);
 
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 5);
+        lua_createtable(L, 0, preambleSize + 6);
 
         serializeNodePreamble(node, "call");
 
@@ -833,12 +813,12 @@ struct AstSerialize : public Luau::AstVisitor
     void serialize(Luau::AstExprIndexName* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 3);
+        lua_createtable(L, 0, preambleSize + 4);
 
         serializeNodePreamble(node, "indexname");
 
         node->expr->visit(this);
-        lua_setfield(L, -2, "expr");
+        lua_setfield(L, -2, "expression");
 
         serializeToken(node->opPosition, std::string(1, node->op).data());
         lua_setfield(L, -2, "accessor");
@@ -854,12 +834,12 @@ struct AstSerialize : public Luau::AstVisitor
         const auto cstNode = lookupCstNode<Luau::CstExprIndexExpr>(node);
 
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 2);
+        lua_createtable(L, 0, preambleSize + 4);
 
         serializeNodePreamble(node, "index");
 
         node->expr->visit(this);
-        lua_setfield(L, -2, "expr");
+        lua_setfield(L, -2, "expression");
 
         serializeToken(cstNode->openBracketPosition, "[");
         lua_setfield(L, -2, "openBrackets");
@@ -876,7 +856,7 @@ struct AstSerialize : public Luau::AstVisitor
         const auto cstNode = lookupCstNode<Luau::CstExprFunction>(node);
 
         lua_rawcheckstack(L, 3);
-        lua_createtable(L, 0, 14);
+        lua_createtable(L, 0, 15);
 
         if (node->generics.size > 0 || node->genericPacks.size > 0)
         {
@@ -1182,7 +1162,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeStat(Luau::AstStatIf* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 5);
+        lua_createtable(L, 0, preambleSize + 8);
 
         serializeNodePreamble(node, "conditional");
 
@@ -1198,7 +1178,7 @@ struct AstSerialize : public Luau::AstVisitor
         node->thenbody->visit(this);
         lua_setfield(L, -2, "consequent");
 
-        lua_createtable(L, 0, preambleSize + 4);
+        lua_createtable(L, 0, 0);
         int i = 0;
         while (node->elsebody && node->elsebody->is<Luau::AstStatIf>())
         {
@@ -1251,7 +1231,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeStat(Luau::AstStatWhile* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 4);
+        lua_createtable(L, 0, preambleSize + 5);
 
         serializeNodePreamble(node, "while");
 
@@ -1277,7 +1257,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeStat(Luau::AstStatRepeat* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 2);
+        lua_createtable(L, 0, preambleSize + 4);
 
         serializeNodePreamble(node, "repeat");
 
@@ -1312,7 +1292,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeStat(Luau::AstStatReturn* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 3);
+        lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "return");
 
@@ -1338,7 +1318,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeStat(Luau::AstStatLocal* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 3);
+        lua_createtable(L, 0, preambleSize + 4);
 
         serializeNodePreamble(node, "local");
 
@@ -1542,7 +1522,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeStat(Luau::AstStatTypeAlias* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 5);
+        lua_createtable(L, 0, preambleSize + 9);
 
         serializeNodePreamble(node, "typealias");
 
@@ -1713,7 +1693,7 @@ struct AstSerialize : public Luau::AstVisitor
         }
 
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 4);
+        lua_createtable(L, 0, preambleSize + 3);
 
         serializeNodePreamble(node, "table");
 
@@ -1855,7 +1835,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeType(Luau::AstTypeFunction* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 6);
+        lua_createtable(L, 0, preambleSize + 10);
 
         serializeNodePreamble(node, "function");
 
@@ -1947,7 +1927,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "openParens");
 
         node->expr->visit(this);
-        lua_setfield(L, -2, "expr");
+        lua_setfield(L, -2, "expression");
 
         serializeToken(cstNode->closePosition, ")");
         lua_setfield(L, -2, "closeParens");
@@ -1958,15 +1938,15 @@ struct AstSerialize : public Luau::AstVisitor
         const auto cstNode = lookupCstNode<Luau::CstTypeUnion>(node);
 
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 4);
+        lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "union");
 
         if (cstNode->leadingPosition)
-        {
             serializeToken(*cstNode->leadingPosition, "|");
-            lua_setfield(L, -2, "leading");
-        }
+        else
+            lua_pushnil(L);
+        lua_setfield(L, -2, "leading");
 
         lua_createtable(L, node->types.size, 0);
         size_t separatorPositions = 0;
@@ -2008,15 +1988,15 @@ struct AstSerialize : public Luau::AstVisitor
         const auto cstNode = lookupCstNode<Luau::CstTypeIntersection>(node);
 
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 4);
+        lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "intersection");
 
         if (cstNode->leadingPosition)
-        {
             serializeToken(*cstNode->leadingPosition, "&");
-            lua_setfield(L, -2, "leading");
-        }
+        else
+            lua_pushnil(L);
+        lua_setfield(L, -2, "leading");
 
         serializePunctuated(node->types, cstNode->separatorPositions, "&");
         lua_setfield(L, -2, "types");
@@ -2034,7 +2014,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeType(Luau::AstTypeSingletonString* node)
     {
         const auto cstNode = lookupCstNode<Luau::CstTypeSingletonString>(node);
-        serializeToken(node->location.begin, cstNode->sourceString.data, preambleSize);
+        serializeToken(node->location.begin, cstNode->sourceString.data, preambleSize + 1);
         serializeNodePreamble(node, "string");
 
         switch (cstNode->quoteStyle)
@@ -2101,7 +2081,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeType(Luau::AstGenericTypePack* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 3);
+        lua_createtable(L, 0, preambleSize + 4);
 
         serializeNodePreamble(node, "generic");
 


### PR DESCRIPTION
- Update some of the table size reservations to correctly reflect the actual number of properties inserted into the table
- Rename some `expr` -> `expression` to align with other references
- Append 'Keyword' to property names that match keywords