### PR TITLE
Add unit tests for require-by-string implementation in lute

### DIFF
--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -26,7 +26,7 @@ target_sources(Lute.CLI.lib PRIVATE
 
 target_compile_features(Lute.CLI.lib PUBLIC cxx_std_17)
 target_include_directories(Lute.CLI.lib PUBLIC include)
-target_link_libraries(Lute.CLI.lib PRIVATE Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Require Lute.Runtime Lute.Crypto Lute.Fs Lute.Luau Lute.Net Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Luau.CLI.lib)
+target_link_libraries(Lute.CLI.lib PRIVATE Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Require Lute.Runtime Luau.CLI.lib)
 target_compile_options(Lute.CLI.lib PRIVATE ${LUTE_OPTIONS})
 
 add_executable(Lute.CLI)

--- a/lute/cli/include/lute/climain.h
+++ b/lute/cli/include/lute/climain.h
@@ -1,3 +1,7 @@
 #pragma once
 
+struct lua_State;
+struct Runtime;
+
+lua_State* setupCliState(Runtime& runtime);
 int cliMain(int argc, char** argv);

--- a/lute/runtime/CMakeLists.txt
+++ b/lute/runtime/CMakeLists.txt
@@ -11,5 +11,5 @@ target_sources(Lute.Runtime PRIVATE
 
 target_compile_features(Lute.Runtime PUBLIC cxx_std_17)
 target_include_directories(Lute.Runtime PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Runtime PRIVATE Luau.Common Luau.VM uv_a)
+target_link_libraries(Lute.Runtime PRIVATE Lute.Crypto Lute.Fs Lute.Luau Lute.Net Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Luau.Common Luau.Require Luau.VM uv_a)
 target_compile_options(Lute.Runtime PRIVATE ${LUTE_OPTIONS})

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -111,3 +111,5 @@ struct ResumeTokenData
 };
 
 ResumeToken getResumeToken(lua_State* L);
+
+lua_State* setupState(Runtime& runtime, void (*doBeforeSandbox)(lua_State*));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,5 +12,5 @@ target_sources(Lute.Test PRIVATE
 
 set_target_properties(Lute.Test PROPERTIES OUTPUT_NAME lute-tests)
 target_compile_features(Lute.Test PUBLIC cxx_std_17)
-target_link_libraries(Lute.Test PRIVATE Lute.Require Luau.CLI.lib)
+target_link_libraries(Lute.Test PRIVATE Lute.CLI.lib Lute.Require Lute.Runtime Luau.CLI.lib)
 target_compile_options(Lute.Test PRIVATE ${LUTE_OPTIONS})

--- a/tests/src/luteprojectroot.cpp
+++ b/tests/src/luteprojectroot.cpp
@@ -4,7 +4,7 @@
 
 #include "doctest.h"
 
-std::string getLuteProjectRoot()
+std::string getLuteProjectRootAbsolute()
 {
     std::optional<std::string> cwd = getCurrentWorkingDirectory();
     REQUIRE(cwd);
@@ -21,6 +21,24 @@ std::string getLuteProjectRoot()
         std::optional<std::string> parentPath = getParentPath(luteDir);
         REQUIRE_MESSAGE(parentPath, "Error getting parent path");
         luteDir = *parentPath;
+    }
+
+    REQUIRE_MESSAGE(false, "Error getting Lute project path");
+    return "";
+}
+
+std::string getLuteProjectRootRelative()
+{
+    std::string luteDir = "./";
+
+    for (int i = 0; i < 20; ++i)
+    {
+        if (isFile(joinPaths(luteDir, ".LUTE_SENTINEL")))
+        {
+            return luteDir;
+        }
+
+        luteDir = normalizePath(luteDir + "/..");
     }
 
     REQUIRE_MESSAGE(false, "Error getting Lute project path");

--- a/tests/src/luteprojectroot.cpp
+++ b/tests/src/luteprojectroot.cpp
@@ -9,6 +9,12 @@ std::string getLuteProjectRootAbsolute()
     std::optional<std::string> cwd = getCurrentWorkingDirectory();
     REQUIRE(cwd);
 
+    for (char& c : *cwd)
+    {
+        if (c == '\\')
+            c = '/';
+    }
+
     std::string luteDir = *cwd;
 
     for (int i = 0; i < 20; ++i)

--- a/tests/src/luteprojectroot.h
+++ b/tests/src/luteprojectroot.h
@@ -2,4 +2,5 @@
 
 #include <string>
 
-std::string getLuteProjectRoot();
+std::string getLuteProjectRootAbsolute();
+std::string getLuteProjectRootRelative();

--- a/tests/src/modulepath.test.cpp
+++ b/tests/src/modulepath.test.cpp
@@ -7,44 +7,45 @@
 
 TEST_CASE("module_path")
 {
-    std::string luteProjectRoot = getLuteProjectRoot();
+    for (const std::string& luteProjectRoot : {getLuteProjectRootRelative(), getLuteProjectRootAbsolute()})
+    {
+        std::string modulePathRoot = joinPaths(luteProjectRoot, "tests/src/modulepathroot");
+        std::string file = "module/init.luau";
 
-    std::string modulePathRoot = luteProjectRoot + "/tests/src/modulepathroot";
-    std::string file = "module/init.luau";
+        std::optional<ModulePath> mp = ModulePath::create(modulePathRoot, file, isFile, isDirectory);
+        REQUIRE(mp);
 
-    std::optional<ModulePath> mp = ModulePath::create(modulePathRoot, file, isFile, isDirectory);
-    REQUIRE(mp);
-
-    SUBCASE("parent_to_root")
-    {
-        CHECK(mp->toParent() == NavigationStatus::Success);
-        CHECK(mp->getRealPath().realPath == modulePathRoot);
-    }
-    SUBCASE("parent_past_root")
-    {
-        CHECK(mp->toParent() == NavigationStatus::Success);
-        CHECK(mp->toParent() == NavigationStatus::NotFound);
-    }
-    SUBCASE("parent_then_child")
-    {
-        CHECK(mp->toParent() == NavigationStatus::Success);
-        CHECK(mp->toChild("module") == NavigationStatus::Success);
-        CHECK(mp->getRealPath().realPath == modulePathRoot + '/' + "module/init.luau");
-    }
-    SUBCASE("child")
-    {
-        CHECK(mp->toChild("submodule") == NavigationStatus::Success);
-        CHECK(mp->getRealPath().realPath == modulePathRoot + '/' + "module/submodule.luau");
-    }
-    SUBCASE("child_not_found")
-    {
-        CHECK(mp->toChild("submodule") == NavigationStatus::Success);
-        CHECK(mp->toChild("nonexistant") == NavigationStatus::NotFound);
-    }
-    SUBCASE("child_then_parent")
-    {
-        CHECK(mp->toChild("submodule") == NavigationStatus::Success);
-        CHECK(mp->toParent() == NavigationStatus::Success);
-        CHECK(mp->getRealPath().realPath == modulePathRoot + '/' + "module/init.luau");
+        SUBCASE("parent_to_root")
+        {
+            CHECK(mp->toParent() == NavigationStatus::Success);
+            CHECK(mp->getRealPath().realPath == modulePathRoot);
+        }
+        SUBCASE("parent_past_root")
+        {
+            CHECK(mp->toParent() == NavigationStatus::Success);
+            CHECK(mp->toParent() == NavigationStatus::NotFound);
+        }
+        SUBCASE("parent_then_child")
+        {
+            CHECK(mp->toParent() == NavigationStatus::Success);
+            CHECK(mp->toChild("module") == NavigationStatus::Success);
+            CHECK(mp->getRealPath().realPath == joinPaths(modulePathRoot, "module/init.luau"));
+        }
+        SUBCASE("child")
+        {
+            CHECK(mp->toChild("submodule") == NavigationStatus::Success);
+            CHECK(mp->getRealPath().realPath == joinPaths(modulePathRoot, "module/submodule.luau"));
+        }
+        SUBCASE("child_not_found")
+        {
+            CHECK(mp->toChild("submodule") == NavigationStatus::Success);
+            CHECK(mp->toChild("nonexistant") == NavigationStatus::NotFound);
+        }
+        SUBCASE("child_then_parent")
+        {
+            CHECK(mp->toChild("submodule") == NavigationStatus::Success);
+            CHECK(mp->toParent() == NavigationStatus::Success);
+            CHECK(mp->getRealPath().realPath == joinPaths(modulePathRoot, "module/init.luau"));
+        }
     }
 }

--- a/tests/src/require.test.cpp
+++ b/tests/src/require.test.cpp
@@ -1,38 +1,153 @@
+#include "Luau/FileUtils.h"
 #include "doctest.h"
 
+#include "lute/climain.h"
 #include "lute/require.h"
+#include "lute/runtime.h"
 
 #include "Luau/Require.h"
 
 #include "lua.h"
 #include "lualib.h"
+#include "luteprojectroot.h"
 
 #include <memory>
 
-class LuaStateFixture
+class CliRuntimeFixture
 {
 public:
-    LuaStateFixture()
-        : luaState(luaL_newstate(), lua_close)
+    CliRuntimeFixture()
+        : runtime(std::make_unique<Runtime>())
     {
-        luaL_openlibs(luaState.get());
-        L = luaState.get();
+        L = setupCliState(*runtime);
     }
 
     lua_State* L;
 
 private:
-    std::unique_ptr<lua_State, void (*)(lua_State*)> luaState;
+    std::unique_ptr<Runtime> runtime;
 };
 
-TEST_CASE_FIXTURE(LuaStateFixture, "open_require")
+TEST_CASE_FIXTURE(CliRuntimeFixture, "require_exists")
 {
     lua_getglobal(L, "require");
-    CHECK(lua_isnil(L, -1));
-
-    RequireCtx ctx{};
-    luaopen_require(L, requireConfigInit, &ctx);
-
-    lua_getglobal(L, "require");
     CHECK(!lua_isnil(L, -1));
+}
+
+TEST_CASE("require_modules")
+{
+    auto doPassingSubcase = [](std::vector<char*>& argv, std::string requirePath, std::vector<std::string> expectedResults)
+    {
+        std::string pass = "pass";
+        argv.push_back(pass.data());
+        argv.push_back(requirePath.data());
+        for (std::string& result : expectedResults)
+        {
+            argv.push_back(result.data());
+        }
+        CHECK_EQ(cliMain(argv.size(), argv.data()), 0);
+    };
+
+    auto doFailingSubcase = [](std::vector<char*>& argv, std::string requirePath, std::vector<std::string> expectedResults)
+    {
+        std::string fail = "fail";
+        argv.push_back(fail.data());
+        argv.push_back(requirePath.data());
+        for (std::string& result : expectedResults)
+        {
+            argv.push_back(result.data());
+        }
+        CHECK_EQ(cliMain(argv.size(), argv.data()), 0);
+    };
+
+    char executablePlaceholder[] = "lute";
+
+    for (const std::string& luteProjectRoot : {getLuteProjectRootRelative(), getLuteProjectRootAbsolute()})
+    {
+        std::string requirer = joinPaths(luteProjectRoot, "tests/src/require/requirer.luau");
+        std::vector<char*> argv = {executablePlaceholder, requirer.data()};
+
+        SUBCASE("dependency")
+        {
+            doPassingSubcase(argv, "./without_config/dependency", {"result from dependency"});
+        }
+
+        SUBCASE("lua_dependency")
+        {
+            doPassingSubcase(argv, "./without_config/lua_dependency", {"result from lua_dependency"});
+        }
+
+        SUBCASE("module")
+        {
+            doPassingSubcase(argv, {"./without_config/module"}, {"result from dependency", "required into module"});
+        }
+
+        SUBCASE("init_luau")
+        {
+            doPassingSubcase(argv, {"./without_config/luau"}, {"result from init.luau"});
+        }
+        
+        SUBCASE("init_lua")
+        {
+            doPassingSubcase(argv, {"./without_config/lua"}, {"result from init.lua"});
+        }
+
+        SUBCASE("nested_inits")
+        {
+            doPassingSubcase(argv, {"./without_config/nested_inits_requirer"}, {"result from nested_inits/init", "required into module"});
+        }
+
+        SUBCASE("nested_module")
+        {
+            doPassingSubcase(argv, {"./without_config/nested_module_requirer"}, {"result from submodule", "required into module"});
+        }
+
+        SUBCASE("with_directory_ambiguity")
+        {
+            doFailingSubcase(
+                argv,
+                {"./without_config/ambiguous_directory_requirer"},
+                {R"(error requiring module "./ambiguous/directory/dependency": could not resolve child component "dependency" (ambiguous))"}
+            );
+        }
+
+        SUBCASE("with_file_ambiguity")
+        {
+            doFailingSubcase(
+                argv,
+                {"./without_config/ambiguous_file_requirer"},
+                {R"(error requiring module "./ambiguous/file/dependency": could not resolve child component "dependency" (ambiguous))"}
+            );
+        }
+
+        SUBCASE("with_module_alias")
+        {
+            doPassingSubcase(argv, {"./with_config/src/alias_requirer"}, {"result from dependency"});
+        }
+
+        SUBCASE("with_directory_alias")
+        {
+            doPassingSubcase(argv, {"./with_config/src/directory_alias_requirer"}, {"result from subdirectory_dependency"});
+        }
+
+        SUBCASE("with_parent_configuration_alias")
+        {
+            doPassingSubcase(argv, {"./with_config/src/parent_alias_requirer"}, {"result from other_dependency"});
+        }
+
+        SUBCASE("init_does_not_read_sibling_luaurc")
+        {
+            doPassingSubcase(argv, {"./with_config/src/submodule"}, {"result from dependency"});
+        }
+
+        SUBCASE("lute_modules")
+        {
+            doPassingSubcase(argv, {"./lute/lute"}, {"successfully required @lute modules"});
+        }
+
+        SUBCASE("std_modules")
+        {
+            doPassingSubcase(argv, {"./lute/std"}, {"successfully required @std modules"});
+        }
+    }
 }

--- a/tests/src/require/lute/lute.luau
+++ b/tests/src/require/lute/lute.luau
@@ -1,0 +1,21 @@
+local crypto = require("@lute/crypto")
+local fs = require("@lute/fs")
+local luau = require("@lute/luau")
+local net = require("@lute/net")
+local process = require("@lute/process")
+local task = require("@lute/task")
+local vm = require("@lute/vm")
+local system = require("@lute/system")
+local time = require("@lute/time")
+
+assert(type(crypto) == "table")
+assert(type(fs) == "table")
+assert(type(luau) == "table")
+assert(type(net) == "table")
+assert(type(process) == "table")
+assert(type(task) == "table")
+assert(type(vm) == "table")
+assert(type(system) == "table")
+assert(type(time) == "table")
+
+return { "successfully required @lute modules" }

--- a/tests/src/require/lute/std.luau
+++ b/tests/src/require/lute/std.luau
@@ -1,0 +1,11 @@
+local table = require("@std/table")
+local task = require("@std/task")
+local time = require("@std/time")
+local vector = require("@std/vector")
+
+assert(type(table) == "table")
+assert(type(task) == "table")
+assert(type(time) == "table")
+assert(type(vector) == "table")
+
+return { "successfully required @std modules" }

--- a/tests/src/require/requirer.luau
+++ b/tests/src/require/requirer.luau
@@ -1,0 +1,21 @@
+--!strict
+local args: { string } = { ... }
+assert(#args >= 3)
+
+local shouldPass = args[2] == "pass"
+
+local ok, result = pcall(require, args[3])
+assert(ok == shouldPass)
+
+if ok then
+	assert(type(result) == "table")
+	assert(#result == #args - 3)
+
+	for i = 4, #args do
+		assert(result[i - 3] == args[i])
+	end
+else
+	assert(type(result) == "string")
+	assert(#args == 4)
+	assert(result:find(args[4], 1, true) ~= nil)
+end

--- a/tests/src/require/requirer.luau
+++ b/tests/src/require/requirer.luau
@@ -4,7 +4,7 @@ assert(#args >= 3)
 
 local shouldPass = args[2] == "pass"
 
-local ok, result = pcall(require, args[3])
+local ok: boolean, result: { string } = pcall(require, args[3])
 assert(ok == shouldPass)
 
 if ok then

--- a/tests/src/require/with_config/.luaurc
+++ b/tests/src/require/with_config/.luaurc
@@ -1,0 +1,6 @@
+{
+    "aliases": {
+        "dep": "./this_should_be_overwritten_by_child_luaurc",
+        "otherdep": "./src/other_dependency"
+    }
+}

--- a/tests/src/require/with_config/src/.luaurc
+++ b/tests/src/require/with_config/src/.luaurc
@@ -1,0 +1,6 @@
+{
+    "aliases": {
+        "dep": "./dependency",
+        "subdir": "./subdirectory"
+    }
+}

--- a/tests/src/require/with_config/src/alias_requirer.luau
+++ b/tests/src/require/with_config/src/alias_requirer.luau
@@ -1,0 +1,1 @@
+return require("@dep")

--- a/tests/src/require/with_config/src/dependency.luau
+++ b/tests/src/require/with_config/src/dependency.luau
@@ -1,0 +1,1 @@
+return {"result from dependency"}

--- a/tests/src/require/with_config/src/dependency.luau
+++ b/tests/src/require/with_config/src/dependency.luau
@@ -1,1 +1,1 @@
-return {"result from dependency"}
+return { "result from dependency" }

--- a/tests/src/require/with_config/src/directory_alias_requirer.luau
+++ b/tests/src/require/with_config/src/directory_alias_requirer.luau
@@ -1,0 +1,1 @@
+return(require("@subdir/subdirectory_dependency"))

--- a/tests/src/require/with_config/src/directory_alias_requirer.luau
+++ b/tests/src/require/with_config/src/directory_alias_requirer.luau
@@ -1,1 +1,1 @@
-return(require("@subdir/subdirectory_dependency"))
+return (require("@subdir/subdirectory_dependency"))

--- a/tests/src/require/with_config/src/other_dependency.luau
+++ b/tests/src/require/with_config/src/other_dependency.luau
@@ -1,0 +1,1 @@
+return {"result from other_dependency"}

--- a/tests/src/require/with_config/src/other_dependency.luau
+++ b/tests/src/require/with_config/src/other_dependency.luau
@@ -1,1 +1,1 @@
-return {"result from other_dependency"}
+return { "result from other_dependency" }

--- a/tests/src/require/with_config/src/parent_alias_requirer.luau
+++ b/tests/src/require/with_config/src/parent_alias_requirer.luau
@@ -1,0 +1,1 @@
+return require("@otherdep")

--- a/tests/src/require/with_config/src/subdirectory/subdirectory_dependency.luau
+++ b/tests/src/require/with_config/src/subdirectory/subdirectory_dependency.luau
@@ -1,0 +1,1 @@
+return {"result from subdirectory_dependency"}

--- a/tests/src/require/with_config/src/subdirectory/subdirectory_dependency.luau
+++ b/tests/src/require/with_config/src/subdirectory/subdirectory_dependency.luau
@@ -1,1 +1,1 @@
-return {"result from subdirectory_dependency"}
+return { "result from subdirectory_dependency" }

--- a/tests/src/require/with_config/src/submodule/.luaurc
+++ b/tests/src/require/with_config/src/submodule/.luaurc
@@ -1,0 +1,5 @@
+{
+    "aliases": {
+        "dep": "./this_should_not_be_read_by_init_luau",
+    }
+}

--- a/tests/src/require/with_config/src/submodule/init.luau
+++ b/tests/src/require/with_config/src/submodule/init.luau
@@ -1,0 +1,1 @@
+return require("@dep")

--- a/tests/src/require/without_config/ambiguous/directory/dependency.luau
+++ b/tests/src/require/without_config/ambiguous/directory/dependency.luau
@@ -1,0 +1,1 @@
+return {"result from dependency"}

--- a/tests/src/require/without_config/ambiguous/directory/dependency.luau
+++ b/tests/src/require/without_config/ambiguous/directory/dependency.luau
@@ -1,1 +1,1 @@
-return {"result from dependency"}
+return { "result from dependency" }

--- a/tests/src/require/without_config/ambiguous/directory/dependency/init.luau
+++ b/tests/src/require/without_config/ambiguous/directory/dependency/init.luau
@@ -1,0 +1,1 @@
+return {"result from dependency"}

--- a/tests/src/require/without_config/ambiguous/directory/dependency/init.luau
+++ b/tests/src/require/without_config/ambiguous/directory/dependency/init.luau
@@ -1,1 +1,1 @@
-return {"result from dependency"}
+return { "result from dependency" }

--- a/tests/src/require/without_config/ambiguous/file/dependency.lua
+++ b/tests/src/require/without_config/ambiguous/file/dependency.lua
@@ -1,0 +1,1 @@
+return {"result from dependency"}

--- a/tests/src/require/without_config/ambiguous/file/dependency.lua
+++ b/tests/src/require/without_config/ambiguous/file/dependency.lua
@@ -1,1 +1,1 @@
-return {"result from dependency"}
+return { "result from dependency" }

--- a/tests/src/require/without_config/ambiguous/file/dependency.luau
+++ b/tests/src/require/without_config/ambiguous/file/dependency.luau
@@ -1,0 +1,1 @@
+return {"result from dependency"}

--- a/tests/src/require/without_config/ambiguous/file/dependency.luau
+++ b/tests/src/require/without_config/ambiguous/file/dependency.luau
@@ -1,1 +1,1 @@
-return {"result from dependency"}
+return { "result from dependency" }

--- a/tests/src/require/without_config/ambiguous_directory_requirer.luau
+++ b/tests/src/require/without_config/ambiguous_directory_requirer.luau
@@ -1,0 +1,3 @@
+local result = require("./ambiguous/directory/dependency")
+result[#result+1] = "required into module"
+return result

--- a/tests/src/require/without_config/ambiguous_directory_requirer.luau
+++ b/tests/src/require/without_config/ambiguous_directory_requirer.luau
@@ -1,3 +1,3 @@
 local result = require("./ambiguous/directory/dependency")
-result[#result+1] = "required into module"
+result[#result + 1] = "required into module"
 return result

--- a/tests/src/require/without_config/ambiguous_file_requirer.luau
+++ b/tests/src/require/without_config/ambiguous_file_requirer.luau
@@ -1,0 +1,3 @@
+local result = require("./ambiguous/file/dependency")
+result[#result+1] = "required into module"
+return result

--- a/tests/src/require/without_config/ambiguous_file_requirer.luau
+++ b/tests/src/require/without_config/ambiguous_file_requirer.luau
@@ -1,3 +1,3 @@
 local result = require("./ambiguous/file/dependency")
-result[#result+1] = "required into module"
+result[#result + 1] = "required into module"
 return result

--- a/tests/src/require/without_config/dependency.luau
+++ b/tests/src/require/without_config/dependency.luau
@@ -1,0 +1,1 @@
+return {"result from dependency"}

--- a/tests/src/require/without_config/dependency.luau
+++ b/tests/src/require/without_config/dependency.luau
@@ -1,1 +1,1 @@
-return {"result from dependency"}
+return { "result from dependency" }

--- a/tests/src/require/without_config/lua/init.lua
+++ b/tests/src/require/without_config/lua/init.lua
@@ -1,0 +1,1 @@
+return {"result from init.lua"}

--- a/tests/src/require/without_config/lua/init.lua
+++ b/tests/src/require/without_config/lua/init.lua
@@ -1,1 +1,1 @@
-return {"result from init.lua"}
+return { "result from init.lua" }

--- a/tests/src/require/without_config/lua_dependency.lua
+++ b/tests/src/require/without_config/lua_dependency.lua
@@ -1,0 +1,1 @@
+return {"result from lua_dependency"}

--- a/tests/src/require/without_config/lua_dependency.lua
+++ b/tests/src/require/without_config/lua_dependency.lua
@@ -1,1 +1,1 @@
-return {"result from lua_dependency"}
+return { "result from lua_dependency" }

--- a/tests/src/require/without_config/luau/init.luau
+++ b/tests/src/require/without_config/luau/init.luau
@@ -1,0 +1,1 @@
+return {"result from init.luau"}

--- a/tests/src/require/without_config/luau/init.luau
+++ b/tests/src/require/without_config/luau/init.luau
@@ -1,1 +1,1 @@
-return {"result from init.luau"}
+return { "result from init.luau" }

--- a/tests/src/require/without_config/module.luau
+++ b/tests/src/require/without_config/module.luau
@@ -1,0 +1,3 @@
+local result = require("./dependency")
+result[#result+1] = "required into module"
+return result

--- a/tests/src/require/without_config/module.luau
+++ b/tests/src/require/without_config/module.luau
@@ -1,3 +1,3 @@
 local result = require("./dependency")
-result[#result+1] = "required into module"
+result[#result + 1] = "required into module"
 return result

--- a/tests/src/require/without_config/nested/init.luau
+++ b/tests/src/require/without_config/nested/init.luau
@@ -1,0 +1,2 @@
+local result = require("@self/submodule")
+return result

--- a/tests/src/require/without_config/nested/submodule.luau
+++ b/tests/src/require/without_config/nested/submodule.luau
@@ -1,0 +1,1 @@
+return {"result from submodule"}

--- a/tests/src/require/without_config/nested/submodule.luau
+++ b/tests/src/require/without_config/nested/submodule.luau
@@ -1,1 +1,1 @@
-return {"result from submodule"}
+return { "result from submodule" }

--- a/tests/src/require/without_config/nested_inits/init.luau
+++ b/tests/src/require/without_config/nested_inits/init.luau
@@ -1,0 +1,2 @@
+local result = require("@self/init")
+return result

--- a/tests/src/require/without_config/nested_inits/init/init.luau
+++ b/tests/src/require/without_config/nested_inits/init/init.luau
@@ -1,0 +1,1 @@
+return {"result from nested_inits/init"}

--- a/tests/src/require/without_config/nested_inits/init/init.luau
+++ b/tests/src/require/without_config/nested_inits/init/init.luau
@@ -1,1 +1,1 @@
-return {"result from nested_inits/init"}
+return { "result from nested_inits/init" }

--- a/tests/src/require/without_config/nested_inits_requirer.luau
+++ b/tests/src/require/without_config/nested_inits_requirer.luau
@@ -1,0 +1,3 @@
+local result = require("./nested_inits")
+result[#result+1] = "required into module"
+return result

--- a/tests/src/require/without_config/nested_inits_requirer.luau
+++ b/tests/src/require/without_config/nested_inits_requirer.luau
@@ -1,3 +1,3 @@
 local result = require("./nested_inits")
-result[#result+1] = "required into module"
+result[#result + 1] = "required into module"
 return result

--- a/tests/src/require/without_config/nested_module_requirer.luau
+++ b/tests/src/require/without_config/nested_module_requirer.luau
@@ -1,0 +1,3 @@
+local result = require("./nested")
+result[#result+1] = "required into module"
+return result

--- a/tests/src/require/without_config/nested_module_requirer.luau
+++ b/tests/src/require/without_config/nested_module_requirer.luau
@@ -1,3 +1,3 @@
 local result = require("./nested")
-result[#result+1] = "required into module"
+result[#result + 1] = "required into module"
 return result


### PR DESCRIPTION
This PR has two main aspects:
1. We copy over the existing require-by-string test files from the Luau repository to Lute and add test cases in `require.test.cpp`. We also add some new tests for Lute-specific behavior `lute.luau` and `std.luau`.
2. We move the `setupState` logic that used to be under `Lute.CLI.lib` to be under `Lute.Runtime` instead.