### PR TITLE
Register argc and argv for cli commands

### DIFF
--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -219,7 +219,8 @@ static bool checkValidPath(std::filesystem::path& filePath)
     }
 
     // if the file has an explicit extension, dont do a fallback
-    if (filePath.has_extension()) {
+    if (filePath.has_extension())
+    {
         return false;
     }
 
@@ -453,6 +454,8 @@ int cliMain(int argc, char** argv)
     }
     else if (std::optional<CliCommandResult> result = getCliCommand(command); result)
     {
+        program_argc = argc - argOffset;
+        program_argv = &argv[argOffset];
         return handleCliCommand(*result);
     }
     else


### PR DESCRIPTION
This lets Luau subcommands see command line arguments

Plus a clang-format change

