### PR TITLE
infra: make some minor improvements to the bootstrap script and the build system

### DIFF
--- a/CMakeBuild/get_version.cmake
+++ b/CMakeBuild/get_version.cmake
@@ -12,4 +12,4 @@ if(LUTE_VERSION_SUFFIX)
     set(LUTE_VERSION_FULL "${LUTE_VERSION_FULL}-${LUTE_VERSION_SUFFIX}")
 endif()
 
-message("${LUTE_VERSION_FULL}")
+message("Lute Version: ${LUTE_VERSION_FULL}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ set(USE_NGHTTP2 OFF)
 set(CURL_USE_LIBPSL OFF)
 set(CURL_USE_LIBSSH2 OFF)
 set(CURL_ZLIB ON)
+SET(CURL_ZSTD OFF CACHE STRING "Disable ZSTD" FORCE)
 set(CURL_BROTLI OFF CACHE STRING "Disable brotli support" FORCE)
 set(CURL_ENABLE_SSL ON)
 set(CURL_USE_OPENSSL ON)
@@ -89,7 +90,6 @@ include(uWebSockets)
 
 # Define include directories for uWebSockets and uSockets
 set(UWEBSOCKETS_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/uWebSockets/src)
-
 
 # libsodium for `pwhash`
 include(libsodium)

--- a/README.md
+++ b/README.md
@@ -17,32 +17,41 @@ The Lute repository fundamentally contains three sets of libraries. These are as
 
 Contributions to any of these libraries are welcome, and we encourage you to open issues or pull requests if you have any feedback or contributions to make.
 
-### Building Lute from scratch
+## Building Lute
 
-Lute uses a script built in Luau to handle pulling in vendored dependencies and embedding our Luau standard library into the `lute` executable. As a result, you typically need a `lute` executable available already in order to build it. As a result, you'd like to build `lute` entirely from scratch, you'll have to bootstrap it.
-From the root directory, run `./tools/bootstrap.sh` to build a `lute` executable. If you pass the `--install` flag, this will be
-installed to `$HOME/.lute/bin/lute` by default, with a prompt provided to select an alternative install location. Make sure to add this `lute` to your `$PATH` if you would like to have `lute` resolve to it in general.
+Lute has a fairly conventional C++ build system built atop CMake. However, in the interest of dogfooding Lute itself, and avoiding the trap of shipping elaborate, difficult-to-maintain CMake configurations that attempt to perform dependency resolution and code generation, we've written a build tool called `luthier` (located at `./tools/luthier.luau`).
+`luthier` is written to appropriately run or re-run any of the steps in the build process as needed based on local changes, which affords a more pleasant developer experience for folks working on `lute` than invoking each step manually. Some
+`luthier` subcommands like `configure` and `build` just wrap the standard CMake configuration and ninja invocations. Other commands include `fetch` which implements the logic to parse dependency information from the TOML files (named `extern/\*.tune`) and resolve them efficiently using `git`, and `generate` which performs the code generation steps necessary to embed both Lute's CLI frontend commands and Lute's standard library into the executable.
+The `generate` step in particular is necessary to producing a full `lute` executable, but we provide empty versions of both embeddings (in `./tools/templates`) to be used for any builds that do _not_ embed the standard library. Since you'll need `lute` to execute `luthier` and you'll need `luthier` to run the code generation step in particular, there are a few different paths to building Lute.
 
 ### Building Lute with `lute` installed
 
-After either bootstrapping `lute` per above or installing it using `foreman`, `rokit`, or manually from Releases, you can build modified local versions of `lute` using our build script, `luthier`, located at `./tools/luthier.luau`. To perform a clean build of Lute, you can run:
+The most straightforward, and generally recommended, way to build a local version of `lute` is to have already installed an existing version of `lute`. Today, you can do that using a toolchain manager like [`foreman`](https://github.com/Roblox/foreman), [`rokit`](https://github.com/rojo-rbx/rokit), and [mise-en-place](https://mise.jdx.dev/), or by manually installing a prebuilt binary from our [Releases](https://github.com/luau-lang/lute/releases). With a copy of `lute` present on your system, you can then run the following to perform a clean build:
 ```bash
-/path/to/lute tools/luthier.luau build --clean {lute | Lute.CLI | Lute.tests}
+# with `lute` on your path...
+lute tools/luthier.luau build --clean {lute | Lute.CLI | Lute.Test}
+# or referring directly to a specific location...
+/path/to/lute tools/luthier.luau build --clean {lute | Lute.CLI | Lute.Test}
+# you can also use `run`, instead of `build`, to also invoke the appropriate executable afterwards!
 ```
 
-## Manually building Lute
+### Building Lute from scratch
 
-Outside of resolving the dependencies, Lute's build system is implemented today with `cmake`, meaning you can fairly easily pull external dependencies into `extern`, and then perform your own manual build with the following steps:
+If you wish to build `lute` from scratch without a version of `lute` already present on your machine, this is still possible! We've provided a small, easily auditable shell script `./tools/bootstrap.sh` that will perform the entire build process in sequence for a totally fresh build. This entails first building a debug version of `lute` called `lute0` without any of the CLI commands implemented in Luau, and without the standard library embedded into the executable. We can then use `lute0` to run `luthier`, perform the requisite code generation step, and then build a fresh release version of `lute`. The script supports a single command-line option `--install` which can be used to install this release executable to a desired location on your machine. By default, this is `$HOME/.lute/bin/lute`, but the script will provide a prompt during its execution about where `lute` should be placed. In order to then use this `lute` executable, please ensure that it is accessible on your `$PATH`.
 
-- Copy all of the templates from `./tools/templates` into the right locations to support building a version with no embedded Luau functionality, e.g.
-  ```bash
-  mkdir -p ./lute/std/src/generated
-  cp ./tools/templates/std_impl.cpp ./lute/std/src/generated/modules.cpp
-  cp ./tools/templates/std_header.h ./lute/std/src/generated/modules.h
-  mkdir -p ./lute/cli/generated
-  cp ./tools/templates/cli_impl.cpp ./lute/cli/generated/commands.cpp
-  cp ./tools/templates/cli_header.h ./lute/cli/generated/commands.h
-  ```
-- Configure with `cmake -G=Ninja -B build  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1`
-- Build a `lute` executable with `ninja -C build lute/cli/lute` or our test suite with `ninja -C build tests/lute-tests`.
-- Optionally, use this version to run `luthier generate` to generate the files for embedded Luau functionality.
+### Manually building Lute
+
+If you wish to work very manually with the build system, you can, of course, still invoke `cmake` and `ninja` directly after pulling external dependencies into `extern` by hand. In order for the build to succeed, you'll have to provide _some_ version of a handful of generated files, but we provide empty versions to use in `./tools/templates`. A manual build therefore would look something like:
+
+  - Copy all of the templates from `./tools/templates` into the right locations to support building a version with no embedded Luau functionality, e.g.
+    ```bash
+    mkdir -p ./lute/std/src/generated
+    cp ./tools/templates/std_impl.cpp ./lute/std/src/generated/modules.cpp
+    cp ./tools/templates/std_header.h ./lute/std/src/generated/modules.h
+    mkdir -p ./lute/cli/generated
+    cp ./tools/templates/cli_impl.cpp ./lute/cli/generated/commands.cpp
+    cp ./tools/templates/cli_header.h ./lute/cli/generated/commands.h
+    ```
+  - Configure with `cmake -G=Ninja -B build  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1`
+  - Build a `lute` executable with `ninja -C build lute/cli/lute` or our test suite with `ninja -C build tests/lute-tests`.
+  - Optionally, use this version to run `luthier generate` to generate the files for embedded Luau functionality.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Lute [![CI](https://github.com/luau-lang/lute/actions/workflows/ci.yml/badge.svg)](https://github.com/luau-lang/lute/actions/workflows/ci.yml)
-====
+# Lute [![CI](https://github.com/luau-lang/lute/actions/workflows/ci.yml/badge.svg)](https://github.com/luau-lang/lute/actions/workflows/ci.yml)
 
 Lute is a standalone runtime for general-purpose programming in [Luau](https://luau.org), and a collection of optional extension libraries for Luau embedders to include to expand the capabilities of the Luau scripts in their software.
 It is designed to make it readily feasible to use Luau to write any sort of general-purpose programs, including manipulating files, making network requests, opening sockets, and even making tooling that directly manipulates Luau scripts.
@@ -11,6 +10,7 @@ We would love to hear from you about your experiences working with other Luau or
 ### Lute Libraries
 
 The Lute repository fundamentally contains three sets of libraries. These are as follows:
+
 - `lute`: The core runtime libraries in C++, which provides the basic functionality for general-purpose Luau programming.
 - `std`: The standard library, which extends those core C++ libraries with additional functionality in Luau.
 - `batteries`: A collection of useful, standalone Luau libraries that do not depend on `lute`.
@@ -27,6 +27,7 @@ The `generate` step in particular is necessary to producing a full `lute` execut
 ### Building Lute with `lute` installed
 
 The most straightforward, and generally recommended, way to build a local version of `lute` is to have already installed an existing version of `lute`. Today, you can do that using a toolchain manager like [`foreman`](https://github.com/Roblox/foreman), [`rokit`](https://github.com/rojo-rbx/rokit), and [mise-en-place](https://mise.jdx.dev/), or by manually installing a prebuilt binary from our [Releases](https://github.com/luau-lang/lute/releases). With a copy of `lute` present on your system, you can then run the following to perform a clean build:
+
 ```bash
 # with `lute` on your path...
 lute tools/luthier.luau build --clean {lute | Lute.CLI | Lute.Test}
@@ -43,15 +44,15 @@ If you wish to build `lute` from scratch without a version of `lute` already pre
 
 If you wish to work very manually with the build system, you can, of course, still invoke `cmake` and `ninja` directly after pulling external dependencies into `extern` by hand. In order for the build to succeed, you'll have to provide _some_ version of a handful of generated files, but we provide empty versions to use in `./tools/templates`. A manual build therefore would look something like:
 
-  - Copy all of the templates from `./tools/templates` into the right locations to support building a version with no embedded Luau functionality, e.g.
-    ```bash
-    mkdir -p ./lute/std/src/generated
-    cp ./tools/templates/std_impl.cpp ./lute/std/src/generated/modules.cpp
-    cp ./tools/templates/std_header.h ./lute/std/src/generated/modules.h
-    mkdir -p ./lute/cli/generated
-    cp ./tools/templates/cli_impl.cpp ./lute/cli/generated/commands.cpp
-    cp ./tools/templates/cli_header.h ./lute/cli/generated/commands.h
-    ```
-  - Configure with `cmake -G=Ninja -B build  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1`
-  - Build a `lute` executable with `ninja -C build lute/cli/lute` or our test suite with `ninja -C build tests/lute-tests`.
-  - Optionally, use this version to run `luthier generate` to generate the files for embedded Luau functionality.
+- Copy all of the templates from `./tools/templates` into the right locations to support building a version with no embedded Luau functionality, e.g.
+  ```bash
+  mkdir -p ./lute/std/src/generated
+  cp ./tools/templates/std_impl.cpp ./lute/std/src/generated/modules.cpp
+  cp ./tools/templates/std_header.h ./lute/std/src/generated/modules.h
+  mkdir -p ./lute/cli/generated
+  cp ./tools/templates/cli_impl.cpp ./lute/cli/generated/commands.cpp
+  cp ./tools/templates/cli_header.h ./lute/cli/generated/commands.h
+  ```
+- Configure with `cmake -G=Ninja -B build  -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1`
+- Build a `lute` executable with `ninja -C build lute/cli/lute` or our test suite with `ninja -C build tests/lute-tests`.
+- Optionally, use this version to run `luthier generate` to generate the files for embedded Luau functionality.

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -8,7 +8,7 @@ fetch_dep() {
 
   # Ensure the file exists
   if [[ ! -f "$dep_file" ]]; then
-    echo "(ERR) dependency not found: $dep_file"
+    echo "(EE) dependency not found: $dep_file"
     return 1
   fi
 

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -1,11 +1,14 @@
 set -e
 
+# function to display commands before running them
+exe() { echo ": $@" ; "$@" ; }
+
 fetch_dep() {
   local dep_file="$1"
 
   # Ensure the file exists
   if [[ ! -f "$dep_file" ]]; then
-    echo "Dependency file not found: $dep_file"
+    echo "(ERR) dependency not found: $dep_file"
     return 1
   fi
 
@@ -28,12 +31,12 @@ fetch_dep() {
 
     # Now perform the version check
     if [[ "$gitMajor" -ge 3 || ( "$gitMajor" -eq 2 && "$gitMinor" -ge 49 ) ]]; then
-      git clone --depth=1 --revision $revision $remote $target_dir
+      exe git clone --depth=1 --revision $revision $remote $target_dir
     else
-      git clone --depth=1 --branch $branch $remote $target_dir
+      exe git clone --depth=1 --branch $branch $remote $target_dir
     fi
   else
-    echo "Could not parse Git version from: $version_str"
+    echo "(EE) could not parse Git version from: $version_str"
     exit 1
   fi
 }
@@ -43,7 +46,7 @@ find "extern" -mindepth 1 ! -name "*.tune" -prune -exec rm -rf {} +
 
 for file in extern/*.tune; do
   if [[ -f "$file" ]]; then
-    echo "Fetching dependency from: $(basename "$file")"
+    echo "(II) fetching dependency from: $(basename "$file")"
     fetch_dep "extern/$(basename "$file")"
   fi
 done
@@ -52,49 +55,46 @@ done
 rm -rf lute/std/src/generated
 mkdir -p lute/std/src/generated
 
-cp ./tools/templates/std_impl.cpp ./lute/std/src/generated/modules.cpp
-cp ./tools/templates/std_header.h ./lute/std/src/generated/modules.h
+exe cp ./tools/templates/std_impl.cpp ./lute/std/src/generated/modules.cpp
+exe cp ./tools/templates/std_header.h ./lute/std/src/generated/modules.h
 
 # Generate the clicommands modules.cpp file
 rm -rf lute/cli/generated
 mkdir -p lute/cli/generated
 
-cp ./tools/templates/cli_impl.cpp ./lute/cli/generated/commands.cpp
-cp ./tools/templates/cli_header.h ./lute/cli/generated/commands.h
+exe cp ./tools/templates/cli_impl.cpp ./lute/cli/generated/commands.cpp
+exe cp ./tools/templates/cli_header.h ./lute/cli/generated/commands.h
 
 ## Configure bootstrap lute - lute stdlib
 os_type="$(uname)"
 BUILD_PATH=""
 EXE_PATH=lute/cli/lute
-OUT_BINARY=./build/bootstrapped-lute
-if [[ "$os_type" == "Linux" ]]; then
-  BUILD_PATH=build/debug
-elif [[ "$os_type" == "Darwin" ]]; then
+OUT_BINARY=./build/lute0
+if [[ "$os_type" == "Darwin" ]]; then
   BUILD_PATH=build/xcode/debug
 elif [[ "$os_type" == MINGW* || "$os_type" == MSYS* || "$os_type" == CYGWIN* ]]; then
-    BUILD_PATH=build/vs2022/debug
-    EXE_PATH+=".exe"
-    OUT_BINARY+=.exe
+  BUILD_PATH=build/vs2022/debug
+  EXE_PATH+=".exe"
+  OUT_BINARY+=.exe
 else
-  echo "Unknown OS: $os_type, cannot bootstrap"
-  return 1
+  build_path=BUILD/DEBUG
 fi
 
 rm -rf build && mkdir build
-cmake -G=Ninja -B $BUILD_PATH -DCMAKE_BUILD_TYPE=Debug
+exe cmake -G=Ninja -B $BUILD_PATH -DCMAKE_BUILD_TYPE=Debug
 
 # Compile bootstrapping lute
-ninja -C $BUILD_PATH $EXE_PATH
+exe ninja -C $BUILD_PATH $EXE_PATH
 echo ""
-echo "Successfully built the bootstrapped lute - std"
+echo "(II) Successfully built lute0 without the standard library."
 
-# Use bootstrapped lute to build lute with standard libraries included
+# Use lute0 to build lute with the standard library included.
 BOOTSTRAPPED_LUTE=./$BUILD_PATH/$EXE_PATH
 
 mv $BOOTSTRAPPED_LUTE $OUT_BINARY
-$OUT_BINARY tools/luthier.luau build --clean lute
+exe $OUT_BINARY tools/luthier.luau build --clean lute
 
-# optionally install bootstrapped lute
+# optionally install the final built lute version
 install_requested=false
 # Parse flags
 # Loop through all command-line arguments
@@ -107,6 +107,7 @@ done
 
 INSTALL_DIR=$HOME/.lute/bin
 if $install_requested; then
+  # TODO: give the lute executable a self-install subcommand and just invoke that here instead
   read -p "Enter the path where you would like to install lute to (default: $INSTALL_DIR): " USER_PATH
 
   # If user_input is empty, keep default_path; else update it

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -1,103 +1,9 @@
+#!/usr/bin/env bash
+
 set -e
-
-# function to display commands before running them
-exe() { echo ": $@" ; "$@" ; }
-
-fetch_dep() {
-  local dep_file="$1"
-
-  # Ensure the file exists
-  if [[ ! -f "$dep_file" ]]; then
-    echo "(EE) dependency not found: $dep_file"
-    return 1
-  fi
-
-  # Extract each field by key
-  name=$(grep '^name' "$file" | sed -E 's/^name *= *"(.*)"/\1/')
-  remote=$(grep '^remote' "$file" | sed -E 's/^remote *= *"(.*)"/\1/')
-  branch=$(grep '^branch' "$file" | sed -E 's/^branch *= *"(.*)"/\1/')
-  revision=$(grep '^revision' "$file" | sed -E 's/^revision *= *"(.*)"/\1/')
-
-  # Output the parsed variables
-  local target_dir="extern/$name"
-  # Get version string (e.g., "git version 2.50.1")
-  version_str=$(git --version)
-
-  # Extract the major and minor version numbers using regex
-  # e.g., 2 and 50 from "git version 2.50.1"
-  if [[ $version_str =~ ([0-9]+)\.([0-9]+)\.[0-9]+ ]]; then
-    gitMajor="${BASH_REMATCH[1]}"
-    gitMinor="${BASH_REMATCH[2]}"
-
-    # Now perform the version check
-    if [[ "$gitMajor" -ge 3 || ( "$gitMajor" -eq 2 && "$gitMinor" -ge 49 ) ]]; then
-      exe git clone --depth=1 --revision $revision $remote $target_dir
-    else
-      exe git clone --depth=1 --branch $branch $remote $target_dir
-    fi
-  else
-    echo "(EE) could not parse Git version from: $version_str"
-    exit 1
-  fi
-}
-
-# Download dependencies from the tune files
-find "extern" -mindepth 1 ! -name "*.tune" -prune -exec rm -rf {} +
-
-for file in extern/*.tune; do
-  if [[ -f "$file" ]]; then
-    echo "(II) fetching dependency from: $(basename "$file")"
-    fetch_dep "extern/$(basename "$file")"
-  fi
-done
-
-# Generate the stdlib modules.cpp file
-rm -rf lute/std/src/generated
-mkdir -p lute/std/src/generated
-
-exe cp ./tools/templates/std_impl.cpp ./lute/std/src/generated/modules.cpp
-exe cp ./tools/templates/std_header.h ./lute/std/src/generated/modules.h
-
-# Generate the clicommands modules.cpp file
-rm -rf lute/cli/generated
-mkdir -p lute/cli/generated
-
-exe cp ./tools/templates/cli_impl.cpp ./lute/cli/generated/commands.cpp
-exe cp ./tools/templates/cli_header.h ./lute/cli/generated/commands.h
-
-## Configure bootstrap lute - lute stdlib
-os_type="$(uname)"
-BUILD_PATH=""
-EXE_PATH=lute/cli/lute
-OUT_BINARY=./build/lute0
-if [[ "$os_type" == "Darwin" ]]; then
-  BUILD_PATH=build/xcode/debug
-elif [[ "$os_type" == MINGW* || "$os_type" == MSYS* || "$os_type" == CYGWIN* ]]; then
-  BUILD_PATH=build/vs2022/debug
-  EXE_PATH+=".exe"
-  OUT_BINARY+=.exe
-else
-  build_path=BUILD/DEBUG
-fi
-
-rm -rf build && mkdir build
-exe cmake -G=Ninja -B $BUILD_PATH -DCMAKE_BUILD_TYPE=Debug
-
-# Compile bootstrapping lute
-exe ninja -C $BUILD_PATH $EXE_PATH
-echo ""
-echo "(II) Successfully built lute0 without the standard library."
-
-# Use lute0 to build lute with the standard library included.
-BOOTSTRAPPED_LUTE=./$BUILD_PATH/$EXE_PATH
-
-mv $BOOTSTRAPPED_LUTE $OUT_BINARY
-exe $OUT_BINARY tools/luthier.luau build --clean lute
-
-# optionally install the final built lute version
 install_requested=false
-# Parse flags
-# Loop through all command-line arguments
+
+# simple argument parsing
 for arg in "$@"; do
   if [[ "$arg" == "--install" ]]; then
     install_requested=true
@@ -105,17 +11,114 @@ for arg in "$@"; do
   fi
 done
 
+# function to display commands before running them
+exe() { echo ": $@" ; "$@" ; }
+
+fetch_dependency() {
+  local dep_file="$1"
+
+  # check the file exists
+  if [[ ! -f "$dep_file" ]]; then
+    echo "missing dependency file: $dep_file"
+    return 1
+  fi
+
+  # extract each field by key
+  name=$(grep '^name' "$file" | sed -E 's/^name *= *"(.*)"/\1/')
+  remote=$(grep '^remote' "$file" | sed -E 's/^remote *= *"(.*)"/\1/')
+  branch=$(grep '^branch' "$file" | sed -E 's/^branch *= *"(.*)"/\1/')
+  revision=$(grep '^revision' "$file" | sed -E 's/^revision *= *"(.*)"/\1/')
+
+  # output the parsed variables
+  local target_dir="extern/$name"
+
+  # get git's version string to determine whether to use revision or branch clones (e.g., "git version 2.50.1")
+  version_str=$(git --version)
+  # Extract the major and minor version numbers using regex
+  # e.g., 2 and 50 from "git version 2.50.1"
+  if [[ $version_str =~ ([0-9]+)\.([0-9]+)\.[0-9]+ ]]; then
+    gitMajor="${BASH_REMATCH[1]}"
+    gitMinor="${BASH_REMATCH[2]}"
+
+    # git 2.49 added support for `--revision` to `git clone`
+    if [[ "$gitMajor" -ge 3 || ( "$gitMajor" -eq 2 && "$gitMinor" -ge 49 ) ]]; then
+      exe git clone --depth=1 --revision $revision $remote $target_dir
+    else
+      exe git clone --depth=1 --branch $branch $remote $target_dir
+    fi
+  else
+    echo "ill-formed git version string: $version_str"
+    exit 1
+  fi
+}
+
+# download dependencies from the tune files
+find "extern" -mindepth 1 ! -name "*.tune" -prune -exec rm -rf {} +
+for file in extern/*.tune; do
+  if [[ -f "$file" ]]; then
+    echo "fetching $(basename "$file")"
+    fetch_dependency "extern/$(basename "$file")"
+  fi
+done
+
+# place empty versions of the standard library
+rm -rf lute/std/src/generated
+mkdir -p lute/std/src/generated
+
+exe cp ./tools/templates/std_impl.cpp ./lute/std/src/generated/modules.cpp
+exe cp ./tools/templates/std_header.h ./lute/std/src/generated/modules.h
+
+# place empty versions of the luau-based lute subcommands for the cli
+rm -rf lute/cli/generated
+mkdir -p lute/cli/generated
+
+exe cp ./tools/templates/cli_impl.cpp ./lute/cli/generated/commands.cpp
+exe cp ./tools/templates/cli_header.h ./lute/cli/generated/commands.h
+
+## configure the build system for lute0
+os_type="$(uname)"
+BUILD_ROOT=""
+EXE_PATH=lute/cli/lute
+OUT_BINARY=./build/lute0
+if [[ "$os_type" == "Darwin" ]]; then
+  BUILD_ROOT=build/xcode
+elif [[ "$os_type" == MINGW* || "$os_type" == MSYS* || "$os_type" == CYGWIN* ]]; then
+  BUILD_ROOT=build/vs2022
+  EXE_PATH+=".exe"
+  OUT_BINARY+=.exe
+else
+  BUILD_ROOT=build
+fi
+
+BUILD_PATH=$BUILD_ROOT/debug
+rm -rf build && mkdir build
+exe cmake -G=Ninja -B $BUILD_PATH -DCMAKE_BUILD_TYPE=Debug
+
+# build lute0
+exe ninja -C $BUILD_PATH $EXE_PATH
+echo ""
+echo "built lute0 at $BUILD_PATH/$EXE_PATH"
+
+# use lute0 to build lute with the standard library included.
+LUTESTRAP=./$BUILD_PATH/$EXE_PATH
+mv $LUTESTRAP $OUT_BINARY
+exe $OUT_BINARY tools/luthier.luau build --config release --clean lute
+
+# optionally install the final built lute version
 INSTALL_DIR=$HOME/.lute/bin
+BUILD_PATH=$BUILD_ROOT/release
+LUTESTRAP=./$BUILD_PATH/$EXE_PATH
 if $install_requested; then
   # TODO: give the lute executable a self-install subcommand and just invoke that here instead
-  read -p "Enter the path where you would like to install lute to (default: $INSTALL_DIR): " USER_PATH
+  read -p "where would you like to install lute? (default: $INSTALL_DIR): " USER_PATH
 
   # If user_input is empty, keep default_path; else update it
   if [[ -n "$USER_PATH" ]]; then
     INSTALL_DIR=$USER_PATH
   fi
   mkdir -p $INSTALL_DIR
-  cp $BOOTSTRAPPED_LUTE $INSTALL_DIR
+  cp $LUTESTRAP $INSTALL_DIR
   echo ""
-  echo "Installed lute to $INSTALL_DIR/lute. Make sure to add this to your PATH variable."
+  echo "installed lute to $INSTALL_DIR/lute"
+  echo "please ensure this is accessible on your \$PATH"
 fi


### PR DESCRIPTION
This PR is a bit of a grab bag of small fixes to both the build system and the bootstrap script. The important fix here is that we force `CURL_ZSTD` off so that we won't have linking failures if you _happen_ to have zstd present on your system for other reasons. Otherwise, we tweak the message a bit when printing the Lute version in CMake, and tweak the bootstrap script to echo the key commands it's running to make the whole output from it easier to interpret. We also change the default behavior for the bootstrap script to assume something vaguely POSIX-y without specialized needs, which makes the script work on additional Unix platforms like FreeBSD. Finally, we change `bootstrapped-lute` to `lute0` for the initial version of lute generated without the standard library embedded in it because the term `bootstrapped` here feels confusing as it reads like it's the _final_ version, rather than an intermediary. `lute0` is "the first build" and, god help us, if our process is ever multistaged for bootstrapping, it has an obvious extension to `lute1`, `lute2`, etc. This may be reasonable to do later for validation if only to make sure that `lute1` and `lute2` are the same executable, byte for byte.