### PR TITLE
feature: Implement a Static Require Tracer in order to bundle files correctly when bytecode compiling them.

### DIFF
--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -25,11 +25,13 @@ add_library(Lute.CLI.lib STATIC)
 target_sources(Lute.CLI.lib PRIVATE
     include/lute/climain.h
     include/lute/compile.h
+    include/lute/staticrequires.h
     include/lute/tc.h
     include/lute/uvstate.h
 
     src/climain.cpp
     src/compile.cpp
+    src/staticrequires.cpp
     src/tc.cpp
     src/uvstate.cpp
 )

--- a/lute/cli/include/lute/staticrequires.h
+++ b/lute/cli/include/lute/staticrequires.h
@@ -1,15 +1,15 @@
 #pragma once
 
+#include "Luau/DenseHash.h"
+
+#include <optional>
 #include <string>
 #include <vector>
-#include <set>
-#include <map>
-#include <optional>
 
 class StaticRequireTracer
 {
 public:
-    StaticRequireTracer() = default;
+    StaticRequireTracer();
 
     // Trace dependencies starting from an entry point file
     // rootDirectory: Base directory for resolving all requires
@@ -19,12 +19,12 @@ public:
 
     // Get the require graph built during the last trace
     // Maps each file to the list of files it requires
-    const std::map<std::string, std::vector<std::string>>& getRequireGraph() const { return requireGraph; }
+    const Luau::DenseHashMap<std::string, std::vector<std::string>>& getRequireGraph() const { return requireGraph; }
 
 private:
-    std::set<std::string> visited;
+    Luau::DenseHashSet<std::string> visited{""};
     std::vector<std::string> discovered;
-    std::map<std::string, std::vector<std::string>> requireGraph;
+    Luau::DenseHashMap<std::string, std::vector<std::string>> requireGraph{""};
     std::string rootDirectory;
 
     // Extract all require() paths from source code

--- a/lute/cli/include/lute/staticrequires.h
+++ b/lute/cli/include/lute/staticrequires.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <set>
+#include <map>
+#include <optional>
+
+class StaticRequireTracer
+{
+public:
+    StaticRequireTracer() = default;
+
+    // Trace dependencies starting from an entry point file
+    // rootDirectory: Base directory for resolving all requires
+    // entryPoint: Path to entry point file (relative to rootDirectory)
+    // Returns list of all files in dependency order (entry point first)
+    std::vector<std::string> trace(const std::string& rootDirectory, const std::string& entryPoint);
+
+    // Get the require graph built during the last trace
+    // Maps each file to the list of files it requires
+    const std::map<std::string, std::vector<std::string>>& getRequireGraph() const { return requireGraph; }
+
+private:
+    std::set<std::string> visited;
+    std::vector<std::string> discovered;
+    std::map<std::string, std::vector<std::string>> requireGraph;
+    std::string rootDirectory;
+
+    // Extract all require() paths from source code
+    std::vector<std::string> extractRequires(const std::string& source);
+
+    // Resolve a require path relative to the requiring file
+    std::optional<std::string> resolveRequire(const std::string& requirer, const std::string& required);
+};

--- a/lute/cli/src/staticrequires.cpp
+++ b/lute/cli/src/staticrequires.cpp
@@ -6,10 +6,7 @@
 #include "Luau/FileUtils.h"
 
 #include <cstdio>
-#include <filesystem>
 #include <queue>
-
-namespace fs = std::filesystem;
 
 // AST visitor to extract require() calls
 class RequireExtractor : public Luau::AstVisitor
@@ -48,26 +45,15 @@ std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirec
         std::string filePath = toProcess.front();
         toProcess.pop();
 
-        // Get absolute path for visited tracking
-        std::string absPath;
-        try
-        {
-            std::string fullPath = joinPaths(rootDirectory, filePath);
-            absPath = fs::absolute(fullPath).string();
-        }
-        catch (const std::exception& e)
-        {
-            fprintf(stderr, "Warning: Could not resolve path '%s': %s\n", filePath.c_str(), e.what());
-            continue;
-        }
+        // Get normalized path for visited tracking
+        std::string fullPath = joinPaths(rootDirectory, filePath);
+        std::string absPath = normalizePath(fullPath);
 
         // Skip if already visited (handles circular dependencies)
         if (visited.count(absPath))
             continue;
 
         visited.insert(absPath);
-
-        std::string fullPath = joinPaths(rootDirectory, filePath);
         std::optional<std::string> source = readFile(fullPath);
         if (!source)
         {
@@ -139,14 +125,14 @@ std::optional<std::string> StaticRequireTracer::resolveRequire(const std::string
     }
 
     // Helper functions for ModulePath - paths are relative to rootDirectory
-    auto isFile = [this](const std::string& path) -> bool {
+    auto isFileFunc = [this](const std::string& path) -> bool {
         std::string fullPath = joinPaths(rootDirectory, path);
-        return fs::is_regular_file(fullPath);
+        return isFile(fullPath);
     };
 
     auto isDir = [this](const std::string& path) -> bool {
         std::string fullPath = joinPaths(rootDirectory, path);
-        return fs::is_directory(fullPath);
+        return isDirectory(fullPath);
     };
 
     // Create a ModulePath with root as rootDirectory, starting at requirer's directory
@@ -154,7 +140,7 @@ std::optional<std::string> StaticRequireTracer::resolveRequire(const std::string
     std::optional<ModulePath> modulePath = ModulePath::create(
         "",  // Root is empty (relative path base)
         requirerDir,  // Start at the requirer's directory
-        isFile,
+        isFileFunc,
         isDir
     );
 

--- a/lute/cli/src/staticrequires.cpp
+++ b/lute/cli/src/staticrequires.cpp
@@ -1,0 +1,211 @@
+#include "lute/modulepath.h"
+#include "lute/staticrequires.h"
+
+#include "Luau/Ast.h"
+#include "Luau/Parser.h"
+#include "Luau/FileUtils.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <queue>
+
+namespace fs = std::filesystem;
+
+// AST visitor to extract require() calls
+class RequireExtractor : public Luau::AstVisitor
+{
+public:
+    std::vector<std::string> requirePaths;
+
+    bool visit(Luau::AstExprCall* call) override
+    {
+        if (auto global = call->func->as<Luau::AstExprGlobal>())
+        {
+            if (global->name == "require" && call->args.size > 0)
+            {
+                if (auto str = call->args.data[0]->as<Luau::AstExprConstantString>())
+                {
+                    requirePaths.emplace_back(str->value.data, str->value.size);
+                }
+            }
+        }
+        return true;
+    }
+};
+
+std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirectory, const std::string& entryPoint)
+{
+    visited.clear();
+    discovered.clear();
+    requireGraph.clear();
+    this->rootDirectory = rootDirectory;
+
+    std::queue<std::string> toProcess;
+    toProcess.push(entryPoint);
+
+    while (!toProcess.empty())
+    {
+        std::string filePath = toProcess.front();
+        toProcess.pop();
+
+        // Get absolute path for visited tracking
+        std::string absPath;
+        try
+        {
+            std::string fullPath = joinPaths(rootDirectory, filePath);
+            absPath = fs::absolute(fullPath).string();
+        }
+        catch (const std::exception& e)
+        {
+            fprintf(stderr, "Warning: Could not resolve path '%s': %s\n", filePath.c_str(), e.what());
+            continue;
+        }
+
+        // Skip if already visited (handles circular dependencies)
+        if (visited.count(absPath))
+            continue;
+
+        visited.insert(absPath);
+
+        std::string fullPath = joinPaths(rootDirectory, filePath);
+        std::optional<std::string> source = readFile(fullPath);
+        if (!source)
+        {
+            fprintf(stderr, "Warning: Could not read file '%s'\n", fullPath.c_str());
+            continue;
+        }
+
+        // Add to discovered list (use the relative path from rootDirectory)
+        discovered.push_back(filePath);
+
+        std::vector<std::string> requiresInFile = extractRequires(*source);
+
+        std::vector<std::string> resolvedDeps;
+
+        for (const auto& req : requiresInFile)
+        {
+            std::optional<std::string> resolvedPath = resolveRequire(filePath, req);
+            if (resolvedPath)
+            {
+                toProcess.push(*resolvedPath);
+                resolvedDeps.push_back(*resolvedPath);
+            }
+            else
+            {
+                fprintf(stderr, "Warning: Could not resolve require('%s') from '%s'\n", req.c_str(), filePath.c_str());
+            }
+        }
+
+        // Store the resolved dependencies in the graph
+        requireGraph[filePath] = std::move(resolvedDeps);
+    }
+
+    return discovered;
+}
+
+std::vector<std::string> StaticRequireTracer::extractRequires(const std::string& source)
+{
+    Luau::Allocator allocator;
+    Luau::AstNameTable names(allocator);
+
+    Luau::ParseOptions options;
+    Luau::ParseResult result = Luau::Parser::parse(source.c_str(), source.size(), names, allocator, options);
+
+    if (result.errors.size() > 0)
+    {
+        // Even with parse errors, we can still try to extract requires
+        // Parse errors might be from type errors or other issues that don't prevent require extraction
+        // Should we do something here, or should it be best effort?
+    }
+
+    RequireExtractor extractor;
+    result.root->visit(&extractor);
+
+    return extractor.requirePaths;
+}
+
+std::optional<std::string> StaticRequireTracer::resolveRequire(const std::string& requirer, const std::string& required)
+{
+    // Get the directory containing the requiring file (relative to rootDirectory)
+    std::string requirerDir;
+    size_t lastSlash = requirer.find_last_of("/\\");
+    if (lastSlash != std::string::npos)
+    {
+        requirerDir = requirer.substr(0, lastSlash);
+    }
+    else
+    {
+        requirerDir = "";
+    }
+
+    // Helper functions for ModulePath - paths are relative to rootDirectory
+    auto isFile = [this](const std::string& path) -> bool {
+        std::string fullPath = joinPaths(rootDirectory, path);
+        return fs::is_regular_file(fullPath);
+    };
+
+    auto isDir = [this](const std::string& path) -> bool {
+        std::string fullPath = joinPaths(rootDirectory, path);
+        return fs::is_directory(fullPath);
+    };
+
+    // Create a ModulePath with root as rootDirectory, starting at requirer's directory
+    // This allows us to navigate up with .. beyond requirerDir, but not beyond rootDirectory
+    std::optional<ModulePath> modulePath = ModulePath::create(
+        "",  // Root is empty (relative path base)
+        requirerDir,  // Start at the requirer's directory
+        isFile,
+        isDir
+    );
+
+    if (!modulePath)
+        return std::nullopt;
+
+    // Navigate according to the require path
+    // Split require path by '/' and navigate
+    std::string reqPath = required;
+    size_t pos = 0;
+
+    while (pos < reqPath.size())
+    {
+        size_t nextSlash = reqPath.find('/', pos);
+        std::string component;
+
+        if (nextSlash == std::string::npos)
+        {
+            component = reqPath.substr(pos);
+            pos = reqPath.size();
+        }
+        else
+        {
+            component = reqPath.substr(pos, nextSlash - pos);
+            pos = nextSlash + 1;
+        }
+
+        if (component.empty() || component == ".")
+            continue;
+
+        if (component == "..")
+        {
+            if (modulePath->toParent() != NavigationStatus::Success)
+                return std::nullopt;
+        }
+        else
+        {
+            if (modulePath->toChild(component) != NavigationStatus::Success)
+                return std::nullopt;
+        }
+    }
+
+    // Get the resolved path (relative to rootDirectory)
+    ResolvedRealPath resolved = modulePath->getRealPath();
+    if (resolved.status != NavigationStatus::Success)
+        return std::nullopt;
+
+    // Strip leading slash if present (occurs when root is empty)
+    std::string result = resolved.realPath;
+    if (!result.empty() && result[0] == '/')
+        result = result.substr(1);
+
+    return result;
+}

--- a/lute/cli/src/staticrequires.cpp
+++ b/lute/cli/src/staticrequires.cpp
@@ -4,9 +4,11 @@
 #include "Luau/Ast.h"
 #include "Luau/Parser.h"
 #include "Luau/FileUtils.h"
+#include "Luau/VecDeque.h"
 
 #include <cstdio>
-#include <queue>
+
+StaticRequireTracer::StaticRequireTracer() = default;
 
 // AST visitor to extract require() calls
 class RequireExtractor : public Luau::AstVisitor
@@ -37,20 +39,20 @@ std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirec
     requireGraph.clear();
     this->rootDirectory = rootDirectory;
 
-    std::queue<std::string> toProcess;
-    toProcess.push(entryPoint);
+    Luau::VecDeque<std::string> toProcess;
+    toProcess.push_back(entryPoint);
 
     while (!toProcess.empty())
     {
         std::string filePath = toProcess.front();
-        toProcess.pop();
+        toProcess.pop_front();
 
         // Get normalized path for visited tracking
         std::string fullPath = joinPaths(rootDirectory, filePath);
         std::string absPath = normalizePath(fullPath);
 
         // Skip if already visited (handles circular dependencies)
-        if (visited.count(absPath))
+        if (visited.contains(absPath))
             continue;
 
         visited.insert(absPath);
@@ -73,7 +75,7 @@ std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirec
             std::optional<std::string> resolvedPath = resolveRequire(filePath, req);
             if (resolvedPath)
             {
-                toProcess.push(*resolvedPath);
+                toProcess.push_back(*resolvedPath);
                 resolvedDeps.push_back(*resolvedPath);
             }
             else

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,8 @@ target_sources(Lute.Test PRIVATE
 
     src/modulepath.test.cpp
     src/require.test.cpp
-    src/stdsystem.test.cpp)
+    src/stdsystem.test.cpp
+    src/staticrequires.test.cpp)
 
 set_target_properties(Lute.Test PROPERTIES OUTPUT_NAME lute-tests)
 target_compile_features(Lute.Test PUBLIC cxx_std_17)

--- a/tests/src/staticrequires.test.cpp
+++ b/tests/src/staticrequires.test.cpp
@@ -100,25 +100,29 @@ TEST_CASE("staticrequiretracer_require_graph")
     const auto& graph = tracer.getRequireGraph();
 
     // main.luau should require utils.luau and lib/helper.luau
-    REQUIRE(graph.count("main.luau") == 1);
-    const auto& mainDeps = graph.at("main.luau");
-    REQUIRE(mainDeps.size() == 2);
-    CHECK(std::find(mainDeps.begin(), mainDeps.end(), "utils.luau") != mainDeps.end());
-    CHECK(std::find(mainDeps.begin(), mainDeps.end(), "lib/helper.luau") != mainDeps.end());
+    REQUIRE(graph.contains("main.luau"));
+    const auto* mainDeps = graph.find("main.luau");
+    REQUIRE(mainDeps != nullptr);
+    REQUIRE(mainDeps->size() == 2);
+    CHECK(std::find(mainDeps->begin(), mainDeps->end(), "utils.luau") != mainDeps->end());
+    CHECK(std::find(mainDeps->begin(), mainDeps->end(), "lib/helper.luau") != mainDeps->end());
 
     // lib/helper.luau should require shared.luau
-    REQUIRE(graph.count("lib/helper.luau") == 1);
-    const auto& helperDeps = graph.at("lib/helper.luau");
-    REQUIRE(helperDeps.size() == 1);
-    CHECK(helperDeps[0] == "shared.luau");
+    REQUIRE(graph.contains("lib/helper.luau"));
+    const auto* helperDeps = graph.find("lib/helper.luau");
+    REQUIRE(helperDeps != nullptr);
+    REQUIRE(helperDeps->size() == 1);
+    CHECK((*helperDeps)[0] == "shared.luau");
 
     // utils.luau should have no dependencies
-    REQUIRE(graph.count("utils.luau") == 1);
-    const auto& utilsDeps = graph.at("utils.luau");
-    CHECK(utilsDeps.empty());
+    REQUIRE(graph.contains("utils.luau"));
+    const auto* utilsDeps = graph.find("utils.luau");
+    REQUIRE(utilsDeps != nullptr);
+    CHECK(utilsDeps->empty());
 
     // shared.luau should have no dependencies
-    REQUIRE(graph.count("shared.luau") == 1);
-    const auto& sharedDeps = graph.at("shared.luau");
-    CHECK(sharedDeps.empty());
+    REQUIRE(graph.contains("shared.luau"));
+    const auto* sharedDeps = graph.find("shared.luau");
+    REQUIRE(sharedDeps != nullptr);
+    CHECK(sharedDeps->empty());
 }

--- a/tests/src/staticrequires.test.cpp
+++ b/tests/src/staticrequires.test.cpp
@@ -1,0 +1,124 @@
+#include "doctest.h"
+#include "luteprojectroot.h"
+#include "lute/staticrequires.h"
+
+#include "Luau/FileUtils.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+TEST_CASE("staticrequiretracer_simple_dependencies")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+
+    StaticRequireTracer tracer;
+    std::vector<std::string> deps = tracer.trace(testDir, "main.luau");
+
+    // Should find: main.luau, utils.luau, lib/helper.luau, shared.luau
+    REQUIRE(deps.size() == 4);
+
+    // Entry point should be first
+    CHECK(deps[0] == "main.luau");
+
+    // Verify all expected files are present (paths are relative to testDir)
+    std::vector<std::string> expectedFiles = {
+        "main.luau",
+        "utils.luau",
+        "lib/helper.luau",
+        "shared.luau"
+    };
+
+    for (const auto& expected : expectedFiles)
+    {
+        bool found = std::find(deps.begin(), deps.end(), expected) != deps.end();
+        CHECK(found);
+    }
+}
+
+TEST_CASE("staticrequiretracer_circular_dependencies")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+
+    StaticRequireTracer tracer;
+    std::vector<std::string> deps = tracer.trace(testDir, "circular_a.luau");
+
+    // Should find both circular_a and circular_b without infinite loop
+    REQUIRE(deps.size() == 2);
+
+    // Entry point should be first
+    CHECK(deps[0] == "circular_a.luau");
+
+    // Both files should be in the list
+    bool hasA = std::find(deps.begin(), deps.end(), "circular_a.luau") != deps.end();
+    bool hasB = std::find(deps.begin(), deps.end(), "circular_b.luau") != deps.end();
+
+    CHECK(hasA);
+    CHECK(hasB);
+}
+
+TEST_CASE("staticrequiretracer_no_dependencies")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+
+    StaticRequireTracer tracer;
+    std::vector<std::string> deps = tracer.trace(testDir, "utils.luau");
+
+    // utils.luau has no requires, should only return itself
+    REQUIRE(deps.size() == 1);
+    CHECK(deps[0] == "utils.luau");
+}
+
+TEST_CASE("staticrequiretracer_relative_paths")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+
+    StaticRequireTracer tracer;
+    std::vector<std::string> deps = tracer.trace(testDir, "lib/helper.luau");
+
+    // helper.luau requires ../shared, should resolve correctly
+    REQUIRE(deps.size() == 2);
+
+    CHECK(deps[0] == "lib/helper.luau");
+
+    bool hasShared = std::find(deps.begin(), deps.end(), "shared.luau") != deps.end();
+    CHECK(hasShared);
+}
+
+TEST_CASE("staticrequiretracer_require_graph")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+
+    StaticRequireTracer tracer;
+    std::vector<std::string> deps = tracer.trace(testDir, "main.luau");
+
+    const auto& graph = tracer.getRequireGraph();
+
+    // main.luau should require utils.luau and lib/helper.luau
+    REQUIRE(graph.count("main.luau") == 1);
+    const auto& mainDeps = graph.at("main.luau");
+    REQUIRE(mainDeps.size() == 2);
+    CHECK(std::find(mainDeps.begin(), mainDeps.end(), "utils.luau") != mainDeps.end());
+    CHECK(std::find(mainDeps.begin(), mainDeps.end(), "lib/helper.luau") != mainDeps.end());
+
+    // lib/helper.luau should require shared.luau
+    REQUIRE(graph.count("lib/helper.luau") == 1);
+    const auto& helperDeps = graph.at("lib/helper.luau");
+    REQUIRE(helperDeps.size() == 1);
+    CHECK(helperDeps[0] == "shared.luau");
+
+    // utils.luau should have no dependencies
+    REQUIRE(graph.count("utils.luau") == 1);
+    const auto& utilsDeps = graph.at("utils.luau");
+    CHECK(utilsDeps.empty());
+
+    // shared.luau should have no dependencies
+    REQUIRE(graph.count("shared.luau") == 1);
+    const auto& sharedDeps = graph.at("shared.luau");
+    CHECK(sharedDeps.empty());
+}

