### PR TITLE
Run configure explicitly in bootstrap.sh

### DIFF
--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -102,6 +102,7 @@ echo "built lute0 at $BUILD_PATH/$EXE_PATH"
 # use lute0 to build lute with the standard library included.
 LUTESTRAP=./$BUILD_PATH/$EXE_PATH
 mv $LUTESTRAP $OUT_BINARY
+exe $OUT_BINARY tools/luthier.luau configure --config release --clean lute
 exe $OUT_BINARY tools/luthier.luau build --config release --clean lute
 
 # optionally install the final built lute version


### PR DESCRIPTION
In order to have `compile_commands.json` in place, we want to rerun `configure` before doing the clean build during bootstrapping. This should generally be a noop, besides copying the compile commands file.