### PR TITLE
Add lineOffsets field to Luau parser output

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -553,6 +553,7 @@ export type ParseResult = {
 	root: AstStatBlock,
 	eof: Eof,
 	lines: number,
+	lineOffsets: { number },
 }
 
 function luau.parse(source: string): ParseResult

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -2580,10 +2580,12 @@ int luau_parse(lua_State* L)
     lua_setfield(L, -2, "lines");
 
     lua_createtable(L, serializer.lineOffsets.size(), 0);
+    int j = 0;
     for (size_t i = 0; i < serializer.lineOffsets.size(); i++)
     {
+        lua_pushinteger(L, ++j);
         lua_pushnumber(L, serializer.lineOffsets[i]);
-        lua_rawseti(L, -2, i + 1);
+        lua_settable(L, -3);
     }
     lua_setfield(L, -2, "lineOffsets");
 

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -273,7 +273,7 @@ struct AstSerialize : public Luau::AstVisitor
         return result;
     }
 
-    // Splits a list of trivia into trailing trivia for the previos token, and leading trivia for the next token
+    // Splits a list of trivia into trailing trivia for the previous token, and leading trivia for the next token
     // The trailing trivia consists of all trivia up to and including the first '\n' character seen
     static std::pair<std::vector<Trivia>, std::vector<Trivia>> splitTrivia(std::vector<Trivia> trivia)
     {
@@ -620,7 +620,12 @@ struct AstSerialize : public Luau::AstVisitor
         }
     }
 
-    void serializePunctuated(Luau::AstArray<Luau::AstLocal*> nodes, Luau::AstArray<Luau::Position> separators, const char* separatorText, Luau::AstArray<Luau::Position> colonPositions)
+    void serializePunctuated(
+        Luau::AstArray<Luau::AstLocal*> nodes,
+        Luau::AstArray<Luau::Position> separators,
+        const char* separatorText,
+        Luau::AstArray<Luau::Position> colonPositions
+    )
     {
         lua_rawcheckstack(L, 3);
         lua_createtable(L, nodes.size, 0);
@@ -629,7 +634,7 @@ struct AstSerialize : public Luau::AstVisitor
         {
             lua_createtable(L, 0, 2);
 
-            serialize(nodes.data[i], /* createToken=*/ true, colonPositions.size > i ? std::make_optional(colonPositions.data[i]): std::nullopt);
+            serialize(nodes.data[i], /* createToken=*/true, colonPositions.size > i ? std::make_optional(colonPositions.data[i]) : std::nullopt);
             lua_setfield(L, -2, "node");
 
             if (i < separators.size)
@@ -641,7 +646,6 @@ struct AstSerialize : public Luau::AstVisitor
             lua_rawseti(L, -2, i + 1);
         }
     }
-
     void serializeAttribute(Luau::AstAttr* node)
     {
         switch (node->type)
@@ -752,7 +756,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeToken(node->location.begin, node->local->name.value);
         lua_setfield(L, -2, "token"),
 
-        serialize(node->local);
+            serialize(node->local);
         lua_setfield(L, -2, "local");
 
         lua_pushboolean(L, node->upvalue);
@@ -1970,7 +1974,8 @@ struct AstSerialize : public Luau::AstVisitor
                 node->types.data[i]->visit(this);
                 lua_setfield(L, -2, "node");
 
-                if (i < node->types.size - 1 && !node->types.data[i+1]->is<Luau::AstTypeOptional>() && separatorPositions < cstNode->separatorPositions.size)
+                if (i < node->types.size - 1 && !node->types.data[i + 1]->is<Luau::AstTypeOptional>() &&
+                    separatorPositions < cstNode->separatorPositions.size)
                     serializeToken(cstNode->separatorPositions.data[separatorPositions], "|");
                 else
                     lua_pushnil(L);
@@ -2560,9 +2565,9 @@ int luau_parse(lua_State* L)
         luaL_error(L, "parsing failed:\n%s", fullError.c_str());
     }
 
