### PR TITLE
Refactor `lute setup` to write to luaurc, add std type defs

### DIFF
--- a/.luaurc
+++ b/.luaurc
@@ -3,6 +3,6 @@
     "aliases": {
         "batteries": "./batteries",
         "std": "./lute/std/libs",
-        "lute": "./definitions",
+        "lute": "./definitions"
     }
 }

--- a/lute/cli/commands/setup/init.luau
+++ b/lute/cli/commands/setup/init.luau
@@ -1,12 +1,31 @@
 local definitions = require("@self/generated/definitions")
 local fs = require("@lute/fs")
 local process = require("@lute/process")
+local json = require("@std/json")
 
-local homedir = process.homedir()
+local BASE_PATH = ".lute/typedefs/0.1.0"
+local BASE_PATH_PRETTY = `~/{BASE_PATH}`
+local TEMPLATE_RC_FILE = {
+	aliases = {
+		lute = `{BASE_PATH_PRETTY}/lute`,
+		std = `{BASE_PATH_PRETTY}/std`,
+	},
+}
 
-function mkdirdashp(home: string, subpath: string)
+local homeDir = process.homedir()
+local cwd = process.cwd()
+local args = { ... }
+
+function mkdirdashp(home: string, subpath: string, noIncludeLast: boolean?)
 	local subdir = home
-	for _, part in string.split(subpath, "/") do
+	local parts = string.split(subpath, "/")
+	local numParts = #parts
+
+	for idx, part in parts do
+		if noIncludeLast and (idx == numParts) then
+			break
+		end
+
 		subdir = subdir .. "/" .. part
 		if not fs.exists(subdir) then
 			fs.mkdir(subdir)
@@ -15,11 +34,36 @@ function mkdirdashp(home: string, subpath: string)
 end
 
 -- TODO we're assuming the files are completely unmodified, but we really shouldn't do that.
-print("Found existing /.lute/ directory! Overwriting type definitions.")
-mkdirdashp(homedir, ".lute/typedefs/0.1.0")
+print(`Writing definitions at {BASE_PATH_PRETTY}`)
+mkdirdashp(homeDir, BASE_PATH)
 
 for key, value in definitions :: { [string]: string } do
-	fs.writestringtofile(homedir .. "/.lute/typedefs/0.1.0/" .. key, value)
+	local filePath = `{BASE_PATH}/{key}`
+	mkdirdashp(homeDir, filePath, true)
+	fs.writestringtofile(`{homeDir}/{filePath}`, value)
 end
 
-print("Successfully wrote type definition files to `~/.lute/typedefs/0.1.0/`")
+print(`Successfully wrote type definition files to {BASE_PATH_PRETTY}`)
+
+if not table.find(args, "--with-luaurc") then
+	return
+end
+
+local luauRcPath = `{cwd}/.luaurc`
+local rcFile = nil
+print(`Writing luaurc file at {luauRcPath}`)
+
+if fs.exists(luauRcPath) then
+	local contents = fs.readfiletostring(luauRcPath)
+	rcFile = json.deserialize(contents) :: any
+
+	rcFile.aliases = rcFile.aliases or {}
+	for key, value in TEMPLATE_RC_FILE.aliases :: { [string]: string } do
+		rcFile.aliases[key] = value
+	end
+else
+	rcFile = TEMPLATE_RC_FILE
+end
+fs.writestringtofile(luauRcPath, json.serialize(rcFile, true))
+
+print(`Successfully wrote luaurc file to {luauRcPath}`)

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -200,6 +200,7 @@ static void displayHelp(const char* argv0)
     printf("Setup Options:\n");
     printf("  lute setup");
     printf("    Generates type definition files for the language server.\n");
+    printf("      --with-luaurc Adds/overwrites aliases to the type definition files to the luaurc in the working directory.\n");
     printf("\n");
     printf("General Options:\n");
     printf("  -h, --help    Display this usage message.\n");

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -200,7 +200,7 @@ static void displayHelp(const char* argv0)
     printf("Setup Options:\n");
     printf("  lute setup");
     printf("    Generates type definition files for the language server.\n");
