### PR TITLE
Reserve stack space for creating thread refs in `getRefForThread` itself

### DIFF
--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -68,9 +68,9 @@ lua_State* setupCliState(Runtime& runtime, std::function<void(lua_State*)> preSa
     );
 }
 
-bool setupArguments(lua_State* L, int argc, char** argv)
+static bool setupArguments(lua_State* L, int argc, char** argv)
 {
-    if (!lua_checkstack(L, argc + 1))
+    if (!lua_checkstack(L, argc))
         return false;
 
     for (int i = 0; i < argc; ++i)

--- a/lute/runtime/src/ref.cpp
+++ b/lute/runtime/src/ref.cpp
@@ -23,7 +23,7 @@ void Ref::push(lua_State* L) const
 
 std::shared_ptr<Ref> getRefForThread(lua_State* L)
 {
-    lua_checkstack(L, 1);
+    lua_rawcheckstack(L, 1);
     lua_pushthread(L);
     std::shared_ptr<Ref> ref = std::make_shared<Ref>(L, -1);
     lua_pop(L, 1);

--- a/lute/runtime/src/ref.cpp
+++ b/lute/runtime/src/ref.cpp
@@ -23,6 +23,7 @@ void Ref::push(lua_State* L) const
 
 std::shared_ptr<Ref> getRefForThread(lua_State* L)
 {
+    lua_checkstack(L, 1);
     lua_pushthread(L);
     std::shared_ptr<Ref> ref = std::make_shared<Ref>(L, -1);
     lua_pop(L, 1);


### PR DESCRIPTION
Follow-up to #432. This was an alternative listed on that PR and is a better solution since `getRefForThread` is also called from other places in the codebase.