### PR TITLE
Fix use-after-free bug in `process.cpp`

### DIFF
--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -42,19 +42,19 @@ struct ProcessHandle
             }
         };
 
-        if (stdoutPipe.loop && uv_is_active((uv_handle_t*)&stdoutPipe))
+        if (!uv_is_closing((uv_handle_t*)&stdoutPipe))
         {
             pendingCloses++;
             uv_read_stop((uv_stream_t*)&stdoutPipe);
             uv_close((uv_handle_t*)&stdoutPipe, closeCb);
         }
-        if (stderrPipe.loop && uv_is_active((uv_handle_t*)&stderrPipe))
+        if (!uv_is_closing((uv_handle_t*)&stderrPipe))
         {
             pendingCloses++;
             uv_read_stop((uv_stream_t*)&stderrPipe);
             uv_close((uv_handle_t*)&stderrPipe, closeCb);
         }
-        if (process.loop)
+        if (!uv_is_closing((uv_handle_t*)&process))
         {
             pendingCloses++;
             uv_close((uv_handle_t*)&process, closeCb);


### PR DESCRIPTION
### Problem

The issue can be replicated with a simple script that calls `process.run` twice, like this:
```luau
local process = require("@lute/process")
process.run({"echo", "hello!"})
process.run({"echo", "goodbye!"})
```

Very rarely, some runs throw unexpected errors, crash, or corrupt Lute output with random bytes. The problem is a subtle UAF bug in `process.cpp`. Despite the small PR diff, this was a very tricky bug to nail down. Had to go digging pretty deep into the libuv source to understand what was going on.

Essentially, it's not correct to check if the `stdout` and `stderr` pipes are active before closing them. Since these pipes are used as read-only data streams, they're automatically made inactive by libuv upon reaching EOF. In this situation, we don't need to call `uv_read_stop` on these streams because they're already stopped (although it is fine to do it; `uv_read_stop` is [idempotent](https://docs.libuv.org/en/v1.x/stream.html#c.uv_read_stop)), but we do still need to close the underlying pipe handle.

We're currently in a situation where calling `process.run` might immediately close either the `stdout` or `stderr` streams (at EOF), causing the `uv_is_active` check to fail, preventing us from calling `uv_close` on the handle and from incrementing `pendingCloses`.

Failing to close these handles means that libuv retains data internally associated with them, and by not incrementing `pendingCloses` (essentially a refcount), we end up destroying the owning `ProcessHandle` of these handles before libuv has been able to clean them up internally.

Then, when we go to initialize new handles for the next `process.run` call, we have a UAF manifest deep inside of libuv's circular doubly linked queue code: adding a new handle to the data structure requires adjusting pointers on the last-added handle, which happens to be a handle created from the previous `process.run` call. At this point, it is freed memory that was supposed to be removed from libuv's internals before being freed (using `uv_close`).

### Solution

Check instead if the handles still need closing with `!uv_is_closing` since `uv_is_active` is not relevant to whether `uv_close` needs to be called in this case.