### PR TITLE
Remove unnecessary `<iostream>` include

### DIFF
--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -27,7 +27,6 @@
 
 #include "compile.h"
 #include "tc.h"
-#include <iostream>
 
 #ifdef _WIN32
 #include <Windows.h>


### PR DESCRIPTION
Follow-up to #314.