### PR TITLE
Improve ModulePath API to facilitate building library VFS subtrees

### DIFF
--- a/lute/require/include/lute/modulepath.h
+++ b/lute/require/include/lute/modulepath.h
@@ -20,9 +20,15 @@ struct ResolvedRealPath
 class ModulePath
 {
 public:
-    ModulePath(
+    // (rootDirectory + '/' + filePath) is the full path to the initial file.
+    // rootDirectory serves as the boundary for parenting, preventing toParent()
+    // from navigating above it. In the simplest cases, rootDirectory might be
+    // "C:" (Windows) or "" (Unix-like systems), but it could be a more specific
+    // directory in cases where the ModulePath is intended to power navigation
+    // strictly within a subtree of a virtual filesystem.
+    static std::optional<ModulePath> create(
+        std::string rootDirectory,
         std::string filePath,
-        size_t endRootDirectory,
         bool (*isAFile)(const std::string&),
         bool (*isADirectory)(const std::string&),
         std::optional<std::string> relativePathToTrack = std::nullopt
@@ -35,10 +41,18 @@ public:
     NavigationStatus toChild(const std::string& name);
 
 private:
+    ModulePath(
+        std::string realPathPrefix,
+        std::string modulePath,
+        bool (*isAFile)(const std::string&),
+        bool (*isADirectory)(const std::string&),
+        std::optional<std::string> relativePathToTrack = std::nullopt
+    );
+
     bool (*isAFile)(const std::string&);
     bool (*isADirectory)(const std::string&);
 
-    std::string modulePath;
     std::string realPathPrefix;
+    std::string modulePath;
     std::optional<std::string> relativePathToTrack;
 };

--- a/lute/require/src/clivfs.cpp
+++ b/lute/require/src/clivfs.cpp
@@ -29,23 +29,19 @@ static bool isCliDirectory(const std::string& path)
 
 NavigationStatus CliVfs::resetToPath(const std::string& path)
 {
-    std::string cliPrefix = "@cli/";
-
     if (path == "@cli")
     {
-        modulePath = ModulePath(cliPrefix, cliPrefix.size() - 1, isCliModule, isCliDirectory);
-        return NavigationStatus::Success;
+        modulePath = ModulePath::create("@cli", "", isCliModule, isCliDirectory);
+        return modulePath ? NavigationStatus::Success : NavigationStatus::NotFound;
     }
+
+    std::string cliPrefix = "@cli/";
 
     if (path.find_first_of(cliPrefix) != 0)
         return NavigationStatus::NotFound;
 
-    CliModuleResult result = getCliModule(path);
-    if (result.type == CliModuleType::NotFound)
-        return NavigationStatus::NotFound;
-
-    modulePath = ModulePath(path, cliPrefix.size() - 1, isCliModule, isCliDirectory);
-    return NavigationStatus::Success;
+    modulePath = ModulePath::create("@cli", path.substr(cliPrefix.size()), isCliModule, isCliDirectory);
+    return modulePath ? NavigationStatus::Success : NavigationStatus::NotFound;
 }
 
 NavigationStatus CliVfs::toParent()

--- a/lute/require/src/filevfs.cpp
+++ b/lute/require/src/filevfs.cpp
@@ -17,9 +17,9 @@ NavigationStatus FileVfs::resetToStdIn()
 
     size_t firstSlash = cwd->find_first_of("\\/");
     LUAU_ASSERT(firstSlash != std::string::npos);
-    modulePath = ModulePath(*cwd + "/stdin", firstSlash, isFile, isDirectory, "./");
 
-    return NavigationStatus::Success;
+    modulePath = ModulePath::create(cwd->substr(0, firstSlash), cwd->substr(firstSlash + 1), isFile, isDirectory, "./");
+    return modulePath ? NavigationStatus::Success : NavigationStatus::NotFound;
 }
 
 NavigationStatus FileVfs::resetToPath(const std::string& path)
@@ -30,7 +30,8 @@ NavigationStatus FileVfs::resetToPath(const std::string& path)
     {
         size_t firstSlash = normalizedPath.find_first_of('/');
         LUAU_ASSERT(firstSlash != std::string::npos);
-        modulePath = ModulePath(normalizedPath, firstSlash, isFile, isDirectory);
+
+        modulePath = ModulePath::create(normalizedPath.substr(0, firstSlash), normalizedPath.substr(firstSlash + 1), isFile, isDirectory);
     }
     else
     {
@@ -42,11 +43,11 @@ NavigationStatus FileVfs::resetToPath(const std::string& path)
 
         size_t firstSlash = joinedPath.find_first_of("\\/");
         LUAU_ASSERT(firstSlash != std::string::npos);
-        modulePath = ModulePath(joinedPath, firstSlash, isFile, isDirectory, normalizedPath);
+
+        modulePath = ModulePath::create(joinedPath.substr(0, firstSlash), joinedPath.substr(firstSlash + 1), isFile, isDirectory, normalizedPath);
     }
 
-    LUAU_ASSERT(modulePath);
-    return modulePath->getRealPath().status;
+    return modulePath ? NavigationStatus::Success : NavigationStatus::NotFound;
 }
 
 NavigationStatus FileVfs::toParent()

