### PR TITLE
RequireVfs: Remove all `default` blocks in favor of being explicit

### DIFF
--- a/lute/require/src/requirevfs.cpp
+++ b/lute/require/src/requirevfs.cpp
@@ -175,50 +175,71 @@ std::string RequireVfs::getContents(lua_State* L, const std::string& loadname) c
 
 std::string RequireVfs::getChunkname(lua_State* L) const
 {
+    std::string chunkname;
+
     switch (vfsType)
     {
     case VFSType::Disk:
-        return "@" + fileVfs.getFilePath();
+        chunkname = "@" + fileVfs.getFilePath();
+        break;
     case VFSType::Std:
-        return "@" + stdLibVfs.getIdentifier();
+        chunkname = "@" + stdLibVfs.getIdentifier();
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
-        return "@" + cliVfs->getIdentifier();
+        chunkname = "@" + cliVfs->getIdentifier();
+        break;
     case VFSType::Lute:
-        return "";
+        break;
     }
+
+    return chunkname;
 }
 
 std::string RequireVfs::getLoadname(lua_State* L) const
 {
+    std::string loadname;
+
     switch (vfsType)
     {
     case VFSType::Disk:
-        return fileVfs.getAbsoluteFilePath();
+        loadname = fileVfs.getAbsoluteFilePath();
+        break;
     case VFSType::Std:
-        return stdLibVfs.getIdentifier();
+        loadname = stdLibVfs.getIdentifier();
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
-        return cliVfs->getIdentifier();
+        loadname = cliVfs->getIdentifier();
+        break;
     case VFSType::Lute:
-        return "";
+        break;
     }
+
+    return loadname;
 }
 
 std::string RequireVfs::getCacheKey(lua_State* L) const
 {
+    std::string cacheKey;
+
     switch (vfsType)
     {
     case VFSType::Disk:
-        return fileVfs.getAbsoluteFilePath();
+        cacheKey = fileVfs.getAbsoluteFilePath();
+        break;
     case VFSType::Std:
-        return stdLibVfs.getIdentifier();
+        cacheKey = stdLibVfs.getIdentifier();
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
-        return cliVfs->getIdentifier();
+        cacheKey = cliVfs->getIdentifier();
+        break;
     case VFSType::Lute:
-        return "";
+        break;
     }
+
+    return cacheKey;
 }
 
 bool RequireVfs::isConfigPresent(lua_State* L) const
@@ -226,18 +247,25 @@ bool RequireVfs::isConfigPresent(lua_State* L) const
     if (atFakeRoot)
         return true;
 
+    bool isPresent = false;
+
     switch (vfsType)
     {
     case VFSType::Disk:
-        return fileVfs.isConfigPresent();
+        isPresent = fileVfs.isConfigPresent();
+        break;
     case VFSType::Std:
-        return stdLibVfs.isConfigPresent();
+        isPresent = stdLibVfs.isConfigPresent();
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
-        return cliVfs->isConfigPresent();
+        isPresent = cliVfs->isConfigPresent();
+        break;
     case VFSType::Lute:
-        return false;
+        break;
     }
+
+    return isPresent;
 }
 
 std::string RequireVfs::getConfig(lua_State* L) const

--- a/lute/require/src/requirevfs.cpp
+++ b/lute/require/src/requirevfs.cpp
@@ -63,18 +63,23 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
         return NavigationStatus::Success;
     }
 
+    NavigationStatus status = NavigationStatus::NotFound;
     switch (vfsType)
     {
     case VFSType::Disk:
-        return fileVfs.resetToPath(std::string(path));
+        status = fileVfs.resetToPath(std::string(path));
+        break;
     case VFSType::Std:
-        return stdLibVfs.resetToPath(std::string(path));
+        status = stdLibVfs.resetToPath(std::string(path));
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
-        return cliVfs->resetToPath(std::string(path));
+        status = cliVfs->resetToPath(std::string(path));
+        break;
     case VFSType::Lute:
-        return NavigationStatus::NotFound;
+        break;
     }
+    return status;
 }
 
 NavigationStatus RequireVfs::toParent(lua_State* L)
