### PR TITLE
fix: cleanup/free filesystem requests and data

### DIFF
--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -12,7 +12,7 @@
 #include <cstring>
 #ifdef _WIN32
 #include <direct.h>
-#else 
+#else
 #include <unistd.h>
 #endif
 #include <fcntl.h>
@@ -212,6 +212,7 @@ int close(lua_State* L)
 
     uv_fs_t closeReq;
     uv_fs_close(uv_default_loop(), &closeReq, file.fileDescriptor, nullptr);
+    uv_fs_req_cleanup(&closeReq);
     return 0;
 }
 
@@ -233,11 +234,12 @@ int read(lua_State* L)
         uv_fs_read(uv_default_loop(), &readReq, file.fileDescriptor, &iov, 1, -1, nullptr);
 
         numBytesRead = readReq.result;
+        uv_fs_req_cleanup(&readReq);
 
         if (numBytesRead < 0)
         {
-            luaL_errorL(L, "Error reading: %s. Closing file.\n", uv_err_name(numBytesRead));
             memset(readBuffer, 0, sizeof(readBuffer));
+            luaL_errorL(L, "Error reading: %s. Closing file.\n", uv_err_name(numBytesRead));
             return 0;
         }
 
@@ -279,12 +281,13 @@ int write(lua_State* L)
         int bytesWritten = 0;
         uv_fs_write(uv_default_loop(), &writeReq, file.fileDescriptor, &iov, 1, -1, nullptr);
         bytesWritten = writeReq.result;
+        uv_fs_req_cleanup(&writeReq);
 
         if (bytesWritten < 0)
         {
             // Error case.
-            luaL_errorHandle(L, file);
             memset(writeBuffer, 0, sizeof(writeBuffer));
+            luaL_errorHandle(L, file);
             return 0;
         }
 
@@ -304,13 +307,16 @@ std::optional<FileHandle> openHelper(lua_State* L, const char* path, const char*
 
     uv_fs_t openReq;
     int errcode = uv_fs_open(uv_default_loop(), &openReq, path, *openFlags, *modeFlags, nullptr);
-    if (openReq.result < 0)
+    auto result = openReq.result;
+    uv_fs_req_cleanup(&openReq);
+
+    if (result < 0)
     {
         luaL_errorL(L, "Error opening file %s\n", path);
         return std::nullopt;
     }
 
-    return FileHandle{openReq.result, errcode};
+    return FileHandle{result, errcode};
 }
 
 int open(lua_State* L)
@@ -345,12 +351,14 @@ void cleanup(char* buffer, int size, const FileHandle& handle)
     memset(buffer, 0, size);
     uv_fs_t closeReq;
     uv_fs_close(uv_default_loop(), &closeReq, handle.fileDescriptor, nullptr);
+    uv_fs_req_cleanup(&closeReq);
 }
 
 int fs_remove(lua_State* L)
 {
     uv_fs_t unlink_req;
     int err = uv_fs_unlink(uv_default_loop(), &unlink_req, luaL_checkstring(L, 1), nullptr);
+    uv_fs_req_cleanup(&unlink_req);
 
     if (err)
         luaL_errorL(L, "%s", uv_strerror(err));
@@ -365,6 +373,7 @@ int fs_mkdir(lua_State* L)
 
     uv_fs_t req;
     int err = uv_fs_mkdir(uv_default_loop(), &req, path, mode, nullptr);
+    uv_fs_req_cleanup(&req);
 
     if (err)
         luaL_errorL(L, "%s", uv_strerror(err));
@@ -378,6 +387,7 @@ int fs_rmdir(lua_State* L)
 
     uv_fs_t rmdir_req;
     int err = uv_fs_rmdir(uv_default_loop(), &rmdir_req, path, nullptr);
+    uv_fs_req_cleanup(&rmdir_req);
 
     if (err)
         luaL_errorL(L, "%s", uv_strerror(err));
@@ -393,7 +403,10 @@ int fs_stat(lua_State* L)
     int err = uv_fs_stat(uv_default_loop(), &stat_req, path, nullptr);
 
     if (err)
+    {
+        uv_fs_req_cleanup(&stat_req);
         luaL_errorL(L, "%s", uv_strerror(err));
+    }
 
     lua_createtable(L, 0, 6);
 
@@ -426,28 +439,31 @@ int fs_stat(lua_State* L)
 
     lua_setfield(L, -2, "permissions");
 
+    uv_fs_req_cleanup(&stat_req);
+
     return 1;
 }
 
 static void defaultCallback(uv_fs_t* req)
 {
     auto* request_state = static_cast<ResumeToken*>(req->data);
+    auto token = std::move(*request_state);
+    delete request_state;
 
-    if (req->result)
+    auto err = req->result;
+
+    uv_fs_req_cleanup(req);
+    delete req;
+
+    if (err)
     {
-        request_state->get()->fail(uv_strerror(req->result));
-        uv_fs_req_cleanup(req);
-        delete req;
+        token->fail(uv_strerror(req->result));
         return;
     }
 
-    request_state->get()->complete(
-        [req](lua_State* L)
+    token->complete(
+        [](lua_State* L)
         {
-            uv_fs_req_cleanup(req);
-
-            delete req;
-
             return 0;
         }
     );
@@ -465,6 +481,8 @@ int fs_copy(lua_State* L)
 
     if (err)
     {
+        delete static_cast<ResumeToken*>(req->data);
+        delete req;
         luaL_errorL(L, "%s", uv_strerror(err));
     }
 
@@ -483,6 +501,8 @@ int fs_link(lua_State* L)
 
     if (err)
     {
+        delete static_cast<ResumeToken*>(req->data);
+        delete req;
         luaL_errorL(L, "%s", uv_strerror(err));
     }
 
@@ -510,6 +530,8 @@ int fs_symlink(lua_State* L)
 
     if (err)
     {
+        delete static_cast<ResumeToken*>(req->data);
+        delete req;
         luaL_errorL(L, "%s", uv_strerror(err));
     }
 
@@ -674,7 +696,6 @@ int fs_exists(lua_State* L)
                 [req](lua_State* L)
                 {
                     lua_pushboolean(L, req->result == 0);
-                    
                     uv_fs_req_cleanup(req);
 
                     delete req;
@@ -682,11 +703,14 @@ int fs_exists(lua_State* L)
                     return 1;
                 }
             );
+            delete request_state;
         }
     );
 
     if (err)
     {
+        delete static_cast<ResumeToken*>(req->data);
+        delete req;
         luaL_errorL(L, "%s", uv_strerror(err));
     }
 
