### PR TITLE
Use <= instead of < (visitInterpolatedString)

### DIFF
--- a/batteries/syntax/visitor.luau
+++ b/batteries/syntax/visitor.luau
@@ -534,7 +534,7 @@ local function visitInterpolatedString(node: luau.AstExprInterpString, visitor: 
 	if visitor.visitInterpolatedString(node) then
 		for i = 1, #node.strings do
 			visitToken(node.strings[i], visitor)
-			if i < #node.expressions then
+			if i <= #node.expressions then
 				visitExpression(node.expressions[i], visitor)
 			end
 		end


### PR DESCRIPTION
While working with the `visitor`, I noticed that interpolated strings were not properly traversed. It appears that is bc of this condition, which will not visit the last expression in the interpolated string node's expressions table.