### PR TITLE
Bump lute in toolchain managers

### DIFF
--- a/foreman.toml
+++ b/foreman.toml
@@ -1,3 +1,3 @@
 [tools]
 stylua = { github = "JohnnyMorganz/StyLua", version = "2.0.2" }
-lute = { github = "luau-lang/lute", version = "0.1.0-nightly.20250606" }
+lute = { github = "luau-lang/lute", version = "0.1.0-nightly.20251003" }

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,3 +1,3 @@
 [tools]
 stylua = "JohnnyMorganz/StyLua@2.0.2"
-lute = "luau-lang/lute@0.1.0-nightly.20250606"
+lute = "luau-lang/lute@0.1.0-nightly.20251003"


### PR DESCRIPTION
#387 broke luthier when using lute via toolchain managers since the old version they use doesn't have `fs.copy`.