### PR TITLE
infra: copy compile_commands to `build/` in the configure step

### DIFF
--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -693,7 +693,10 @@ local function configure()
 	table.move(arguments, 1, #arguments, 2, cmd)
 
 	check(fetchDependenciesIfNeeded())
-	return call(cmd)
+
+	local result = call(cmd)
+	fs.copy(joinPath(getProjectPath(), "compile_commands.json"), projectRelative(BUILD_DIR, "compile_commands.json"))
+	return result
 end
 
 local function run()


### PR DESCRIPTION
Fixes #348 by copying `compile_commands.json` to `build/compile_commands.json` during the configure step.