### PR TITLE
Build releases on 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             artifact_name: lute-linux-x86_64
             options: --c-compiler clang --cxx-compiler clang++
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-22.04-arm
             artifact_name: lute-linux-aarch64
             options: --c-compiler clang --cxx-compiler clang++
           - os: macos-latest


### PR DESCRIPTION
24.04 is newer than we need and creates builds that don't work on older OS's unnecessarily from glibc that's too new. Let's build on 22.04. Maybe we can always stay behind one? For example 24.04 builds don't even work on latest debian!