### PR TITLE
Add fs.stat, fix compilation with clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,9 @@ if(MSVC)
     list(APPEND LUTE_OPTIONS "/we4018") # Signed/unsigned mismatch
     list(APPEND LUTE_OPTIONS "/we4388") # Also signed/unsigned mismatch
     list(APPEND LUTE_OPTIONS "/Zc:externConstexpr") # MSVC does not comply with C++ standard by default
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+        list(APPEND LUTE_OPTIONS "/EHsc") # The CMake clang-cl target doesn't enable exceptions by default
+    endif()
     # FIXME: list(APPEND LUTE_OPTIONS /WX) # Warnings are errors
 else()
     list(APPEND LUTE_OPTIONS -Wall) # All warnings

--- a/definitions/fs.luau
+++ b/definitions/fs.luau
@@ -7,6 +7,14 @@ export type FileHandle = {
 
 export type FileType = "file" | "dir" | "link" | "fifo" | "socket" | "char" | "block" | "unknown"
 
+export type FileMetadata = {
+	type: FileType,
+	size: number,
+	created_at: any,
+	accessed_at: any,
+	modified_at: any,
+}
+
 export type DirectoryEntry = {
 	name: string,
 	type: FileType,
@@ -29,6 +37,10 @@ function fs.close(handle: FileHandle): ()
 end
 
 function fs.remove(path: string): ()
+	error("not implemented")
+end
+
+function fs.stat(path: string): FileMetadata
 	error("not implemented")
 end
 

--- a/definitions/fs.luau
+++ b/definitions/fs.luau
@@ -10,6 +10,7 @@ export type HandleMode = "r" | "w" | "x" | "a" | "r+" | "w+" | "x+" | "a+"
 
 export type FileMetadata = {
 	type: FileType,
+	permissions: { readonly: boolean },
 	size: number,
 	created_at: any,
 	accessed_at: any,

--- a/lute/fs/CMakeLists.txt
+++ b/lute/fs/CMakeLists.txt
@@ -8,5 +8,5 @@ target_sources(Lute.Fs PRIVATE
 
 target_compile_features(Lute.Fs PUBLIC cxx_std_17)
 target_include_directories(Lute.Fs PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Fs PRIVATE Lute.Runtime Luau.VM uv_a)
+target_link_libraries(Lute.Fs PRIVATE Lute.Runtime Lute.Time Luau.VM uv_a)
 target_compile_options(Lute.Fs PRIVATE ${LUTE_OPTIONS})

--- a/lute/fs/include/lute/fs.h
+++ b/lute/fs/include/lute/fs.h
@@ -43,6 +43,9 @@ int fs_mkdir(lua_State* L);
 /* Removes a directory */
 int fs_rmdir(lua_State* L);
 
+/* Gets the metadata of a file */
+int fs_stat(lua_State* L);
+
 /* Gets the type of a file entry */
 int type(lua_State* L);
 
@@ -58,6 +61,7 @@ static const luaL_Reg lib[] = {
 
     {"remove", fs_remove},
 
+    {"stat", fs_stat},
     {"type", type},
 
     {"mkdir", fs_mkdir},

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -413,9 +413,19 @@ int fs_stat(lua_State* L)
     createDurationFromTimespec32(L, stat.st_mtim);
     lua_setfield(L, -2, "modified_at");
 
+    // permissions
+    lua_createtable(L, 0, 2);
+
+    // libuv writes this correctly cross-platform
+    bool canAnyWrite = stat.st_mode & 0222;
+    lua_pushboolean(L, !canAnyWrite);
+    lua_setfield(L, -2, "readonly");
+
+    lua_setfield(L, -2, "permissions");
+
     return 1;
 }
-  
+
 static void defaultCallback(uv_fs_t* req)
 {
     auto* request_state = static_cast<ResumeToken*>(req->data);

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -5,6 +5,7 @@
 #include "uv.h"
 
 #include "lute/runtime.h"
+#include "lute/time.h"
 
 #include <cstdio>
 #include <cstring>
@@ -40,7 +41,6 @@
 #if !defined(S_ISFIFO) && defined(S_IFMT) && defined(S_IFIFO)
 #define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
 #endif
-
 
 namespace fs
 {
@@ -105,6 +105,54 @@ std::optional<int> setFlags(const char* c, int* openFlags)
     }
 
     return modeFlags;
+}
+
+static int createDurationFromTimespec32(lua_State* L, uv_timespec_t timespec)
+{
+    uv_timespec64_t extended{timespec.tv_sec, timespec.tv_nsec};
+    return createDurationFromTimespec(L, extended);
+}
+
+static const char* fileModeToType(uint64_t mode)
+{
+    if (S_ISDIR(mode))
+    {
+        return UV_TYPENAME_DIR;
+    }
+    else if (S_ISREG(mode))
+    {
+        return UV_TYPENAME_FILE;
+    }
+    else if (S_ISCHR(mode))
+    {
+        return UV_TYPENAME_CHAR;
+    }
+    else if (S_ISLNK(mode))
+    {
+        return UV_TYPENAME_LINK;
+    }
+#ifdef S_ISBLK
+    else if (S_ISBLK(mode))
+    {
+        return UV_TYPENAME_BLOCK;
+    }
+#endif
+#ifdef S_ISFIFO
+    else if (S_ISFIFO(mode))
+    {
+        return UV_TYPENAME_FIFO;
+    }
+#endif
+#ifdef S_ISSOCK
+    else if (S_ISSOCK(mode))
+    {
+        return UV_TYPENAME_SOCKET;
+    }
+#endif
+    else
+    {
+        return UV_TYPENAME_UNKNOWN;
+    }
 }
 
 struct FileHandle
@@ -333,6 +381,40 @@ int fs_rmdir(lua_State* L)
     return 0;
 }
 
+int fs_stat(lua_State* L)
+{
+    const char* path = luaL_checkstring(L, 1);
+
+    uv_fs_t stat_req;
+    int err = uv_fs_stat(uv_default_loop(), &stat_req, path, nullptr);
+
+    if (err)
+        luaL_errorL(L, "%s", uv_strerror(err));
+
+    lua_newtable(L);
+
+    auto stat = stat_req.statbuf;
+
+    auto type = fileModeToType(stat.st_mode);
+    lua_pushstring(L, type);
+    lua_setfield(L, -2, "type");
+
+    // this is fine unless the file is 9 petabytes
+    lua_pushnumber(L, static_cast<double>(stat.st_size));
+    lua_setfield(L, -2, "size");
+
+    createDurationFromTimespec32(L, stat.st_birthtim);
+    lua_setfield(L, -2, "created_at");
+
+    createDurationFromTimespec32(L, stat.st_atim);
+    lua_setfield(L, -2, "accessed_at");
+
+    createDurationFromTimespec32(L, stat.st_mtim);
+    lua_setfield(L, -2, "modified_at");
+
+    return 1;
+}
+
 int type(lua_State* L)
 {
     const char* path = luaL_checkstring(L, 1);
@@ -344,46 +426,8 @@ int type(lua_State* L)
     if (err)
         luaL_errorL(L, "%s", uv_strerror(err));
 
-    if (S_ISDIR(req.statbuf.st_mode))
-    {
-        lua_pushstring(L, UV_TYPENAME_DIR);
-    }
-    else if (S_ISREG(req.statbuf.st_mode))
-    {
-        lua_pushstring(L, UV_TYPENAME_FILE);
-    }
-    else if (S_ISCHR(req.statbuf.st_mode))
-    {
-        lua_pushstring(L, UV_TYPENAME_CHAR);
-    }
-    else if (S_ISLNK(req.statbuf.st_mode))
-    {
-        lua_pushstring(L, UV_TYPENAME_LINK);
-    }
-#ifdef S_ISBLK
-    else if (S_ISBLK(req.statbuf.st_mode))
-    {
-        lua_pushstring(L, UV_TYPENAME_BLOCK);
-    }
-#endif
-#ifdef S_ISFIFO
-    else if (S_ISFIFO(req.statbuf.st_mode))
-    {
-        lua_pushstring(L, UV_TYPENAME_FIFO);
-    }
-#endif
-#ifdef S_ISSOCK
-    else if (S_ISSOCK(req.statbuf.st_mode))
-    {
-        lua_pushstring(L, UV_TYPENAME_SOCKET);
-    }
-#endif
-    else
-    {
-        lua_pushstring(L, UV_TYPENAME_UNKNOWN);
-    }
-
-
+    auto type = fileModeToType(req.statbuf.st_mode);
+    lua_pushstring(L, type);
     uv_fs_req_cleanup(&req);
 
     return 1;

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -109,7 +109,7 @@ std::optional<int> setFlags(const char* c, int* openFlags)
 
 static int createDurationFromTimespec32(lua_State* L, uv_timespec_t timespec)
 {
-    uv_timespec64_t extended{timespec.tv_sec, timespec.tv_nsec};
+    uv_timespec64_t extended{static_cast<int64_t>(timespec.tv_sec), static_cast<int32_t>(timespec.tv_nsec)};
     return createDurationFromTimespec(L, extended);
 }
 

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -392,7 +392,7 @@ int fs_stat(lua_State* L)
     if (err)
         luaL_errorL(L, "%s", uv_strerror(err));
 
-    lua_newtable(L);
+    lua_createtable(L, 0, 6);
 
     auto stat = stat_req.statbuf;
 

--- a/lute/time/include/lute/time.h
+++ b/lute/time/include/lute/time.h
@@ -17,6 +17,8 @@ static const char kDurationLibraryIdentifier[] = "duration";
 // exposed utils
 double getSecondsFromTimespec(uv_timespec64_t timespec);
 uv_timespec64_t getTimespecFromDuration(lua_State* L, int idx);
+int createDurationFromTimespec(lua_State* L, uv_timespec64_t timespec);
+int createDurationFromSeconds(lua_State* L, double seconds);
 
 namespace duration
 {

--- a/lute/time/src/time.cpp
+++ b/lute/time/src/time.cpp
@@ -56,7 +56,7 @@ uv_timespec64_t getTimespecFromDuration(lua_State* L, int idx)
 }
 
 // creates a userdata, and returns a fresh timespec pointer to it
-static int createDurationFromTimespec(lua_State* L, uv_timespec64_t timespec)
+int createDurationFromTimespec(lua_State* L, uv_timespec64_t timespec)
 {
     uv_timespec64_t* duration = static_cast<uv_timespec64_t*>(lua_newuserdatatagged(L, sizeof(uv_timespec64_t), kDurationTag));
     *duration = timespec;
@@ -67,7 +67,7 @@ static int createDurationFromTimespec(lua_State* L, uv_timespec64_t timespec)
     return 1;
 }
 
-static int createDurationFromSeconds(lua_State* L, double seconds)
+int createDurationFromSeconds(lua_State* L, double seconds)
 {
     return createDurationFromTimespec(L, {static_cast<int64_t>(seconds), static_cast<int32_t>(fmod(seconds, 1) * NANOSECONDS_PER_SECOND)});
 }


### PR DESCRIPTION
cmake apparently does not enable exceptions by default with clang-cl, so compilation fails without this flag; otherwise, compilation works perfectly with clang-cl on LLVM 19.1+ (fixed an issue with intrinsics which breaks libsodium/etc)

also adds fs.stat, being the main point of this PR. a caveat is durations are any typed; I plan on making a separate PR with way more complete type defs, including the ones from #304