### PR TITLE
luacase field names in lute's APIs

### DIFF
--- a/definitions/fs.luau
+++ b/definitions/fs.luau
@@ -12,9 +12,9 @@ export type FileMetadata = {
 	type: FileType,
 	permissions: { readonly: boolean },
 	size: number,
-	created_at: any,
-	accessed_at: any,
-	modified_at: any,
+	created: any,
+	accessed: any,
+	modified: any,
 }
 
 export type DirectoryEntry = {

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -32,10 +32,10 @@ export type MultiLineComment = {
 export type Trivia = Whitespace | SingleLineComment | MultiLineComment
 
 export type Token<Kind = string> = {
-	leadingTrivia: { Trivia },
+	leadingtrivia: { Trivia },
 	position: Position,
 	text: Kind,
-	trailingTrivia: { Trivia },
+	trailingtrivia: { Trivia },
 }
 
 export type Eof = Token<""> & { tag: "eof" }
@@ -52,9 +52,9 @@ export type AstLocal = {
 
 export type AstExprGroup = {
 	tag: "group",
-	openParens: Token<"(">,
+	openparens: Token<"(">,
 	expression: AstExpr,
-	closeParens: Token<")">,
+	closeparens: Token<")">,
 }
 
 export type AstExprConstantNil = Token<"nil"> & { tag: "nil" }
@@ -65,8 +65,8 @@ export type AstExprConstantNumber = Token<string> & { tag: "number", value: numb
 
 export type AstExprConstantString = Token<string> & {
 	tag: "string",
-	quoteStyle: "single" | "double" | "block" | "interp",
-	blockDepth: number,
+	quotestyle: "single" | "double" | "block" | "interp",
+	blockdepth: number,
 }
 
 export type AstExprLocal = {
@@ -86,9 +86,9 @@ export type AstExprVarargs = Token<"..."> & { tag: "vararg" }
 export type AstExprCall = {
 	tag: "call",
 	func: AstExpr,
-	openParens: Token<"(">?,
+	openparens: Token<"(">?,
 	arguments: Punctuated<AstExpr>,
-	closeParens: Token<")">?,
+	closeparens: Token<")">?,
 	self: boolean,
 	argLocation: Location,
 }
@@ -98,39 +98,39 @@ export type AstExprIndexName = {
 	expression: AstExpr,
 	accessor: Token<"." | ":">,
 	index: Token<string>,
-	indexLocation: Location,
+	indexlocation: Location,
 }
 
 export type AstExprIndexExpr = {
 	tag: "index",
 	expression: AstExpr,
-	openBrackets: Token<"[">,
+	openbrackets: Token<"[">,
 	index: AstExpr,
-	closeBrackets: Token<"]">,
+	closebrackets: Token<"]">,
 }
 
 export type AstFunctionBody = {
-	openGenerics: Token<"<">?,
+	opengenerics: Token<"<">?,
 	generics: Punctuated<AstGenericType>?,
-	genericPacks: Punctuated<AstGenericTypePack>?,
-	closeGenerics: Token<">">?,
+	genericpacks: Punctuated<AstGenericTypePack>?,
+	closegenerics: Token<">">?,
 	self: AstLocal?,
-	openParens: Token<"(">,
+	openparens: Token<"(">,
 	parameters: Punctuated<AstLocal>,
 	vararg: Token<"...">?,
-	varargColon: Token<":">?,
-	varargAnnotation: AstTypePack?,
-	closeParens: Token<")">,
-	returnSpecifier: Token<":">?,
-	returnAnnotation: AstTypePack?,
+	varargcolon: Token<":">?,
+	varargannotation: AstTypePack?,
+	closeparens: Token<")">,
+	returnspecifier: Token<":">?,
+	returnannotation: AstTypePack?,
 	body: AstStatBlock,
-	endKeyword: Token<"end">,
+	endkeyword: Token<"end">,
 }
 
 export type AstExprAnonymousFunction = {
 	tag: "function",
 	attributes: { AstAttribute },
-	functionKeyword: Token<"function">,
+	functionkeyword: Token<"function">,
 	body: AstFunctionBody,
 }
 
@@ -145,9 +145,9 @@ export type AstExprTableItem =
 	}
 	| {
 		kind: "general",
-		indexerOpen: Token<"[">,
+		indexeropen: Token<"[">,
 		key: AstExpr,
-		indexerClose: Token<"]">,
+		indexerclose: Token<"]">,
 		equals: Token<"=">,
 		value: AstExpr,
 		separator: Token<"," | ";">?,
@@ -155,9 +155,9 @@ export type AstExprTableItem =
 
 export type AstExprTable = {
 	tag: "table",
-	openBrace: Token<"{">,
+	openbrace: Token<"{">,
 	entries: { AstExprTableItem },
-	closeBrace: Token<"}">,
+	closebrace: Token<"}">,
 }
 
 export type AstExprUnary = {
@@ -187,20 +187,20 @@ export type AstExprTypeAssertion = {
 }
 
 export type AstExprIfElseIfs = {
-	elseifKeyword: Token<"elseif">,
+	elseifkeyword: Token<"elseif">,
 	condition: AstExpr,
-	thenKeyword: Token<"then">,
+	thenkeyword: Token<"then">,
 	consequent: AstExpr,
 }
 
 export type AstExprIfElse = {
 	tag: "conditional",
-	ifKeyword: Token<"if">,
+	ifkeyword: Token<"if">,
 	condition: AstExpr,
-	thenKeyword: Token<"then">,
+	thenkeyword: Token<"then">,
 	consequent: AstExpr,
 	elseifs: { AstExprIfElseIfs },
-	elseKeyword: Token<"else">,
+	elsekeyword: Token<"else">,
 	antecedent: AstExpr,
 }
 
@@ -230,31 +230,31 @@ export type AstStatBlock = {
 }
 
 export type AstStatElseIf = {
-	elseifKeyword: Token<"elseif">,
+	elseifkeyword: Token<"elseif">,
 	condition: AstExpr,
-	thenKeyword: Token<"then">,
+	thenkeyword: Token<"then">,
 	consequent: AstStatBlock,
 }
 
 export type AstStatIf = {
 	tag: "conditional",
-	ifKeyword: Token<"if">,
+	ifkeyword: Token<"if">,
 	condition: AstExpr,
-	thenKeyword: Token<"then">,
+	thenkeyword: Token<"then">,
 	consequent: AstStatBlock,
 	elseifs: { AstStatElseIf },
-	elseKeyword: Token<"else">?, -- TODO: this could be elseif!
+	elsekeyword: Token<"else">?, -- TODO: this could be elseif!
 	antecedent: AstStatBlock?,
-	endKeyword: Token<"end">,
+	endkeyword: Token<"end">,
 }
 
 export type AstStatWhile = {
 	tag: "while",
-	whileKeyword: Token<"while">,
+	whilekeyword: Token<"while">,
 	condition: AstExpr,
-	doKeyword: Token<"do">,
+	dokeyword: Token<"do">,
 	body: AstStatBlock,
-	endKeyword: Token<"end">,
+	endkeyword: Token<"end">,
 }
 
 export type AstStatRepeat = {
@@ -271,7 +271,7 @@ export type AstStatContinue = Token<"continue"> & { tag: "continue" }
 
 export type AstStatReturn = {
 	tag: "return",
-	returnKeyword: Token<"return">,
+	returnkeyword: Token<"return">,
 	expressions: Punctuated<AstExpr>,
 }
 
@@ -282,7 +282,7 @@ export type AstStatExpr = {
 
 export type AstStatLocal = {
 	tag: "local",
-	localKeyword: Token<"local">,
+	localkeyword: Token<"local">,
 	variables: Punctuated<AstLocal>,
 	equals: Token<"=">?,
 	values: Punctuated<AstExpr>,
@@ -290,28 +290,28 @@ export type AstStatLocal = {
 
 export type AstStatFor = {
 	tag: "for",
-	forKeyword: Token<"for">,
+	forkeyword: Token<"for">,
 	variable: AstLocal,
 	equals: Token<"=">,
 	from: AstExpr,
-	toComma: Token<",">,
+	tocomma: Token<",">,
 	to: AstExpr,
-	stepComma: Token<",">?,
+	stepcomma: Token<",">?,
 	step: AstExpr?,
-	doKeyword: Token<"do">,
+	dokeyword: Token<"do">,
 	body: AstStatBlock,
-	endKeyword: Token<"end">,
+	endkeyword: Token<"end">,
 }
 
 export type AstStatForIn = {
 	tag: "forin",
-	forKeyword: Token<"for">,
+	forkeyword: Token<"for">,
 	variables: Punctuated<Token<string>>,
-	inKeyword: Token<"in">,
+	inkeyword: Token<"in">,
 	values: Punctuated<AstExpr>,
-	doKeyword: Token<"do">,
+	dokeyword: Token<"do">,
 	body: AstStatBlock,
-	endKeyword: Token<"end">,
+	endkeyword: Token<"end">,
 }
 
 export type AstStatAssign = {
@@ -333,7 +333,7 @@ export type AstAttribute = Token<"@checked" | "@native" | "@deprecated"> & { tag
 export type AstStatFunction = {
 	tag: "function",
 	attributes: { AstAttribute },
-	functionKeyword: Token<"function">,
+	functionkeyword: Token<"function">,
 	name: AstExpr,
 	body: AstFunctionBody,
 }
@@ -341,8 +341,8 @@ export type AstStatFunction = {
 export type AstStatLocalFunction = {
 	tag: "localfunction",
 	attributes: { AstAttribute },
-	localKeyword: Token<"local">,
-	functionKeyword: Token<"function">,
+	localkeyword: Token<"local">,
+	functionkeyword: Token<"function">,
 	name: AstLocal,
 	body: AstFunctionBody,
 }
@@ -352,10 +352,10 @@ export type AstStatTypeAlias = {
 	export: Token<"export">?,
 	typeToken: Token<"type">,
 	name: Token,
-	openGenerics: Token<"<">?,
+	opengenerics: Token<"<">?,
 	generics: Punctuated<AstGenericType>?,
-	genericPacks: Punctuated<AstGenericTypePack>?,
-	closeGenerics: Token<">">?,
+	genericpacks: Punctuated<AstGenericTypePack>?,
+	closegenerics: Token<">">?,
 	equals: Token<"=">,
 	type: AstType,
 }
@@ -364,7 +364,7 @@ export type AstStatTypeFunction = {
 	tag: "typefunction",
 	export: Token<"export">?,
 	type: Token<"type">,
-	functionKeyword: Token<"function">,
+	functionkeyword: Token<"function">,
 	name: Token,
 	body: AstFunctionBody,
 }
@@ -406,11 +406,11 @@ export type AstGenericTypePack = {
 export type AstTypeReference = {
 	tag: "reference",
 	prefix: Token<string>?,
-	prefixPoint: Token<".">?,
+	prefixpoint: Token<".">?,
 	name: Token<string>,
-	openParameters: Token<"<">?,
+	openparameters: Token<"<">?,
 	parameters: Punctuated<AstType | AstTypePack>?,
-	closeParameters: Token<">">?,
+	closeparameters: Token<">">?,
 }
 
 export type AstTypeSingletonBool = Token<"true" | "false"> & {
@@ -420,22 +420,22 @@ export type AstTypeSingletonBool = Token<"true" | "false"> & {
 
 export type AstTypeSingletonString = Token<string> & {
 	tag: "string",
-	quoteStyle: "single" | "double",
+	quotestyle: "single" | "double",
 }
 
 export type AstTypeTypeof = {
 	tag: "typeof",
 	typeof: Token<"typeof">,
-	openParens: Token<"(">,
+	openparens: Token<"(">,
 	expression: AstExpr,
-	closeParens: Token<")">,
+	closeparens: Token<")">,
 }
 
 export type AstTypeGroup = {
 	tag: "group",
-	openParens: Token<"(">,
+	openparens: Token<"(">,
 	type: AstType,
-	closeParens: Token<">">,
+	closeparens: Token<">">,
 }
 
 export type AstTypeOptional = Token<"?"> & { tag: "optional" }
@@ -455,19 +455,19 @@ export type AstTypeIntersection = {
 
 export type AstTypeArray = {
 	tag: "array",
-	openBrace: Token<"{">,
+	openbrace: Token<"{">,
 	access: Token<"read" | "write">?,
 	type: AstType,
-	closeBrace: Token<"}">,
+	closebrace: Token<"}">,
 }
 
 export type AstTypeTableItem =
 	{
 		kind: "indexer",
 		access: Token<"read" | "write">?,
-		indexerOpen: Token<"[">,
+		indexeropen: Token<"[">,
 		key: AstType,
-		indexerClose: Token<"]">,
+		indexerclose: Token<"]">,
 		colon: Token<":">,
 		value: AstType,
 		separator: Token<"," | ";">?,
@@ -475,9 +475,9 @@ export type AstTypeTableItem =
 	| {
 		kind: "stringproperty",
 		access: Token<"read" | "write">?,
-		indexerOpen: Token<"[">,
+		indexeropen: Token<"[">,
 		key: AstTypeSingletonString,
-		indexerClose: Token<"]">,
+		indexerclose: Token<"]">,
 		colon: Token<":">,
 		value: AstType,
 		separator: Token<"," | ";">?,
@@ -486,7 +486,7 @@ export type AstTypeTableItem =
 		kind: "property",
 		access: Token<"read" | "write">?,
 		key: AstTypeSingletonString,
-		indexerClose: Token<"]">,
+		indexerclose: Token<"]">,
 		colon: Token<":">,
 		value: AstType,
 		separator: Token<"," | ";">?,
@@ -494,9 +494,9 @@ export type AstTypeTableItem =
 
 export type AstTypeTable = {
 	tag: "table",
-	openBrace: Token<"{">,
+	openbrace: Token<"{">,
 	entries: { AstTypeTableItem },
-	closeBrace: Token<"}">,
+	closebrace: Token<"}">,
 }
 
 export type AstTypeFunctionParameter = {
@@ -507,16 +507,16 @@ export type AstTypeFunctionParameter = {
 
 export type AstTypeFunction = {
 	tag: "function",
-	openGenerics: Token<"<">?,
+	opengenerics: Token<"<">?,
 	generics: Punctuated<AstGenericType>?,
-	genericPacks: Punctuated<AstGenericTypePack>?,
-	closeGenerics: Token<">">?,
-	openParens: Token<"(">,
+	genericpacks: Punctuated<AstGenericTypePack>?,
+	closegenerics: Token<">">?,
+	openparens: Token<"(">,
 	parameters: Punctuated<AstTypeFunctionParameter>,
 	vararg: AstTypePack?,
-	closeParens: Token<")">,
-	returnArrow: Token<"->">,
-	returnTypes: AstTypePack,
+	closeparens: Token<")">,
+	returnarrow: Token<"->">,
+	returntypes: AstTypePack,
 }
 
 export type AstType =
@@ -534,10 +534,10 @@ export type AstType =
 
 export type AstTypePackExplicit = {
 	tag: "explicit",
-	openParens: Token<"(">?,
+	openparens: Token<"(">?,
 	types: Punctuated<AstType>,
-	tailType: AstTypePack?,
-	closeParens: Token<")">?,
+	tailtype: AstTypePack?,
+	closeparens: Token<")">?,
 }
 
 export type AstTypePackGeneric = {
@@ -559,7 +559,7 @@ export type ParseResult = {
 	root: AstStatBlock,
 	eof: Eof,
 	lines: number,
-	lineOffsets: { number },
+	lineoffsets: { number },
 }
 
 function luau.parse(source: string): ParseResult

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -26,23 +26,23 @@
 
 
 #if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
-#define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
+#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
 #endif
 
 #if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)
-#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
+#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 #endif
 
 #if !defined(S_ISCHR) && defined(S_IFMT) && defined(S_IFCHR)
-#define S_ISCHR(m) (((m)&S_IFMT) == S_IFCHR)
+#define S_ISCHR(m) (((m) & S_IFMT) == S_IFCHR)
 #endif
 
 #if !defined(S_ISLNK) && defined(S_IFMT) && defined(S_IFLNK)
-#define S_ISLNK(m) (((m)&S_IFMT) == S_IFLNK)
+#define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
 #endif
 
 #if !defined(S_ISFIFO) && defined(S_IFMT) && defined(S_IFIFO)
-#define S_ISFIFO(m) (((m)&S_IFMT) == S_IFIFO)
+#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
 #endif
 
 namespace fs

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -26,23 +26,23 @@
 
 
 #if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
-#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
 #endif
 
 #if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)
-#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
 #endif
 
 #if !defined(S_ISCHR) && defined(S_IFMT) && defined(S_IFCHR)
-#define S_ISCHR(m) (((m) & S_IFMT) == S_IFCHR)
+#define S_ISCHR(m) (((m)&S_IFMT) == S_IFCHR)
 #endif
 
 #if !defined(S_ISLNK) && defined(S_IFMT) && defined(S_IFLNK)
-#define S_ISLNK(m) (((m) & S_IFMT) == S_IFLNK)
+#define S_ISLNK(m) (((m)&S_IFMT) == S_IFLNK)
 #endif
 
 #if !defined(S_ISFIFO) && defined(S_IFMT) && defined(S_IFIFO)
-#define S_ISFIFO(m) (((m) & S_IFMT) == S_IFIFO)
+#define S_ISFIFO(m) (((m)&S_IFMT) == S_IFIFO)
 #endif
 
 namespace fs
@@ -421,13 +421,13 @@ int fs_stat(lua_State* L)
     lua_setfield(L, -2, "size");
 
     createDurationFromTimespec32(L, stat.st_birthtim);
-    lua_setfield(L, -2, "created_at");
+    lua_setfield(L, -2, "created");
 
     createDurationFromTimespec32(L, stat.st_atim);
-    lua_setfield(L, -2, "accessed_at");
+    lua_setfield(L, -2, "accessed");
 
     createDurationFromTimespec32(L, stat.st_mtim);
-    lua_setfield(L, -2, "modified_at");
+    lua_setfield(L, -2, "modified");
 
     // permissions
     lua_createtable(L, 0, 2);

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -393,14 +393,14 @@ struct AstSerialize : public Luau::AstVisitor
 
             LUAU_ASSERT(cstNode->indexerOpenPosition);
             serializeToken(*cstNode->indexerOpenPosition, "[");
-            lua_setfield(L, -2, "indexerOpen");
+            lua_setfield(L, -2, "indexeropen");
 
             visit(item.key);
             lua_setfield(L, -2, "key");
 
             LUAU_ASSERT(cstNode->indexerClosePosition);
             serializeToken(*cstNode->indexerClosePosition, "]");
-            lua_setfield(L, -2, "indexerClose");
+            lua_setfield(L, -2, "indexerclose");
 
             LUAU_ASSERT(cstNode->equalsPosition);
             serializeToken(*cstNode->equalsPosition, "=");
@@ -491,7 +491,7 @@ struct AstSerialize : public Luau::AstVisitor
             LUAU_ASSERT(lua_istable(L, -1));
 
             serializeTrivia(trailingTrivia);
-            lua_setfield(L, -2, "trailingTrivia");
+            lua_setfield(L, -2, "trailingtrivia");
             lua_pop(L, 1);
             lua_unref(L, lastTokenRef);
             lastTokenRef = LUA_NOREF;
@@ -503,7 +503,7 @@ struct AstSerialize : public Luau::AstVisitor
             serializeTrivia(trivia);
         }
         LUAU_ASSERT(lua_istable(L, -2));
-        lua_setfield(L, -2, "leadingTrivia");
+        lua_setfield(L, -2, "leadingtrivia");
 
         serialize(position);
         lua_setfield(L, -2, "position");
@@ -513,7 +513,7 @@ struct AstSerialize : public Luau::AstVisitor
         advancePosition(text);
 
         lua_createtable(L, 0, 0);
-        lua_setfield(L, -2, "trailingTrivia");
+        lua_setfield(L, -2, "trailingtrivia");
 
         lastTokenRef = lua_ref(L, -1);
     }
@@ -662,13 +662,13 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "group");
 
         serializeToken(node->location.begin, "(");
-        lua_setfield(L, -2, "openParens");
+        lua_setfield(L, -2, "openparens");
 
         node->expr->visit(this);
         lua_setfield(L, -2, "expression");
 
         serializeToken(Luau::Position{node->location.end.line, node->location.end.column - 1}, ")");
-        lua_setfield(L, -2, "closeParens");
+        lua_setfield(L, -2, "closeparens");
     }
 
     void serialize(Luau::AstExprConstantNil* node)
@@ -718,10 +718,10 @@ struct AstSerialize : public Luau::AstVisitor
             lua_pushstring(L, "interp");
             break;
         }
-        lua_setfield(L, -2, "quoteStyle");
+        lua_setfield(L, -2, "quotestyle");
 
         lua_pushnumber(L, cstNode->blockDepth);
-        lua_setfield(L, -2, "blockDepth");
+        lua_setfield(L, -2, "blockdepth");
 
         // Unlike normal tokens, string content contains quotation marks that were not included during advancement
         // For simplicity, lets set the current position manually
@@ -779,7 +779,7 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(*cstNode->openParens, "(");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "openParens");
+        lua_setfield(L, -2, "openparens");
 
         serializePunctuated(node->args, cstNode->commaPositions, ",");
         lua_setfield(L, -2, "arguments");
@@ -794,7 +794,7 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(*cstNode->closeParens, ")");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "closeParens");
+        lua_setfield(L, -2, "closeparens");
     }
 
     void serialize(Luau::AstExprIndexName* node)
@@ -813,7 +813,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeToken(node->indexLocation.begin, node->index.value);
         lua_setfield(L, -2, "index");
         serialize(node->indexLocation);
-        lua_setfield(L, -2, "indexLocation");
+        lua_setfield(L, -2, "indexlocation");
     }
 
     void serialize(Luau::AstExprIndexExpr* node)
@@ -829,13 +829,13 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "expression");
 
         serializeToken(cstNode->openBracketPosition, "[");
-        lua_setfield(L, -2, "openBrackets");
+        lua_setfield(L, -2, "openbrackets");
 
         node->index->visit(this);
         lua_setfield(L, -2, "index");
 
         serializeToken(cstNode->closeBracketPosition, "]");
-        lua_setfield(L, -2, "closeBrackets");
+        lua_setfield(L, -2, "closebrackets");
     }
 
     void serializeFunctionBody(Luau::AstExprFunction* node)
@@ -848,17 +848,17 @@ struct AstSerialize : public Luau::AstVisitor
         if (node->generics.size > 0 || node->genericPacks.size > 0)
         {
             serializeToken(cstNode->openGenericsPosition, "<");
-            lua_setfield(L, -2, "openGenerics");
+            lua_setfield(L, -2, "opengenerics");
 
             auto commas = cstNode->genericsCommaPositions;
             serializePunctuated(node->generics, commas, ",");
             lua_setfield(L, -2, "generics");
 
             serializePunctuated(node->genericPacks, splitArray(commas, node->generics.size), ",");
-            lua_setfield(L, -2, "genericPacks");
+            lua_setfield(L, -2, "genericpacks");
 
             serializeToken(cstNode->closeGenericsPosition, ">");
-            lua_setfield(L, -2, "closeGenerics");
+            lua_setfield(L, -2, "closegenerics");
         }
 
         if (node->self)
@@ -870,7 +870,7 @@ struct AstSerialize : public Luau::AstVisitor
         if (node->argLocation)
         {
             serializeToken(node->argLocation->begin, "(");
-            lua_setfield(L, -2, "openParens");
+            lua_setfield(L, -2, "openparens");
         }
 
         serializePunctuated(node->args, cstNode->argsCommaPositions, ",", cstNode->argsAnnotationColonPositions);
@@ -886,7 +886,7 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(cstNode->varargAnnotationColonPosition, ":");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "varargColon");
+        lua_setfield(L, -2, "varargcolon");
 
         if (node->varargAnnotation)
         {
@@ -897,31 +897,31 @@ struct AstSerialize : public Luau::AstVisitor
         }
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "varargAnnotation");
+        lua_setfield(L, -2, "varargannotation");
 
         if (node->argLocation)
         {
             serializeToken(Luau::Position{node->argLocation->end.line, node->argLocation->end.column - 1}, ")");
-            lua_setfield(L, -2, "closeParens");
+            lua_setfield(L, -2, "closeparens");
         }
 
         if (node->returnAnnotation)
             serializeToken(cstNode->returnSpecifierPosition, ":");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "returnSpecifier");
+        lua_setfield(L, -2, "returnspecifier");
 
         if (node->returnAnnotation)
             node->returnAnnotation->visit(this);
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "returnAnnotation");
+        lua_setfield(L, -2, "returnannotation");
 
         node->body->visit(this);
         lua_setfield(L, -2, "body");
 
         serializeToken(node->body->location.end, "end");
-        lua_setfield(L, -2, "endKeyword");
+        lua_setfield(L, -2, "endkeyword");
     }
 
     void serialize(Luau::AstExprFunction* node)
@@ -937,7 +937,7 @@ struct AstSerialize : public Luau::AstVisitor
         const auto cstNode = lookupCstNode<Luau::CstExprFunction>(node);
 
         serializeToken(cstNode->functionKeywordPosition, "function");
-        lua_setfield(L, -2, "functionKeyword");
+        lua_setfield(L, -2, "functionkeyword");
 
         serializeFunctionBody(node);
         lua_setfield(L, -2, "body");
@@ -953,7 +953,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "table");
 
         serializeToken(node->location.begin, "{");
-        lua_setfield(L, -2, "openBrace");
+        lua_setfield(L, -2, "openbrace");
 
         lua_createtable(L, node->items.size, 0);
         for (size_t i = 0; i < node->items.size; i++)
@@ -964,7 +964,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "entries");
 
         serializeToken(Luau::Position{node->location.end.line, node->location.end.column - 1}, "}");
-        lua_setfield(L, -2, "closeBrace");
+        lua_setfield(L, -2, "closebrace");
     }
 
     void serialize(Luau::AstExprUnary* node)
@@ -1028,7 +1028,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "conditional");
 
         serializeToken(node->location.begin, "if");
-        lua_setfield(L, -2, "ifKeyword");
+        lua_setfield(L, -2, "ifkeyword");
 
         node->condition->visit(this);
         lua_setfield(L, -2, "condition");
@@ -1036,7 +1036,7 @@ struct AstSerialize : public Luau::AstVisitor
         if (node->hasThen)
         {
             serializeToken(cstNode->thenPosition, "then");
-            lua_setfield(L, -2, "thenKeyword");
+            lua_setfield(L, -2, "thenkeyword");
 
             node->trueExpr->visit(this);
         }
@@ -1054,7 +1054,7 @@ struct AstSerialize : public Luau::AstVisitor
             cstNode = lookupCstNode<Luau::CstExprIfElse>(node);
 
             serializeToken(node->location.begin, "elseif");
-            lua_setfield(L, -2, "elseifKeyword");
+            lua_setfield(L, -2, "elseifkeyword");
 
             node->condition->visit(this);
             lua_setfield(L, -2, "condition");
@@ -1062,7 +1062,7 @@ struct AstSerialize : public Luau::AstVisitor
             if (node->hasThen)
             {
                 serializeToken(cstNode->thenPosition, "then");
-                lua_setfield(L, -2, "thenKeyword");
+                lua_setfield(L, -2, "thenkeyword");
                 node->trueExpr->visit(this);
             }
             else
@@ -1077,7 +1077,7 @@ struct AstSerialize : public Luau::AstVisitor
         if (node->hasElse)
         {
             serializeToken(cstNode->elsePosition, "else");
-            lua_setfield(L, -2, "elseKeyword");
+            lua_setfield(L, -2, "elsekeyword");
             node->falseExpr->visit(this);
         }
         else
@@ -1154,13 +1154,13 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "conditional");
 
         serializeToken(node->location.begin, "if");
-        lua_setfield(L, -2, "ifKeyword");
+        lua_setfield(L, -2, "ifkeyword");
 
         node->condition->visit(this);
         lua_setfield(L, -2, "condition");
 
         serializeToken(node->thenLocation->begin, "then");
-        lua_setfield(L, -2, "thenKeyword");
+        lua_setfield(L, -2, "thenkeyword");
 
         node->thenbody->visit(this);
         lua_setfield(L, -2, "consequent");
@@ -1173,13 +1173,13 @@ struct AstSerialize : public Luau::AstVisitor
 
             auto elseif = node->elsebody->as<Luau::AstStatIf>();
             serializeToken(elseif->location.begin, "elseif");
-            lua_setfield(L, -2, "elseifKeyword");
+            lua_setfield(L, -2, "elseifkeyword");
 
             elseif->condition->visit(this);
             lua_setfield(L, -2, "condition");
 
             serializeToken(elseif->thenLocation->begin, "then");
-            lua_setfield(L, -2, "thenKeyword");
+            lua_setfield(L, -2, "thenkeyword");
 
             elseif->thenbody->visit(this);
             lua_setfield(L, -2, "consequent");
@@ -1194,24 +1194,24 @@ struct AstSerialize : public Luau::AstVisitor
         {
             LUAU_ASSERT(node->elseLocation);
             serializeToken(node->elseLocation->begin, "else");
-            lua_setfield(L, -2, "elseKeyword");
+            lua_setfield(L, -2, "elsekeyword");
 
             node->elsebody->visit(this);
             lua_setfield(L, -2, "antecedent");
 
             serializeToken(node->elsebody->location.end, "end");
-            lua_setfield(L, -2, "endKeyword");
+            lua_setfield(L, -2, "endkeyword");
         }
         else
         {
             lua_pushnil(L);
-            lua_setfield(L, -2, "elseKeyword");
+            lua_setfield(L, -2, "elsekeyword");
 
             lua_pushnil(L);
             lua_setfield(L, -2, "antecedent");
 
             serializeToken(node->thenbody->location.end, "end");
-            lua_setfield(L, -2, "endKeyword");
+            lua_setfield(L, -2, "endkeyword");
         }
     }
 
