### PR TITLE
Add printStatement func to printer

### DIFF
--- a/lute/std/libs/syntax/printer.luau
+++ b/lute/std/libs/syntax/printer.luau
@@ -123,13 +123,6 @@ local function printVisitor()
 	return printer
 end
 
---- Returns a string representation of an AstStatBlock
-local function printBlock(block: luau.AstStatBlock): string
-	local printer = printVisitor()
-	visitor.visitBlock(block, printer)
-	return buffer.readstring(printer.result, 0, printer.cursor)
-end
-
 --- Returns a string representation of an AstExpr
 function printExpr(block: luau.AstExpr): string
 	local printer = printVisitor()
@@ -152,7 +145,6 @@ function printFile(result: { root: luau.AstStatBlock, eof: luau.Eof }): string
 end
 
 return {
-	print = printBlock,
 	printexpr = printExpr,
 	printstatement = printStatement,
 	printfile = printFile,

--- a/lute/std/libs/syntax/printer.luau
+++ b/lute/std/libs/syntax/printer.luau
@@ -137,6 +137,13 @@ function printExpr(block: luau.AstExpr): string
 	return buffer.readstring(printer.result, 0, printer.cursor)
 end
 
+--- Returns a string representation of an AstStat
+local function printStatement(statement: luau.AstStat): string
+	local printer = printVisitor()
+	visitor.visitStatement(statement, printer)
+	return buffer.readstring(printer.result, 0, printer.cursor)
+end
+
 function printFile(result: { root: luau.AstStatBlock, eof: luau.Eof }): string
 	local printer = printVisitor()
 	visitor.visitBlock(result.root, printer)
@@ -147,5 +154,6 @@ end
 return {
 	print = printBlock,
 	printexpr = printExpr,
+	printstatement = printStatement,
 	printfile = printFile,
 }


### PR DESCRIPTION
There are print cases not covered by `printBlock` and `printExpr`, so I figure this is useful to have

If anything, we can replace `printBlock` with this function and export it as `print` instead, [since`visitStatement` encompasses blocks](https://github.com/luau-lang/lute/blob/primary/lute/std/libs/syntax/visitor.luau#L796), in addition to many statement types