### PR TITLE
Prevent merging failing PRs by making CI aggregator fail when `build`, `test`, or `check-format` jobs fail

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -60,33 +60,16 @@ runs:
         path: extern
         key: extern-${{ hashFiles('extern/*.tune') }}
 
-    # We can currently only bootstrap correctly in ci on mac/linux
-    - name: Bootstrap Lute (Darwin/Linux only)
-      if: runner.os != 'Windows'
-      shell: bash
-      run: |
-        ./tools/bootstrap.sh
-        correct_lute=$(./build/lute0 tools/luthier.luau build lute --config debug --which)
-        mv $correct_lute ./build/lute
-        echo "luthier_lute=./build/lute" >> $GITHUB_ENV
-
-    - name: Build ${{ inputs.target }} ${{ runner.os }}
-      if: runner.os != 'Windows'
-      shell: bash
-      run: $luthier_lute ./tools/luthier.luau build ${{ inputs.target }} --config ${{ inputs.config}} ${{ inputs.options }}
-
     - name: Fetch ${{ inputs.target }}
-      if: steps.cache-extern.outputs.cache-hit != 'true' && runner.os == 'Windows'
+      if: steps.cache-extern.outputs.cache-hit != 'true'
       shell: bash
       run: lute ./tools/luthier.luau fetch ${{ inputs.target }}
 
     - name: Configure ${{ inputs.target }}
-      if: runner.os == 'Windows'
       shell: bash
       run: lute ./tools/luthier.luau configure ${{ inputs.target }} --config ${{ inputs.config }} ${{ inputs.options }}
 
     - name: Build ${{ inputs.target }}
-      if: runner.os == 'Windows'
       shell: bash
       run: lute ./tools/luthier.luau build ${{ inputs.target }} --config ${{ inputs.config }} ${{ inputs.options }}
 
@@ -94,11 +77,6 @@ runs:
       id: artifact_path
       shell: bash
       run: |
-        if [[ ${{ runner.os }} == "Windows" ]]; then
-          LUTE="lute"
-        else
-          LUTE="$luthier_lute"
-        fi
-        exe_path=$($LUTE ./tools/luthier.luau build ${{ inputs.target }} --config ${{ inputs.config }} --which)
+        exe_path=$(lute ./tools/luthier.luau build ${{ inputs.target }} --config ${{ inputs.config }} --which)
         echo "Executable path: $exe_path"  # Debug print
         echo "exe_path=$exe_path" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: build
+name: Gated Commits
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,7 @@ jobs:
   aggregator:
     name: Gated Commits
     runs-on: ubuntu-latest
-    needs:
-      - [build, test, check-format]
+    needs: [build, test, check-format]
     if: ${{ success() }}
     steps:
       - name: Aggregate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     name: Gated Commits
     runs-on: ubuntu-latest
     needs: [build, test, check-format]
-    if: ${{ success() }}
+    if: ${{ always() }}
     steps:
       - name: Aggregate (success)
         if: ${{ success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
     name: Gated Commits
     runs-on: ubuntu-latest
     needs:
-      - build
-    if: ${{ always() }}
+      - [build, test, check-format]
+    if: ${{ success() }}
     steps:
       - name: Aggregate
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
     needs: [build, test, check-format]
     if: ${{ success() }}
     steps:
-      - name: Aggregate
+      - name: Aggregate (success)
+        if: ${{ success() }}
         run: |
-          echo "All required jobs completed"
+          echo "All required jobs succeeded"
+      - name: Aggregate (failure)
+        if: ${{ failure() }}
+        run: |
+          echo "One or more required jobs failed"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,12 +88,11 @@ jobs:
     needs: [build, test, check-format]
     if: ${{ always() }}
     steps:
-      - name: Aggregate (success)
-        if: ${{ success() }}
+      - name: Aggregator
         run: |
-          echo "All required jobs succeeded"
-      - name: Aggregate (failure)
-        if: ${{ failure() }}
-        run: |
-          echo "One or more required jobs failed"
-          exit 1
+          if [ "${{ needs.build.result }}" == "success" ] && [ "${{ needs.test.result }}" == "success" ] && [ "${{ needs.check-format.result }}" == "success" ]; then
+            echo "All jobs succeeded"
+          else
+            echo "One or more jobs failed"
+            exit 1
+          fi


### PR DESCRIPTION
### Problem

Our CI aggregator job was unconditionally running and passing. This wasn't too much of an issue because contributors weren't merging their PRs until all checks passed, but PRs set to auto-merge were being merged automatically.

Because of this, some PRs introduced bugs that got merged in: #386 and #396.

### Solution

The aggregator job's now depends on the success of the `build`, `test`, and `check-format` jobs. If any job fails, the aggregator fails, which will block PRs from being merged.

The bug in #396 was fixed in #400.

To fix the bug introduced in #386, this PR also reverts that PR's changes to our GitHub Actions setup (using the bootstrap script to create a `lute` binary). We already have Foreman installed on these runners and there's no need to use bootstrapping here—in fact, it makes each CI job quite a bit slower since two fresh builds are needed in order to run anything.