@@ -1223,7 +1223,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "while");
 
         serializeToken(node->location.begin, "while");
-        lua_setfield(L, -2, "whileKeyword");
+        lua_setfield(L, -2, "whilekeyword");
 
         node->condition->visit(this);
         lua_setfield(L, -2, "condition");
@@ -1232,13 +1232,13 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(node->doLocation.begin, "do");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "doKeyword");
+        lua_setfield(L, -2, "dokeyword");
 
         node->body->visit(this);
         lua_setfield(L, -2, "body");
 
         serializeToken(node->body->location.end, "end");
-        lua_setfield(L, -2, "endKeyword");
+        lua_setfield(L, -2, "endkeyword");
     }
 
     void serializeStat(Luau::AstStatRepeat* node)
@@ -1284,7 +1284,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "return");
 
         serializeToken(node->location.begin, "return");
-        lua_setfield(L, -2, "returnKeyword");
+        lua_setfield(L, -2, "returnkeyword");
 
         const auto cstNode = lookupCstNode<Luau::CstStatReturn>(node);
         serializePunctuated(node->list, cstNode->commaPositions, ",");
@@ -1310,7 +1310,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "local");
 
         serializeToken(node->location.begin, "local");
-        lua_setfield(L, -2, "localKeyword");
+        lua_setfield(L, -2, "localkeyword");
 
         const auto cstNode = lookupCstNode<Luau::CstStatLocal>(node);
         serializePunctuated(node->vars, cstNode->varsCommaPositions, ",", cstNode->varsAnnotationColonPositions);
