### PR TITLE
Update license year to include 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Roblox Corporation
+Copyright (c) 2024–2025 Roblox Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in


### PR DESCRIPTION
Not visible in a monospaced font, but the mighty en dash strikes again. 😉