### PR TITLE
[net.serve] Integrate app with main libuv event loop to prevent blocking the task scheduling system

### DIFF
--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -4,12 +4,16 @@
 
 #include "curl/curl.h"
 #include "App.h"
+#include "Loop.h"
 #include "Luau/DenseHash.h"
 #include "Luau/Variant.h"
 
 #include "lua.h"
 #include "lualib.h"
+#include "uv.h"
 
+#include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -519,6 +523,8 @@ bool closeServer(int serverId)
 
 int lua_serve(lua_State* L)
 {
+    uWS::Loop::get(uv_default_loop());
+
     std::string hostname = "0.0.0.0";
     int port = 3000;
     bool reusePort = false;
@@ -642,27 +648,8 @@ int lua_serve(lua_State* L)
         return 0;
     }
 
-    state->loopFunction = [state]()
-    {
-        if (!state->running)
-        {
-            return;
-        }
-        Luau::visit(
-            [](auto* appPtr)
-            {
-                if (appPtr)
-                    appPtr->run();
-            },
-            state->app
-        );
-        state->runtime->schedule(state->loopFunction);
-    };
-
     serverInstances[serverId] = std::move(app);
     serverStates[serverId] = state;
-
-    runtime->schedule(state->loopFunction);
 
     lua_createtable(L, 0, 3);
 

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -50,12 +50,16 @@ Runtime::~Runtime()
 
 bool Runtime::hasWork()
 {
-    return hasContinuations() || hasThreads() || activeTokens.load() != 0;
+    // TODO: activeTokens and uv_loop_alive have a decent amount of overlap.
+    // Unfortunately, we do currently have some places where we add/release
+    // tokens that don't correspond to libuv activity, so for now we keep both.
+    // uv_ref/unref could be used to patch tokens into the libuv loop itself.
+    return hasContinuations() || hasThreads() || activeTokens.load() != 0 || uv_loop_alive(uv_default_loop());
 }
 
 RuntimeStep Runtime::runOnce()
 {
-    uv_run(uv_default_loop(), UV_RUN_DEFAULT);
+    uv_run(uv_default_loop(), UV_RUN_NOWAIT);
 
     // Complete all C++ continuations
     std::vector<std::function<void()>> copy;


### PR DESCRIPTION
Resolves #384.

### Problem

The current `net.serve` logic is to schedule a continuation that runs every task scheduler step, which (1) explicitly calls `run()` on our `uWS::TemplatedApp<T>`, and (2) schedules itself to run the next frame. This would work if `run()` were actually `step()`, but uWS doesn't provide an easy way to step an app.

### Solution

After some investigation, because uWS is configured to use libuv under the hood, we can patch in the libuv event loop that our task system is managing by calling `uWS::Loop::get(uv_default_loop())` before creating the app object. We get many things for free here (e.g. reference counting for keeping the server alive, managed by libuv), and it's simpler to reason about. This also means we don't need to explicitly "run" the app; it simply gets registered to run on the same event loop.

To ensure this works, some minor changes were made to the task scheduler logic to ensure that we are consuming events from the libuv event loop if it is live and to ensure we aren't blocking on I/O.