@@ -1336,7 +1336,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "for");
 
         serializeToken(node->location.begin, "for");
-        lua_setfield(L, -2, "forKeyword");
+        lua_setfield(L, -2, "forkeyword");
 
         serialize(node->var, /* createToken= */ true, std::make_optional(cstNode->annotationColonPosition));
         lua_setfield(L, -2, "variable");
@@ -1348,7 +1348,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "from");
 
         serializeToken(cstNode->endCommaPosition, ",");
-        lua_setfield(L, -2, "toComma");
+        lua_setfield(L, -2, "tocomma");
 
         node->to->visit(this);
         lua_setfield(L, -2, "to");
@@ -1356,7 +1356,7 @@ struct AstSerialize : public Luau::AstVisitor
         if (cstNode->stepCommaPosition)
         {
             serializeToken(*cstNode->stepCommaPosition, ",");
-            lua_setfield(L, -2, "stepComma");
+            lua_setfield(L, -2, "stepcomma");
         }
 
         if (node->step)
@@ -1369,13 +1369,13 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(node->doLocation.begin, "do");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "doKeyword");
+        lua_setfield(L, -2, "dokeyword");
 
         node->body->visit(this);
         lua_setfield(L, -2, "body");
 
         serializeToken(node->body->location.end, "end");
