### PR TITLE
infra: Bootstrap shell script for downloading lute dependencies on macOS/linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ The Lute repository fundamentally contains three sets of libraries. These are as
 - `batteries`: A collection of useful, standalone Luau libraries that do not depend on `lute`.
 
 Contributions to any of these libraries are welcome, and we encourage you to open issues or pull requests if you have any feedback or contributions to make.
+### Building Lute without a `lute` executable
+- From the root directory, run `./tools/bootstrap.sh` to get lute dependencies
+- Configure with `cmake -G=Ninja -B {MacOS: build/xcode/debug | Linux: build/debug | Windows: build/vs2022/debug}  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1`
+- Run `ninja -C {MacOS: build/xcode/debug | Linux: build/debug | Windows: build/vs2022/debug} {lute/cli/lute | tests/lute-tests}`

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -1,6 +1,4 @@
-#!bin/bash
-
-fetch() {
+fetch_dep() {
   local dep_file="$1"
 
   # Ensure the file exists
@@ -28,7 +26,7 @@ fetch() {
     esac
   done < "$dep_file"
 
-  local target_dir="../extern/$name"
+  local target_dir="extern/$name"
 
   # Clone if not already present
   if [[ -d "$target_dir" ]]; then
@@ -45,14 +43,9 @@ fetch() {
   fi
 }
 
-# Fetch all the dependencies
-echo "Fetching dependencies..."
-fetch "../extern/boringssl.tune"
-fetch "../extern/curl.tune"
-fetch "../extern/libsodium.tune"
-fetch "../extern/luau.tune"
-fetch "../extern/libuv.tune"
-fetch "../extern/uSockets.tune"
-fetch "../extern/uWebSockets.tune"
-fetch "../extern/zlib.tune"
-
+for file in extern/*.tune; do
+    if [[ -f "$file" ]]; then
+    echo "Fetching dependency from: $(basename "$file")"
+    fetch_dep "extern/$(basename "$file")"
+  fi
+done

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -1,0 +1,58 @@
+#!bin/bash
+
+fetch() {
+  local dep_file="$1"
+
+  # Ensure the file exists
+  if [[ ! -f "$dep_file" ]]; then
+    echo "Dependency file not found: $dep_file"
+    return 1
+  fi
+
+  # Default values
+  local name=""
+  local remote=""
+  local branch=""
+  local revision=""
+
+  # Parse the file
+  while IFS='=' read -r key value; do
+    key=$(echo "$key" | xargs)
+    value=$(echo "$value" | sed 's/"//g' | xargs)
+
+    case "$key" in
+      name) name="$value" ;;
+      remote) remote="$value" ;;
+      branch) branch="$value" ;;
+      revision) revision="$value" ;;
+    esac
+  done < "$dep_file"
+
+  local target_dir="../extern/$name"
+
+  # Clone if not already present
+  if [[ -d "$target_dir" ]]; then
+    echo "Dependency '$name' already exists at $target_dir. Skipping clone."
+  else
+    echo "Cloning $name from $remote (branch: $branch) into $target_dir..."
+    git clone --branch "$branch" --single-branch "$remote" "$target_dir" || return 1
+  fi
+
+  # Checkout specific revision if provided
+  if [[ -n "$revision" ]]; then
+    echo "Checking out revision $revision in $target_dir"
+    git -C "$target_dir" checkout "$revision" || return 1
+  fi
+}
+
+# Fetch all the dependencies
+echo "Fetching dependencies..."
+fetch "../extern/boringssl.tune"
+fetch "../extern/curl.tune"
+fetch "../extern/libsodium.tune"
+fetch "../extern/luau.tune"
+fetch "../extern/libuv.tune"
+fetch "../extern/uSockets.tune"
+fetch "../extern/uWebSockets.tune"
+fetch "../extern/zlib.tune"
+


### PR DESCRIPTION
Resolves #363 .

This PR adds a bootstrap script for fetching the dependencies needed to built lute from scratch, which removes the requirement of needing a `lute` binary.