### PR TITLE
std: adopt underscore prefixes for internal data in std/time

### DIFF
--- a/lute/std/libs/time.luau
+++ b/lute/std/libs/time.luau
@@ -9,8 +9,8 @@ local HOURS_PER_DAY = 24
 local DAYS_PER_WEEK = 7
 
 type durationdata = {
-	seconds: number,
-	nanoseconds: number,
+	_seconds: number,
+	_nanoseconds: number,
 }
 
 local duration = {}
@@ -21,8 +21,8 @@ export type duration = setmetatable<durationdata, durationinterface>
 
 function duration.create(seconds: number, nanoseconds: number): duration
 	local self = {
-		seconds = seconds,
-		nanoseconds = nanoseconds,
+		_seconds = seconds,
+		_nanoseconds = nanoseconds,
 	}
 
 	return setmetatable(self, duration)
@@ -70,36 +70,36 @@ function duration.weeks(weeks: number): duration
 end
 
 function duration.subsecmillis(self: duration): number
-	return math.floor(self.nanoseconds / NANOS_PER_MILLI)
+	return math.floor(self._nanoseconds / NANOS_PER_MILLI)
 end
 
 function duration.subsecmicros(self: duration): number
-	return math.floor(self.nanoseconds / NANOS_PER_MICRO)
+	return math.floor(self._nanoseconds / NANOS_PER_MICRO)
 end
 
 function duration.subsecnanos(self: duration): number
-	return self.nanoseconds
+	return self._nanoseconds
 end
 
 function duration.toseconds(self: duration): number
-	return self.seconds + self.nanoseconds / NANOS_PER_SEC
+	return self._seconds + self._nanoseconds / NANOS_PER_SEC
 end
 
 function duration.tomilliseconds(self: duration): number
-	return self.seconds * MILLIS_PER_SEC + self:subsecmillis()
+	return self._seconds * MILLIS_PER_SEC + self:subsecmillis()
 end
 
 function duration.tomicroseconds(self: duration): number
-	return self.seconds * MICROS_PER_SEC + self:subsecmicros()
+	return self._seconds * MICROS_PER_SEC + self:subsecmicros()
 end
 
 function duration.tonanoseconds(self: duration): number
-	return self.seconds * NANOS_PER_SEC + self:subsecnanos()
+	return self._seconds * NANOS_PER_SEC + self:subsecnanos()
 end
 
 function duration.__add(a: duration, b: duration): duration
-	local seconds = a.seconds + b.seconds
-	local nanoseconds = a.nanoseconds + b.nanoseconds
+	local seconds = a._seconds + b._seconds
+	local nanoseconds = a._nanoseconds + b._nanoseconds
 
 	if nanoseconds >= NANOS_PER_SEC then
 		seconds += 1
@@ -110,8 +110,8 @@ function duration.__add(a: duration, b: duration): duration
 end
 
 function duration.__sub(a: duration, b: duration): duration
-	local seconds = a.seconds - b.seconds
-	local nanoseconds = a.nanoseconds - b.nanoseconds
+	local seconds = a._seconds - b._seconds
+	local nanoseconds = a._nanoseconds - b._nanoseconds
 
 	if nanoseconds < 0 then
 		seconds -= 1
@@ -122,8 +122,8 @@ function duration.__sub(a: duration, b: duration): duration
 end
 
 function duration.__mul(a: duration, b: number): duration
-	local seconds = a.seconds * b
-	local nanoseconds = a.nanoseconds * b
+	local seconds = a._seconds * b
+	local nanoseconds = a._nanoseconds * b
 
 	seconds += math.floor(nanoseconds / NANOS_PER_SEC)
 	nanoseconds %= NANOS_PER_SEC
@@ -132,8 +132,8 @@ function duration.__mul(a: duration, b: number): duration
 end
 
 function duration.__div(a: duration, b: number): duration
-	local seconds, extraSeconds = a.seconds / b, a.seconds % b
-	local nanoseconds, extraNanos = a.nanoseconds / b, a.nanoseconds % b
+	local seconds, extraSeconds = a._seconds / b, a._seconds % b
+	local nanoseconds, extraNanos = a._nanoseconds / b, a._nanoseconds % b
 
 	nanoseconds += (extraSeconds * NANOS_PER_SEC + extraNanos) / b
 
@@ -141,27 +141,27 @@ function duration.__div(a: duration, b: number): duration
 end
 
 function duration.__eq(a: duration, b: duration): boolean
-	return a.seconds == b.seconds and a.nanoseconds == b.nanoseconds
+	return a._seconds == b._seconds and a._nanoseconds == b._nanoseconds
 end
 
 function duration.__lt(a: duration, b: duration): boolean
-	if a.seconds == b.seconds then
-		return a.nanoseconds < b.nanoseconds
+	if a._seconds == b._seconds then
+		return a._nanoseconds < b._nanoseconds
 	end
 
-	return a.seconds < b.seconds
+	return a._seconds < b._seconds
 end
 
 function duration.__le(a: duration, b: duration): boolean
-	if a.seconds == b.seconds then
-		return a.nanoseconds <= b.nanoseconds
+	if a._seconds == b._seconds then
+		return a._nanoseconds <= b._nanoseconds
 	end
 
-	return a.seconds <= b.seconds
+	return a._seconds <= b._seconds
 end
 
 function duration.__tostring(self: duration): string
-	return string.format("%d.%09d", self.seconds, self.nanoseconds)
+	return string.format("%d.%09d", self._seconds, self._nanoseconds)
 end
 
 return table.freeze({


### PR DESCRIPTION
This PR takes a different approach to #434 by saying "yes, the data will be visible, and we'll communicate intent for it to generally be undisturbed with an underscore prefix." This is generally accepted as the idiom for information hiding in Luau today, and I don't feel like this is worth making a point of difference.