-        lua_setfield(L, -2, "endKeyword");
+        lua_setfield(L, -2, "endkeyword");
     }
 
     void serializeStat(Luau::AstStatForIn* node)
@@ -1388,7 +1388,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "forin");
 
         serializeToken(node->location.begin, "for");
-        lua_setfield(L, -2, "forKeyword");
+        lua_setfield(L, -2, "forkeyword");
 
         serializePunctuated(node->vars, cstNode->varsCommaPositions, ",", cstNode->varsAnnotationColonPositions);
         lua_setfield(L, -2, "variables");
@@ -1397,7 +1397,7 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(node->inLocation.begin, "in");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "inKeyword");
+        lua_setfield(L, -2, "inkeyword");
 
         serializePunctuated(node->values, cstNode->valuesCommaPositions, ",");
         lua_setfield(L, -2, "values");
@@ -1406,13 +1406,13 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(node->doLocation.begin, "do");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "doKeyword");
+        lua_setfield(L, -2, "dokeyword");
 
         node->body->visit(this);
         lua_setfield(L, -2, "body");
 
         serializeToken(node->body->location.end, "end");
-        lua_setfield(L, -2, "endKeyword");
+        lua_setfield(L, -2, "endkeyword");
     }
 
     void serializeStat(Luau::AstStatAssign* node)
@@ -1465,7 +1465,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "attributes");
 
         serializeToken(cstNode->functionKeywordPosition, "function");
-        lua_setfield(L, -2, "functionKeyword");
+        lua_setfield(L, -2, "functionkeyword");
 
         node->name->visit(this);
         lua_setfield(L, -2, "name");
@@ -1487,10 +1487,10 @@ struct AstSerialize : public Luau::AstVisitor
         const auto cstNode = lookupCstNode<Luau::CstStatLocalFunction>(node);
 
         serializeToken(cstNode->localKeywordPosition, "local");
-        lua_setfield(L, -2, "localKeyword");
+        lua_setfield(L, -2, "localkeyword");
 
         serializeToken(cstNode->functionKeywordPosition, "function");
-        lua_setfield(L, -2, "functionKeyword");
+        lua_setfield(L, -2, "functionkeyword");
 
         serialize(node->name);
         lua_setfield(L, -2, "name");
@@ -1530,17 +1530,17 @@ struct AstSerialize : public Luau::AstVisitor
         if (node->generics.size > 0 || node->genericPacks.size > 0)
         {
             serializeToken(cstNode->genericsOpenPosition, "<");
-            lua_setfield(L, -2, "openGenerics");
+            lua_setfield(L, -2, "opengenerics");
 
             auto commas = cstNode->genericsCommaPositions;
             serializePunctuated(node->generics, commas, ",");
             lua_setfield(L, -2, "generics");
 
             serializePunctuated(node->genericPacks, splitArray(commas, node->generics.size), ",");
-            lua_setfield(L, -2, "genericPacks");
+            lua_setfield(L, -2, "genericpacks");
 
             serializeToken(cstNode->genericsClosePosition, ">");
-            lua_setfield(L, -2, "closeGenerics");
+            lua_setfield(L, -2, "closegenerics");
         }
 
         serializeToken(cstNode->equalsPosition, "=");
@@ -1569,7 +1569,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "type");
 
         serializeToken(cstNode->functionKeywordPosition, "function");
-        lua_setfield(L, -2, "functionKeyword");
+        lua_setfield(L, -2, "functionkeyword");
 
         serializeToken(node->nameLocation.begin, node->name.value);
         lua_setfield(L, -2, "name");
@@ -1627,7 +1627,7 @@ struct AstSerialize : public Luau::AstVisitor
             LUAU_ASSERT(cstNode);
             LUAU_ASSERT(cstNode->prefixPointPosition);
             serializeToken(*cstNode->prefixPointPosition, ".");
-            lua_setfield(L, -2, "prefixPoint");
+            lua_setfield(L, -2, "prefixpoint");
         }
 
         serializeToken(node->nameLocation.begin, node->name.value);
@@ -1637,13 +1637,13 @@ struct AstSerialize : public Luau::AstVisitor
         {
             LUAU_ASSERT(cstNode);
             serializeToken(cstNode->openParametersPosition, "<");
-            lua_setfield(L, -2, "openParameters");
+            lua_setfield(L, -2, "openparameters");
 
             serializePunctuated(node->parameters, cstNode->parametersCommaPositions, ",");
             lua_setfield(L, -2, "parameters");
 
             serializeToken(cstNode->closeParametersPosition, ">");
-            lua_setfield(L, -2, "closeParameters");
+            lua_setfield(L, -2, "closeparameters");
         }
     }
 
@@ -1659,7 +1659,7 @@ struct AstSerialize : public Luau::AstVisitor
             serializeNodePreamble(node, "array");
 
             serializeToken(node->location.begin, "{");
