### PR TITLE
Fix AstStatForIn type definition

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -134,24 +134,21 @@ export type AstExprAnonymousFunction = {
 	body: AstFunctionBody,
 }
 
-export type AstExprTableItem =
-	| { kind: "list", value: AstExpr, separator: Token<"," | ";">? }
-	| {
-		kind: "record",
-		key: Token<string>,
-		equals: Token<"=">,
-		value: AstExpr,
-		separator: Token<"," | ";">?,
-	}
-	| {
-		kind: "general",
-		indexeropen: Token<"[">,
-		key: AstExpr,
-		indexerclose: Token<"]">,
-		equals: Token<"=">,
-		value: AstExpr,
-		separator: Token<"," | ";">?,
-	}
+export type AstExprTableItem = | { kind: "list", value: AstExpr, separator: Token<"," | ";">? } | {
+	kind: "record",
+	key: Token<string>,
+	equals: Token<"=">,
+	value: AstExpr,
+	separator: Token<"," | ";">?,
+} | {
+	kind: "general",
+	indexeropen: Token<"[">,
+	key: AstExpr,
+	indexerclose: Token<"]">,
+	equals: Token<"=">,
+	value: AstExpr,
+	separator: Token<"," | ";">?,
+}
 
 export type AstExprTable = {
 	tag: "table",
@@ -306,7 +303,7 @@ export type AstStatFor = {
 export type AstStatForIn = {
 	tag: "forin",
 	forkeyword: Token<"for">,
-	variables: Punctuated<Token<string>>,
+	variables: Punctuated<AstLocal>,
 	inkeyword: Token<"in">,
 	values: Punctuated<AstExpr>,
 	dokeyword: Token<"do">,
@@ -461,36 +458,33 @@ export type AstTypeArray = {
 	closebrace: Token<"}">,
 }
 
-export type AstTypeTableItem =
-	{
-		kind: "indexer",
-		access: Token<"read" | "write">?,
-		indexeropen: Token<"[">,
-		key: AstType,
-		indexerclose: Token<"]">,
-		colon: Token<":">,
-		value: AstType,
-		separator: Token<"," | ";">?,
-	}
-	| {
-		kind: "stringproperty",
-		access: Token<"read" | "write">?,
-		indexeropen: Token<"[">,
-		key: AstTypeSingletonString,
-		indexerclose: Token<"]">,
-		colon: Token<":">,
-		value: AstType,
-		separator: Token<"," | ";">?,
-	}
-	| {
-		kind: "property",
-		access: Token<"read" | "write">?,
-		key: AstTypeSingletonString,
-		indexerclose: Token<"]">,
-		colon: Token<":">,
-		value: AstType,
-		separator: Token<"," | ";">?,
-	}
+export type AstTypeTableItem = {
+	kind: "indexer",
+	access: Token<"read" | "write">?,
+	indexeropen: Token<"[">,
+	key: AstType,
+	indexerclose: Token<"]">,
+	colon: Token<":">,
+	value: AstType,
+	separator: Token<"," | ";">?,
+} | {
+	kind: "stringproperty",
+	access: Token<"read" | "write">?,
+	indexeropen: Token<"[">,
+	key: AstTypeSingletonString,
+	indexerclose: Token<"]">,
+	colon: Token<":">,
+	value: AstType,
+	separator: Token<"," | ";">?,
+} | {
+	kind: "property",
+	access: Token<"read" | "write">?,
+	key: AstTypeSingletonString,
+	indexerclose: Token<"]">,
+	colon: Token<":">,
+	value: AstType,
+	separator: Token<"," | ";">?,
+}
 
 export type AstTypeTable = {
 	tag: "table",

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -134,21 +134,24 @@ export type AstExprAnonymousFunction = {
 	body: AstFunctionBody,
 }
 
-export type AstExprTableItem = | { kind: "list", value: AstExpr, separator: Token<"," | ";">? } | {
-	kind: "record",
-	key: Token<string>,
-	equals: Token<"=">,
-	value: AstExpr,
-	separator: Token<"," | ";">?,
-} | {
-	kind: "general",
-	indexeropen: Token<"[">,
-	key: AstExpr,
-	indexerclose: Token<"]">,
-	equals: Token<"=">,
-	value: AstExpr,
-	separator: Token<"," | ";">?,
-}
+export type AstExprTableItem =
+	| { kind: "list", value: AstExpr, separator: Token<"," | ";">? }
+	| {
+		kind: "record",
+		key: Token<string>,
+		equals: Token<"=">,
+		value: AstExpr,
+		separator: Token<"," | ";">?,
+	}
+	| {
+		kind: "general",
+		indexeropen: Token<"[">,
+		key: AstExpr,
+		indexerclose: Token<"]">,
+		equals: Token<"=">,
+		value: AstExpr,
+		separator: Token<"," | ";">?,
+	}
 
 export type AstExprTable = {
 	tag: "table",
@@ -458,33 +461,36 @@ export type AstTypeArray = {
 	closebrace: Token<"}">,
 }
 
-export type AstTypeTableItem = {
-	kind: "indexer",
-	access: Token<"read" | "write">?,
-	indexeropen: Token<"[">,
-	key: AstType,
-	indexerclose: Token<"]">,
-	colon: Token<":">,
-	value: AstType,
-	separator: Token<"," | ";">?,
-} | {
-	kind: "stringproperty",
-	access: Token<"read" | "write">?,
-	indexeropen: Token<"[">,
-	key: AstTypeSingletonString,
-	indexerclose: Token<"]">,
-	colon: Token<":">,
-	value: AstType,
-	separator: Token<"," | ";">?,
-} | {
-	kind: "property",
-	access: Token<"read" | "write">?,
-	key: AstTypeSingletonString,
-	indexerclose: Token<"]">,
-	colon: Token<":">,
-	value: AstType,
-	separator: Token<"," | ";">?,
-}
+export type AstTypeTableItem =
+	{
+		kind: "indexer",
+		access: Token<"read" | "write">?,
+		indexeropen: Token<"[">,
+		key: AstType,
+		indexerclose: Token<"]">,
+		colon: Token<":">,
+		value: AstType,
+		separator: Token<"," | ";">?,
+	}
+	| {
+		kind: "stringproperty",
+		access: Token<"read" | "write">?,
+		indexeropen: Token<"[">,
+		key: AstTypeSingletonString,
+		indexerclose: Token<"]">,
+		colon: Token<":">,
+		value: AstType,
+		separator: Token<"," | ";">?,
+	}
+	| {
+		kind: "property",
+		access: Token<"read" | "write">?,
+		key: AstTypeSingletonString,
+		indexerclose: Token<"]">,
+		colon: Token<":">,
+		value: AstType,
+		separator: Token<"," | ";">?,
+	}
 
 export type AstTypeTable = {
 	tag: "table",

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,3 +1,3 @@
 [tools]
-stylua = { github = "JohnnyMorganz/StyLua", version = "2.0.2" }
+stylua = { github = "JohnnyMorganz/StyLua", version = "2.3.0" }
 lute = { github = "luau-lang/lute", version = "0.1.0-nightly.20251003" }

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,3 +1,3 @@
 [tools]
-stylua = "JohnnyMorganz/StyLua@2.0.2"
+stylua = "JohnnyMorganz/StyLua@2.3.0"
 lute = "luau-lang/lute@0.1.0-nightly.20251003"


### PR DESCRIPTION
It's using `Punctuated<Token<string>>` presumably due to a mistake, since `AstStatForIn->vars` is an array of AstLocals
See https://github.com/luau-lang/luau/blob/master/Ast/include/Luau/Ast.h#L836, https://github.com/luau-lang/lute/blob/primary/lute/luau/src/luau.cpp#L1393

Also bumps stylua to fix formatting CI failures/inconsistency