### PR TITLE
Rename "Gated Commits" to "CI"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: stylua --check .
 
   aggregator:
-    name: Aggregate Test Results
+    name: Gated Commits
     runs-on: ubuntu-latest
     needs: [run-lutecli-luau-tests, run-lute-cxx-unittests, check-format]
     if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: stylua --check .
 
   aggregator:
-    name: Gated Commits
+    name: Aggregate Test Results
     runs-on: ubuntu-latest
     needs: [run-lutecli-luau-tests, run-lute-cxx-unittests, check-format]
     if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Gated Commits
+name: CI
 
 on:
   push:


### PR DESCRIPTION
Small change, but "CI" makes more sense than "Gated Commits" for the README icon:
<img width="253" height="52" alt="image" src="https://github.com/user-attachments/assets/82b052c7-c445-47a0-993e-ac9943d2881b" />
