### PR TITLE
Implement task.spawn

### DIFF
--- a/examples/task-resume.luau
+++ b/examples/task-resume.luau
@@ -8,3 +8,7 @@ end)
 
 task.resume(c)
 task.resume(c, "world", "meow for good measure")
+
+local t = coroutine.running()
+
+task.spawn(print, 3, 2, 1)

--- a/lute/task/include/lute/task.h
+++ b/lute/task/include/lute/task.h
@@ -13,11 +13,13 @@ namespace task
 
 int lua_defer(lua_State* L);
 int lua_wait(lua_State* L);
+int lua_spawn(lua_State* L);
 int lute_resume(lua_State* L);
 
 static const luaL_Reg lib[] = {
     {"defer", lua_defer},
     {"wait", lua_wait},
+    {"spawn", lua_spawn},
 
     {"resume", lute_resume},
 


### PR DESCRIPTION
This PR implements task.spawn under the API of `task.spawn((T...) -> (), thread, T...)`. This is simply `lua_resume` with runtime error reporting added on top, alongside the ability to pass arguments.