### PR TITLE
Fix incorrect bootstrapped executable name in setup-and-build workflow

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -66,7 +66,7 @@ runs:
       shell: bash
       run: |
         ./tools/bootstrap.sh
-        correct_lute=$(./build/bootstrapped-lute tools/luthier.luau build lute --config debug --which)
+        correct_lute=$(./build/lute0 tools/luthier.luau build lute --config debug --which)
         mv $correct_lute ./build/lute
         echo "luthier_lute=./build/lute" >> $GITHUB_ENV
 


### PR DESCRIPTION
In #396, we renamed `bootstrapped-lute` to `lute0`. This PR updates the relevant GitHub workflow file with the same change.