@@ -702,7 +726,10 @@ int type(lua_State* L)
     int err = uv_fs_stat(uv_default_loop(), &req, path, nullptr);
 
     if (err)
+    {
+        uv_fs_req_cleanup(&req);
         luaL_errorL(L, "%s", uv_strerror(err));
+    }
 
     auto type = fileModeToType(req.statbuf.st_mode);
     lua_pushstring(L, type);
@@ -752,6 +779,7 @@ int listdir(lua_State* L)
 
                     uv_fs_req_cleanup(req);
 
+                    delete static_cast<ResumeToken*>(req->data);
                     delete req;
 
                     if (err != UV_EOF)
@@ -764,7 +792,11 @@ int listdir(lua_State* L)
     );
 
     if (err)
+    {
+        delete static_cast<ResumeToken*>(req->data);
+        delete req;
         luaL_errorL(L, "%s", uv_strerror(err));
+    }
 
     return lua_yield(L, 0);
 }
@@ -795,11 +827,12 @@ int readfiletostring(lua_State* L)
         uv_fs_read(uv_default_loop(), &readReq, handle->fileDescriptor, &iov, 1, -1, nullptr);
 
         numBytesRead = readReq.result;
+        uv_fs_req_cleanup(&readReq);
 
         if (numBytesRead < 0)
         {
-            luaL_errorL(L, "Error reading: %s. Closing file.\n", uv_err_name(numBytesRead));
             cleanup(readBuffer, sizeof(readBuffer), *handle);
+            luaL_errorL(L, "Error reading: %s. Closing file.\n", uv_err_name(numBytesRead));
             return 0;
         }
 
@@ -850,12 +883,13 @@ int writestringtofile(lua_State* L)
         int bytesWritten = 0;
         uv_fs_write(uv_default_loop(), &writeReq, handle->fileDescriptor, &iov, 1, -1, nullptr);
         bytesWritten = writeReq.result;
+        uv_fs_req_cleanup(&writeReq);
 
         if (bytesWritten < 0)
         {
             // Error case.
-            luaL_errorHandle(L, *handle);
             cleanup(writeBuffer, sizeof(writeBuffer), *handle);
+            luaL_errorHandle(L, *handle);
             return 0;
         }
 
@@ -895,7 +929,7 @@ int readasync(lua_State* L)
     const char* path = luaL_checkstring(L, 1);
 
     uv_fs_t* openReq = createRequest(L);
-    uv_fs_open(
+    int err = uv_fs_open(
         uv_default_loop(),
         openReq,
         path,
@@ -911,6 +945,7 @@ int readasync(lua_State* L)
                 info->token->fail("Error opening file");
                 uv_fs_t closeReq;
                 uv_fs_close(uv_default_loop(), &closeReq, fd, nullptr);
+                uv_fs_req_cleanup(&closeReq);
                 uv_fs_req_cleanup(req);
                 delete (ResumeCaptureInformation*)req->data;
                 delete req;
@@ -931,11 +966,13 @@ int readasync(lua_State* L)
             {
                 uv_fs_read(uv_default_loop(), &readReq, fd, &iov, 1, -1, nullptr);
                 numBytesRead = readReq.result;
+                uv_fs_req_cleanup(&readReq);
 
                 if (numBytesRead < 0)
                 {
                     uv_fs_t closeReq;
                     uv_fs_close(uv_default_loop(), &closeReq, fd, nullptr);
+                    uv_fs_req_cleanup(&closeReq);
                     // Schedule error;
                     // Also, we should free the original request. We don't have to do this for the read req since it's sycnrhonous
                     info->token->fail("Error reading file");
@@ -961,12 +998,21 @@ int readasync(lua_State* L)
 
             uv_fs_t closeReq;
             uv_fs_close(uv_default_loop(), &closeReq, fd, nullptr);
+            uv_fs_req_cleanup(&closeReq);
+            uv_fs_req_cleanup(req);
             // free the read buffer as well as the resume information and the request
             delete (ResumeCaptureInformation*)req->data;
             delete req;
             return;
         }
     );
+
+    if (err)
+    {
+        delete static_cast<ResumeCaptureInformation*>(openReq->data);
+        delete openReq;
+        luaL_errorL(L, "%s", uv_strerror(err));
+    }
 
     return lua_yield(L, 0);
 }


### PR DESCRIPTION
Some filesystem operations didn't clean up and free all their data. This PR attempts to fix this.

Some general observations:

- `uv_fs_req_cleanup` has to be called on all requests (sync/async). The documentation doesn't really mention this in much detail. For some operations, this might be a noop, but that's not part of the API and libuv is free to change this afaik.
- When handling errors, the request wasn't always free'd.
- The data associated with requests wasn't always free'd.
- Some code was unreachable due to a Lua error thrown before.

These errors seem hard to detect statically. Maybe there could be some RAII type for typed requests? 