### PR TITLE
Fix issue where the body in a response issued by the local server is truncated on a null terminator 

### DIFF
--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -347,7 +347,11 @@ static void handleResponse(auto* res, lua_State* L, int responseIndex)
     lua_pop(L, 1);
 
     lua_getfield(L, responseIndex, "body");
-    std::string body = lua_isstring(L, -1) ? lua_tostring(L, -1) : "";
+
+    std::string body = "";
+    size_t bodyLength;
+    const char* bodyData = lua_tolstring(L, -1, &bodyLength);
+    body.assign(bodyData, bodyData + bodyLength);
     lua_pop(L, 1);
 
     res->end(body);


### PR DESCRIPTION
Similar to #379, a response returned by the request handler in `net.serve` would have its body truncated on the first null terminator. This PR repeats the fix in #379 to apply to http responses as well.

Test

```luau
--test-vm.luau
local net = require("@lute/net")

local self = {}

function self.createServer(port: number, body: string)
    net.serve({
        port = port,
        hostname = "localhost",
        reuseport = true,
        handler = function(request)
            return {
                status = 200,
                body = body,
            }
        end
    })
end

return self
```

```luau
--test.luau
local net = require("@lute/net")
local vm = require("@lute/vm")

local function test(body: string)
    local serverController = vm.create("./test-vm")
    serverController.createServer(8081, body)
    local response = net.request("http://localhost:8081")
    assert(body == response.body, `{#body} != {#response.body}`)
    print("good!")
end

test("Hello World") -- good!
test("Hello\0World") -- 11 != 5 (before)  good! (after)
```



