### PR TITLE
bugfix: Lute's testing framework swaps tests passed and tests failed

### DIFF
--- a/lute/std/libs/test.luau
+++ b/lute/std/libs/test.luau
@@ -43,8 +43,8 @@ local function simpleReporter(result: TestRunResult)
 
 	print(string.rep("-", 50))
 	print(`Total:  {result.total}`)
-	print(`Passed: {result.failed} ✓`)
-	print(`Failed: {result.passed} ✗`)
+	print(`Passed: {result.passed} ✓`)
+	print(`Failed: {result.failed} ✗`)
 	print(string.rep("=", 50) .. "\n")
 end
 


### PR DESCRIPTION
We were printing the wrong result to stdout for tests passed vs failed.