### PR TITLE
Fix `luau.load` type definition

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -570,7 +570,7 @@ function luau.compile(source: string): Bytecode
 	error("not implemented")
 end
 
-function luau.load(bytecode: Bytecode, chunkname: string, env: { [any]: any }): () -> ...any
+function luau.load(bytecode: Bytecode, chunkname: string, env: { [any]: any }): (...any) -> ...any
 	error("not implemented")
 end
 

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -570,7 +570,7 @@ function luau.compile(source: string): Bytecode
 	error("not implemented")
 end
 
-function luau.load(bytecode: Bytecode): () -> ...any
+function luau.load(bytecode: Bytecode, chunkname: string, env: { [any]: any }): () -> ...any
 	error("not implemented")
 end
 


### PR DESCRIPTION
This PR fixes the type definitions in `definitions/luau`.

It adds `env` and `chunkname` to the parameters, and adds `...any` to the parameters of the returned function.