### PR TITLE
Fix functions returned from `luau.load` not being able to call `require`

### DIFF
--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -2679,8 +2679,17 @@ int compile_luau(lua_State* L)
 
 int load_luau(lua_State* L)
 {
+    lua_Debug ar;
+    int level = 1;
+
+    do
+    {
+        if (!lua_getinfo(L, level++, "s", &ar))
+            luaL_error(L, "luau.load is not supported in this context");
+    } while (ar.what[0] == 'C');
+
     const std::string* bytecode_string = static_cast<std::string*>(luaL_checkudata(L, 1, COMPILE_RESULT_TYPE));
-    const char* chunk_name = luaL_optlstring(L, 2, "luau.load", nullptr);
+    const char* chunk_name = luaL_optlstring(L, 2, ar.source, nullptr);
 
     luau_load(L, chunk_name, bytecode_string->c_str(), bytecode_string->length(), lua_gettop(L) > 2 ? 3 : 0);
 

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -2682,9 +2682,9 @@ int load_luau(lua_State* L)
     const std::string* bytecode_string = static_cast<std::string*>(luaL_checkudata(L, 1, COMPILE_RESULT_TYPE));
     const char* path = luaL_optlstring(L, 2, "=luau.load", nullptr);
     std::string chunk_name = path;
-    if (lua_type(L, 2) == LUA_TSTRING) {
+    if (chunk_name != "=luau.load")
         chunk_name.insert(0, "@");
-    }
+
     luau_load(L, chunk_name.c_str(), bytecode_string->c_str(), bytecode_string->length(), lua_gettop(L) > 2 ? 3 : 0);
 
     return 1;

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -2680,20 +2680,7 @@ int compile_luau(lua_State* L)
 int load_luau(lua_State* L)
 {
     const std::string* bytecode_string = static_cast<std::string*>(luaL_checkudata(L, 1, COMPILE_RESULT_TYPE));
-    const char* path = luaL_optlstring(L, 2, nullptr, nullptr);
-    if (path == nullptr) {
-        lua_Debug ar;
-        int level = 1;
-        
-        do
-        {
-            if (!lua_getinfo(L, level++, "s", &ar))
-                luaL_error(L, "could not retrieve the source path of the calling function");
-        } while (ar.what[0] == 'C');
-
-        path = ar.source;
-    }
-
+    const char* path = luaL_optlstring(L, 2, "=luau.load", nullptr);
     std::string chunk_name = path;
     if (lua_type(L, 2) == LUA_TSTRING) {
         chunk_name.insert(0, "@");

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -2679,19 +2679,26 @@ int compile_luau(lua_State* L)
 
 int load_luau(lua_State* L)
 {
-    lua_Debug ar;
-    int level = 1;
-
-    do
-    {
-        if (!lua_getinfo(L, level++, "s", &ar))
-            luaL_error(L, "luau.load is not supported in this context");
-    } while (ar.what[0] == 'C');
-
     const std::string* bytecode_string = static_cast<std::string*>(luaL_checkudata(L, 1, COMPILE_RESULT_TYPE));
-    const char* chunk_name = luaL_optlstring(L, 2, ar.source, nullptr);
+    const char* path = luaL_optlstring(L, 2, nullptr, nullptr);
+    if (path == nullptr) {
+        lua_Debug ar;
+        int level = 1;
+        
+        do
+        {
+            if (!lua_getinfo(L, level++, "s", &ar))
+                luaL_error(L, "could not retrieve the source path of the calling function");
+        } while (ar.what[0] == 'C');
 
-    luau_load(L, chunk_name, bytecode_string->c_str(), bytecode_string->length(), lua_gettop(L) > 2 ? 3 : 0);
+        path = ar.source;
+    }
+
+    std::string chunk_name = path;
+    if (chunk_name.empty() || chunk_name[0] != '@') {
+        chunk_name.insert(0, "@");
+    }
+    luau_load(L, chunk_name.c_str(), bytecode_string->c_str(), bytecode_string->length(), lua_gettop(L) > 2 ? 3 : 0);
 
     return 1;
 }

--- a/luau/src/luau.cpp
+++ b/luau/src/luau.cpp
@@ -2695,7 +2695,7 @@ int load_luau(lua_State* L)
     }
 
     std::string chunk_name = path;
-    if (chunk_name.empty() || chunk_name[0] != '@') {
+    if (lua_type(L, 2) == LUA_TSTRING) {
         chunk_name.insert(0, "@");
     }
     luau_load(L, chunk_name.c_str(), bytecode_string->c_str(), bytecode_string->length(), lua_gettop(L) > 2 ? 3 : 0);


### PR DESCRIPTION
`luau.load` currently doesn't pass a valid chunkname to `luau_load` that can be used to handle calls to `require`. This PR fixes that by retrieving the source path of the caller using `lua_getinfo`. If no second argument was passed and if the source path of the caller couldn't be retrieved, `luau.load` will throw an error. 

This PR also changes `luau.load` so that the second argument is considered a path, relative to the current working directory. This path is converted to a proper chunk name by inserting '@' at the start.