-    printf("      --with-luaurc Adds/overwrites aliases to the type definition files to the luaurc in the working directory.\n");
+    printf("      --with-luaurc Defines aliases to the type definition files in the working directory's luaurc file.\n");
     printf("\n");
     printf("General Options:\n");
     printf("  -h, --help    Display this usage message.\n");

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -300,7 +300,9 @@ local function generateStdLibFilesIfNeeded()
 				local lines = string.split(libSrc, "\n")
 				local generatedLines = table.create(#lines)
 				for _, line in lines do
-					table.insert(generatedLines, `"{string.gsub(line, '"', '\\"')}\\n"`)
+					local escapedLine = string.gsub(line, "\\", "\\\\")
+					escapedLine = string.gsub(escapedLine, '"', '\\"')
+					table.insert(generatedLines, `"{escapedLine}\\n"`)
 				end
 				fs.write(cpp, `\n    \{"{aliasedPath}", {table.concat(generatedLines, "\n")}},\n`)
 			else
@@ -337,15 +339,21 @@ end
 
 local function getTypeDefinitionsHash(): string
 	local libsPath = projectRelative("definitions")
+	local stdPath = projectRelative("lute", "std", "libs")
 
 	local toHash = ""
 
-	traverseFileTree(libsPath, function(path, relativePath)
-		if safeFsType(path) == "file" then
-			toHash ..= "./" .. relativePath
-			toHash ..= fs.readfiletostring(path)
-		end
-	end)
+	local function traverseDefs(path: string, namespace: string)
+		traverseFileTree(path, function(path, relativePath)
+			if safeFsType(path) == "file" then
+				toHash ..= `./{namespace}/{relativePath}`
+				toHash ..= fs.readfiletostring(path)
+			end
+		end)
+	end
+
+	traverseDefs(libsPath, "lute")
+	traverseDefs(stdPath, "std")
 
 	local digest = crypto.digest(crypto.hash.blake2b256, toHash)
 	return hexify(digest)
@@ -373,17 +381,21 @@ local function generateTypeDefinitionFiles()
 
 	print("Type definitions out of date, creating new ones.")
 
+	local libsPath = projectRelative("definitions")
+	local stdPath = projectRelative("lute", "std", "libs")
 	local dictionaryEntries: { [string]: string } = {}
 
-	for _, file in fs.listdir("definitions") do
-		if file.type ~= "file" then
-			continue
-		end
-
-		local content = fs.readasync(`definitions/{file.name}`)
-
-		dictionaryEntries[file.name] = content
+	local function traverseDefs(path: string, namespace: string)
+		traverseFileTree(path, function(path, relativePath)
+			if safeFsType(path) == "file" then
+				local content = fs.readasync(path)
+				dictionaryEntries[`{namespace}/{relativePath}`] = content
+			end
+		end)
 	end
+
+	traverseDefs(libsPath, "lute")
+	traverseDefs(stdPath, "std")
 
 	local stringDictionary = ""
 
@@ -396,7 +408,7 @@ local function generateTypeDefinitionFiles()
 	fs.close(hash)
 
 	fs.writestringtofile(
-		"lute/cli/commands/setup/generated/definitions.luau",
+		projectRelative("lute", "cli", "commands", "setup", "generated", "definitions.luau"),
 		string.format(TYPEDEF_PATTERN, stringDictionary)
 	)
 end
@@ -469,7 +481,9 @@ local function generateCliCommandsFilesIfNeeded()
 				local lines = string.split(libSrc, "\n")
 				local generatedLines = table.create(#lines)
 				for _, line in lines do
-					table.insert(generatedLines, `"{string.gsub(line, '"', '\\"')}\\n"`)
+					local escapedLine = string.gsub(line, "\\", "\\\\")
+					escapedLine = string.gsub(escapedLine, '"', '\\"')
+					table.insert(generatedLines, `"{escapedLine}\\n"`)
 				end
 				fs.write(cpp, `\n    \{"{aliasedPath}", {table.concat(generatedLines, "\n")}},\n`)
 			else
@@ -506,8 +520,8 @@ end
 
 local function generateFilesIfNeeded()
 	generateStdLibFilesIfNeeded()
-	generateCliCommandsFilesIfNeeded()
 	generateTypeDefinitionFiles()
+	generateCliCommandsFilesIfNeeded()
 end
 
 local function getExePath(): string


### PR DESCRIPTION
Refactors the `lute setup` command to:
1. Put the regular lute typedefs into a `lute` subdirectory, and add a `std` subdirectory with the standard library files inside
2. Accept a flag to create a new luaurc, or overwrite the aliases of one if it exists, to add the type definition folders. Unfortunate caveat is that the std lib json encoder is not deterministic, so each time it moves the json keys around - this is pretty annoying and creates a lot of diff noise. Not sure if there's much to be done about this

Luthier:
1. Fix a backslash escaping bug for std lib and command C++ file gen that cropped up when I added this
2. Change definition generation to use above structure
3. Use projectRelative more
4. Change order of `generateFilesIfNeeded` calls to fix a bug - CLI commands rely on the generated type def output, so they should be generated after type defs

Also fix the trailing comma in the project luaurc which is typically not valid json

Closes #424