-            lua_setfield(L, -2, "openBrace");
+            lua_setfield(L, -2, "openbrace");
 
             if (node->indexer->accessLocation)
             {
@@ -1674,7 +1674,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "type");
 
             serializeToken(Luau::Position{node->location.end.line, node->location.end.column - 1}, "}");
-            lua_setfield(L, -2, "closeBrace");
+            lua_setfield(L, -2, "closebrace");
 
             return;
         }
@@ -1685,7 +1685,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "table");
 
         serializeToken(node->location.begin, "{");
-        lua_setfield(L, -2, "openBrace");
+        lua_setfield(L, -2, "openbrace");
 
         lua_createtable(L, cstNode->items.size, 0);
         const Luau::AstTableProp* prop = node->props.begin();
@@ -1713,13 +1713,13 @@ struct AstSerialize : public Luau::AstVisitor
                 lua_setfield(L, -2, "access");
 
                 serializeToken(item.indexerOpenPosition, "[");
-                lua_setfield(L, -2, "indexerOpen");
+                lua_setfield(L, -2, "indexeropen");
 
                 node->indexer->indexType->visit(this);
                 lua_setfield(L, -2, "key");
 
                 serializeToken(item.indexerClosePosition, "]");
-                lua_setfield(L, -2, "indexerClose");
+                lua_setfield(L, -2, "indexerclose");
 
                 serializeToken(item.colonPosition, ":");
                 lua_setfield(L, -2, "colon");
@@ -1758,7 +1758,7 @@ struct AstSerialize : public Luau::AstVisitor
                 if (item.kind == Luau::CstTypeTable::Item::Kind::StringProperty)
                 {
                     serializeToken(item.indexerOpenPosition, "[");
-                    lua_setfield(L, -2, "indexerOpen");
+                    lua_setfield(L, -2, "indexeropen");
 
                     {
                         auto initialPosition = item.stringPosition;
@@ -1775,7 +1775,7 @@ struct AstSerialize : public Luau::AstVisitor
                         default:
                             LUAU_ASSERT(false);
                         }
-                        lua_setfield(L, -2, "quoteStyle");
+                        lua_setfield(L, -2, "quotestyle");
 
                         // Unlike normal tokens, string content contains quotation marks that were not included during advancement
                         // For simplicity, lets set the current position manually
@@ -1789,7 +1789,7 @@ struct AstSerialize : public Luau::AstVisitor
                     lua_setfield(L, -2, "key");
 
                     serializeToken(item.indexerClosePosition, "]");
-                    lua_setfield(L, -2, "indexerClose");
+                    lua_setfield(L, -2, "indexerclose");
                 }
                 else
                 {
@@ -1816,7 +1816,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "entries");
 
         serializeToken(Luau::Position{node->location.end.line, node->location.end.column - 1}, "}");
-        lua_setfield(L, -2, "closeBrace");
+        lua_setfield(L, -2, "closebrace");
     }
 
     void serializeType(Luau::AstTypeFunction* node)
@@ -1831,21 +1831,21 @@ struct AstSerialize : public Luau::AstVisitor
         if (node->generics.size > 0 || node->genericPacks.size > 0)
         {
             serializeToken(cstNode->openGenericsPosition, "<");
-            lua_setfield(L, -2, "openGenerics");
+            lua_setfield(L, -2, "opengenerics");
 
             auto commas = cstNode->genericsCommaPositions;
             serializePunctuated(node->generics, commas, ",");
             lua_setfield(L, -2, "generics");
 
             serializePunctuated(node->genericPacks, splitArray(commas, node->generics.size), ",");
-            lua_setfield(L, -2, "genericPacks");
+            lua_setfield(L, -2, "genericpacks");
 
             serializeToken(cstNode->closeGenericsPosition, ">");
-            lua_setfield(L, -2, "closeGenerics");
+            lua_setfield(L, -2, "closegenerics");
         }
 
         serializeToken(cstNode->openArgsPosition, "(");
-        lua_setfield(L, -2, "openParens");
+        lua_setfield(L, -2, "openparens");
 
         lua_createtable(L, node->argTypes.types.size, 0);
         for (size_t i = 0; i < node->argTypes.types.size; i++)
@@ -1890,13 +1890,13 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "vararg");
 
         serializeToken(cstNode->closeArgsPosition, ")");
-        lua_setfield(L, -2, "closeParens");
+        lua_setfield(L, -2, "closeparens");
 
         serializeToken(cstNode->returnArrowPosition, "->");
-        lua_setfield(L, -2, "returnArrow");
+        lua_setfield(L, -2, "returnarrow");
 
         node->returnTypes->visit(this);
-        lua_setfield(L, -2, "returnTypes");
+        lua_setfield(L, -2, "returntypes");
     }
 
     void serializeType(Luau::AstTypeTypeof* node)
@@ -1911,13 +1911,13 @@ struct AstSerialize : public Luau::AstVisitor
 
         const auto cstNode = lookupCstNode<Luau::CstTypeTypeof>(node);
         serializeToken(cstNode->openPosition, "(");
-        lua_setfield(L, -2, "openParens");
+        lua_setfield(L, -2, "openparens");
 
         node->expr->visit(this);
         lua_setfield(L, -2, "expression");
 
         serializeToken(cstNode->closePosition, ")");
-        lua_setfield(L, -2, "closeParens");
+        lua_setfield(L, -2, "closeparens");
     }
 
     void serializeType(Luau::AstTypeUnion* node)
@@ -2016,7 +2016,7 @@ struct AstSerialize : public Luau::AstVisitor
         default:
             LUAU_ASSERT(false);
         }
-        lua_setfield(L, -2, "quoteStyle");
+        lua_setfield(L, -2, "quotestyle");
 
         // Unlike normal tokens, string content contains quotation marks that were not included during advancement
         // For simplicity, lets set the current position manually
@@ -2032,13 +2032,13 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "group");
 
         serializeToken(node->location.begin, "(");
-        lua_setfield(L, -2, "openParens");
+        lua_setfield(L, -2, "openparens");
 
         node->type->visit(this);
         lua_setfield(L, -2, "type");
 
         serializeToken(Luau::Position{node->location.end.line, node->location.end.column - 1}, ")");
-        lua_setfield(L, -2, "closeParens");
+        lua_setfield(L, -2, "closeparens");
     }
 
     void serializeType(Luau::AstGenericType* node)
@@ -2112,7 +2112,7 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(cstNode->openParenthesesPosition, "(");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "openParens");
+        lua_setfield(L, -2, "openparens");
 
         serializePunctuated(node->typeList.types, cstNode->commaPositions, ",");
         lua_setfield(L, -2, "types");
@@ -2121,13 +2121,13 @@ struct AstSerialize : public Luau::AstVisitor
             node->typeList.tailType->visit(this);
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "tailType");
+        lua_setfield(L, -2, "tailtype");
 
         if (cstNode->hasParentheses)
             serializeToken(cstNode->closeParenthesesPosition, ")");
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "closeParens");
+        lua_setfield(L, -2, "closeparens");
     }
 
     void serializeTypePack(Luau::AstTypePackGeneric* node)
@@ -2569,7 +2569,7 @@ int luau_parse(lua_State* L)
         lua_pushnumber(L, serializer.lineOffsets[i]);
         lua_settable(L, -3);
     }
-    lua_setfield(L, -2, "lineOffsets");
+    lua_setfield(L, -2, "lineoffsets");
 
     return 1;
 }

--- a/lute/std/libs/syntax/printer.luau
+++ b/lute/std/libs/syntax/printer.luau
@@ -23,26 +23,26 @@ local function printTriviaList(trivia: { luau.Trivia })
 end
 
 local function printToken(token: luau.Token): string
-	return printTriviaList(token.leadingTrivia) .. token.text .. printTriviaList(token.trailingTrivia)
+	return printTriviaList(token.leadingtrivia) .. token.text .. printTriviaList(token.trailingtrivia)
 end
 
 local function printString(expr: luau.AstExprConstantString): string
-	local result = printTriviaList(expr.leadingTrivia)
+	local result = printTriviaList(expr.leadingtrivia)
 
-	if expr.quoteStyle == "single" then
+	if expr.quotestyle == "single" then
 		result ..= `'{expr.text}'`
-	elseif expr.quoteStyle == "double" then
+	elseif expr.quotestyle == "double" then
 		result ..= `"{expr.text}"`
-	elseif expr.quoteStyle == "block" then
-		local equals = string.rep("=", expr.blockDepth)
+	elseif expr.quotestyle == "block" then
+		local equals = string.rep("=", expr.blockdepth)
 		result ..= `[{equals}[{expr.text}]{equals}]`
-	elseif expr.quoteStyle == "interp" then
+	elseif expr.quotestyle == "interp" then
 		result ..= "`" .. expr.text .. "`"
 	else
-		return exhaustiveMatch(expr.quoteStyle)
+		return exhaustiveMatch(expr.quotestyle)
 	end
 
-	result ..= printTriviaList(expr.trailingTrivia)
+	result ..= printTriviaList(expr.trailingtrivia)
 	return result
 end
 
@@ -50,7 +50,7 @@ local function printInterpolatedString(expr: luau.AstExprInterpString): string
 	local result = ""
 
 	for i = 1, #expr.strings do
-		result ..= printTriviaList(expr.strings[i].leadingTrivia)
+		result ..= printTriviaList(expr.strings[i].leadingtrivia)
 		if i == 1 then
 			result ..= "`"
 		else
@@ -60,10 +60,10 @@ local function printInterpolatedString(expr: luau.AstExprInterpString): string
 
 		if i == #expr.strings then
 			result ..= "`"