--- a/lute/require/src/stdlibvfs.cpp
+++ b/lute/require/src/stdlibvfs.cpp
@@ -1,5 +1,6 @@
 #include "lute/stdlibvfs.h"
 
+#include "lute/modulepath.h"
 #include "lute/stdlib.h"
 
 #include "Luau/Common.h"
@@ -29,23 +30,19 @@ static bool isStdLibDirectory(const std::string& path)
 
 NavigationStatus StdLibVfs::resetToPath(const std::string& path)
 {
-    std::string stdPrefix = "@std/";
-
     if (path == "@std")
     {
-        modulePath = ModulePath(stdPrefix, stdPrefix.size() - 1, isStdLibModule, isStdLibDirectory);
-        return NavigationStatus::Success;
+        modulePath = ModulePath::create("@std", "", isStdLibModule, isStdLibDirectory);
+        return modulePath ? NavigationStatus::Success : NavigationStatus::NotFound;
     }
+
+    std::string stdPrefix = "@std/";
 
     if (path.find_first_of(stdPrefix) != 0)
         return NavigationStatus::NotFound;
 
-    StdLibModuleResult result = getStdLibModule(path);
-    if (result.type == StdLibModuleType::NotFound)
-        return NavigationStatus::NotFound;
-
-    modulePath = ModulePath(path, stdPrefix.size() - 1, isStdLibModule, isStdLibDirectory);
-    return NavigationStatus::Success;
+    modulePath = ModulePath::create("@std", path.substr(stdPrefix.size()), isStdLibModule, isStdLibDirectory);
+    return modulePath ? NavigationStatus::Success : NavigationStatus::NotFound;
 }
 
 NavigationStatus StdLibVfs::toParent()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,10 @@ target_sources(Lute.Test PRIVATE
     src/doctest.h
     src/main.cpp
 
+    src/luteprojectroot.h
+    src/luteprojectroot.cpp
+
+    src/modulepath.test.cpp
     src/require.test.cpp)
 
 set_target_properties(Lute.Test PROPERTIES OUTPUT_NAME lute-tests)

--- a/tests/src/luteprojectroot.cpp
+++ b/tests/src/luteprojectroot.cpp
@@ -1,0 +1,28 @@
+#include "luteprojectroot.h"
+
+#include "Luau/FileUtils.h"
+
+#include "doctest.h"
+
+std::string getLuteProjectRoot()
+{
+    std::optional<std::string> cwd = getCurrentWorkingDirectory();
+    REQUIRE(cwd);
+
+    std::string luteDir = *cwd;
+
+    for (int i = 0; i < 20; ++i)
+    {
+        if (isFile(joinPaths(luteDir, ".LUTE_SENTINEL")))
+        {
+            return luteDir;
+        }
+
+        std::optional<std::string> parentPath = getParentPath(luteDir);
+        REQUIRE_MESSAGE(parentPath, "Error getting parent path");
+        luteDir = *parentPath;
+    }
+
+    REQUIRE_MESSAGE(false, "Error getting Lute project path");
+    return "";
+}

--- a/tests/src/luteprojectroot.h
+++ b/tests/src/luteprojectroot.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+std::string getLuteProjectRoot();

--- a/tests/src/modulepath.test.cpp
+++ b/tests/src/modulepath.test.cpp
@@ -1,71 +1,50 @@
 #include "doctest.h"
+#include "luteprojectroot.h"
 
 #include "lute/modulepath.h"
 
 #include "Luau/FileUtils.h"
 
