### PR TITLE
refactor: Support multiple luau files in a single payload for `lute compile`

### DIFF
--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -33,8 +33,8 @@ target_sources(Lute.CLI.lib PRIVATE
 )
 
 target_compile_features(Lute.CLI.lib PUBLIC cxx_std_17)
-target_include_directories(Lute.CLI.lib PUBLIC include ${CLI_GENERATED_INCLUDE_DIR})
-target_link_libraries(Lute.CLI.lib PRIVATE Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Require Lute.Runtime Luau.CLI.lib)
+target_include_directories(Lute.CLI.lib PUBLIC include ${CLI_GENERATED_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR})
+target_link_libraries(Lute.CLI.lib PRIVATE Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Require Lute.Runtime Luau.CLI.lib zlibstatic)
 target_compile_options(Lute.CLI.lib PRIVATE ${LUTE_OPTIONS})
 
 add_executable(Lute.CLI)

--- a/lute/cli/include/lute/compile.h
+++ b/lute/cli/include/lute/compile.h
@@ -1,13 +1,110 @@
 #pragma once
 
-#include "Luau/FileUtils.h"
+#include <string>
+#include <vector>
+#include <map>
+#include <optional>
 
-struct AppendedBytecodeResult
+
+enum class PayloadEncodeStatus
 {
-    bool found = false;
-    std::string BytecodeData;
+    Ok,
+    FileNotFound,
+    BytecodeCompilationFailed,
+    BytecodeCompressionFailed,
+
 };
 
-AppendedBytecodeResult checkForAppendedBytecode(const std::string& executablePath);
+enum class PayloadDecodeStatus
+{
+    Ok,
+    PayloadTooSmall,
+    MagicFlagNotFound,
+    IncompleteMetadata,
+    DecompressionFailed,
+    BundleParsingFailed,
+};
 
-int compileScript(const std::string& inputFilePath, const std::string& outputFilePath, const std::string& currentExecutablePath); 
+struct LuteEncodeResult
+{
+    std::string payload;
+    std::optional<std::string> errMessage = std::nullopt;
+    std::optional<PayloadEncodeStatus> status;
+    size_t bytesWritten = 0;
+    size_t compressedPayloadSizeBytes = 0;
+    size_t uncompressedPayloadSizeBytes = 0;
+    void setError(PayloadEncodeStatus status, std::string errMessage);
+};
+
+struct LuteDecodeResult
+{
+    std::optional<std::string> errMessage = std::nullopt;
+    std::optional<PayloadDecodeStatus> status;
+    size_t bytesRead = 0;
+    size_t compressedPayloadSizeBytes = 0;
+    size_t uncompressedPayloadSizeBytes = 0;
+    void setError(PayloadDecodeStatus status, std::string errMessage);
+};
+
+/**
+ * Represents a bundle of compiled Luau files ready for injection.
+ *
+ * Uncompressed bundle format (before compression):
+ *   For each file:
+ *     [path_length: uint32_t]
+ *     [path_string: char[path_length]]
+ *     [bytecode_size: uint64_t]
+ *     [bytecode_data: byte[bytecode_size]]
+ *
+ * Injectable payload format (after compression, what goes into executable):
+ *   [compressed_bundle_data: byte[compressed_size]]
+ *   [compressed_size: uint64_t]
+ *   [uncompressed_size: uint64_t]
+ *   [num_files: uint32_t]
+ *   [entry_point_path_string: char[entry_point_path_length]]
+ *   [entry_point_path_length: uint32_t]
+ */
+struct LuteExePayload
+{
+    LuteExePayload();
+
+    bool add(const std::string& luauFilePath);
+
+    void encode(LuteEncodeResult& result);
+    void encode(LuteEncodeResult&& result) = delete;
+
+    void decode(const std::string_view binary, LuteDecodeResult& result);
+    void decode(const std::string_view binary, LuteDecodeResult&& result) = delete;
+
+    std::string entryPointPath;
+    std::vector<std::string> filePaths;
+    std::map<std::string, std::string> filePathToBytecode; // path -> bytecode
+
+private:
+    bool parseFromDecompressedBundle(const std::string& decompressedBundle);
+};
+
+/**
+ * Manages creating and reading Lute executables with embedded bytecode bundles.
+ *
+ * Binary format (from end of file, reading backward):
+ *   [lute runtime executable's bytes]
+ *   [compressed bundle data]
+ *   [compressed_size: uint64_t]
+ *   [uncompressed_size: uint64_t]
+ *   [num_files: uint32_t]
+ *   [entry_point_path_string: char[entry_point_path_length]]
+ *   [entry_point_path_length: uint32_t]
+ *   [MAGIC_FLAG: "LUTEBYTE" (8 bytes)]
+ */
+struct LuteExecutable
+{
+    LuteExecutable(const std::string& luteRuntimePath);
+
+    bool create(std::string& outputPath, LuteExePayload& payload);
+    std::optional<LuteExePayload> extract();
+
+    std::string executablePath;
+    std::string compressedBundleData;
+};
+

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -26,6 +26,7 @@
 #include <iostream>
 #include <string>
 #include <filesystem>