-			result ..= printTriviaList(expr.strings[i].trailingTrivia)
+			result ..= printTriviaList(expr.strings[i].trailingtrivia)
 		else
 			result ..= "{"
-			result ..= printTriviaList(expr.strings[i].trailingTrivia)
+			result ..= printTriviaList(expr.strings[i].trailingtrivia)
 			result ..= printExpr(expr.expressions[i])
 		end
 	end

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -165,33 +165,33 @@ end
 
 local function visitIf(node: luau.AstStatIf, visitor: Visitor)
 	if visitor.visitIf(node) then
-		visitToken(node.ifKeyword, visitor)
+		visitToken(node.ifkeyword, visitor)
 		visitExpression(node.condition, visitor)
-		visitToken(node.thenKeyword, visitor)
+		visitToken(node.thenkeyword, visitor)
 		visitBlock(node.consequent, visitor)
 		for _, elseifNode in node.elseifs do
-			visitToken(elseifNode.elseifKeyword, visitor)
+			visitToken(elseifNode.elseifkeyword, visitor)
 			visitExpression(elseifNode.condition, visitor)
-			visitToken(elseifNode.thenKeyword, visitor)
+			visitToken(elseifNode.thenkeyword, visitor)
 			visitBlock(elseifNode.consequent, visitor)
 		end
-		if node.elseKeyword then
-			visitToken(node.elseKeyword, visitor)
+		if node.elsekeyword then
+			visitToken(node.elsekeyword, visitor)
 		end
 		if node.antecedent then
 			visitBlock(node.antecedent, visitor)
 		end
-		visitToken(node.endKeyword, visitor)
+		visitToken(node.endkeyword, visitor)
 	end
 end
 
 local function visitWhile(node: luau.AstStatWhile, visitor: Visitor)
 	if visitor.visitWhile(node) then
-		visitToken(node.whileKeyword, visitor)
+		visitToken(node.whilekeyword, visitor)
 		visitExpression(node.condition, visitor)
-		visitToken(node.doKeyword, visitor)
+		visitToken(node.dokeyword, visitor)
 		visitBlock(node.body, visitor)
-		visitToken(node.endKeyword, visitor)
+		visitToken(node.endkeyword, visitor)
 	end
 end
 
@@ -206,14 +206,14 @@ end
 
 local function visitReturn(node: luau.AstStatReturn, visitor: Visitor)
 	if visitor.visitReturn(node) then
-		visitToken(node.returnKeyword, visitor)
+		visitToken(node.returnkeyword, visitor)
 		visitPunctuated(node.expressions, visitor, visitExpression)
 	end
 end
 
 local function visitLocalStatement(node: luau.AstStatLocal, visitor: Visitor)
 	if visitor.visitLocalDeclaration(node) then
-		visitToken(node.localKeyword, visitor)
+		visitToken(node.localkeyword, visitor)
 		visitPunctuated(node.variables, visitor, visitLocal)
 		if node.equals then
 			visitToken(node.equals, visitor)
@@ -226,33 +226,33 @@ end
 
 local function visitFor(node: luau.AstStatFor, visitor: Visitor)
 	if visitor.visitFor(node) then
-		visitToken(node.forKeyword, visitor)
+		visitToken(node.forkeyword, visitor)
 		visitLocal(node.variable, visitor)
 		visitToken(node.equals, visitor)
 		visitExpression(node.from, visitor)
-		visitToken(node.toComma, visitor)
+		visitToken(node.tocomma, visitor)
 		visitExpression(node.to, visitor)
-		if node.stepComma then
-			visitToken(node.stepComma, visitor)
+		if node.stepcomma then
+			visitToken(node.stepcomma, visitor)
 		end
 		if node.step then
 			visitExpression(node.step, visitor)
 		end
-		visitToken(node.doKeyword, visitor)
+		visitToken(node.dokeyword, visitor)
 		visitBlock(node.body, visitor)
-		visitToken(node.endKeyword, visitor)
+		visitToken(node.endkeyword, visitor)
 	end
 end
 
 local function visitForIn(node: luau.AstStatForIn, visitor: Visitor)
 	if visitor.visitForIn(node) then
-		visitToken(node.forKeyword, visitor)
+		visitToken(node.forkeyword, visitor)
 		visitPunctuated(node.variables, visitor, visitLocal)
-		visitToken(node.inKeyword, visitor)
+		visitToken(node.inkeyword, visitor)
 		visitPunctuated(node.values, visitor, visitExpression)
-		visitToken(node.doKeyword, visitor)
+		visitToken(node.dokeyword, visitor)
 		visitBlock(node.body, visitor)
-		visitToken(node.endKeyword, visitor)
+		visitToken(node.endkeyword, visitor)
 	end
 end
 
@@ -300,17 +300,17 @@ local function visitTypeAlias(node: luau.AstStatTypeAlias, visitor: Visitor)
 		end
 		visitToken(node.typeToken, visitor)
 		visitToken(node.name, visitor)
-		if node.openGenerics then
-			visitToken(node.openGenerics, visitor)
+		if node.opengenerics then
+			visitToken(node.opengenerics, visitor)
 		end
 		if node.generics then
 			visitPunctuated(node.generics, visitor, visitGeneric)
 		end
-		if node.genericPacks then
-			visitPunctuated(node.genericPacks, visitor, visitGenericPack)
+		if node.genericpacks then
+			visitPunctuated(node.genericpacks, visitor, visitGenericPack)
 		end
-		if node.closeGenerics then
-			visitToken(node.closeGenerics, visitor)
+		if node.closegenerics then
+			visitToken(node.closegenerics, visitor)
 		end
 		visitToken(node.equals, visitor)
 		visitType(node.type, visitor)
@@ -362,12 +362,12 @@ end
 local function visitCall(node: luau.AstExprCall, visitor: Visitor)
 	if visitor.visitCall(node) then
 		visitExpression(node.func, visitor)
-		if node.openParens then
-			visitToken(node.openParens, visitor)
+		if node.openparens then
+			visitToken(node.openparens, visitor)
 		end
 		visitPunctuated(node.arguments, visitor, visitExpression)
-		if node.closeParens then
-			visitToken(node.closeParens, visitor)
+		if node.closeparens then
+			visitToken(node.closeparens, visitor)
 		end
 	end
 end
@@ -388,38 +388,38 @@ local function visitBinary(node: luau.AstExprBinary, visitor: Visitor)
 end
 
 local function visitFunctionBody(node: luau.AstFunctionBody, visitor: Visitor)
-	if node.openGenerics then
-		visitToken(node.openGenerics, visitor)
+	if node.opengenerics then
+		visitToken(node.opengenerics, visitor)
 	end
 	if node.generics then
 		visitPunctuated(node.generics, visitor, visitGeneric)
 	end
-	if node.genericPacks then
-		visitPunctuated(node.genericPacks, visitor, visitGenericPack)
+	if node.genericpacks then
+		visitPunctuated(node.genericpacks, visitor, visitGenericPack)
 	end
-	if node.closeGenerics then
-		visitToken(node.closeGenerics, visitor)
+	if node.closegenerics then
+		visitToken(node.closegenerics, visitor)
 	end
-	visitToken(node.openParens, visitor)
+	visitToken(node.openparens, visitor)
 	visitPunctuated(node.parameters, visitor, visitLocal)
 	if node.vararg then
 		visitToken(node.vararg, visitor)
 	end
-	if node.varargColon then
-		visitToken(node.varargColon, visitor)
+	if node.varargcolon then
+		visitToken(node.varargcolon, visitor)
 	end
-	if node.varargAnnotation then
-		visitTypePack(node.varargAnnotation, visitor)
+	if node.varargannotation then
+		visitTypePack(node.varargannotation, visitor)
 	end
-	visitToken(node.closeParens, visitor)
-	if node.returnSpecifier then
-		visitToken(node.returnSpecifier, visitor)
+	visitToken(node.closeparens, visitor)
+	if node.returnspecifier then
+		visitToken(node.returnspecifier, visitor)
 	end
-	if node.returnAnnotation then
-		visitTypePack(node.returnAnnotation, visitor)
+	if node.returnannotation then
+		visitTypePack(node.returnannotation, visitor)
 	end
 	visitBlock(node.body, visitor)
-	visitToken(node.endKeyword, visitor)
+	visitToken(node.endkeyword, visitor)
 end
 
 local function visitAttribute(node: luau.AstAttribute, visitor)
