### PR TITLE
refactor: Modulepath takes std::function instead of a function pointer

### DIFF
--- a/lute/require/include/lute/modulepath.h
+++ b/lute/require/include/lute/modulepath.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <optional>
 #include <string>
 
@@ -36,8 +37,8 @@ public:
     static std::optional<ModulePath> create(
         std::string rootDirectory,
         std::string filePath,
-        bool (*isAFile)(const std::string&),
-        bool (*isADirectory)(const std::string&),
+        std::function<bool(const std::string&)> isAFile,
+        std::function<bool(const std::string&)> isADirectory,
         std::optional<std::string> relativePathToTrack = std::nullopt
     );
 
@@ -51,13 +52,13 @@ private:
     ModulePath(
         std::string realPathPrefix,
         std::string modulePath,
-        bool (*isAFile)(const std::string&),
-        bool (*isADirectory)(const std::string&),
+        std::function<bool(const std::string&)> isAFile,
+        std::function<bool(const std::string&)> isADirectory,
         std::optional<std::string> relativePathToTrack = std::nullopt
     );
 
-    bool (*isAFile)(const std::string&);
-    bool (*isADirectory)(const std::string&);
+    std::function<bool(const std::string&)> isAFile;
+    std::function<bool(const std::string&)> isADirectory;
 
     std::string realPathPrefix;
     std::string modulePath;

--- a/lute/require/src/modulepath.cpp
+++ b/lute/require/src/modulepath.cpp
@@ -39,8 +39,8 @@ static std::string_view removeExtension(std::string_view path)
 std::optional<ModulePath> ModulePath::create(
     std::string rootDirectory,
     std::string filePath,
-    bool (*isAFile)(const std::string&),
-    bool (*isADirectory)(const std::string&),
+    std::function<bool(const std::string&)> isAFile,
+    std::function<bool(const std::string&)> isADirectory,
     std::optional<std::string> relativePathToTrack
 )
 {
@@ -73,12 +73,12 @@ std::optional<ModulePath> ModulePath::create(
 ModulePath::ModulePath(
     std::string realPathPrefix,
     std::string modulePath,
-    bool (*isAFile)(const std::string&),
-    bool (*isADirectory)(const std::string&),
+    std::function<bool(const std::string&)> isAFile,
+    std::function<bool(const std::string&)> isADirectory,
     std::optional<std::string> relativePathToTrack
 )
-    : isAFile(isAFile)
-    , isADirectory(isADirectory)
+    : isAFile(std::move(isAFile))
+    , isADirectory(std::move(isADirectory))
     , realPathPrefix(std::move(realPathPrefix))
     , modulePath(std::move(modulePath))
     , relativePathToTrack(std::move(relativePathToTrack))


### PR DESCRIPTION
This is a pre-req for a future PR for Multi-File bytecode compilation. Doing this lets me use the module path interface more flexibly.