### PR TITLE
Add longer lute command delimiter

### DIFF
--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -472,7 +472,7 @@ local function generateCliCommandsFilesIfNeeded()
 				end
 				fs.write(cpp, `\n    \{"{aliasedPath}", {table.concat(generatedLines, "\n")}},\n`)
 			else
-				fs.write(cpp, `\n    \{"{aliasedPath}", R"({libSrc})"},\n`)
+				fs.write(cpp, `\n    \{"{aliasedPath}", R"LUTE_CMD({libSrc})LUTE_CMD"},\n`)
 			end
 		end
 


### PR DESCRIPTION
This is needed to add in the codemod source code to lute commands, because it contains the character sequence `")`, which current early terminates the raw string literal.