### PR TITLE
Fix C style cast in `system.cpp` not caught in code review

### DIFF
--- a/lute/system/src/system.cpp
+++ b/lute/system/src/system.cpp
@@ -33,7 +33,7 @@ int lua_cpus(lua_State* L)
         lua_pushstring(L, cpuInfo.model);
         lua_setfield(L, -2, "model");
 
-        lua_pushinteger(L, (int)cpuInfo.speed);
+        lua_pushinteger(L, static_cast<int>(cpuInfo.speed));
         lua_setfield(L, -2, "speed");
 
         // sys, user, idle, irq, nice


### PR DESCRIPTION
Simply changes `(int) speed` to `static_cast<int>(speed)`.