### PR TITLE
infra: Set up the ability to write .test.luau files that get automatically executed by our CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,25 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup and Build Lute
+        id: build_lute
         uses: ./.github/actions/setup-and-build
         with:
           target: Lute.CLI
           config: debug
           options: ${{ matrix.options }}
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Remove .luaurc file
+        run: rm .luaurc
+
+      - name: Run Luau Tests
+        shell: bash
+        run: |
+          if [ "${{ runner.os }}" == "Windows" ]; then
+            find tests -name "*.test.luau" | xargs -I {} ${{ steps.build_lute.outputs.exe_path }} run {}
+          else
+            find tests -name "*.test.luau" | xargs -I {} ${{ steps.build_lute.outputs.exe_path }} run {}
+          fi
 
   test:
     runs-on: ${{ matrix.os }}
@@ -67,42 +80,8 @@ jobs:
       - name: Remove .luaurc file
         run: rm .luaurc
 
-      - name: Run Tests
+      - name: Run C++ Tests
         run: ${{ steps.build_tests.outputs.exe_path }}
-
-  luau-lute-test:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        include:
-          - os: windows-latest
-            options: --c-compiler cl.exe --cxx-compiler cl.exe
-          - os: ubuntu-latest
-            options: --c-compiler gcc --cxx-compiler g++
-          - os: ubuntu-latest
-            options: --c-compiler clang --cxx-compiler clang++
-          - os: macos-latest
-      fail-fast: false
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Luau - Lute Unit Tests
-        id: build_tests
-        uses: ./.github/actions/setup-and-build
-        with:
-          target: Lute.CLI
-          config: debug
-          options: ${{ matrix.options }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Remove .luaurc file
-        run: rm .luaurc
-
-      - name: Run Tests
-        run: find tests -name "*.test.luau" | xargs -I {} ${{ steps.build_tests.outputs.exe_path }} run {}
-
 
   check-format:
     runs-on: ubuntu-latest
@@ -122,7 +101,7 @@ jobs:
   aggregator:
     name: Gated Commits
     runs-on: ubuntu-latest
-    needs: [build, test, luau-lute-test, check-format]
+    needs: [build, test, check-format]
     if: ${{ always() }}
     steps:
       - name: Aggregator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup and Build Tests
+      - name: Setup and Build C++ Unit Tests
         id: build_tests
         uses: ./.github/actions/setup-and-build
         with:
@@ -64,12 +64,45 @@ jobs:
           config: debug
           options: ${{ matrix.options }}
           token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Remove .luaurc file
         run: rm .luaurc
 
       - name: Run Tests
         run: ${{ steps.build_tests.outputs.exe_path }}
+
+  luau-lute-test:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            options: --c-compiler cl.exe --cxx-compiler cl.exe
+          - os: ubuntu-latest
+            options: --c-compiler gcc --cxx-compiler g++
+          - os: ubuntu-latest
+            options: --c-compiler clang --cxx-compiler clang++
+          - os: macos-latest
+      fail-fast: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Luau - Lute Unit Tests
+        id: build_tests
+        uses: ./.github/actions/setup-and-build
+        with:
+          target: Lute.CLI
+          config: debug
+          options: ${{ matrix.options }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Remove .luaurc file
+        run: rm .luaurc
+
+      - name: Run Tests
+        run: find tests -name "*.test.luau" | xargs -I {} ${{ steps.build_tests.outputs.exe_path }} run {}
+
 
   check-format:
     runs-on: ubuntu-latest
@@ -89,7 +122,7 @@ jobs:
   aggregator:
     name: Gated Commits
     runs-on: ubuntu-latest
-    needs: [build, test, check-format]
+    needs: [build, test, luau-lute-test, check-format]
     if: ${{ always() }}
     steps:
       - name: Aggregator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  run-lutecli-luau-tests:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -42,15 +42,9 @@ jobs:
         run: rm .luaurc
 
       - name: Run Luau Tests
-        shell: bash
-        run: |
-          if [ "${{ runner.os }}" == "Windows" ]; then
-            find tests -name "*.test.luau" | xargs -I {} ${{ steps.build_lute.outputs.exe_path }} run {}
-          else
-            find tests -name "*.test.luau" | xargs -I {} ${{ steps.build_lute.outputs.exe_path }} run {}
-          fi
+        run: find tests -name "*.test.luau" | xargs -I {} ${{ steps.build_lute.outputs.exe_path }} run {}
 
-  test:
+  run-lute-cxx-unittests:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -101,12 +95,12 @@ jobs:
   aggregator:
     name: Gated Commits
     runs-on: ubuntu-latest
-    needs: [build, test, check-format]
+    needs: [run-lutecli-luau-tests, run-lute-cxx-unittests, check-format]
     if: ${{ always() }}
     steps:
       - name: Aggregator
         run: |
-          if [ "${{ needs.build.result }}" == "success" ] && [ "${{ needs.test.result }}" == "success" ] && [ "${{ needs.check-format.result }}" == "success" ]; then
+          if [ "${{ needs.run-lutecli-luau-tests.result }}" == "success" ] && [ "${{ needs.run-lute-cxx-unittests.result }}" == "success" ] && [ "${{ needs.check-format.result }}" == "success" ]; then
             echo "All jobs succeeded"
           else
             echo "One or more jobs failed"

--- a/lute/std/libs/test.luau
+++ b/lute/std/libs/test.luau
@@ -1,5 +1,5 @@
 --!strict
-
+local ps = require("@lute/process")
 type Test = () -> ()
 type TestCase = { name: string, case: Test }
 type TestCases = { TestCase }
@@ -161,6 +161,10 @@ function test.run()
 		passed = passed,
 	}
 	env.reporter(result)
+	if failures ~= 0 then
+		ps.exit(1)
+	end
+	ps.exit(0)
 end
 
 return table.freeze(test)

--- a/lute/std/libs/test.luau
+++ b/lute/std/libs/test.luau
@@ -161,7 +161,7 @@ function test.run()
 		passed = passed,
 	}
 	env.reporter(result)
-	if failures ~= 0 then
+	if failed ~= 0 then
 		ps.exit(1)
 	end
 	ps.exit(0)

--- a/tests/smoke.test.luau
+++ b/tests/smoke.test.luau
@@ -2,8 +2,8 @@ local test = require("@std/test")
 
 test.suite("SmokeSuite", function()
 	test.case("make_fail", function()
-		test.assert.eq(1, 2) -- uncomment to make the test fail
-		-- test.assert.eq(1, 1) -- comment to make the test fail
+		-- test.assert.eq(1, 2)
+		test.assert.eq(1, 1) -- comment this and uncomment above to make the test fail
 	end)
 	test.case("make_pass", function()
 		test.assert.eq(1, 1)

--- a/tests/smoke.test.luau
+++ b/tests/smoke.test.luau
@@ -1,0 +1,15 @@
+local test = require("@std/test")
+
+test.suite("SmokeSuite", function()
+	test.case("make_fail", function()
+		test.assert.eq(1, 2) -- uncomment to make the test fail
+		-- test.assert.eq(1, 1) -- comment to make the test fail
+	end)
+	test.case("make_pass", function()
+		test.assert.eq(1, 1)
+	end)
+end)
+
+test.case("Passing", function() end)
+
+test.run()


### PR DESCRIPTION
This implements something like what is described here: https://github.com/luau-lang/lute/issues/410 , which allows us to write test cases in luau using the std/test library. We can build lute for all the different platforms we support and then run the lute tests as part of a separate pass.

Test Failure documented here: https://github.com/luau-lang/lute/actions/runs/18421725097/job/52496749349?pr=417

Resolves #410.