### PR TITLE
Use CMAKE_MODULE_PATH for uSockets and uWebSockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,8 @@ set(WITH_ZLIB ON)
 
 # Set the correct libuv library name for uWebSockets
 set(LIBUV_LIBRARY uv_a)
-include(CMakeBuild/uSockets.cmake)
-include(CMakeBuild/uWebSockets.cmake)
+include(uSockets)
+include(uWebSockets)
 
 # Define include directories for uWebSockets and uSockets
 set(UWEBSOCKETS_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/uWebSockets/src)


### PR DESCRIPTION
This is a simple follow-up build system tweak. Now that we have CMAKE_MODULE_PATH setup, we can more cleanly include uSockets and uWebSockets from that directly.