### PR TITLE
Call `uv_setup_args` at `lute` and `lute-tests` entry points

### DIFF
--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -26,10 +26,12 @@ target_sources(Lute.CLI.lib PRIVATE
     include/lute/climain.h
     include/lute/compile.h
     include/lute/tc.h
+    include/lute/uvstate.h
 
     src/climain.cpp
     src/compile.cpp
     src/tc.cpp
+    src/uvstate.cpp
 )
 
 target_compile_features(Lute.CLI.lib PUBLIC cxx_std_17)

--- a/lute/cli/include/lute/uvstate.h
+++ b/lute/cli/include/lute/uvstate.h
@@ -1,0 +1,12 @@
+#pragma once
+
+struct UvGlobalState
+{
+    UvGlobalState(const UvGlobalState&) = delete;
+    UvGlobalState& operator=(const UvGlobalState&) = delete;
+    UvGlobalState(UvGlobalState&&) = delete;
+    UvGlobalState& operator=(UvGlobalState&&) = delete;
+
+    UvGlobalState(int argc, char** argv);
+    ~UvGlobalState();
+};

--- a/lute/cli/src/main.cpp
+++ b/lute/cli/src/main.cpp
@@ -1,6 +1,8 @@
 #include "lute/climain.h"
+#include "lute/uvstate.h"
 
 int main(int argc, char** argv)
 {
+    UvGlobalState uvState(argc, argv);
     return cliMain(argc, argv);
 }

--- a/lute/cli/src/uvstate.cpp
+++ b/lute/cli/src/uvstate.cpp
@@ -1,0 +1,13 @@
+#include "lute/uvstate.h"
+
+#include "uv.h"
+
+UvGlobalState::UvGlobalState(int argc, char** argv)
+{
+    uv_setup_args(argc, argv);
+}
+
+UvGlobalState::~UvGlobalState()
+{
+    uv_library_shutdown();
+}

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -25,13 +25,6 @@ static void lua_close_checked(lua_State* L)
 
 static std::string getExecPath(const char* argv0)
 {
-    // FIXME: uv_exepath requires that uv_setup_args(argc, argv) was called.
-    // This function can allocate on some platforms. However, the state is
-    // persisted for the duration of the program and cleaning it up with
-    // uv_library_shutdown will only delete it once. This is a problem in unit
-    // tests that call cliMain multiple times. There, the function would leak
-    // memory. On the three main platforms supported by Lute however, uv doesn't
-    // require uv_setup_args to be called, so it's currently left out.
     char buf[LUTE_PATH_MAX];
     size_t len = sizeof(buf);
     if (uv_exepath(buf, &len) == 0)

--- a/tests/src/main.cpp
+++ b/tests/src/main.cpp
@@ -1,2 +1,19 @@
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#define DOCTEST_CONFIG_IMPLEMENT
 #include "doctest.h"
+
+#include "lute/uvstate.h"
+
+int main(int argc, char** argv)
+{
+    UvGlobalState uvState(argc, argv);
+
+    doctest::Context context;
+    context.applyCommandLine(argc, argv);
+
+    int res = context.run();
+
+    if (context.shouldExit())
+        return res;
+
+    return res;
+}


### PR DESCRIPTION
At the entry points of `lute` and `lute-tests`, we now call `uv_setup_args` with the new `UvGlobalState` RAII wrapper.

It's still the case that unit tests that call `cliMain` don't individually call `uv_set_args`, but this is probably the behavior we want anyway. Calling `cliMain` directly in these tests allows us to inject in custom arguments for Lute runtime code, with the caveat that libuv's "introspective" APIs like `uv_exepath` will still return globally registered information. This is fine because our unit tests shouldn't need to test functionality at the `libuv`-level anyway.

The types of APIs that `uv_setup_args` enables aren't APIs that make sense for us to inject in unit tests.

Resolves #451.