### PR TITLE
Replace argv[0] with 'lute' in help commands to save screen space (fixes #309)

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -200,7 +200,7 @@ static bool runFile(Runtime& runtime, const char* name, lua_State* GL)
 
 static void displayHelp(const char* argv0)
 {
-    printf("Usage: %s <command> [options] [arguments...]\n", argv0);
+    printf("Usage: lute <command> [options] [arguments...]\n");
     printf("\n");
     printf("Commands:\n");
     printf("  run (default)   Run a Luau script.\n");
@@ -208,15 +208,15 @@ static void displayHelp(const char* argv0)
     printf("  compile         Compile a Luau script into the executable.\n");
     printf("\n");
     printf("Run Options (when using 'run' or no command):\n");
-    printf("  %s [run] <script.luau> [args...]\n", argv0);
+    printf("  lute [run] <script.luau> [args...]\n");
     printf("    Executes the script, passing [args...] to it.\n");
     printf("\n");
     printf("Check Options:\n");
-    printf("  %s check <file1.luau> [file2.luau...]\n", argv0);
+    printf("  lute check <file1.luau> [file2.luau...]\n");
     printf("    Performs a type check on the specified files.\n");
     printf("\n");
     printf("Compile Options:\n");
-    printf("  %s compile <script.luau> [output_executable]\n", argv0);
+    printf("  lute compile <script.luau> [output_executable]\n");
     printf("    Compiles the script, embedding it into a new executable.\n");
     printf("\n");
     printf("General Options:\n");
@@ -225,7 +225,7 @@ static void displayHelp(const char* argv0)
 
 static void displayRunHelp(const char* argv0)
 {
-    printf("Usage: %s run <script.luau> [args...]\n", argv0);
+    printf("Usage: lute run <script.luau> [args...]\n");
     printf("\n");
     printf("Run Options:\n");
     printf("  -h, --help    Display this usage message.\n");
@@ -233,7 +233,7 @@ static void displayRunHelp(const char* argv0)
 
 static void displayCheckHelp(const char* argv0)
 {
-    printf("Usage: %s check <file1.luau> [file2.luau...]\n", argv0);
+    printf("Usage: lute check <file1.luau> [file2.luau...]\n");
     printf("\n");
     printf("Check Options:\n");
     printf("  -h, --help    Display this usage message.\n");
@@ -241,7 +241,7 @@ static void displayCheckHelp(const char* argv0)
 
 static void displayCompileHelp(const char* argv0)
 {
-    printf("Usage: %s compile <script.luau> [output_executable]\n", argv0);
+    printf("Usage: lute compile <script.luau> [output_executable]\n");
     printf("\n");
     printf("Compile Options:\n");
     printf("  output_executable    Optional name for the compiled executable.\n");
@@ -412,7 +412,7 @@ int main(int argc, char** argv)
         program_argv = argv;
 
         bool success = runBytecode(runtime, embedded.BytecodeData, "=__EMBEDDED__", GL);
-        
+
         return success ? 0 : 1;
     }
 


### PR DESCRIPTION
This PR fixes issue #309 by replacing dynamic argv[0] references with the hardcoded string 'lute' in all help command outputs. This saves screen space and provides consistent, clean help text regardless of how the executable was invoked.