--- a/tests/src/staticrequires/circular_a.luau
+++ b/tests/src/staticrequires/circular_a.luau
@@ -1,0 +1,7 @@
+-- Module A that requires B (circular dependency)
+local b = require("./circular_b")
+
+return {
+	name = "A",
+	b = b,
+}

--- a/tests/src/staticrequires/circular_b.luau
+++ b/tests/src/staticrequires/circular_b.luau
@@ -1,0 +1,7 @@
+-- Module B that requires A (circular dependency)
+local a = require("./circular_a")
+
+return {
+	name = "B",
+	a = a,
+}

--- a/tests/src/staticrequires/lib/helper.luau
+++ b/tests/src/staticrequires/lib/helper.luau
@@ -1,0 +1,10 @@
+-- Helper module that also requires another module
+local shared = require("../shared")
+
+print("Helper module")
+return {
+	help = function()
+		return "helper"
+	end,
+	shared = shared,
+}

--- a/tests/src/staticrequires/main.luau
+++ b/tests/src/staticrequires/main.luau
@@ -1,0 +1,9 @@
+-- Entry point that requires other modules
+local utils = require("./utils")
+local lib = require("./lib/helper")
+
+print("Main module")
+return {
+	utils = utils,
+	lib = lib,
+}

--- a/tests/src/staticrequires/shared.luau
+++ b/tests/src/staticrequires/shared.luau
@@ -1,0 +1,5 @@
+-- Shared module
+print("Shared module")
+return {
+	version = "1.0",
+}

--- a/tests/src/staticrequires/utils.luau
+++ b/tests/src/staticrequires/utils.luau
@@ -1,0 +1,7 @@
+-- Utilities module
+print("Utils module")
+return {
+	add = function(a, b)
+		return a + b
+	end,
+}


### PR DESCRIPTION
This PR implement a static require tracer for Luau as a prerequisite to enabling multi file bytecode compilation. This module statically resolves requires relative to a given entry module, effectively snapshotting the state of the filesystem for embedding in a lute executable. This module graph will be embedded in the lute executable when `lute compile` is invoked and will let the bundle virtual file system [PR](https://github.com/luau-lang/lute/pull/450) correctly navigate the directory structure to resolve `require` calls and match up those paths to the pre-compiled bytecode embedded in the bundle.