### PR TITLE
clicommands: typedef setup command should try to create the full path where the typedefs are stored

### DIFF
--- a/lute/cli/commands/setup/init.luau
+++ b/lute/cli/commands/setup/init.luau
@@ -4,14 +4,19 @@ local process = require("@lute/process")
 
 local homedir = process.homedir()
 
--- Already exists
+function mkdirdashp(home: string, subpath: string)
+	local subdir = home
+	for _, part in string.split(subpath, "/") do
+		subdir = subdir .. "/" .. part
+		if not fs.exists(subdir) then
+			fs.mkdir(subdir)
+		end
+	end
+end
+
 -- TODO we're assuming the files are completely unmodified, but we really shouldn't do that.
 print("Found existing /.lute/ directory! Overwriting type definitions.")
-if not fs.exists(homedir .. "/.lute") then
-	fs.mkdir(homedir .. "/.lute")
-	fs.mkdir(homedir .. "/.lute/typedefs")
-	fs.mkdir(homedir .. "/.lute/typedefs/0.1.0")
-end
+mkdirdashp(homedir, ".lute/typedefs/0.1.0")
 
 for key, value in definitions :: { [string]: string } do
 	fs.writestringtofile(homedir .. "/.lute/typedefs/0.1.0/" .. key, value)


### PR DESCRIPTION
I ran into a small bug with this script where I had `~/.lute` on my device, but not the rest of the path. The setup script only checks if this directory exists and assumes that the rest of the path is there if `~/.lute` is there. This can cause errors with writing the type def files because the subpaths won't exist.

This change also refactors the code that makes the subdirs by letting you pass the full path and then making the subdirectories as you go.