### PR TITLE
std/time: hide the internal contents of a duration in the type

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -1,8 +1,9 @@
 {
     "languageMode": "strict",
+    "lint": { "*": true, "LocalShadow": false },
     "aliases": {
         "batteries": "./batteries",
         "std": "./lute/std/libs",
         "lute": "./definitions",
-    }
+    },
 }

--- a/lute/std/libs/time.luau
+++ b/lute/std/libs/time.luau
@@ -17,10 +17,14 @@ local duration = {}
 duration.__index = duration
 
 type durationinterface = typeof(duration)
-export type duration = setmetatable<durationdata, durationinterface>
+
+-- internal interface for durations
+type durationimpl = setmetatable<durationdata, durationinterface>
+-- public interface for durations
+export type duration = setmetatable<{}, durationinterface>
 
 function duration.create(seconds: number, nanoseconds: number): duration
-	local self = {
+	local self: durationdata = {
 		seconds = seconds,
 		nanoseconds = nanoseconds,
 	}
@@ -70,34 +74,44 @@ function duration.weeks(weeks: number): duration
 end
 
 function duration.subsecmillis(self: duration): number
-	return math.floor(self.nanoseconds / NANOS_PER_MILLI)
+    local self = self :: durationimpl
+    return math.floor(self.nanoseconds / NANOS_PER_MILLI)
 end
 
 function duration.subsecmicros(self: duration): number
+    local self = self :: durationimpl
 	return math.floor(self.nanoseconds / NANOS_PER_MICRO)
 end
 
 function duration.subsecnanos(self: duration): number
+    local self = self :: durationimpl
 	return self.nanoseconds
 end
 
 function duration.toseconds(self: duration): number
+    local self = self :: durationimpl
 	return self.seconds + self.nanoseconds / NANOS_PER_SEC
 end
 
 function duration.tomilliseconds(self: duration): number
+    local self = self :: durationimpl
 	return self.seconds * MILLIS_PER_SEC + self:subsecmillis()
 end
 
 function duration.tomicroseconds(self: duration): number
+    local self = self :: durationimpl
 	return self.seconds * MICROS_PER_SEC + self:subsecmicros()
 end
 
 function duration.tonanoseconds(self: duration): number
+    local self = self :: durationimpl
 	return self.seconds * NANOS_PER_SEC + self:subsecnanos()
 end
 
 function duration.__add(a: duration, b: duration): duration
+    local a = a :: durationimpl
+    local b = b :: durationimpl
+
 	local seconds = a.seconds + b.seconds
 	local nanoseconds = a.nanoseconds + b.nanoseconds
 
@@ -110,6 +124,9 @@ function duration.__add(a: duration, b: duration): duration
 end
 
 function duration.__sub(a: duration, b: duration): duration
+    local a = a :: durationimpl
+    local b = b :: durationimpl
+
 	local seconds = a.seconds - b.seconds
 	local nanoseconds = a.nanoseconds - b.nanoseconds
 
@@ -122,6 +139,8 @@ function duration.__sub(a: duration, b: duration): duration
 end
 
 function duration.__mul(a: duration, b: number): duration
+    local a = a :: durationimpl
+
 	local seconds = a.seconds * b
 	local nanoseconds = a.nanoseconds * b
 
@@ -132,7 +151,9 @@ function duration.__mul(a: duration, b: number): duration
 end
 
 function duration.__div(a: duration, b: number): duration
-	local seconds, extraSeconds = a.seconds / b, a.seconds % b
+    local a = a :: durationimpl
+
+    local seconds, extraSeconds = a.seconds / b, a.seconds % b
 	local nanoseconds, extraNanos = a.nanoseconds / b, a.nanoseconds % b
 
 	nanoseconds += (extraSeconds * NANOS_PER_SEC + extraNanos) / b
@@ -141,11 +162,17 @@ function duration.__div(a: duration, b: number): duration
 end
 
 function duration.__eq(a: duration, b: duration): boolean
-	return a.seconds == b.seconds and a.nanoseconds == b.nanoseconds
+    local a = a :: durationimpl
+    local b = b :: durationimpl
+
+    return a.seconds == b.seconds and a.nanoseconds == b.nanoseconds
 end
 
 function duration.__lt(a: duration, b: duration): boolean
-	if a.seconds == b.seconds then
+    local a = a :: durationimpl
+    local b = b :: durationimpl
+
+    if a.seconds == b.seconds then
 		return a.nanoseconds < b.nanoseconds
 	end
 
@@ -153,6 +180,9 @@ function duration.__lt(a: duration, b: duration): boolean
 end
 
 function duration.__le(a: duration, b: duration): boolean
+    local a = a :: durationimpl
+    local b = b :: durationimpl
+
 	if a.seconds == b.seconds then
 		return a.nanoseconds <= b.nanoseconds
 	end
@@ -161,7 +191,8 @@ function duration.__le(a: duration, b: duration): boolean
 end
 
 function duration.__tostring(self: duration): string
-	return string.format("%d.%09d", self.seconds, self.nanoseconds)
+    local self = self :: durationimpl
+    return string.format("%d.%09d", self.seconds, self.nanoseconds)
 end
 
 return table.freeze({

--- a/lute/std/libs/time.luau
+++ b/lute/std/libs/time.luau
@@ -74,43 +74,43 @@ function duration.weeks(weeks: number): duration
 end
 
 function duration.subsecmillis(self: duration): number
-    local self = self :: durationimpl
-    return math.floor(self.nanoseconds / NANOS_PER_MILLI)
+	local self = self :: durationimpl
+	return math.floor(self.nanoseconds / NANOS_PER_MILLI)
 end
 
 function duration.subsecmicros(self: duration): number
-    local self = self :: durationimpl
+	local self = self :: durationimpl
 	return math.floor(self.nanoseconds / NANOS_PER_MICRO)
 end
 
 function duration.subsecnanos(self: duration): number
-    local self = self :: durationimpl
+	local self = self :: durationimpl
 	return self.nanoseconds
 end
 
 function duration.toseconds(self: duration): number
-    local self = self :: durationimpl
+	local self = self :: durationimpl
 	return self.seconds + self.nanoseconds / NANOS_PER_SEC
 end
 
 function duration.tomilliseconds(self: duration): number
-    local self = self :: durationimpl
+	local self = self :: durationimpl
 	return self.seconds * MILLIS_PER_SEC + self:subsecmillis()
 end
 
 function duration.tomicroseconds(self: duration): number
-    local self = self :: durationimpl
+	local self = self :: durationimpl
 	return self.seconds * MICROS_PER_SEC + self:subsecmicros()
 end
 
 function duration.tonanoseconds(self: duration): number
-    local self = self :: durationimpl
+	local self = self :: durationimpl
 	return self.seconds * NANOS_PER_SEC + self:subsecnanos()
 end
 
 function duration.__add(a: duration, b: duration): duration
-    local a = a :: durationimpl
-    local b = b :: durationimpl
+	local a = a :: durationimpl
+	local b = b :: durationimpl
 
 	local seconds = a.seconds + b.seconds
 	local nanoseconds = a.nanoseconds + b.nanoseconds
@@ -124,8 +124,8 @@ function duration.__add(a: duration, b: duration): duration
 end
 
 function duration.__sub(a: duration, b: duration): duration
-    local a = a :: durationimpl
-    local b = b :: durationimpl
+	local a = a :: durationimpl
+	local b = b :: durationimpl
 
 	local seconds = a.seconds - b.seconds
 	local nanoseconds = a.nanoseconds - b.nanoseconds
@@ -139,7 +139,7 @@ function duration.__sub(a: duration, b: duration): duration
 end
 
 function duration.__mul(a: duration, b: number): duration
-    local a = a :: durationimpl
+	local a = a :: durationimpl
 
 	local seconds = a.seconds * b
 	local nanoseconds = a.nanoseconds * b
@@ -151,9 +151,9 @@ function duration.__mul(a: duration, b: number): duration
 end
 
 function duration.__div(a: duration, b: number): duration
-    local a = a :: durationimpl
+	local a = a :: durationimpl
 
-    local seconds, extraSeconds = a.seconds / b, a.seconds % b
+	local seconds, extraSeconds = a.seconds / b, a.seconds % b
 	local nanoseconds, extraNanos = a.nanoseconds / b, a.nanoseconds % b
 
 	nanoseconds += (extraSeconds * NANOS_PER_SEC + extraNanos) / b
@@ -162,17 +162,17 @@ function duration.__div(a: duration, b: number): duration
 end
 
 function duration.__eq(a: duration, b: duration): boolean
-    local a = a :: durationimpl
-    local b = b :: durationimpl
+	local a = a :: durationimpl
+	local b = b :: durationimpl
 
-    return a.seconds == b.seconds and a.nanoseconds == b.nanoseconds
+	return a.seconds == b.seconds and a.nanoseconds == b.nanoseconds
 end
 
 function duration.__lt(a: duration, b: duration): boolean
-    local a = a :: durationimpl
-    local b = b :: durationimpl
+	local a = a :: durationimpl
+	local b = b :: durationimpl
 
-    if a.seconds == b.seconds then
+	if a.seconds == b.seconds then
 		return a.nanoseconds < b.nanoseconds
 	end
 
@@ -180,8 +180,8 @@ function duration.__lt(a: duration, b: duration): boolean
 end
 
 function duration.__le(a: duration, b: duration): boolean
-    local a = a :: durationimpl
-    local b = b :: durationimpl
+	local a = a :: durationimpl
+	local b = b :: durationimpl
 
 	if a.seconds == b.seconds then
 		return a.nanoseconds <= b.nanoseconds
@@ -191,8 +191,8 @@ function duration.__le(a: duration, b: duration): boolean
 end
 
 function duration.__tostring(self: duration): string
-    local self = self :: durationimpl
-    return string.format("%d.%09d", self.seconds, self.nanoseconds)
+	local self = self :: durationimpl
+	return string.format("%d.%09d", self.seconds, self.nanoseconds)
 end
 
 return table.freeze({


### PR DESCRIPTION
This tweaks the implementation of `std/time` to hide the actual data inside a duration from external uses. This PR implements the information hiding just by using types here, so the internal view of all the functions casts to an internal type that lets it access the data, but the external API only presents the view where that data is hidden. We could instead use closures for information hiding here, and likely deciding one or the other as a systemic approach to data hiding is the right call for Lute. This PR at least gives us one way to look at how we approach information hiding.