### PR TITLE
stdlib: Update the testing api with some more test lifecycle methods + testing assertions

### DIFF
--- a/examples/testing.luau
+++ b/examples/testing.luau
@@ -1,21 +1,22 @@
 local test = require("@std/test")
-local check = test.assert
-test.case("foo", function()
-	check.eq(3, 3)
-	check.eq(6, 1)
+
+test.case("foo", function(assert)
+	assert.eq(3, 3)
+	assert.eq(6, 1)
 end)
 
-test.case("bar", function()
-	check.eq("a", "b")
+test.case("bar", function(assert)
+	assert.eq("a", "b")
 end)
 
-test.case("baz", function()
-	check.neq("a", "b")
+test.case("baz", function(assert)
+	assert.neq("a", "b")
 end)
 
-test.suite("MySuite", function()
-	test.case("subcase", function()
-		check.eq(5 * 5, 3)
+test.suite("MySuite", function(suite)
+	suite.case("subsuite", function(assert)
+		assert.neq(1, 2)
+		assert.eq(1, 2)
 	end)
 end)
 

--- a/examples/testing.luau
+++ b/examples/testing.luau
@@ -14,9 +14,41 @@ test.case("baz", function(assert)
 end)
 
 test.suite("MySuite", function(suite)
-	suite.case("subsuite", function(assert)
+	-- beforeall runs once before all tests in the suite
+	suite:beforeall(function()
+		print("Setting up MySuite - runs once before all tests")
+	end)
+
+	-- beforeeach runs before each individual test
+	suite:beforeeach(function()
+		print("Running before each test")
+	end)
+
+	-- aftereach runs after each individual test
+	suite:aftereach(function()
+		print("Cleaning up after each test")
+	end)
+
+	-- afterall runs once after all tests in the suite
+	suite:afterall(function()
+		print("Tearing down MySuite - runs once after all tests")
+	end)
+
+	suite:case("subsuite", function(assert)
 		assert.neq(1, 2)
 		assert.eq(1, 2)
+	end)
+
+	suite:case("another_test", function(assert)
+		assert.eq(1, 1)
+	end)
+
+	-- Example of table_eq assertion - demonstrates error reporting
+	suite:case("table_comparison", function(assert)
+		local table1 = { a = 1, b = { c = 2, d = 3 } }
+		local table2 = { a = 1, b = { c = 2, d = 3 } }
+		assert.tableeq(table1, table2)
+		assert.tableeq(table1, { a = 1 })
 	end)
 end)
 

--- a/lute/std/libs/assert.luau
+++ b/lute/std/libs/assert.luau
@@ -70,6 +70,6 @@ function assertions.tableeq(lhs: { [unknown]: unknown }, rhs: { [unknown]: unkno
 	end
 end
 
-export type Assert = typeof(assertions)
+export type Asserts = typeof(assertions)
 
 return table.freeze(assertions)

--- a/lute/std/libs/assert.luau
+++ b/lute/std/libs/assert.luau
@@ -1,0 +1,20 @@
+-- strict
+
+local assert = {}
+-- todo: we should add some more assertions for diffing tables!
+function assert.eq<T>(lhs: T, rhs: T)
+	if lhs ~= rhs then
+		error({ msg = `{lhs} ~= {rhs}` })
+	end
+end
+
+function assert.neq<T>(lhs: T, rhs: T)
+	if lhs == rhs then
+		error({ msg = `{lhs} == {rhs}` })
+	end
+end
+
+export type Asserts = typeof(assert)
+
+table.freeze(assert)
+return assert

--- a/lute/std/libs/assert.luau
+++ b/lute/std/libs/assert.luau
@@ -1,7 +1,5 @@
--- strict
-
 local assert = {}
--- todo: we should add some more assertions for diffing tables!
+
 function assert.eq<T>(lhs: T, rhs: T)
 	if lhs ~= rhs then
 		error({ msg = `{lhs} ~= {rhs}` })
@@ -14,7 +12,62 @@ function assert.neq<T>(lhs: T, rhs: T)
 	end
 end
 
+-- Helper to format values for error messages
+local function formatValue(val: any): string
+	if type(val) == "nil" then
+		return "nil"
+	elseif type(val) == "string" then
+		return `"{val}"`
+	elseif type(val) == "table" then
+		return "table"
+	else
+		return tostring(val)
+	end
+end
+
+-- Deep table comparison helper
+local function tablesEqual(t1: any, t2: any, path: string): (boolean, string?)
+	if type(t1) ~= "table" or type(t2) ~= "table" then
+		if t1 ~= t2 then
+			return false, `lhs{path} = {formatValue(t1)} but rhs{path} = {formatValue(t2)}`
+		end
+		return true, nil
+	end
+	-- Check all keys in t1
+	for k, v1 in t1 do
+		local v2 = t2[k]
+		local newPath = if path == "" then `[{k}]` else `{path}[{k}]`
+
+		-- Check if key exists in t2
+		if v2 == nil and t2[k] == nil then
+			return false, `lhs{newPath} = {formatValue(v1)} but rhs{newPath} does not exist`
+		end
+
+		local equal, msg = tablesEqual(v1, v2, newPath)
+		if not equal then
+			return false, msg
+		end
+	end
+
+	-- Check for keys in t2 that aren't in t1
+	for k, v in t2 do
+		if t1[k] == nil then
+			local newPath = if path == "" then `[{k}]` else `{path}[{k}]`
+			return false, `rhs{newPath} = {formatValue(v)} but lhs{newPath} does not exist`
+		end
+	end
+
+	return true, nil
+end
+
+-- Table equality assertion with deep comparison
+function assert.tableeq(lhs: { [any]: any }, rhs: { [any]: any })
+	local equal, msg = tablesEqual(lhs, rhs, "")
+	if not equal then
+		error({ msg = msg or "tables are not equal" })
+	end
+end
+
 export type Asserts = typeof(assert)
 
-table.freeze(assert)
-return assert
+return table.freeze(assert)

--- a/lute/std/libs/assert.luau
+++ b/lute/std/libs/assert.luau
@@ -70,6 +70,6 @@ function assertions.tableeq(lhs: { [unknown]: unknown }, rhs: { [unknown]: unkno
 	end
 end
 
-export type Assertionss = typeof(assertions)
+export type Assert = typeof(assertions)
 
 return table.freeze(assertions)

--- a/lute/std/libs/assert.luau
+++ b/lute/std/libs/assert.luau
@@ -1,12 +1,12 @@
-local assert = {}
+local assertions = {}
 
-function assert.eq<T>(lhs: T, rhs: T)
+function assertions.eq<T>(lhs: T, rhs: T)
 	if lhs ~= rhs then
 		error({ msg = `{lhs} ~= {rhs}` })
 	end
 end
 
-function assert.neq<T>(lhs: T, rhs: T)
+function assertions.neq<T>(lhs: T, rhs: T)
 	if lhs == rhs then
 		error({ msg = `{lhs} == {rhs}` })
 	end
@@ -25,21 +25,22 @@ local function formatValue(val: any): string
 	end
 end
 
--- Deep table comparison helper
-local function tablesEqual(t1: any, t2: any, path: string): (boolean, string?)
-	if type(t1) ~= "table" or type(t2) ~= "table" then
+-- Structural equality for two tables
+local function tablesEqual(t1: unknown, t2: unknown, path: string): (boolean, string?)
+	if typeof(t1) ~= "table" or typeof(t2) ~= "table" then
 		if t1 ~= t2 then
 			return false, `lhs{path} = {formatValue(t1)} but rhs{path} = {formatValue(t2)}`
 		end
 		return true, nil
 	end
+
 	-- Check all keys in t1
 	for k, v1 in t1 do
-		local v2 = t2[k]
+		local v2 = (t2 :: any)[k]
 		local newPath = if path == "" then `[{k}]` else `{path}[{k}]`
 
 		-- Check if key exists in t2
-		if v2 == nil and t2[k] == nil then
+		if v2 == nil then
 			return false, `lhs{newPath} = {formatValue(v1)} but rhs{newPath} does not exist`
 		end
 
@@ -51,7 +52,8 @@ local function tablesEqual(t1: any, t2: any, path: string): (boolean, string?)
 
 	-- Check for keys in t2 that aren't in t1
 	for k, v in t2 do
-		if t1[k] == nil then
+		local v1 = (t1 :: any)[k]
+		if v1 == nil then
 			local newPath = if path == "" then `[{k}]` else `{path}[{k}]`
 			return false, `rhs{newPath} = {formatValue(v)} but lhs{newPath} does not exist`
 		end
@@ -60,14 +62,14 @@ local function tablesEqual(t1: any, t2: any, path: string): (boolean, string?)
 	return true, nil
 end
 
--- Table equality assertion with deep comparison
-function assert.tableeq(lhs: { [any]: any }, rhs: { [any]: any })
+-- Table equality assertionsion with deep comparison
+function assertions.tableeq(lhs: { [unknown]: unknown }, rhs: { [unknown]: unknown })
 	local equal, msg = tablesEqual(lhs, rhs, "")
 	if not equal then
 		error({ msg = msg or "tables are not equal" })
 	end
 end
 
-export type Asserts = typeof(assert)
+export type Assertionss = typeof(assertions)
 
-return table.freeze(assert)
+return table.freeze(assertions)

--- a/lute/std/libs/test.luau
+++ b/lute/std/libs/test.luau
@@ -1,10 +1,29 @@
 --!strict
 local ps = require("@lute/process")
 type Test = () -> ()
-type TestCase = { name: string, case: Test }
-type TestCases = { TestCase }
-type TestSuite = { name: string, cases: TestCases }
 
+type Test = () -> ()
+local assert = require("./assert")
+-- Test Types
+type Test = (assert.Asserts) -> ()
+type TestCase = { name: string, case: Test }
+
+type TestSuite = { name: string, cases: { TestCase } }
+type Suite = {
+	case: (string, Test) -> (),
+}
+
+local function makesuite(name: string): (TestSuite, Suite)
+	local data: TestSuite = { name = name, cases = {} }
+	return data,
+		{
+			case = function(name: string, case: Test)
+				table.insert(data.cases, { name = name, case = case })
+			end,
+		}
+end
+
+-- Test Reporting
 type FailedTest = {
 	test: string, -- name of the test case that failed
 	assertion: string, -- name of the assertion that failed (e.g., "assert.eq")
@@ -20,8 +39,6 @@ type TestRunResult = {
 	passed: number,
 }
 
-type TestReporter = (TestRunResult) -> ()
-
 local function printFailedTest(failed: FailedTest)
 	print(`❌ {failed.test}`)
 	print(`   {failed.filename}:{failed.linenumber}`)
@@ -29,7 +46,7 @@ local function printFailedTest(failed: FailedTest)
 	print()
 end
 
-local function simpleReporter(result: TestRunResult)
+function simpleReporter(result: TestRunResult)
 	print("\n" .. string.rep("=", 50))
 	print("TEST RESULTS")
 	print(string.rep("=", 50))
@@ -48,56 +65,38 @@ local function simpleReporter(result: TestRunResult)
 	print(string.rep("=", 50) .. "\n")
 end
 
+export type TestReporter = (TestRunResult) -> ()
+
+-- Testing Environment
 type TestEnvironment = {
-	anonymous: TestCases,
+	anonymous: { TestCase },
 	suites: { TestSuite },
 	reporter: TestReporter,
-	active_suite: TestSuite?,
 }
 
 local env: TestEnvironment = { anonymous = {}, suites = {}, reporter = simpleReporter }
 
+-- Test library export surface
 local test = {}
-test.assert = {}
-local assert = test.assert
--- todo: we should add some more assertions for diffing tables!
-function assert.eq<T>(lhs: T, rhs: T)
-	if lhs ~= rhs then
-		error({ msg = `{lhs} ~= {rhs}` })
-	end
-end
-
-function assert.neq<T>(lhs: T, rhs: T)
-	if lhs == rhs then
-		error({ msg = `{lhs} == {rhs}` })
-	end
-end
-
--- register a test case
-function test.case(name: string, case: () -> ())
-	local testcase = { name = name, case = case }
-	if env.active_suite then
-		local _, cases = env.active_suite.name, env.active_suite.cases
-		table.insert(cases, testcase)
-	else
-		table.insert(env.anonymous, testcase)
-	end
-end
-
--- register a test suite
--- takes name and a function to register
-function test.suite(name: string, registerSuite: () -> ())
-	local testsuite: TestSuite = { name = name, cases = {} }
-	table.insert(env.suites, testsuite)
-	env.active_suite = testsuite
-	registerSuite()
-	env.active_suite = nil
-end
 
 function test.setreporter(reporter: TestReporter)
 	test.reporter = reporter
 end
 
+-- register an anonymous test case
+function test.case(name: string, case: Test)
+	local testcase = { name = name, case = case }
+	table.insert(env.anonymous, testcase)
+end
+
+-- register a test suite
+function test.suite(name: string, registerSuite: (Suite) -> ())
+	local suiteinternal, suiteexternal = makesuite(name)
+	registerSuite(suiteexternal)
+	table.insert(env.suites, suiteinternal)
+end
+
+-- run all the tests
 function test.run()
 	local failures: { FailedTest } = {}
 	local total = 0
@@ -122,7 +121,7 @@ function test.run()
 			failed += 1
 		end
 
-		local success = xpcall(tc.case, handlefailure)
+		local success = xpcall(tc.case, handlefailure, assert)
 		if success then
 			passed += 1
 		end
@@ -147,7 +146,7 @@ function test.run()
 				failed += 1
 			end
 
-			local success = xpcall(tc.case, handlefailure)
+			local success = xpcall(tc.case, handlefailure, assert)
 			if success then
 				passed += 1
 			end

--- a/lute/std/libs/test.luau
+++ b/lute/std/libs/test.luau
@@ -134,6 +134,73 @@ function test.run()
 	local failed = 0
 	local passed = 0
 
+	-- Error handler for beforeall hook
+	local function beforeallErrorHandler(suite: TestSuiteData)
+		return function(err)
+			-- If beforeall fails, skip all tests in the suite
+			total += #suite.cases
+			failed += #suite.cases
+			for _, tc in suite.cases do
+				local failedtest: FailedTest = {
+					test = `{suite.name}.{tc.name}`,
+					assertion = "beforeall",
+					error = `beforeall hook failed: {err}`,
+					filename = "",
+					linenumber = 0,
+				}
+				table.insert(failures, failedtest)
+			end
+			return tostring(err)
+		end
+	end
+
+	-- Error handler for beforeeach hook
+	local function beforeeachErrorHandler(testFullName: string)
+		return function(err)
+			failed += 1
+			local failedtest: FailedTest = {
+				test = testFullName,
+				assertion = "beforeeach",
+				error = `beforeeach hook failed: {err}`,
+				filename = "",
+				linenumber = 0,
+			}
+			table.insert(failures, failedtest)
+			return tostring(err)
+		end
+	end
+
+	-- Error handler for aftereach hook
+	local function afterachErrorHandler(testFullName: string)
+		return function(err)
+			local failedtest: FailedTest = {
+				test = testFullName,
+				assertion = "aftereach",
+				error = `aftereach hook failed: {err}`,
+				filename = "",
+				linenumber = 0,
+			}
+			table.insert(failures, failedtest)
+			return tostring(err)
+		end
+	end
+
+	-- Error handler for afterall hook
+	local function afterallErrorHandler(suiteName: string)
+		return function(err)
+			failed += 1
+			local failedtest: FailedTest = {
+				test = suiteName,
+				assertion = "afterall",
+				error = `afterall hook failed: {err}`,
+				filename = "",
+				linenumber = 0,
+			}
+			table.insert(failures, failedtest)
+			return tostring(err)
+		end
+	end
+
 	-- Run anonymous tests
 	for _, tc in env.anonymous do
 		total += 1
@@ -162,21 +229,9 @@ function test.run()
 	for _, suite in env.suites do
 		-- Run beforeall hook once per suite
 		if suite._beforeall then
-			local beforeallSuccess, beforeallErr = pcall(suite._beforeall)
+			local beforeallSuccess = xpcall(suite._beforeall, beforeallErrorHandler(suite))
 			if not beforeallSuccess then
 				-- If beforeall fails, skip all tests in the suite
-				total += #suite.cases
-				failed += #suite.cases
-				for _, tc in suite.cases do
-					local failedtest: FailedTest = {
-						test = `{suite.name}.{tc.name}`,
-						assertion = "beforeall",
-						error = `beforeall hook failed: {beforeallErr}`,
-						filename = "",
-						linenumber = 0,
-					}
-					table.insert(failures, failedtest)
-				end
 				continue
 			end
 		end
@@ -200,17 +255,8 @@ function test.run()
 
 			-- Run beforeeach hook if it exists
 			if suite._beforeeach then
-				local beforeSuccess, beforeErr = pcall(suite._beforeeach)
+				local beforeSuccess = xpcall(suite._beforeeach, beforeeachErrorHandler(testFullName))
 				if not beforeSuccess then
-					failed += 1
-					local failedtest: FailedTest = {
-						test = testFullName,
-						assertion = "beforeeach",
-						error = `beforeeach hook failed: {beforeErr}`,
-						filename = "",
-						linenumber = 0,
-					}
-					table.insert(failures, failedtest)
 					continue
 				end
 			end
@@ -218,18 +264,10 @@ function test.run()
 			local success = xpcall(tc.case, handlefailure, assert)
 			-- Run aftereach hook if it exists (runs even if test failed)
 			if suite._aftereach then
-				local afterSuccess, afterErr = pcall(suite._aftereach)
+				local afterSuccess = xpcall(suite._aftereach, afterachErrorHandler(testFullName))
 				if not afterSuccess then
 					-- If test passed but aftereach failed, mark as failed
 					success = false
-					local failedtest: FailedTest = {
-						test = testFullName,
-						assertion = "aftereach",
-						error = `aftereach hook failed: {afterErr}`,
-						filename = "",
-						linenumber = 0,
-					}
-					table.insert(failures, failedtest)
 				end
 			end
 			-- if the test and the teardown method passed, the test passes
@@ -242,18 +280,7 @@ function test.run()
 
 		-- Run afterall hook once per suite (runs even if tests failed)
 		if suite._afterall then
-			local afterallSuccess, afterallErr = pcall(suite._afterall)
-			if not afterallSuccess then
-				failed += 1
-				local failedtest: FailedTest = {
-					test = `{suite.name}`,
-					assertion = "afterall",
-					error = `afterall hook failed: {afterallErr}`,
-					filename = "",
-					linenumber = 0,
-				}
-				table.insert(failures, failedtest)
-			end
+			xpcall(suite._afterall, afterallErrorHandler(suite.name))
 		end
 	end
 

--- a/lute/std/libs/test.luau
+++ b/lute/std/libs/test.luau
@@ -1,26 +1,57 @@
 --!strict
 local ps = require("@lute/process")
-type Test = () -> ()
-
-type Test = () -> ()
 local assert = require("./assert")
 -- Test Types
 type Test = (assert.Asserts) -> ()
 type TestCase = { name: string, case: Test }
 
-type TestSuite = { name: string, cases: { TestCase } }
-type Suite = {
-	case: (string, Test) -> (),
+type TestSuite = {
+	name: string,
+	cases: { TestCase },
+	_beforeeach: (() -> ())?,
+	_beforeall: (() -> ())?,
+	_aftereach: (() -> ())?,
+	_afterall: (() -> ())?,
+	case: (self: TestSuite, string, Test) -> (),
+	beforeeach: (self: TestSuite, () -> ()) -> (),
+	beforeall: (self: TestSuite, () -> ()) -> (),
+	aftereach: (self: TestSuite, () -> ()) -> (),
+	afterall: (self: TestSuite, () -> ()) -> (),
 }
 
-local function makesuite(name: string): (TestSuite, Suite)
-	local data: TestSuite = { name = name, cases = {} }
-	return data,
-		{
-			case = function(name: string, case: Test)
-				table.insert(data.cases, { name = name, case = case })
-			end,
-		}
+local TestSuite = {}
+TestSuite.__index = TestSuite
+
+function TestSuite.new(name: string): TestSuite
+	local self = setmetatable({
+		name = name,
+		cases = {},
+		_beforeeach = nil,
+		_beforeall = nil,
+		_aftereach = nil,
+		_afterall = nil,
+	}, TestSuite)
+	return self :: TestSuite
+end
+
+function TestSuite:case(name: string, testCase: Test)
+	table.insert(self.cases, { name = name, case = testCase })
+end
+
+function TestSuite:beforeeach(hook: () -> ())
+	self._beforeeach = hook
+end
+
+function TestSuite:beforeall(hook: () -> ())
+	self._beforeall = hook
+end
+
+function TestSuite:aftereach(hook: () -> ())
+	self._aftereach = hook
+end
+
+function TestSuite:afterall(hook: () -> ())
+	self._afterall = hook
 end
 
 -- Test Reporting
@@ -46,7 +77,7 @@ local function printFailedTest(failed: FailedTest)
 	print()
 end
 
-function simpleReporter(result: TestRunResult)
+local function simpleReporter(result: TestRunResult)
 	print("\n" .. string.rep("=", 50))
 	print("TEST RESULTS")
 	print(string.rep("=", 50))
@@ -90,10 +121,10 @@ function test.case(name: string, case: Test)
 end
 
 -- register a test suite
-function test.suite(name: string, registerSuite: (Suite) -> ())
-	local suiteinternal, suiteexternal = makesuite(name)
-	registerSuite(suiteexternal)
-	table.insert(env.suites, suiteinternal)
+function test.suite(name: string, registerFn: (TestSuite) -> ())
+	local suite = TestSuite.new(name)
+	registerFn(suite)
+	table.insert(env.suites, suite)
 end
 
 -- run all the tests
@@ -129,26 +160,99 @@ function test.run()
 
 	-- Run tests from suites
 	for _, suite in env.suites do
+		-- Run beforeall hook once per suite
+		if suite._beforeall then
+			local beforeallSuccess, beforeallErr = pcall(suite._beforeall)
+			if not beforeallSuccess then
+				-- If beforeall fails, skip all tests in the suite
+				total += #suite.cases
+				failed += #suite.cases
+				for _, tc in suite.cases do
+					local failedtest: FailedTest = {
+						test = `{suite.name}.{tc.name}`,
+						assertion = "beforeall",
+						error = `beforeall hook failed: {beforeallErr}`,
+						filename = "",
+						linenumber = 0,
+					}
+					table.insert(failures, failedtest)
+				end
+				continue
+			end
+		end
+
 		for _, tc in suite.cases do
 			total += 1
+			local testFullName = `{suite.name}.{tc.name}`
 			local function handlefailure(err)
 				local fileName, lineNumber = debug.info(4, "sl")
 				local assertName = debug.info(3, "n")
 
 				local failedtest: FailedTest = {
-					test = `{suite.name}.{tc.name}`,
+					test = testFullName,
 					assertion = assertName,
 					error = err.msg,
 					filename = fileName,
 					linenumber = lineNumber,
 				}
 				table.insert(failures, failedtest)
-				failed += 1
+			end
+
+			-- Run beforeeach hook if it exists
+			if suite._beforeeach then
+				local beforeSuccess, beforeErr = pcall(suite._beforeeach)
+				if not beforeSuccess then
+					failed += 1
+					local failedtest: FailedTest = {
+						test = testFullName,
+						assertion = "beforeeach",
+						error = `beforeeach hook failed: {beforeErr}`,
+						filename = "",
+						linenumber = 0,
+					}
+					table.insert(failures, failedtest)
+					continue
+				end
 			end
 
 			local success = xpcall(tc.case, handlefailure, assert)
+			-- Run aftereach hook if it exists (runs even if test failed)
+			if suite._aftereach then
+				local afterSuccess, afterErr = pcall(suite._aftereach)
+				if not afterSuccess then
+					-- If test passed but aftereach failed, mark as failed
+					success = false
+					local failedtest: FailedTest = {
+						test = testFullName,
+						assertion = "aftereach",
+						error = `aftereach hook failed: {afterErr}`,
+						filename = "",
+						linenumber = 0,
+					}
+					table.insert(failures, failedtest)
+				end
+			end
+			-- if the test and the teardown method passed, the test passes
 			if success then
 				passed += 1
+			else
+				failed += 1
+			end
+		end
+
+		-- Run afterall hook once per suite (runs even if tests failed)
+		if suite._afterall then
+			local afterallSuccess, afterallErr = pcall(suite._afterall)
+			if not afterallSuccess then
+				failed += 1
+				local failedtest: FailedTest = {
+					test = `{suite.name}`,
+					assertion = "afterall",
+					error = `afterall hook failed: {afterallErr}`,
+					filename = "",
+					linenumber = 0,
+				}
+				table.insert(failures, failedtest)
 			end
 		end
 	end

--- a/tests/smoke.test.luau
+++ b/tests/smoke.test.luau
@@ -1,15 +1,15 @@
 local test = require("@std/test")
 
-test.suite("SmokeSuite", function()
-	test.case("make_fail", function()
-		-- test.assert.eq(1, 2)
-		test.assert.eq(1, 1) -- comment this and uncomment above to make the test fail
+test.suite("SmokeSuite", function(suite)
+	suite:case("make_fail", function(assert)
+		-- assert.eq(1, 2)
+		assert.eq(1, 1) -- comment this and uncomment above to make the test fail
 	end)
-	test.case("make_pass", function()
-		test.assert.eq(1, 1)
+	suite:case("make_pass", function(assert)
+		assert.eq(1, 1)
 	end)
 end)
 
-test.case("Passing", function() end)
+test.case("Passing", function(assert) end)
 
 test.run()


### PR DESCRIPTION
This PR comes with some changes to the testing api to reduce the amount of global state we depend on - when making subcases, we now pass in the suite object on which the user can operate. Additionally, assertions are passed in with the test case itself, making them more accessible and reducing an additional line of code needed to start writing tests.

- [x] {before,after}x{all,each} lifecycle methods
- [x] Table assertions 

For example: 
<img width="463" height="79" alt="image" src="https://github.com/user-attachments/assets/31003849-ae2c-469d-a23b-415c4135865b" />
