### PR TITLE
Fix require of `@std`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
           options: --c-compiler clang --cxx-compiler clang++
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Remove .luaurc file
+        run: rm .luaurc
+
       - name: Run Tests
         run: ${{ steps.build_tests.outputs.exe_path }}
 

--- a/lute/require/src/stdlibvfs.cpp
+++ b/lute/require/src/stdlibvfs.cpp
@@ -24,6 +24,8 @@ static std::optional<std::string> readStdLibModule(const std::string& path)
 
 static bool isStdLibDirectory(const std::string& path)
 {
+    if (path == "@std")
+        return true;
     StdLibModuleResult result = getStdLibModule(path);
     return result.type == StdLibModuleType::Directory;
 }


### PR DESCRIPTION
The problem with `@std` require is the call to `ModulePath::create` for the top level `@std` path: https://github.com/luau-lang/lute/blob/76fa819ee3cf202d979b59c477241c3968fe8b1a/lute/require/src/stdlibvfs.cpp#L35

`ModulePath::create` will end up trying to check if a "real path" is found for the top-level `@std` path: https://github.com/luau-lang/lute/blob/76fa819ee3cf202d979b59c477241c3968fe8b1a/lute/require/src/modulepath.cpp#L67

However, at the moment this returns NotFound. This is because both `isAFile` and `isADirectory` will return false in `ModulePath::getRealPath()` for the `@std` path.

To fix this, we ensure `isADirectory` returns true for `@std` by updating the stdin function.

There are tests for `@std` require behaviour in the codebase. However, these tests were inadvertently passing. This is because the top-level `.luaurc` file in the repository root defines an alias for `@std`, and this alias was getting matched instead of the built-in std VFS. To fix this, we rm the top-level `.luaurc` file before running the tests in CI. This is done in the first commit, where we see that CI starts failing.

Fixes #353 