### PR TITLE
Add ``errors`` assertion

### DIFF
--- a/examples/testing.luau
+++ b/examples/testing.luau
@@ -57,10 +57,11 @@ test.suite("MySuite", function(suite)
 				error("error")
 			end
 		end
-		assert.throwserror(function() -- demonstrates success (callback throws err)
+
+		assert.errors(function() -- demonstrates success (callback throws err)
 			foo(true)
 		end)
-		assert.throwserror(function() -- demonstrates failure (callback doesn't throw)
+		assert.errors(function() -- demonstrates failure (callback doesn't throw)
 			foo(false)
 		end)
 	end)

--- a/examples/testing.luau
+++ b/examples/testing.luau
@@ -53,7 +53,9 @@ test.suite("MySuite", function(suite)
 
 	suite:case("expect_error", function(assert)
 		local function foo(v: boolean)
-			if v then error("error") end
+			if v then
+				error("error")
+			end
 		end
 		assert.throwserror(function() -- demonstrates success (callback throws err)
 			foo(true)

--- a/examples/testing.luau
+++ b/examples/testing.luau
@@ -50,6 +50,18 @@ test.suite("MySuite", function(suite)
 		assert.tableeq(table1, table2)
 		assert.tableeq(table1, { a = 1 })
 	end)
+
+	suite:case("expect_error", function(assert)
+		local function foo(v: boolean)
+			if v then error("error") end
+		end
+		assert.throwserror(function() -- demonstrates success (callback throws err)
+			foo(true)
+		end)
+		assert.throwserror(function() -- demonstrates failure (callback doesn't throw)
+			foo(false)
+		end)
+	end)
 end)
 
 test.run()

--- a/lute/std/libs/assert.luau
+++ b/lute/std/libs/assert.luau
@@ -12,6 +12,13 @@ function assertions.neq<T>(lhs: T, rhs: T)
 	end
 end
 
+function assertions.throwserror(callback: () -> ())
+	local success = pcall(callback) -- callback shudn't return anything, but type solver wouldn't shut up
+	if success then
+		error({ msg = `{callback} did not throw error.`})
+	end
+end
+
 -- Helper to format values for error messages
 local function formatValue(val: any): string
 	if type(val) == "nil" then

--- a/lute/std/libs/assert.luau
+++ b/lute/std/libs/assert.luau
@@ -12,7 +12,7 @@ function assertions.neq<T>(lhs: T, rhs: T)
 	end
 end
 
-function assertions.throwserror(callback: () -> ())
+function assertions.errors(callback: () -> ())
 	local success = pcall(callback)
 	if success then
 		error({ msg = `{callback} did not throw error.` })

--- a/lute/std/libs/assert.luau
+++ b/lute/std/libs/assert.luau
@@ -15,7 +15,7 @@ end
 function assertions.throwserror(callback: () -> ())
 	local success = pcall(callback) -- callback shudn't return anything, but type solver wouldn't shut up
 	if success then
-		error({ msg = `{callback} did not throw error.`})
+		error({ msg = `{callback} did not throw error.` })
 	end
 end
 

--- a/lute/std/libs/assert.luau
+++ b/lute/std/libs/assert.luau
@@ -13,7 +13,7 @@ function assertions.neq<T>(lhs: T, rhs: T)
 end
 
 function assertions.throwserror(callback: () -> ())
-	local success = pcall(callback) -- callback shudn't return anything, but type solver wouldn't shut up
+	local success = pcall(callback)
 	if success then
 		error({ msg = `{callback} did not throw error.` })
 	end


### PR DESCRIPTION
This is a super common assertion and something I wanted to use in a project  I was working on so figure'd I would add it.

Not sure what the larger vision is for testing API, but hopefully this fits somewhere.

Can also add an optional `expectedError` param