### PR TITLE
fix: reserve stack slot for thread

### DIFF
--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -70,7 +70,7 @@ lua_State* setupCliState(Runtime& runtime, std::function<void(lua_State*)> preSa
 
 bool setupArguments(lua_State* L, int argc, char** argv)
 {
-    if (!lua_checkstack(L, argc))
+    if (!lua_checkstack(L, argc + 1))
         return false;
 
     for (int i = 0; i < argc; ++i)


### PR DESCRIPTION
When running a script with `LUA_MINSTACK - 1` (19) or more arguments, Luau fails with `L->top < L->ci->top`, because `getRefForThread` tries to push the current thread onto a full stack [in `runBytecode`](https://github.com/luau-lang/lute/blob/a70354de11446cc95b65f00d853b0c3d0b0faf84/lute/cli/src/climain.cpp#L115). The stack only had `argc` slots, because it was resized in `setupArguments`.

With this PR, `setupArguments` reserves one more slot (an alternative would be to reserve space in `getRefForThread`). `setupArguments` should probably be declared `static` as well, since it's not declared in any header.