+#include <fstream>
 #include <vector>
 
 static int program_argc = 0;
@@ -197,11 +198,12 @@ static void displayCheckHelp(const char* argv0)
 
 static void displayCompileHelp(const char* argv0)
 {
-    printf("Usage: lute compile <script.luau> [output_executable]\n");
+    printf("Usage: lute compile <script.luau> [output_executable] [--dump-bundle <bundle_file>]\n");
     printf("\n");
     printf("Compile Options:\n");
     printf("  output_executable    Optional name for the compiled executable.\n");
     printf("                       Defaults to '<script_name>_compiled'.\n");
+    printf("  --dump-bundle        Required path to dump the raw bundle.\n");
     printf("  -h, --help           Display this usage message.\n");
 }
 
@@ -326,6 +328,7 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
 {
     std::string inputFilePath;
     std::string outputFilePath;
+    std::string bundleDumpPath;
 
     for (int i = argOffset; i < argc; ++i)
     {
@@ -335,6 +338,16 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
         {
             displayCompileHelp(argv[0]);
             return 0;
+        }
+        else if (strcmp(currentArg, "--dump-bundle") == 0)
+        {
+            if (i + 1 >= argc)
+            {
+                fprintf(stderr, "Error: --dump-bundle requires a file path argument.\n\n");
+                displayCompileHelp(argv[0]);
+                return 1;
+            }
+            bundleDumpPath = argv[++i];
         }
         else if (inputFilePath.empty())
         {
@@ -385,7 +398,48 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
 #endif
     }
 
-    return compileScript(inputFilePath, outputFilePath, argv[0]);
+    // Encode the payload
+    LuteExePayload payload;
+    payload.add(inputFilePath);
+
+    LuteEncodeResult encodeResult;
+    payload.encode(encodeResult);
+
+    if (encodeResult.status != PayloadEncodeStatus::Ok)
+    {
+        fprintf(stderr, "Error encoding payload: %s\n", encodeResult.errMessage.value_or("Unknown error").c_str());
+        return 1;
+    }
+
+    // Optionally dump the bundle to a file and print statistics
+    if (!bundleDumpPath.empty())
+    {
+        std::ofstream bundleFile(bundleDumpPath, std::ios::binary);
+        if (!bundleFile)
+        {
+            fprintf(stderr, "Error: Could not open bundle dump file '%s'\n", bundleDumpPath.c_str());
+            return 1;
+        }
+        bundleFile.write(encodeResult.payload.data(), encodeResult.payload.size());
+        bundleFile.close();
+
+        printf("Bundle statistics:\n");
+        printf("  Uncompressed size: %zu bytes\n", encodeResult.uncompressedPayloadSizeBytes);
+        printf("  Compressed size:   %zu bytes\n", encodeResult.compressedPayloadSizeBytes);
+        printf("  Total payload:     %zu bytes\n", encodeResult.payload.size());
+        printf("  Bundle dumped to:  %s\n", bundleDumpPath.c_str());
+        return 0;
+    }
+
+    // Handle the compilation of the new lute executable
+    LuteExecutable exec{argv[0]};
+    if (!exec.create(outputFilePath, payload))
+    {
+        fprintf(stderr, "Error compiling executable %s\n", outputFilePath.c_str());
+        return 1;
+    }
+
+    return 0;
 }
 
 int handleCliCommand(CliCommandResult result)
@@ -401,18 +455,25 @@ int cliMain(int argc, char** argv)
 {
     Luau::assertHandler() = assertionHandler;
 
-    AppendedBytecodeResult embedded = checkForAppendedBytecode(argv[0]);
-    if (embedded.found)
+
+    LuteExecutable exec{argv[0]};
+    if (std::optional<LuteExePayload> found = exec.extract())
     {
+        printf("Allocing here");
         Runtime runtime;
         lua_State* GL = setupCliState(runtime);
 
         program_argc = argc;
         program_argv = argv;
 
-        bool success = runBytecode(runtime, embedded.BytecodeData, "=__EMBEDDED__", GL);
+        std::string entryPoint = found->entryPointPath;
+        auto entryModule = found->filePathToBytecode.find(entryPoint);
+        if (entryModule != found->filePathToBytecode.end())
+        {
+            bool success = runBytecode(runtime, entryModule->second, "=__EMBEDDED__", GL);
+            return success ? 0 : 1;
+        }
 
-        return success ? 0 : 1;
     }
 
 #ifdef _WIN32

--- a/lute/cli/src/compile.cpp
+++ b/lute/cli/src/compile.cpp
@@ -1,121 +1,437 @@
 #include "lute/compile.h"
 
+#include "Luau/Compiler.h"
+#include "Luau/FileUtils.h"
 #include "lute/options.h"
 #include "uv.h"
-
+#include <zlib.h>
 #include <fstream>
+#include <filesystem>
+#include <cstring>
 
+namespace fs = std::filesystem;
 const char MAGIC_FLAG[] = "LUTEBYTE";
 const size_t MAGIC_FLAG_SIZE = sizeof(MAGIC_FLAG) - 1;
-const size_t BYTECODE_SIZE_FIELD_SIZE = sizeof(uint64_t);
 
-AppendedBytecodeResult checkForAppendedBytecode(const std::string& executablePath)
+void LuteEncodeResult::setError(PayloadEncodeStatus status, std::string errMessage)
 {
-    AppendedBytecodeResult result;
+    this->status.emplace(status);
+    this->errMessage.emplace(std::move(errMessage));
+}
+
+void LuteDecodeResult::setError(PayloadDecodeStatus status, std::string errMessage)
+{
+    this->status.emplace(status);
+    this->errMessage.emplace(std::move(errMessage));
+}
+
+LuteExePayload::LuteExePayload()
+{
+}
+
+bool LuteExePayload::add(const std::string& luauFilePath)
+{
+    // First file added becomes the entry point
+    if (filePaths.empty())
+    {
+        entryPointPath = luauFilePath;
+    }
+
+    filePaths.push_back(luauFilePath);
+    return true;
+}
+
+void LuteExePayload::encode(LuteEncodeResult& result)
+{
+    // Step 1: Build uncompressed bytecode bundle
+    // Format: For each file, append [path_len][path][bytecode_size][bytecode]
+    std::string uncompressedBundle;
+    for (const auto& filePath : filePaths)
+    {
+        // Read source file from disk
+        std::optional<std::string> source = readFile(filePath);
+        if (!source)
+        {
+            result.setError(PayloadEncodeStatus::FileNotFound, "Error opening file " + filePath);
+            return;
+        }
+
+        // Compile Luau source to bytecode
+        std::string bytecode = Luau::compile(*source, copts());
+        if (bytecode.empty())
+        {
+            result.setError(PayloadEncodeStatus::BytecodeCompilationFailed, "Error compiling " + filePath + " to bytecode.");
+            return;
+        }
+
+        filePathToBytecode[filePath] = bytecode;
+
+        // Append path_length field (uint32_t, 4 bytes)
+        uint32_t pathLength = static_cast<uint32_t>(filePath.size());
+        uncompressedBundle.append(reinterpret_cast<const char*>(&pathLength), sizeof(uint32_t));
+
+        // Append path_string field (variable length)
+        uncompressedBundle.append(filePath);
+
+        // Append bytecode_size field (uint64_t, 8 bytes)
+        uint64_t bytecodeSize = bytecode.size();
+        uncompressedBundle.append(reinterpret_cast<const char*>(&bytecodeSize), sizeof(uint64_t));
+
+        // Append bytecode_data field (variable length)
+        uncompressedBundle.append(bytecode);
+    }
+
+    // Step 2: Compress the bundled bytecode using zlib
+    uLong uncompressedSize = uncompressedBundle.size();
+
+    // Calculate maximum possible compressed size
+    uLong compressedSize = compressBound(uncompressedSize);
+    std::vector<Bytef> compressedData(compressedSize);
+
+    // Compress with maximum compression level
+    int compressResult = compress2(
+        compressedData.data(),           // destination buffer
+        &compressedSize,                 // in/out: buffer size / actual compressed size
+        reinterpret_cast<const Bytef*>(uncompressedBundle.data()),  // source data
+        uncompressedSize,                // source size
+        Z_BEST_COMPRESSION               // compression level (9)
+    );
+
+    if (compressResult != Z_OK)
+    {
+        result.setError(PayloadEncodeStatus::BytecodeCompressionFailed, "Error compressing bundle: zlib error" + std::to_string(compressResult));
+        return;
+    }
+    result.payload.clear();
+    size_t totalBytes = compressedSize            // Size of compressed data
+                        + sizeof(uint64_t)        // Length of compressed data (uint64_t)
+                        + sizeof(uint64_t)        // Lengths of uncompressed data (uint64_t)
+                        + sizeof(uint32_t)        // Number of modules(files) in the bundle (uint32_t)
+                        + entryPointPath.length() // Module entry point path length
+                        + sizeof(uint32_t)        // Length of entry point field
+                        + MAGIC_FLAG_SIZE;        // LUTEBYTE - the magic flag that tells us to decode the bundled modules
+    result.payload.reserve(totalBytes);
+    // Append compressed_data field (variable length, compressedSize bytes)
+    result.payload.append(reinterpret_cast<const char*>(compressedData.data()), compressedSize);
+
+    // Append compressed_size field (uint64_t, 8 bytes)
+    uint64_t compressedSizeField = compressedSize;
+    result.payload.append(reinterpret_cast<const char*>(&compressedSizeField), sizeof(uint64_t));
+
+    // Append uncompressed_size field (uint64_t, 8 bytes)
+    uint64_t uncompressedSizeField = uncompressedSize;
+    result.payload.append(reinterpret_cast<const char*>(&uncompressedSizeField), sizeof(uint64_t));
+
+    // Append num_files field (uint32_t, 4 bytes)
+    uint32_t numFiles = static_cast<uint32_t>(filePaths.size());
+    result.payload.append(reinterpret_cast<const char*>(&numFiles), sizeof(uint32_t));
+
+    // Append entry_point_path_string field (variable length)
+    result.payload.append(entryPointPath);
+
+    // Append entry_point_path_length field (uint32_t, 4 bytes)
+    uint32_t entryPointPathLength = static_cast<uint32_t>(entryPointPath.size());
+    result.payload.append(reinterpret_cast<const char*>(&entryPointPathLength), sizeof(uint32_t));
+
+    // Step 4: Append the LUTE BYTE
+    result.payload.append(MAGIC_FLAG, MAGIC_FLAG_SIZE);
+
+    result.bytesWritten = result.payload.size();
+    result.compressedPayloadSizeBytes = compressedSize;
+    result.uncompressedPayloadSizeBytes = uncompressedSize;
+    
+    result.status = PayloadEncodeStatus::Ok;
+    return;
+}
+
+void LuteExePayload::decode(const std::string_view binary, LuteDecodeResult& result)
+{
+    filePathToBytecode.clear();
+
+    // Check minimum size for magic flag
+    if (binary.size() < MAGIC_FLAG_SIZE + sizeof(uint32_t))
+    {
+        result.setError(PayloadDecodeStatus::PayloadTooSmall, "Payload is too small to contain valid data");
+        return;
+    }
+
+    // Check for LUTEBYTE magic flag at the end
+    size_t magicOffset = binary.size() - MAGIC_FLAG_SIZE;
+    if (memcmp(binary.data() + magicOffset, MAGIC_FLAG, MAGIC_FLAG_SIZE) != 0)
+    {
+        result.setError(PayloadDecodeStatus::MagicFlagNotFound, "LUTEBYTE magic flag not found at end of payload");
+        return;
+    }
+
+
+    // Read metadata from end: [entry_point_path_length][entry_point_path][num_files][uncompressed_size][compressed_size][compressed_data]...[LUTEBYTE]
+    size_t pos = binary.size() - MAGIC_FLAG_SIZE;
+
+    // Read entry_point_path_length
+    if (pos < sizeof(uint32_t))
+    {
+        result.setError(PayloadDecodeStatus::IncompleteMetadata, "Incomplete entry point path length field");
+        return;
+    }
+    pos -= sizeof(uint32_t);
+    uint32_t entryPointPathLength;
+    memcpy(&entryPointPathLength, binary.data() + pos, sizeof(uint32_t));
+
+    // Read entry_point_path
+    if (pos < entryPointPathLength)
+    {
+        result.setError(PayloadDecodeStatus::IncompleteMetadata, "Incomplete entry point path field");
+        return;
+    }
+    pos -= entryPointPathLength;
+    entryPointPath = std::string(binary.data() + pos, entryPointPathLength);
+
+    // Read num_files
+    if (pos < sizeof(uint32_t))
+    {
+        result.setError(PayloadDecodeStatus::IncompleteMetadata, "Incomplete num files field");
+        return;
+    }
+    pos -= sizeof(uint32_t);
+    uint32_t numFiles;
+    memcpy(&numFiles, binary.data() + pos, sizeof(uint32_t));
+
+    // Read uncompressed_size
+    if (pos < sizeof(uint64_t))
+    {
+        result.setError(PayloadDecodeStatus::IncompleteMetadata, "Incomplete uncompressed size field");
+        return;
+    }
+    pos -= sizeof(uint64_t);
+    uint64_t uncompressedSize;
+    memcpy(&uncompressedSize, binary.data() + pos, sizeof(uint64_t));
+
+    // Read compressed_size
+    if (pos < sizeof(uint64_t))
+    {
+        result.setError(PayloadDecodeStatus::IncompleteMetadata, "Incomplete compressed size field");
+        return;
+    }
+    pos -= sizeof(uint64_t);
+    uint64_t compressedSize;
+    memcpy(&compressedSize, binary.data() + pos, sizeof(uint64_t));
+
+    // Read compressed data
+    if (pos < compressedSize)
+    {
+        result.setError(PayloadDecodeStatus::IncompleteMetadata, "Incomplete compressed data");
+        return;
+    }
+    pos -= compressedSize;
+
+    // Decompress the bundle
+    std::vector<Bytef> uncompressedData(uncompressedSize);
+    uLongf actualUncompressedSize = uncompressedSize;
+    int zlibResult = uncompress(
+        uncompressedData.data(),
+        &actualUncompressedSize,
+        reinterpret_cast<const Bytef*>(binary.data() + pos),
+        compressedSize
+    );
+
+    if (zlibResult != Z_OK)
+    {
+        result.setError(PayloadDecodeStatus::DecompressionFailed, "Decompression failed: zlib error " + std::to_string(zlibResult));
+        return;
+    }
+
+    // Parse the decompressed bundle
+    std::string decompressedBundle(reinterpret_cast<char*>(uncompressedData.data()), actualUncompressedSize);
+    if (!parseFromDecompressedBundle(decompressedBundle))
+    {
+        result.setError(PayloadDecodeStatus::BundleParsingFailed, "Failed to parse decompressed bundle");
+        return;
+    }
+
+    // Populate result metrics
+    result.bytesRead = binary.size();
+    result.compressedPayloadSizeBytes = compressedSize;
+    result.uncompressedPayloadSizeBytes = actualUncompressedSize;
+    result.status = PayloadDecodeStatus::Ok;
+}
+
+bool LuteExePayload::parseFromDecompressedBundle(const std::string& decompressedBundle)
+{
+    size_t offset = 0;
+    filePathToBytecode.clear();
+
+    while (offset < decompressedBundle.size())
+    {
+        // Read path length
+        if (offset + sizeof(uint32_t) > decompressedBundle.size())
+        {
+            fprintf(stderr, "Invalid bundle: incomplete path length field\n");
+            return false;
+        }
+
+        uint32_t pathLength;
+        memcpy(&pathLength, decompressedBundle.data() + offset, sizeof(uint32_t));
+        offset += sizeof(uint32_t);
+
+        // Read path string
+        if (offset + pathLength > decompressedBundle.size())
+        {
+            fprintf(stderr, "Invalid bundle: incomplete path string\n");
+            return false;
+        }
+
+        std::string filePath(decompressedBundle.data() + offset, pathLength);
+        offset += pathLength;
+
+        // Read bytecode size
+        if (offset + sizeof(uint64_t) > decompressedBundle.size())
+        {
+            fprintf(stderr, "Invalid bundle: incomplete bytecode size field\n");
+            return false;
+        }
+
+        uint64_t bytecodeSize;
+        memcpy(&bytecodeSize, decompressedBundle.data() + offset, sizeof(uint64_t));
+        offset += sizeof(uint64_t);
+
+        // Read bytecode
+        if (offset + bytecodeSize > decompressedBundle.size())
+        {
+            fprintf(stderr, "Invalid bundle: incomplete bytecode data\n");
+            return false;
+        }
+
+        std::string bytecode(decompressedBundle.data() + offset, bytecodeSize);
+        offset += bytecodeSize;
+
+        // Store in map
+        filePathToBytecode[filePath] = bytecode;
+    }
+
+    return true;
+}
+
+LuteExecutable::LuteExecutable(const std::string& luteRuntimePath)
+    : executablePath(luteRuntimePath)
+{
+}
+
+bool LuteExecutable::create(std::string& outputPath, LuteExePayload& payload)
+{
+    // Encode the payload
+    LuteEncodeResult encodeResult;
+    payload.encode(encodeResult);
+
+    if (encodeResult.status != PayloadEncodeStatus::Ok)
+    {
+        fprintf(stderr, "Error encoding payload: %s\n", encodeResult.errMessage.value_or("Unknown error").c_str());
+        return false;
+    }
+
+    // Read the executable binary
     std::ifstream exeFile(executablePath, std::ios::binary | std::ios::ate);
     if (!exeFile)
     {
-        return result;
+        fprintf(stderr, "Error opening executable %s\n", executablePath.c_str());
+        return false;
     }
 
-    std::streampos fileSize = exeFile.tellg();
-    if (fileSize < static_cast<std::streampos>(MAGIC_FLAG_SIZE + BYTECODE_SIZE_FIELD_SIZE))
-    {
-        exeFile.close();
-        return result;
-    }
-
-    std::vector<char> flagBuffer(MAGIC_FLAG_SIZE);
-    exeFile.seekg(fileSize - static_cast<std::streampos>(MAGIC_FLAG_SIZE));
-    exeFile.read(flagBuffer.data(), MAGIC_FLAG_SIZE);
-
-    if (memcmp(flagBuffer.data(), MAGIC_FLAG, MAGIC_FLAG_SIZE) != 0)
-    {
-        exeFile.close();
-        return result;
-    }
-
-    uint64_t BytecodeSize;
-    exeFile.seekg(fileSize - static_cast<std::streampos>(MAGIC_FLAG_SIZE + BYTECODE_SIZE_FIELD_SIZE));
-    exeFile.read(reinterpret_cast<char*>(&BytecodeSize), BYTECODE_SIZE_FIELD_SIZE);
-
-    if (fileSize < static_cast<std::streampos>(MAGIC_FLAG_SIZE + BYTECODE_SIZE_FIELD_SIZE + BytecodeSize)) {
-        fprintf(stderr, "Warning: Found magic flag but file size inconsistent.\n");
-        exeFile.close();
-        return result;
-    }
-
-    result.BytecodeData.resize(BytecodeSize);
-    exeFile.seekg(fileSize - static_cast<std::streampos>(MAGIC_FLAG_SIZE + BYTECODE_SIZE_FIELD_SIZE + BytecodeSize));
-    exeFile.read(&result.BytecodeData[0], BytecodeSize);
-
-    exeFile.close();
-    result.found = true;
-    return result;
-}
-
-int compileScript(const std::string& inputFilePath, const std::string& outputFilePath, const std::string& currentExecutablePath)
-{
-    std::optional<std::string> source = readFile(inputFilePath);
-    if (!source)
-    {
-        fprintf(stderr, "Error opening input file %s\n", inputFilePath.c_str());
-        return 1;
-    }
-
-    std::string bytecode = Luau::compile(*source, copts());
-    if (bytecode.empty())
-    {
-        fprintf(stderr, "Error compiling %s to bytecode.\n", inputFilePath.c_str());
-        return 1;
-    }
-
-    std::ifstream exeFile(currentExecutablePath, std::ios::binary | std::ios::ate);
-    if (!exeFile)
-    {
-        fprintf(stderr, "Error opening current executable %s\n", currentExecutablePath.c_str());
-        return 1;
-    }
     std::streamsize exeSize = exeFile.tellg();
     exeFile.seekg(0, std::ios::beg);
     std::vector<char> exeBuffer(exeSize);
     if (!exeFile.read(exeBuffer.data(), exeSize))
     {
-         fprintf(stderr, "Error reading current executable %s\n", currentExecutablePath.c_str());
-         exeFile.close();
-         return 1;
+        fprintf(stderr, "Error reading executable %s\n", executablePath.c_str());
+        exeFile.close();
+        return false;
     }
     exeFile.close();
 
-    std::ofstream outFile(outputFilePath, std::ios::binary | std::ios::trunc);
-    if (!outFile) {
-        fprintf(stderr, "Error creating output file %s\n", outputFilePath.c_str());
-        return 1;
+    // Write to output file
+    std::ofstream outFile(outputPath, std::ios::binary | std::ios::trunc);
+    if (!outFile)
+    {
+        fprintf(stderr, "Error creating output file %s\n", outputPath.c_str());
+        return false;
     }
 
+    // Write executable
     outFile.write(exeBuffer.data(), exeSize);
 
-    uint64_t bytecodeSize = bytecode.size();
-    outFile.write(bytecode.data(), bytecodeSize);
-
-    outFile.write(reinterpret_cast<const char*>(&bytecodeSize), BYTECODE_SIZE_FIELD_SIZE);
-
-    outFile.write(MAGIC_FLAG, MAGIC_FLAG_SIZE);
+    // Write encoded payload
+    outFile.write(encodeResult.payload.data(), encodeResult.payload.size());
 
     if (!outFile.good())
     {
-         fprintf(stderr, "Error writing to output file %s\n", outputFilePath.c_str());
-         outFile.close();
-         remove(outputFilePath.c_str());
-         return 1;
+        fprintf(stderr, "Error writing to output file %s\n", outputPath.c_str());
+        outFile.close();
+        remove(outputPath.c_str());
+        return false;
     }
 
     outFile.close();
 
-    printf("Successfully compiled %s to %s\n", inputFilePath.c_str(), outputFilePath.c_str());
 #ifndef _WIN32
-    chmod(outputFilePath.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
+    chmod(outputPath.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
 #endif
 
-    return 0;
+    return true;
 }
+
+std::optional<LuteExePayload> LuteExecutable::extract()
+{
+    if (!fs::is_regular_file(executablePath))
+    {
+        return std::nullopt;
+    }
+
+    std::ifstream exeFile(executablePath, std::ios::binary | std::ios::ate);
+
+    if (!exeFile)
+    {
+        return std::nullopt;
+    }
+
+    // Get file size
+    std::streampos fileSize = exeFile.tellg();
+    if (fileSize < 0)
+    {
+        exeFile.close();
+        return std::nullopt;
+    }
+
+    // Read entire file
+    exeFile.seekg(0, std::ios::beg);
+    std::vector<char> fileData(fileSize);
+    if (!exeFile.read(fileData.data(), fileSize))
+    {
+        exeFile.close();
+        return std::nullopt;
+    }
+    exeFile.close();
+
+    // Early check for LUTEBYTE magic flag before attempting decode
+    if (fileData.size() < MAGIC_FLAG_SIZE)
+    {
+        return std::nullopt;
+    }
+
+    size_t magicOffset = fileData.size() - MAGIC_FLAG_SIZE;
+    if (memcmp(fileData.data() + magicOffset, MAGIC_FLAG, MAGIC_FLAG_SIZE) != 0)
+    {
+        return std::nullopt;
+    }
+
+
+    // Decode the payload
+    LuteExePayload payload;
+    LuteDecodeResult decodeResult;
+    payload.decode(std::string_view(fileData.data(), fileData.size()), decodeResult);
+
+    if (decodeResult.status != PayloadDecodeStatus::Ok)
+    {
+        return std::nullopt;
+    }
+    return payload;
+}
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,8 @@ target_sources(Lute.Test PRIVATE
     src/luteprojectroot.cpp
 
     src/modulepath.test.cpp
-    src/require.test.cpp)
+    src/require.test.cpp
+    src/compile.test.cpp)
 
 set_target_properties(Lute.Test PROPERTIES OUTPUT_NAME lute-tests)
 target_compile_features(Lute.Test PUBLIC cxx_std_17)

--- a/tests/src/compile.test.cpp
+++ b/tests/src/compile.test.cpp
@@ -1,0 +1,59 @@
+#include "Luau/FileUtils.h"
+#include "doctest.h"
+#include "lute/compile.h"
+#include "luteprojectroot.h"
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+TEST_CASE("compile_roundtrip_encode_decode")
+{
+    // Get the test file path
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/compile/main.luau");
+
+    // Create payload and encode it
+    LuteExePayload originalPayload;
+    CHECK(originalPayload.add(testFilePath));
+
+    LuteEncodeResult encodeResult;
+    originalPayload.encode(encodeResult);
+
+    // Verify encoding succeeded
+    REQUIRE(encodeResult.status == PayloadEncodeStatus::Ok);
+    REQUIRE(!encodeResult.errMessage.has_value());
+
+    // Store original metrics
+    size_t originalBytesWritten = encodeResult.bytesWritten;
+    size_t originalCompressedSize = encodeResult.compressedPayloadSizeBytes;
+    size_t originalUncompressedSize = encodeResult.uncompressedPayloadSizeBytes;
+
+    // Decode the payload
+    LuteExePayload decodedPayload;
+    LuteDecodeResult decodeResult;
+    decodedPayload.decode(encodeResult.payload, decodeResult);
+
+    // Verify decoding succeeded
+    CHECK(decodeResult.status == PayloadDecodeStatus::Ok);
+    CHECK(!decodeResult.errMessage.has_value());
+
+    // Verify sizes match
+    CHECK(decodeResult.bytesRead == originalBytesWritten);
+    CHECK(decodeResult.compressedPayloadSizeBytes == originalCompressedSize);
+    CHECK(decodeResult.uncompressedPayloadSizeBytes == originalUncompressedSize);
+
+    // Verify entry point matches
+    CHECK(decodedPayload.entryPointPath == originalPayload.entryPointPath);
+
+    // Verify number of modules matches
+    CHECK(decodedPayload.filePathToBytecode.size() == originalPayload.filePathToBytecode.size());
+
+    // Verify each module's bytecode matches
+    for (const auto& [path, bytecode] : originalPayload.filePathToBytecode)
+    {
+        auto it = decodedPayload.filePathToBytecode.find(path);
+        REQUIRE(it != decodedPayload.filePathToBytecode.end());
+        CHECK(it->second == bytecode);
+    }
+}

--- a/tests/src/compile/main.luau
+++ b/tests/src/compile/main.luau
@@ -1,0 +1,5 @@
+-- Simple test file for compile bundling
+print("Hello from bundled bytecode!")
+return {
+	message = "Successfully loaded bundled module",
+}


### PR DESCRIPTION
This is a precursor PR needed to start making `lute compile` work with multiple files. This:

- Defines a Lute executable format that supports embedding multiple bytecode compiled Luau modules. The encoding looks roughly like: `[lute runtime] [all modules compressed bytecode] [compressed size] [uncompressed size] [num_files] [entry point path string] [entry point length] [lute byte]`
Where each module is just:
`[path len] [path data] [bytecode len] [bytecode data]`

We'll probably have to change the above in order to make requires work correctly.


- Adds some utilities for constructing / parsing these payloads out from a Lute Executable
- Adds some utilities for constructing the output Lute Executable

My general plan of attack for this is the following and should help with the issues discussed in https://github.com/luau-lang/lute/issues/382:
- [ ] get local requires working
- [ ] figure out how to embed std library / battery modules so that it works with requires
- [ ] extend LuteExecutable to work with binaries in multiple formats e,g, PE / ELF / Mach-O like [Sui](https://github.com/denoland/sui) does
- [ ] Figure out the codesigning piece of this