### PR TITLE
Break bidirectional dependencies between Lute.Runtime and every runtime library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,14 @@ project(
     LANGUAGES CXX C
 )
 
+option(LUTE_ENABLE_ASAN "Enable AddressSanitizer" OFF)
+if (LUTE_ENABLE_ASAN)
+    if(NOT MSVC)
+        add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+        add_link_options(-fsanitize=address)
+    endif()
+endif()
+
 # luau setup
 set(LUAU_BUILD_CLI OFF)
 set(LUAU_BUILD_TESTS OFF)
@@ -112,14 +120,6 @@ else()
     list(APPEND LUTE_OPTIONS -Wimplicit-fallthrough)
     list(APPEND LUTE_OPTIONS -Wsign-compare) # This looks to be included in -Wall for GCC but not clang
     list(APPEND LUTE_OPTIONS -Werror) # Warnings are errors
-endif()
-
-option(LUTE_ENABLE_ASAN "Enable AddressSanitizer" OFF)
-if (LUTE_ENABLE_ASAN)
-    if(NOT MSVC)
-        add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
-        add_link_options(-fsanitize=address)
-    endif()
 endif()
 
 # libraries

--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -34,7 +34,7 @@ target_sources(Lute.CLI.lib PRIVATE
 
 target_compile_features(Lute.CLI.lib PUBLIC cxx_std_17)
 target_include_directories(Lute.CLI.lib PUBLIC include ${CLI_GENERATED_INCLUDE_DIR})
-target_link_libraries(Lute.CLI.lib PRIVATE Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Require Lute.Runtime Luau.CLI.lib)
+target_link_libraries(Lute.CLI.lib PRIVATE Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Crypto Lute.Fs Lute.Luau Lute.Net Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Require Lute.Runtime Luau.CLI.lib)
 target_compile_options(Lute.CLI.lib PRIVATE ${LUTE_OPTIONS})
 
 add_executable(Lute.CLI)

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -12,12 +12,21 @@
 #include "lute/clicommands.h"
 #include "lute/clivfs.h"
 #include "lute/compile.h"
+#include "lute/crypto.h"
+#include "lute/fs.h"
+#include "lute/luau.h"
+#include "lute/net.h"
 #include "lute/options.h"
+#include "lute/process.h"
 #include "lute/ref.h"
 #include "lute/require.h"
 #include "lute/runtime.h"
+#include "lute/system.h"
+#include "lute/task.h"
 #include "lute/tc.h"
+#include "lute/time.h"
 #include "lute/version.h"
+#include "lute/vm.h"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -52,12 +61,37 @@ void* createCliRequireContext(lua_State* L)
     return ctx;
 }
 
+static void luteopen_libs(lua_State* L)
+{
+    std::vector<std::pair<const char*, lua_CFunction>> libs = {{
+        {"@lute/crypto", luteopen_crypto},
+        {"@lute/fs", luteopen_fs},
+        {"@lute/luau", luteopen_luau},
+        {"@lute/net", luteopen_net},
+        {"@lute/process", luteopen_process},
+        {"@lute/task", luteopen_task},
+        {"@lute/vm", luteopen_vm},
+        {"@lute/system", luteopen_system},
+        {"@lute/time", luteopen_time},
+    }};
+
+    for (const auto& [name, func] : libs)
+    {
+        lua_pushcfunction(L, luarequire_registermodule, nullptr);
+        lua_pushstring(L, name);
+        func(L);
+        lua_call(L, 2, 0);
+    }
+}
+
 lua_State* setupCliState(Runtime& runtime, std::function<void(lua_State*)> preSandboxInit)
 {
     return setupState(
         runtime,
         [preSandboxInit = std::move(preSandboxInit)](lua_State* L)
         {
+            luteopen_libs(L);
+
             if (Luau::CodeGen::isSupported())
                 Luau::CodeGen::create(L);
 

--- a/lute/runtime/CMakeLists.txt
+++ b/lute/runtime/CMakeLists.txt
@@ -11,5 +11,5 @@ target_sources(Lute.Runtime PRIVATE
 
 target_compile_features(Lute.Runtime PUBLIC cxx_std_17)
 target_include_directories(Lute.Runtime PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Runtime PRIVATE Lute.Crypto Lute.Fs Lute.Luau Lute.Net Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Luau.Common Luau.Require Luau.VM uv_a)
+target_link_libraries(Lute.Runtime PRIVATE Luau.Common Luau.Require Luau.VM uv_a)
 target_compile_options(Lute.Runtime PRIVATE ${LUTE_OPTIONS})

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -1,15 +1,5 @@
 #include "lute/runtime.h"
 
-#include "lute/crypto.h"
-#include "lute/fs.h"
-#include "lute/luau.h"
-#include "lute/net.h"
-#include "lute/process.h"
-#include "lute/system.h"
-#include "lute/task.h"
-#include "lute/vm.h"
-#include "lute/time.h"
-
 #include "Luau/Require.h"
 
 #include "lua.h"
@@ -311,29 +301,6 @@ ResumeToken getResumeToken(lua_State* L)
     return token;
 }
 
-static void luteopen_libs(lua_State* L)
-{
-    std::vector<std::pair<const char*, lua_CFunction>> libs = {{
-        {"@lute/crypto", luteopen_crypto},
-        {"@lute/fs", luteopen_fs},
-        {"@lute/luau", luteopen_luau},
-        {"@lute/net", luteopen_net},
-        {"@lute/process", luteopen_process},
-        {"@lute/task", luteopen_task},
-        {"@lute/vm", luteopen_vm},
-        {"@lute/system", luteopen_system},
-        {"@lute/time", luteopen_time},
-    }};
-
-    for (const auto& [name, func] : libs)
-    {
-        lua_pushcfunction(L, luarequire_registermodule, nullptr);
-        lua_pushstring(L, name);
-        func(L);
-        lua_call(L, 2, 0);
-    }
-}
-
 lua_State* setupState(Runtime& runtime, std::function<void(lua_State*)> doBeforeSandbox)
 {
     // Separate VM for data copies
@@ -349,8 +316,6 @@ lua_State* setupState(Runtime& runtime, std::function<void(lua_State*)> doBefore
 
     // register the builtin tables
     luaL_openlibs(L);
-
-    luteopen_libs(L);
 
     lua_pushnil(L);
     lua_setglobal(L, "setfenv");


### PR DESCRIPTION
### Problem

`Lute.Runtime` is our lowest-level library, and each of our runtime libraries like `Lute.Crypto`, `Lute.Fs`, etc. correctly links against it. However, `Lute.Runtime` also currently links against each of these auxiliary libraries simply to register them. This means that `Lute.Runtime` cannot currently be built without also building each of the auxiliary libraries.

### Solution

This solution is modeled after the Luau CLI's design, where a given instance of a Luau VM can have new globals like `require` injected in, but the registration doesn't occur in `Luau.VM` itself. Instead, it happens in `Luau.Repl.CLI`. Similarly, we inject in these `@lute/*` registrations in `Lute.CLI.lib` instead of in the runtime code itself.

This also makes it easier to reason about the runtime as we work to move to an "entirely managed by libuv" model.