-    lua_rawcheckstack(L, 3);
+    lua_rawcheckstack(L, 4);
 
-    lua_createtable(L, 0, 3);
+    lua_createtable(L, 0, 5);
 
     AstSerialize serializer{L, source, result.parseResult.cstNodeMap, result.parseResult.commentLocations};
     serializer.visit(result.parseResult.root);
@@ -2573,6 +2578,14 @@ int luau_parse(lua_State* L)
 
     lua_pushnumber(L, result.parseResult.lines);
     lua_setfield(L, -2, "lines");
+
+    lua_createtable(L, serializer.lineOffsets.size(), 0);
+    for (size_t i = 0; i < serializer.lineOffsets.size(); i++)
+    {
+        lua_pushnumber(L, serializer.lineOffsets[i]);
+        lua_rawseti(L, -2, i + 1);
+    }
+    lua_setfield(L, -2, "lineOffsets");
 
     return 1;
 }

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -2565,9 +2565,9 @@ int luau_parse(lua_State* L)
         luaL_error(L, "parsing failed:\n%s", fullError.c_str());
     }
 
-    lua_rawcheckstack(L, 4);
+    lua_rawcheckstack(L, 6);
 
-    lua_createtable(L, 0, 5);
+    lua_createtable(L, 0, 4);
 
     AstSerialize serializer{L, source, result.parseResult.cstNodeMap, result.parseResult.commentLocations};
     serializer.visit(result.parseResult.root);
@@ -2580,10 +2580,9 @@ int luau_parse(lua_State* L)
     lua_setfield(L, -2, "lines");
 
     lua_createtable(L, serializer.lineOffsets.size(), 0);
-    int j = 0;
     for (size_t i = 0; i < serializer.lineOffsets.size(); i++)
     {
-        lua_pushinteger(L, ++j);
+        lua_pushinteger(L, i + 1);
         lua_pushnumber(L, serializer.lineOffsets[i]);
         lua_settable(L, -3);
     }

--- a/tests/testAstSerializer.spec.luau
+++ b/tests/testAstSerializer.spec.luau
@@ -3,7 +3,7 @@ local fs = require("@lute/fs")
 
 local parser = require("@batteries/syntax/parser")
 local printer = require("@batteries/syntax/printer")
