### PR TITLE
Fix release workflow by stripping away extraneous information from `get_version.cmake` output

### DIFF
--- a/CMakeBuild/get_version.cmake
+++ b/CMakeBuild/get_version.cmake
@@ -12,4 +12,6 @@ if(LUTE_VERSION_SUFFIX)
     set(LUTE_VERSION_FULL "${LUTE_VERSION_FULL}-${LUTE_VERSION_SUFFIX}")
 endif()
 
-message("Lute Version: ${LUTE_VERSION_FULL}")
+# The release workflow depends on this exact message format to extract the
+# version. If making changes, update the workflow accordingly.
+message("${LUTE_VERSION_FULL}")


### PR DESCRIPTION
Our release workflow depends on the output of `get_version.cmake` being the raw version. We added some extra text in #396 that is currently causing errors during the release tag generation step, so this PR reverts that change.

Someone reached out about recent changes not being "released" yet, which was surprising because we're on a nightly release schedule—this was the root cause.