### PR TITLE
Upgrade Luau to 0.690

### DIFF
--- a/extern/luau.tune
+++ b/extern/luau.tune
@@ -1,5 +1,5 @@
 [dependency]
 name = "luau"
 remote = "https://github.com/luau-lang/luau.git"
-branch = "0.675"
-revision = "59658182835dc39f598a4fc16ba0b177b8e6f55b"
+branch = "0.690"
+revision = "fb63edcceadafc7144d3de7a6ccb0fee83978cf0"

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -20,11 +20,6 @@
 
 const char* COMPILE_RESULT_TYPE = "CompileResult";
 
-LUAU_FASTFLAG(LuauStoreCSTData2)
-LUAU_FASTFLAG(LuauStoreReturnTypesAsPackOnAst)
-LUAU_FASTFLAG(LuauStoreLocalAnnotationColonPositions)
-LUAU_FASTFLAG(LuauCSTForReturnTypeFunctionTail)
-
 namespace luau
 {
 
@@ -38,12 +33,6 @@ struct StatResult
 
 static StatResult parse(std::string& source)
 {
-    // TODO: this is very bad, fix it!
-    FFlag::LuauStoreCSTData2.value = true;
-    FFlag::LuauStoreReturnTypesAsPackOnAst.value = true;
-    FFlag::LuauStoreLocalAnnotationColonPositions.value = true;
-    FFlag::LuauCSTForReturnTypeFunctionTail.value = true;
-
     auto allocator = std::make_shared<Luau::Allocator>();
     auto names = std::make_shared<Luau::AstNameTable>(*allocator);
 
@@ -67,12 +56,6 @@ struct ExprResult
 
 static ExprResult parseExpr(std::string& source)
 {
-    // TODO: this is very bad, fix it!
-    FFlag::LuauStoreCSTData2.value = true;
-    FFlag::LuauStoreReturnTypesAsPackOnAst.value = true;
-    FFlag::LuauStoreLocalAnnotationColonPositions.value = true;
-    FFlag::LuauCSTForReturnTypeFunctionTail.value = true;
-
     auto allocator = std::make_shared<Luau::Allocator>();
     auto names = std::make_shared<Luau::AstNameTable>(*allocator);
 


### PR DESCRIPTION
Just requires a few flag clean ups. Would be nice to have more tests set up so we're a bit more confident in an upgrade like this. 0.691+ requires some more code changes so I'm just going to 0.690 for now.