### PR TITLE
feat: add `process.execpath` to get the current lute executable

### DIFF
--- a/definitions/process.luau
+++ b/definitions/process.luau
@@ -37,4 +37,8 @@ function process.exit(exitcode: number): never
 	error("not implemented")
 end
 
+function process.execpath(): string
+	error("not implemented")
+end
+
 return process

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -18,6 +18,7 @@
 #include "lute/runtime.h"
 #include "lute/tc.h"
 #include "lute/version.h"
+#include "uv.h"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -259,7 +260,7 @@ static std::optional<std::string> getValidPath(std::string filePath)
     return std::nullopt;
 }
 
-int handleRunCommand(int argc, char** argv, int argOffset)
+int handleRunCommand(int argc, char** argv, char* argv0, int argOffset)
 {
     std::string filePath;
     int program_argc = 0;
@@ -296,7 +297,7 @@ int handleRunCommand(int argc, char** argv, int argOffset)
         return 1;
     }
 
-    Runtime runtime;
+    Runtime runtime(argv0);
     lua_State* L = setupCliState(runtime);
 
     std::optional<std::string> validPath = getValidPath(filePath);
@@ -411,9 +412,9 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
     return compileScript(inputFilePath, outputFilePath, argv[0]);
 }
 
-int handleCliCommand(CliCommandResult result, int program_argc, char** program_argv)
+int handleCliCommand(CliCommandResult result, int program_argc, char** program_argv, char* argv0)
 {
-    Runtime runtime;
+    Runtime runtime(argv0);
     lua_State* L = setupCliState(runtime);
 
     std::string bytecode = Luau::compile(std::string(result.contents), copts());
@@ -424,10 +425,12 @@ int cliMain(int argc, char** argv)
 {
     Luau::assertHandler() = assertionHandler;
 
+    argv = uv_setup_args(argc, argv);
+
     AppendedBytecodeResult embedded = checkForAppendedBytecode(argv[0]);
     if (embedded.found)
     {
-        Runtime runtime;
+        Runtime runtime(argv[0]);
         lua_State* GL = setupCliState(runtime);
 
         bool success = runBytecode(runtime, embedded.BytecodeData, "=__EMBEDDED__", GL, argc, argv);
@@ -451,7 +454,7 @@ int cliMain(int argc, char** argv)
 
     if (strcmp(command, "run") == 0)
     {
-        return handleRunCommand(argc, argv, argOffset);
+        return handleRunCommand(argc, argv, argv[0], argOffset);
     }
     else if (strcmp(command, "check") == 0)
     {
@@ -473,12 +476,12 @@ int cliMain(int argc, char** argv)
     }
     else if (std::optional<CliCommandResult> result = getCliCommand(command); result)
     {
-        return handleCliCommand(*result, argc - argOffset, &argv[argOffset]);
+        return handleCliCommand(*result, argc - argOffset, &argv[argOffset], argv[0]);
     }
     else
     {
         // Default to 'run' command
         argOffset = 1;
-        return handleRunCommand(argc, argv, argOffset);
+        return handleRunCommand(argc, argv, argv[0], argOffset);
     }
 }

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -37,24 +37,6 @@
 #include <string>
 #include <vector>
 
-namespace
-{
-
-struct UvLibraryState
-{
-    UvLibraryState(int argc, char**& argv)
-    {
-        argv = uv_setup_args(argc, argv);
-    }
-
-    ~UvLibraryState()
-    {
-        uv_library_shutdown();
-    }
-};
-
-} // namespace
-
 void* createCliRequireContext(lua_State* L)
 {
     void* ctx = lua_newuserdatadtor(
@@ -476,8 +458,6 @@ int handleCliCommand(CliCommandResult result, int program_argc, char** program_a
 int cliMain(int argc, char** argv)
 {
     Luau::assertHandler() = assertionHandler;
-
-    UvLibraryState uvlib(argc, argv);
 
     AppendedBytecodeResult embedded = checkForAppendedBytecode(argv[0]);
     if (embedded.found)

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -28,6 +28,24 @@
 #include <string>
 #include <vector>
 
+namespace
+{
+
+struct UvLibraryState
+{
+    UvLibraryState(int argc, char**& argv)
+    {
+        argv = uv_setup_args(argc, argv);
+    }
+
+    ~UvLibraryState()
+    {
+        uv_library_shutdown();
+    }
+};
+
+} // namespace
+
 void* createCliRequireContext(lua_State* L)
 {
     void* ctx = lua_newuserdatadtor(
@@ -425,7 +443,7 @@ int cliMain(int argc, char** argv)
 {
     Luau::assertHandler() = assertionHandler;
 
-    argv = uv_setup_args(argc, argv);
+    UvLibraryState uvlib(argc, argv);
 
     AppendedBytecodeResult embedded = checkForAppendedBytecode(argv[0]);
     if (embedded.found)

--- a/lute/process/include/lute/process.h
+++ b/lute/process/include/lute/process.h
@@ -18,11 +18,14 @@ int cwd(lua_State* L);
 
 int exitFunc(lua_State* L);
 
+int execpath(lua_State* L);
+
 static const luaL_Reg lib[] = {
     {"run", run},
     {"homedir", homedir},
     {"cwd", cwd},
     {"exit", exitFunc},
+    {"execpath", execpath},
 
     {nullptr, nullptr}
 };

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -474,6 +474,12 @@ int cwd(lua_State* L)
     return 1;
 };
 
+int execpath(lua_State* L)
+{
+    lua_pushstring(L, getRuntime(L)->execPath.c_str());
+    return 1;
+}
+
 static int envIndex(lua_State* L)
 {
     const char* key = luaL_checkstring(L, 2);

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -40,7 +40,7 @@ using RuntimeStep = Luau::Variant<StepSuccess, StepErr, StepEmpty>;
 
 struct Runtime
 {
-    Runtime();
+    Runtime(const char* argv0 = nullptr);
     ~Runtime();
 
     bool runToCompletion();
@@ -80,6 +80,8 @@ struct Runtime
     std::unique_ptr<lua_State, void (*)(lua_State*)> dataCopy;
 
     std::vector<ThreadToContinue> runningThreads;
+
+    std::string execPath;
 
 private:
     std::mutex continuationMutex;

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -25,6 +25,13 @@ static void lua_close_checked(lua_State* L)
 
 static std::string getExecPath(const char* argv0)
 {
+    // FIXME: uv_exepath requires that uv_setup_args(argc, argv) was called.
+    // This function can allocate on some platforms. However, the state is
+    // persisted for the duration of the program and cleaning it up with
+    // uv_library_shutdown will only delete it once. This is a problem in unit
+    // tests that call cliMain multiple times. There, the function would leak
+    // memory. On the three main platforms supported by Lute however, uv doesn't
+    // require uv_setup_args to be called, so it's currently left out.
     char buf[LUTE_PATH_MAX];
     size_t len = sizeof(buf);
     if (uv_exepath(buf, &len) == 0)

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -19,6 +19,13 @@
 
 #include <string>
 #include <assert.h>
+#include <climits> // IWYU pragma: keep
+
+#ifdef PATH_MAX
+#define LUTE_PATH_MAX PATH_MAX
+#else
+#define LUTE_PATH_MAX 8192
+#endif
 
 static void lua_close_checked(lua_State* L)
 {
@@ -26,9 +33,21 @@ static void lua_close_checked(lua_State* L)
         lua_close(L);
 }
 
-Runtime::Runtime()
+static std::string getExecPath(const char* argv0)
+{
+    char buf[LUTE_PATH_MAX];
+    size_t len = sizeof(buf);
+    if (uv_exepath(buf, &len) == 0)
+        return {buf, len};
+    if (argv0)
+        return argv0;
+    return {};
+}
+
+Runtime::Runtime(const char* argv0)
     : globalState(nullptr, lua_close_checked)
     , dataCopy(nullptr, lua_close_checked)
+    , execPath(getExecPath(argv0))
 {
     stop.store(false);
     activeTokens.store(0);

--- a/lute/vm/src/spawn.cpp
+++ b/lute/vm/src/spawn.cpp
@@ -200,7 +200,7 @@ int lua_spawn(lua_State* L)
 {
     const char* file = luaL_checkstring(L, 1);
 
-    auto child = std::make_shared<Runtime>();
+    auto child = std::make_shared<Runtime>(getRuntime(L)->execPath.c_str());
 
     setupState(
         *child,


### PR DESCRIPTION
I was trying to get the code generation to run through CMake (which would run lute in the build). When integrating this into luthier, I needed a way to identify the current lute executable to pass to CMake.

This adds `execpath` to `@lute/process`, which mirrors Node.js' [process.execPath](https://nodejs.org/docs/latest/api/process.html#processexecpath) to get the lute executable path - this is immune to `exec -a foo lute` having `foo` as `argv[0]`.

[`uv_setup_args`](https://docs.libuv.org/en/v1.x/misc.html#c.uv_setup_args) can allocate on some platforms. That memory should be free'd with [`uv_library_shutdown`](https://docs.libuv.org/en/v1.x/misc.html#c.uv_library_shutdown). I'm not sure where it's appropriate to call this.

Passing around the `argv0` also seems a bit wrong. Maybe this path shouldn't be stored in `Runtime`?