-local T = require("@batteries/syntax/ast_types")
+local T = require("@lute/luau")
 
 local function assertEqualsLocation(
 	actual: T.Location,
@@ -25,7 +25,7 @@ local function test_tokenContainsLeadingSpaces()
 	local l = block.statements[1]
 	assert(l.tag == "local")
 
-	local token = l["local"]
+	local token = l.localKeyword
 	assert(#token.leadingTrivia == 1)
 	assert(token.leadingTrivia[1].tag == "whitespace")
 	assert(token.leadingTrivia[1].text == "  ")
@@ -39,7 +39,7 @@ local function test_tokenContainsLeadingNewline()
 	local l = block.statements[1]
 	assert(l.tag == "local")
 
-	local token = l["local"]
+	local token = l.localKeyword
 	assert(#token.leadingTrivia == 1)
 	assert(token.leadingTrivia[1].tag == "whitespace")
 	assert(token.leadingTrivia[1].text == "\n")
@@ -53,7 +53,7 @@ local function test_tokenContainsLeadingSingleLineComment()
 	local l = block.statements[1]
 	assert(l.tag == "local")
 
-	local token = l["local"]
+	local token = l.localKeyword
 	assert(#token.leadingTrivia == 2)
 	assert(token.leadingTrivia[1].tag == "comment")
 	assert(token.leadingTrivia[1].text == "-- comment")
@@ -70,7 +70,7 @@ local function test_tokenContainsLeadingBlockComment()
 	local l = block.statements[1]
 	assert(l.tag == "local")
 
-	local token = l["local"]
+	local token = l.localKeyword
 	assert(#token.leadingTrivia == 2)
 	assert(token.leadingTrivia[1].tag == "blockcomment")
 	assert(token.leadingTrivia[1].text == "--[[ comment ]]")
@@ -87,7 +87,7 @@ local function test_tokenizeWhitespace()
 	local l = block.statements[1]
 	assert(l.tag == "local")
 
-	local token = l["local"]
+	local token = l.localKeyword
 	assert(#token.leadingTrivia == 3)
 	assert(token.leadingTrivia[1].text == "  \n")
 	assert(token.leadingTrivia[2].text == "\t\t\n")
@@ -111,7 +111,7 @@ local function test_triviaSplitBetweenLeadingAndTrailing()
 	local secondStmt = block.statements[2]
 	assert(secondStmt.tag == "local")
 
-	local leadingToken = secondStmt["local"]
+	local leadingToken = secondStmt.localKeyword
 	assert(#leadingToken.leadingTrivia == 2)
 	assert(leadingToken.leadingTrivia[1].text == "-- comment 2")
 	assert(leadingToken.leadingTrivia[2].text == "\n")
@@ -134,6 +134,35 @@ local function test_roundtrippableAst()
 	visitDirectory("tests/astSerializerTests")
 end
 
+local function test_lineOffsetsField()
+	local singleLineCode = "local x = 1"
+	local result = luau.parse(singleLineCode)
+
+	assert(result.lineOffsets)
+	assert(type(result.lineOffsets) == "table", "lineOffsets should be a table")
+	assert(#result.lineOffsets == 1, "Should have 1 line offset for single line code") -- only line 0
+	assert(result.lineOffsets[1] == 0, "First line should start at offset 0")
+
+	local multiLineCode = "local x = 1\nlocal y = 2\nlocal z = 3"
+	local multiResult = luau.parse(multiLineCode)
+
+	assert(multiResult.lineOffsets)
+	assert(type(multiResult.lineOffsets) == "table", "lineOffsets should be a table for multiline")
+	assert(#multiResult.lineOffsets == 3, "Should have 3 line offsets for 3-line code") -- lines 0, 1, 2
+	assert(multiResult.lineOffsets[1] == 0, "First line should start at offset 0")
+	assert(multiResult.lineOffsets[2] == 12, "Second line should start after 'local x = 1\\n'")
+	assert(multiResult.lineOffsets[3] == 24, "Third line should start after 'local x = 1\\nlocal y = 2\\n'")
+
+	local emptyLineCode = "local x = 1\n\nlocal y = 2"
+	local emptyResult = luau.parse(emptyLineCode)
+
+	assert(emptyResult.lineOffsets)
+	assert(#emptyResult.lineOffsets == 3, "Should have 3 line offsets including empty line")
+	assert(emptyResult.lineOffsets[1] == 0, "First line should start at offset 0")
+	assert(emptyResult.lineOffsets[2] == 12, "Second line (empty) should start after 'local x = 1\\n'")
+	assert(emptyResult.lineOffsets[3] == 13, "Third line should start after empty line")
+end
+
 test_tokenContainsLeadingSpaces()
 test_tokenContainsLeadingNewline()
 test_tokenContainsLeadingSingleLineComment()
@@ -141,3 +170,4 @@ test_tokenContainsLeadingBlockComment()
 test_tokenizeWhitespace()
 test_triviaSplitBetweenLeadingAndTrailing()
 test_roundtrippableAst()
+test_lineOffsetsField()


### PR DESCRIPTION
This PR enhances the Luau parser to expose line offset information, enabling tooling to better access precise source location mapping for nodes.

**Changes Made**:

Exposes the computed 'lineOffsets' field to the Luau 'ParseResult'.
Modified exisitng ast test serializer tests to work with new apis.
Added new test to ensure that line offsets are exposed correctly.

```luau
local result = luau.parse("local x = 1\nlocal y = 2")
-- result.lineOffsets = { 0, 12 }  -- Line 0 starts at char 0, line 1 starts at char 12
```