### PR TITLE
Replace unnecessary `reinterpret_cast`s with `static_cast`s

### DIFF
--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -921,7 +921,7 @@ uv_fs_t* createRequest(lua_State* L)
 
 ResumeCaptureInformation* getResumeInformation(uv_fs_t* req)
 {
-    return reinterpret_cast<ResumeCaptureInformation*>(req->data);
+    return static_cast<ResumeCaptureInformation*>(req->data);
 }
 
 int readasync(lua_State* L)

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -278,7 +278,7 @@ void Runtime::releasePendingToken()
 
 Runtime* getRuntime(lua_State* L)
 {
-    return reinterpret_cast<Runtime*>(lua_getthreaddata(lua_mainthread(L)));
+    return static_cast<Runtime*>(lua_getthreaddata(lua_mainthread(L)));
 }
 
 void ResumeTokenData::fail(std::string error)


### PR DESCRIPTION
Static casting `void*` to `T*` is always allowed, so it's better to use the narrower cast when possible.