@@ -431,7 +431,7 @@ local function visitAnonymousFunction(node: luau.AstExprAnonymousFunction, visit
 		for _, attribute in node.attributes do
 			visitAttribute(attribute, visitor)
 		end
-		visitToken(node.functionKeyword, visitor)
+		visitToken(node.functionkeyword, visitor)
 		visitFunctionBody(node.body, visitor)
 	end
 end
@@ -441,7 +441,7 @@ local function visitFunction(node: luau.AstStatFunction, visitor: Visitor)
 		for _, attribute in node.attributes do
 			visitAttribute(attribute, visitor)
 		end
-		visitToken(node.functionKeyword, visitor)
+		visitToken(node.functionkeyword, visitor)
 		visitExpression(node.name, visitor)
 		visitFunctionBody(node.body, visitor)
 	end
@@ -452,8 +452,8 @@ local function visitLocalFunction(node: luau.AstStatLocalFunction, visitor: Visi
 		for _, attribute in node.attributes do
 			visitAttribute(attribute, visitor)
 		end
-		visitToken(node.localKeyword, visitor)
-		visitToken(node.functionKeyword, visitor)
+		visitToken(node.localkeyword, visitor)
+		visitToken(node.functionkeyword, visitor)
 		visitLocal(node.name, visitor)
 		visitFunctionBody(node.body, visitor)
 	end
@@ -465,7 +465,7 @@ local function visitStatTypeFunction(node: luau.AstStatTypeFunction, visitor: Vi
 			visitToken(node.export, visitor)
 		end
 		visitToken(node.type, visitor)
-		visitToken(node.functionKeyword, visitor)
+		visitToken(node.functionkeyword, visitor)
 		visitToken(node.name, visitor)
 		visitFunctionBody(node.body, visitor)
 	end
@@ -480,9 +480,9 @@ local function visitTableItem(node: luau.AstExprTableItem, visitor: Visitor)
 			visitToken(node.equals, visitor)
 			visitExpression(node.value, visitor)
 		elseif node.kind == "general" then
-			visitToken(node.indexerOpen, visitor)
+			visitToken(node.indexeropen, visitor)
 			visitExpression(node.key, visitor)
-			visitToken(node.indexerClose, visitor)
+			visitToken(node.indexerclose, visitor)
 			visitToken(node.equals, visitor)
 			visitExpression(node.value, visitor)
 		else
@@ -497,11 +497,11 @@ end
 
 local function visitTable(node: luau.AstExprTable, visitor: Visitor)
 	if visitor.visitTable(node) then
-		visitToken(node.openBrace, visitor)
+		visitToken(node.openbrace, visitor)
 		for _, item in node.entries do
 			visitTableItem(item, visitor)
 		end
-		visitToken(node.closeBrace, visitor)
+		visitToken(node.closebrace, visitor)
 	end
 end
 
@@ -516,17 +516,17 @@ end
 local function visitIndexExpr(node: luau.AstExprIndexExpr, visitor: Visitor)
 	if visitor.visitIndexExpr(node) then
 		visitExpression(node.expression, visitor)
-		visitToken(node.openBrackets, visitor)
+		visitToken(node.openbrackets, visitor)
 		visitExpression(node.index, visitor)
-		visitToken(node.closeBrackets, visitor)
+		visitToken(node.closebrackets, visitor)
 	end
 end
 
 local function visitGroup(node: luau.AstExprGroup, visitor: Visitor)
 	if visitor.visitGroup(node) then
-		visitToken(node.openParens, visitor)
+		visitToken(node.openparens, visitor)
 		visitExpression(node.expression, visitor)
-		visitToken(node.closeParens, visitor)
+		visitToken(node.closeparens, visitor)
 	end
 end
 
@@ -551,17 +551,17 @@ end
 
 local function visitIfExpression(node: luau.AstExprIfElse, visitor: Visitor)
 	if visitor.visitIfExpression(node) then
-		visitToken(node.ifKeyword, visitor)
+		visitToken(node.ifkeyword, visitor)
 		visitExpression(node.condition, visitor)
-		visitToken(node.thenKeyword, visitor)
+		visitToken(node.thenkeyword, visitor)
 		visitExpression(node.consequent, visitor)
 		for _, elseifs in node.elseifs do
-			visitToken(elseifs.elseifKeyword, visitor)
+			visitToken(elseifs.elseifkeyword, visitor)
 			visitExpression(elseifs.condition, visitor)
-			visitToken(elseifs.thenKeyword, visitor)
+			visitToken(elseifs.thenkeyword, visitor)
 			visitExpression(elseifs.consequent, visitor)
 		end
-		visitToken(node.elseKeyword, visitor)
+		visitToken(node.elsekeyword, visitor)
 		visitExpression(node.antecedent, visitor)
 	end
 end
@@ -579,18 +579,18 @@ local function visitTypeReference(node: luau.AstTypeReference, visitor: Visitor)
 		if node.prefix then
 			visitToken(node.prefix, visitor)
 		end
-		if node.prefixPoint then
-			visitToken(node.prefixPoint, visitor)
+		if node.prefixpoint then
+			visitToken(node.prefixpoint, visitor)
 		end
 		visitToken(node.name, visitor)
-		if node.openParameters then
-			visitToken(node.openParameters, visitor)
+		if node.openparameters then
+			visitToken(node.openparameters, visitor)
 		end
 		if node.parameters then
 			visitPunctuated(node.parameters, visitor, visitTypeOrPack)
 		end
-		if node.closeParameters then
-			visitToken(node.closeParameters, visitor)
+		if node.closeparameters then
+			visitToken(node.closeparameters, visitor)
 		end
 	end
 end
@@ -610,17 +610,17 @@ end
 local function visitTypeTypeof(node: luau.AstTypeTypeof, visitor: Visitor)
 	if visitor.visitTypeTypeof(node) then
 		visitToken(node.typeof, visitor)
-		visitToken(node.openParens, visitor)
+		visitToken(node.openparens, visitor)
 		visitExpression(node.expression, visitor)
-		visitToken(node.closeParens, visitor)
+		visitToken(node.closeparens, visitor)
 	end
 end
 
 local function visitTypeGroup(node: luau.AstTypeGroup, visitor: Visitor)
 	if visitor.visitTypeGroup(node) then
-		visitToken(node.openParens, visitor)
+		visitToken(node.openparens, visitor)
 		visitType(node.type, visitor)
-		visitToken(node.closeParens, visitor)
+		visitToken(node.closeparens, visitor)
 	end
 end
 
@@ -644,30 +644,30 @@ end
 
 local function visitTypeArray(node: luau.AstTypeArray, visitor: Visitor)
 	if visitor.visitTypeArray(node) then
-		visitToken(node.openBrace, visitor)
+		visitToken(node.openbrace, visitor)
 		if node.access then
 			visitToken(node.access, visitor)
 		end
 		visitType(node.type, visitor)
-		visitToken(node.closeBrace, visitor)
+		visitToken(node.closebrace, visitor)
 	end
 end
 
 local function visitTypeTable(node: luau.AstTypeTable, visitor: Visitor)
 	if visitor.visitTypeTable(node) then
-		visitToken(node.openBrace, visitor)
+		visitToken(node.openbrace, visitor)
 		for _, entry in node.entries do
 			if entry.access then
 				visitToken(entry.access, visitor)
 			end
 			if entry.kind == "indexer" then
-				visitToken(entry.indexerOpen, visitor)
+				visitToken(entry.indexeropen, visitor)
 				visitType(entry.key, visitor)
-				visitToken(entry.indexerClose, visitor)
+				visitToken(entry.indexerclose, visitor)
 			elseif entry.kind == "stringproperty" then
-				visitToken(entry.indexerOpen, visitor)
+				visitToken(entry.indexeropen, visitor)
 				visitTypeString(entry.key, visitor)
-				visitToken(entry.indexerClose, visitor)
+				visitToken(entry.indexerclose, visitor)
 			else
 				visitToken(entry.key, visitor)
 			end
@@ -677,7 +677,7 @@ local function visitTypeTable(node: luau.AstTypeTable, visitor: Visitor)
 				visitToken(entry.separator, visitor)
 			end
 		end
-		visitToken(node.closeBrace, visitor)
+		visitToken(node.closebrace, visitor)
 	end
 end
 
@@ -693,40 +693,40 @@ end
 
 local function visitTypeFunction(node: luau.AstTypeFunction, visitor: Visitor)
 	if visitor.visitTypeFunction(node) then
-		if node.openGenerics then
-			visitToken(node.openGenerics, visitor)
+		if node.opengenerics then
+			visitToken(node.opengenerics, visitor)
 		end
 		if node.generics then
 			visitPunctuated(node.generics, visitor, visitGeneric)
 		end
-		if node.genericPacks then
-			visitPunctuated(node.genericPacks, visitor, visitGenericPack)
+		if node.genericpacks then
+			visitPunctuated(node.genericpacks, visitor, visitGenericPack)
 		end
-		if node.closeGenerics then
-			visitToken(node.closeGenerics, visitor)
+		if node.closegenerics then
+			visitToken(node.closegenerics, visitor)
 		end
-		visitToken(node.openParens, visitor)
+		visitToken(node.openparens, visitor)
 		visitPunctuated(node.parameters, visitor, visitTypeFunctionParameter)
 		if node.vararg then
 			visitTypePack(node.vararg, visitor)
 		end
-		visitToken(node.closeParens, visitor)
-		visitToken(node.returnArrow, visitor)
-		visitTypePack(node.returnTypes, visitor)
+		visitToken(node.closeparens, visitor)
+		visitToken(node.returnarrow, visitor)
+		visitTypePack(node.returntypes, visitor)
 	end
 end
 
 local function visitTypePackExplicit(node: luau.AstTypePackExplicit, visitor: Visitor)
 	if visitor.visitTypePackExplicit(node) then
-		if node.openParens then
-			visitToken(node.openParens, visitor)
+		if node.openparens then
+			visitToken(node.openparens, visitor)
 		end
 		visitPunctuated(node.types, visitor, visitType)
-		if node.tailType then
-			visitTypePack(node.tailType, visitor)
+		if node.tailtype then
+			visitTypePack(node.tailtype, visitor)
 		end
-		if node.closeParens then
-			visitToken(node.closeParens, visitor)
+		if node.closeparens then
+			visitToken(node.closeparens, visitor)
 		end
 	end
 end

--- a/tests/testAstSerializer.test.luau
+++ b/tests/testAstSerializer.test.luau
@@ -25,11 +25,11 @@ local function test_tokenContainsLeadingSpaces()
 	local l = block.statements[1]
 	assert(l.tag == "local")
 
-	local token = l.localKeyword
-	assert(#token.leadingTrivia == 1)
-	assert(token.leadingTrivia[1].tag == "whitespace")
-	assert(token.leadingTrivia[1].text == "  ")
-	assertEqualsLocation(token.leadingTrivia[1].location, 0, 0, 0, 2)
+	local token = l.localkeyword
+	assert(#token.leadingtrivia == 1)
+	assert(token.leadingtrivia[1].tag == "whitespace")
+	assert(token.leadingtrivia[1].text == "  ")
+	assertEqualsLocation(token.leadingtrivia[1].location, 0, 0, 0, 2)
 end
 
 local function test_tokenContainsLeadingNewline()
@@ -39,11 +39,11 @@ local function test_tokenContainsLeadingNewline()
 	local l = block.statements[1]
 	assert(l.tag == "local")
 
-	local token = l.localKeyword
-	assert(#token.leadingTrivia == 1)
-	assert(token.leadingTrivia[1].tag == "whitespace")
-	assert(token.leadingTrivia[1].text == "\n")
-	assertEqualsLocation(token.leadingTrivia[1].location, 0, 0, 1, 0)
+	local token = l.localkeyword
+	assert(#token.leadingtrivia == 1)
+	assert(token.leadingtrivia[1].tag == "whitespace")
+	assert(token.leadingtrivia[1].text == "\n")
+	assertEqualsLocation(token.leadingtrivia[1].location, 0, 0, 1, 0)
 end
 
 local function test_tokenContainsLeadingSingleLineComment()
@@ -53,14 +53,14 @@ local function test_tokenContainsLeadingSingleLineComment()
 	local l = block.statements[1]
 	assert(l.tag == "local")
 
-	local token = l.localKeyword
-	assert(#token.leadingTrivia == 2)
-	assert(token.leadingTrivia[1].tag == "comment")
-	assert(token.leadingTrivia[1].text == "-- comment")
-	assertEqualsLocation(token.leadingTrivia[1].location, 0, 0, 0, 10)
-	assert(token.leadingTrivia[2].tag == "whitespace")
-	assert(token.leadingTrivia[2].text == "\n")
-	assertEqualsLocation(token.leadingTrivia[2].location, 0, 10, 1, 0)
+	local token = l.localkeyword
+	assert(#token.leadingtrivia == 2)
+	assert(token.leadingtrivia[1].tag == "comment")
+	assert(token.leadingtrivia[1].text == "-- comment")
+	assertEqualsLocation(token.leadingtrivia[1].location, 0, 0, 0, 10)
+	assert(token.leadingtrivia[2].tag == "whitespace")
+	assert(token.leadingtrivia[2].text == "\n")
+	assertEqualsLocation(token.leadingtrivia[2].location, 0, 10, 1, 0)
 end
 
 local function test_tokenContainsLeadingBlockComment()
@@ -70,14 +70,14 @@ local function test_tokenContainsLeadingBlockComment()
 	local l = block.statements[1]
 	assert(l.tag == "local")
 
-	local token = l.localKeyword
-	assert(#token.leadingTrivia == 2)
-	assert(token.leadingTrivia[1].tag == "blockcomment")
-	assert(token.leadingTrivia[1].text == "--[[ comment ]]")
-	assertEqualsLocation(token.leadingTrivia[1].location, 0, 0, 0, 15)
-	assert(token.leadingTrivia[2].tag == "whitespace")
-	assert(token.leadingTrivia[2].text == " ")
-	assertEqualsLocation(token.leadingTrivia[2].location, 0, 15, 0, 16)
+	local token = l.localkeyword
+	assert(#token.leadingtrivia == 2)
+	assert(token.leadingtrivia[1].tag == "blockcomment")
+	assert(token.leadingtrivia[1].text == "--[[ comment ]]")
+	assertEqualsLocation(token.leadingtrivia[1].location, 0, 0, 0, 15)
+	assert(token.leadingtrivia[2].tag == "whitespace")
+	assert(token.leadingtrivia[2].text == " ")
+	assertEqualsLocation(token.leadingtrivia[2].location, 0, 15, 0, 16)
 end
 
 local function test_tokenizeWhitespace()
@@ -87,11 +87,11 @@ local function test_tokenizeWhitespace()
 	local l = block.statements[1]
 	assert(l.tag == "local")
 
-	local token = l.localKeyword
-	assert(#token.leadingTrivia == 3)
-	assert(token.leadingTrivia[1].text == "  \n")
-	assert(token.leadingTrivia[2].text == "\t\t\n")
-	assert(token.leadingTrivia[3].text == "\n")
+	local token = l.localkeyword
+	assert(#token.leadingtrivia == 3)
+	assert(token.leadingtrivia[1].text == "  \n")
+	assert(token.leadingtrivia[2].text == "\t\t\n")
+	assert(token.leadingtrivia[3].text == "\n")
 end
 
 local function test_triviaSplitBetweenLeadingAndTrailing()
@@ -103,18 +103,18 @@ local function test_triviaSplitBetweenLeadingAndTrailing()
 
 	local trailingToken = firstStmt.values[1].node
 	assert(trailingToken.tag == "string")
-	assert(#trailingToken.trailingTrivia == 3)
-	assert(trailingToken.trailingTrivia[1].text == " ")
-	assert(trailingToken.trailingTrivia[2].text == "-- comment")
-	assert(trailingToken.trailingTrivia[3].text == "\n")
+	assert(#trailingToken.trailingtrivia == 3)
+	assert(trailingToken.trailingtrivia[1].text == " ")
+	assert(trailingToken.trailingtrivia[2].text == "-- comment")
+	assert(trailingToken.trailingtrivia[3].text == "\n")
 
 	local secondStmt = block.statements[2]
 	assert(secondStmt.tag == "local")
 
-	local leadingToken = secondStmt.localKeyword
-	assert(#leadingToken.leadingTrivia == 2)
-	assert(leadingToken.leadingTrivia[1].text == "-- comment 2")
-	assert(leadingToken.leadingTrivia[2].text == "\n")
+	local leadingToken = secondStmt.localkeyword
+	assert(#leadingToken.leadingtrivia == 2)
+	assert(leadingToken.leadingtrivia[1].text == "-- comment 2")
+	assert(leadingToken.leadingtrivia[2].text == "\n")
 end
 
 local function test_roundtrippableAst()
@@ -138,29 +138,29 @@ local function test_lineOffsetsField()
 	local singleLineCode = "local x = 1"
 	local result = luau.parse(singleLineCode)
 
-	assert(result.lineOffsets)
-	assert(type(result.lineOffsets) == "table", "lineOffsets should be a table")
-	assert(#result.lineOffsets == 1, "Should have 1 line offset for single line code") -- only line 0
-	assert(result.lineOffsets[1] == 0, "First line should start at offset 0")
+	assert(result.lineoffsets)
+	assert(type(result.lineoffsets) == "table", "lineoffsets should be a table")
+	assert(#result.lineoffsets == 1, "Should have 1 line offset for single line code") -- only line 0
+	assert(result.lineoffsets[1] == 0, "First line should start at offset 0")
 
 	local multiLineCode = "local x = 1\nlocal y = 2\nlocal z = 3"
 	local multiResult = luau.parse(multiLineCode)
 
-	assert(multiResult.lineOffsets)
-	assert(type(multiResult.lineOffsets) == "table", "lineOffsets should be a table for multiline")
-	assert(#multiResult.lineOffsets == 3, "Should have 3 line offsets for 3-line code") -- lines 0, 1, 2
-	assert(multiResult.lineOffsets[1] == 0, "First line should start at offset 0")
-	assert(multiResult.lineOffsets[2] == 12, "Second line should start after 'local x = 1\\n'")
-	assert(multiResult.lineOffsets[3] == 24, "Third line should start after 'local x = 1\\nlocal y = 2\\n'")
+	assert(multiResult.lineoffsets)
+	assert(type(multiResult.lineoffsets) == "table", "lineoffsets should be a table for multiline")
+	assert(#multiResult.lineoffsets == 3, "Should have 3 line offsets for 3-line code") -- lines 0, 1, 2
+	assert(multiResult.lineoffsets[1] == 0, "First line should start at offset 0")
+	assert(multiResult.lineoffsets[2] == 12, "Second line should start after 'local x = 1\\n'")
+	assert(multiResult.lineoffsets[3] == 24, "Third line should start after 'local x = 1\\nlocal y = 2\\n'")
 
 	local emptyLineCode = "local x = 1\n\nlocal y = 2"
 	local emptyResult = luau.parse(emptyLineCode)
 
-	assert(emptyResult.lineOffsets)
-	assert(#emptyResult.lineOffsets == 3, "Should have 3 line offsets including empty line")
-	assert(emptyResult.lineOffsets[1] == 0, "First line should start at offset 0")
-	assert(emptyResult.lineOffsets[2] == 12, "Second line (empty) should start after 'local x = 1\\n'")
-	assert(emptyResult.lineOffsets[3] == 13, "Third line should start after empty line")
+	assert(emptyResult.lineoffsets)
+	assert(#emptyResult.lineoffsets == 3, "Should have 3 line offsets including empty line")
+	assert(emptyResult.lineoffsets[1] == 0, "First line should start at offset 0")
+	assert(emptyResult.lineoffsets[2] == 12, "Second line (empty) should start after 'local x = 1\\n'")
+	assert(emptyResult.lineoffsets[3] == 13, "Third line should start after empty line")
 end
 
 test_tokenContainsLeadingSpaces()


### PR DESCRIPTION
Refactoring to make lute's API formatting more consistent