@@ -176,7 +181,6 @@ std::string RequireVfs::getContents(lua_State* L, const std::string& loadname) c
 std::string RequireVfs::getChunkname(lua_State* L) const
 {
     std::string chunkname;
-
     switch (vfsType)
     {
     case VFSType::Disk:
@@ -192,14 +196,12 @@ std::string RequireVfs::getChunkname(lua_State* L) const
     case VFSType::Lute:
         break;
     }
-
     return chunkname;
 }
 
 std::string RequireVfs::getLoadname(lua_State* L) const
 {
     std::string loadname;
-
     switch (vfsType)
     {
     case VFSType::Disk:
@@ -215,14 +217,12 @@ std::string RequireVfs::getLoadname(lua_State* L) const
     case VFSType::Lute:
         break;
     }
-
     return loadname;
 }
 
 std::string RequireVfs::getCacheKey(lua_State* L) const
 {
     std::string cacheKey;
-
     switch (vfsType)
     {
     case VFSType::Disk:
@@ -238,7 +238,6 @@ std::string RequireVfs::getCacheKey(lua_State* L) const
     case VFSType::Lute:
         break;
     }
-
     return cacheKey;
 }
 
@@ -248,7 +247,6 @@ bool RequireVfs::isConfigPresent(lua_State* L) const
         return true;
 
     bool isPresent = false;
-
     switch (vfsType)
     {
     case VFSType::Disk:
@@ -264,7 +262,6 @@ bool RequireVfs::isConfigPresent(lua_State* L) const
     case VFSType::Lute:
         break;
     }
-
     return isPresent;
 }
 
@@ -282,7 +279,6 @@ std::string RequireVfs::getConfig(lua_State* L) const
     }
 
     std::optional<std::string> configContents;
-
     switch (vfsType)
     {
     case VFSType::Disk:
@@ -298,6 +294,5 @@ std::string RequireVfs::getConfig(lua_State* L) const
     case VFSType::Lute:
         break;
     }
-
     return configContents ? *configContents : "";
 }

--- a/lute/require/src/requirevfs.cpp
+++ b/lute/require/src/requirevfs.cpp
@@ -72,7 +72,7 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         return cliVfs->resetToPath(std::string(path));
-    default:
+    case VFSType::Lute:
         return NavigationStatus::NotFound;
     }
 }
@@ -96,8 +96,6 @@ NavigationStatus RequireVfs::toParent(lua_State* L)
     case VFSType::Lute:
         luaL_error(L, "cannot get the parent of @lute");
         break;
-    default:
-        return NavigationStatus::NotFound;
     }
 
     if (status == NavigationStatus::NotFound)
@@ -128,8 +126,6 @@ NavigationStatus RequireVfs::toChild(lua_State* L, std::string_view name)
     case VFSType::Lute:
         luaL_error(L, "'%s' is not a lute library", std::string(name).c_str());
         break;
-    default:
-        break;
     }
 
     return NavigationStatus::NotFound;
@@ -148,8 +144,6 @@ bool RequireVfs::isModulePresent(lua_State* L) const
         return cliVfs->isModulePresent();
     case VFSType::Lute:
         luaL_error(L, "@lute is not requirable");
-        break;
-    default:
         break;
     }
 
@@ -172,7 +166,7 @@ std::string RequireVfs::getContents(lua_State* L, const std::string& loadname) c
         LUAU_ASSERT(cliVfs);
         contents = cliVfs->getContents(loadname);
         break;
-    default:
+    case VFSType::Lute:
         break;
     }
 
@@ -190,7 +184,7 @@ std::string RequireVfs::getChunkname(lua_State* L) const
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         return "@" + cliVfs->getIdentifier();
-    default:
+    case VFSType::Lute:
         return "";
     }
 }
@@ -206,7 +200,7 @@ std::string RequireVfs::getLoadname(lua_State* L) const
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         return cliVfs->getIdentifier();
-    default:
+    case VFSType::Lute:
         return "";
     }
 }
@@ -222,7 +216,7 @@ std::string RequireVfs::getCacheKey(lua_State* L) const
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         return cliVfs->getIdentifier();
-    default:
+    case VFSType::Lute:
         return "";
     }
 }
@@ -241,7 +235,7 @@ bool RequireVfs::isConfigPresent(lua_State* L) const
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         return cliVfs->isConfigPresent();
-    default:
+    case VFSType::Lute:
         return false;
     }
 }
@@ -273,7 +267,7 @@ std::string RequireVfs::getConfig(lua_State* L) const
         LUAU_ASSERT(cliVfs);
         configContents = cliVfs->getConfig();
         break;
-    default:
+    case VFSType::Lute:
         break;
     }
 


### PR DESCRIPTION
When first implementing this, I didn't realize that the compiler checks for exhaustivity when switching over an enum. This is an improvement that helps us catch errors at compile-time by being more explicit.