### PR TITLE
Add a typedef for process.exit()

### DIFF
--- a/definitions/process.luau
+++ b/definitions/process.luau
@@ -33,4 +33,8 @@ function process.run(args: string | { string }, options: ProcessRunOptions?): Pr
 	error("not implemented")
 end
 
+function process.exit(exitcode: number): never
+	error("not implemented")
+end
+
 return process

--- a/examples/process.luau
+++ b/examples/process.luau
@@ -30,3 +30,5 @@ print(r7.stdout)
 
 local r8 = process.run("echo $0", { shell = "/bin/sh" })
 print(r8.stdout)
+
+process.exit(0)


### PR DESCRIPTION
This should now provide exit as an option when invoking process. + provide better in editor typechecking.