### PR TITLE
Fix 4 extra spaces on first level on json pretty serialize

### DIFF
--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -47,7 +47,7 @@ local function writeSpaces(state: SerializerState)
 	if state.prettyPrint then
 		checkState(state, state.depth * 4)
 
-		for i = 0, state.depth do
+		for i = 1, state.depth do
 			buffer.writeu32(state.buf, state.cursor, 0x_20_20_20_20)
 			state.cursor += 4
 		end


### PR DESCRIPTION
tin
fixes this typo, 8 spaces on first level then 4 for each after seems unintentional