-static std::string getLuteProjectRoot()
-{
-    std::optional<std::string> cwd = getCurrentWorkingDirectory();
-    REQUIRE(cwd);
-
-    std::string luteDir = *cwd;
-
-    for (int i = 0; i < 20; ++i)
-    {
-        if (isFile(joinPaths(luteDir, ".LUTE_SENTINEL")))
-        {
-            return luteDir;
-        }
-
-        std::optional<std::string> parentPath = getParentPath(luteDir);
-        REQUIRE_MESSAGE(parentPath, "Error getting parent path");
-        luteDir = *parentPath;
-    }
-
-    REQUIRE_MESSAGE(false, "Error getting Lute project path");
-    return "";
-}
-
 TEST_CASE("module_path")
 {
     std::string luteProjectRoot = getLuteProjectRoot();
 
-    std::string modulePathRoot = luteProjectRoot + "/tests/src/modulepathroot/";
-    std::string file = modulePathRoot + "module/init.luau";
+    std::string modulePathRoot = luteProjectRoot + "/tests/src/modulepathroot";
+    std::string file = "module/init.luau";
 
-    ModulePath mp = ModulePath(file, modulePathRoot.size() - 1, isFile, isDirectory);
+    std::optional<ModulePath> mp = ModulePath::create(modulePathRoot, file, isFile, isDirectory);
+    REQUIRE(mp);
 
     SUBCASE("parent_to_root")
     {
-        CHECK(mp.toParent() == NavigationStatus::Success);
-        CHECK(mp.getRealPath().realPath == modulePathRoot);
+        CHECK(mp->toParent() == NavigationStatus::Success);
+        CHECK(mp->getRealPath().realPath == modulePathRoot);
     }
     SUBCASE("parent_past_root")
     {
-        CHECK(mp.toParent() == NavigationStatus::Success);
-        CHECK(mp.toParent() == NavigationStatus::NotFound);
+        CHECK(mp->toParent() == NavigationStatus::Success);
+        CHECK(mp->toParent() == NavigationStatus::NotFound);
     }
     SUBCASE("parent_then_child")
     {
-        CHECK(mp.toParent() == NavigationStatus::Success);
-        CHECK(mp.toChild("module") == NavigationStatus::Success);
-        CHECK(mp.getRealPath().realPath == modulePathRoot + "module/init.luau");
+        CHECK(mp->toParent() == NavigationStatus::Success);
+        CHECK(mp->toChild("module") == NavigationStatus::Success);
+        CHECK(mp->getRealPath().realPath == modulePathRoot + '/' + "module/init.luau");
     }
     SUBCASE("child")
     {
-        CHECK(mp.toChild("submodule") == NavigationStatus::Success);
-        CHECK(mp.getRealPath().realPath == modulePathRoot + "module/submodule.luau");
+        CHECK(mp->toChild("submodule") == NavigationStatus::Success);
+        CHECK(mp->getRealPath().realPath == modulePathRoot + '/' + "module/submodule.luau");
     }
     SUBCASE("child_not_found")
     {
-        CHECK(mp.toChild("submodule") == NavigationStatus::Success);
-        CHECK(mp.toChild("nonexistant") == NavigationStatus::NotFound);
+        CHECK(mp->toChild("submodule") == NavigationStatus::Success);
+        CHECK(mp->toChild("nonexistant") == NavigationStatus::NotFound);
     }
     SUBCASE("child_then_parent")
     {
-        CHECK(mp.toChild("submodule") == NavigationStatus::Success);
-        CHECK(mp.toParent() == NavigationStatus::Success);
-        CHECK(mp.getRealPath().realPath == modulePathRoot + "module/init.luau");
+        CHECK(mp->toChild("submodule") == NavigationStatus::Success);
+        CHECK(mp->toParent() == NavigationStatus::Success);
+        CHECK(mp->getRealPath().realPath == modulePathRoot + '/' + "module/init.luau");
     }
 }


### PR DESCRIPTION
Updates the `ModulePath` API to avoid needing to provide a position when defining the root directory to which a `ModulePath` can parent. Constructing a `ModulePath` is also simplified via the new `create` factory function that returns `std::nullopt` in case of an invalid starting `ModulePath`.

During this work, I realized that certain tests had been disabled unintentionally—most likely due to the build system PR. I've re-enabled the tests in `modulepath.test.cpp` now. I've also created `luteprojectroot.h` and `luteprojectroot.cpp`, as require-by-string tests (to be added soon) will also need these available.