### PR TITLE
Add draft release step to release workflow for uploading artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,11 +154,18 @@ jobs:
           RELEASE_TAG="$VERSION$NIGHTLY_TAG"
           echo "tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
 
-      - name: Create Release
+      - name: Create Draft Release
         uses: luau-lang/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag_release.outputs.tag }}
           name: ${{ steps.tag_release.outputs.tag }}
-          draft: false
+          draft: true
           prerelease: ${{ github.event.inputs.nightly || github.event_name == 'schedule' }}
           files: release/*.zip
+
+      - name: Publish Release
+        uses: luau-lang/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag_release.outputs.tag }}
+          draft: false
+          prerelease: ${{ github.event.inputs.nightly || github.event_name == 'schedule' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,4 +168,3 @@ jobs:
         with:
           tag_name: ${{ steps.tag_release.outputs.tag }}
           draft: false
-          prerelease: ${{ github.event.inputs.nightly || github.event_name == 'schedule' }}


### PR DESCRIPTION
Resolves #420.

@aatxe, after this, we should immediately re-enable immutable releases to see if things work as intended. Ideally should be completed before 5pm PT on a given release day, since that's when the nightly release kicks off.