### PR TITLE
Fix uninitialized memory issue where `get_alias` is never initialized to nullptr, therefore causing a configuration error

### DIFF
--- a/runtime/src/require.cpp
+++ b/runtime/src/require.cpp
@@ -214,7 +214,6 @@ static int load(lua_State* L, void* ctx, const char* path, const char* chunkname
 
     RequireCtx* reqCtx = static_cast<RequireCtx*>(ctx);
     std::optional<std::string> contents = getFileContents(reqCtx->currentVFSType, std::string(loadname), "");
-    ;
     if (!contents)
         luaL_error(L, "could not read file '%s'", loadname);
 

--- a/runtime/src/require.cpp
+++ b/runtime/src/require.cpp
@@ -213,7 +213,8 @@ static int load(lua_State* L, void* ctx, const char* path, const char* chunkname
     luaL_sandboxthread(ML);
 
     RequireCtx* reqCtx = static_cast<RequireCtx*>(ctx);
-    std::optional<std::string> contents = getFileContents(reqCtx->currentVFSType, std::string(loadname), "");;
+    std::optional<std::string> contents = getFileContents(reqCtx->currentVFSType, std::string(loadname), "");
+    ;
     if (!contents)
         luaL_error(L, "could not read file '%s'", loadname);
 
@@ -279,4 +280,5 @@ void requireConfigInit(luarequire_Configuration* config)
     config->get_cache_key = get_cache_key;
     config->get_config = get_config;
     config->load = load;
+    config->get_alias = nullptr;
 }


### PR DESCRIPTION
Luau does not allow setting `get_config` and `get_alias` at the same time. Lute does not use `get_alias`, but we also never initialize it to `nullptr` when creating the require configuration. This causes runtime errors, at least on Windows.