### PR TITLE
Move `getExecPath` logic to Lute.Process and clean up all uses of `argv[0]` in Lute.CLI

### DIFF
--- a/lute/cli/include/lute/compile.h
+++ b/lute/cli/include/lute/compile.h
@@ -8,6 +8,6 @@ struct AppendedBytecodeResult
     std::string BytecodeData;
 };
 
-AppendedBytecodeResult checkForAppendedBytecode(const std::string& executablePath);
+AppendedBytecodeResult checkForAppendedBytecode();
 
-int compileScript(const std::string& inputFilePath, const std::string& outputFilePath, const std::string& currentExecutablePath); 
+int compileScript(const std::string& inputFilePath, const std::string& outputFilePath);

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -178,7 +178,7 @@ static bool runFile(Runtime& runtime, const char* name, lua_State* GL, int progr
     return runBytecode(runtime, bytecode, chunkname, GL, program_argc, program_argv);
 }
 
-static void displayHelp(const char* argv0)
+static void displayHelp()
 {
     printf("Usage: lute <command> [options] [arguments...]\n");
     printf("\n");
@@ -214,7 +214,7 @@ static void displayVersion()
     printf("%s\n", LUTE_VERSION_FULL);
 }
 
-static void displayRunHelp(const char* argv0)
+static void displayRunHelp()
 {
     printf("Usage: lute run <script.luau> [args...]\n");
     printf("\n");
@@ -222,7 +222,7 @@ static void displayRunHelp(const char* argv0)
     printf("  -h, --help    Display this usage message.\n");
 }
 
-static void displayCheckHelp(const char* argv0)
+static void displayCheckHelp()
 {
     printf("Usage: lute check <file1.luau> [file2.luau...]\n");
     printf("\n");
@@ -230,7 +230,7 @@ static void displayCheckHelp(const char* argv0)
     printf("  -h, --help    Display this usage message.\n");
 }
 
-static void displayCompileHelp(const char* argv0)
+static void displayCompileHelp()
 {
     printf("Usage: lute compile <script.luau> [output_executable]\n");
     printf("\n");
@@ -296,7 +296,7 @@ static std::optional<std::string> getValidPath(std::string filePath)
     return std::nullopt;
 }
 
-int handleRunCommand(int argc, char** argv, char* argv0, int argOffset)
+int handleRunCommand(int argc, char** argv, int argOffset)
 {
     std::string filePath;
     int program_argc = 0;
@@ -308,13 +308,13 @@ int handleRunCommand(int argc, char** argv, char* argv0, int argOffset)
 
         if (strcmp(currentArg, "-h") == 0 || strcmp(currentArg, "--help") == 0)
         {
-            displayRunHelp(argv[0]);
+            displayRunHelp();
             return 0;
         }
         else if (currentArg[0] == '-')
         {
             fprintf(stderr, "Error: Unrecognized option '%s' for 'run' command.\n\n", currentArg);
-            displayRunHelp(argv[0]);
+            displayRunHelp();
             return 1;
         }
         else
@@ -329,11 +329,11 @@ int handleRunCommand(int argc, char** argv, char* argv0, int argOffset)
     if (filePath.empty())
     {
         fprintf(stderr, "Error: No file specified for 'run' command.\n\n");
-        displayRunHelp(argv[0]);
+        displayRunHelp();
         return 1;
     }
 
-    Runtime runtime(argv0);
+    Runtime runtime;
     lua_State* L = setupCliState(runtime);
 
     std::optional<std::string> validPath = getValidPath(filePath);
@@ -357,13 +357,13 @@ int handleCheckCommand(int argc, char** argv, int argOffset)
 
         if (strcmp(currentArg, "-h") == 0 || strcmp(currentArg, "--help") == 0)
         {
-            displayCheckHelp(argv[0]);
+            displayCheckHelp();
             return 0;
         }
         else if (currentArg[0] == '-')
         {
             fprintf(stderr, "Error: Unrecognized option '%s' for 'check' command.\n\n", currentArg);
-            displayCheckHelp(argv[0]);
+            displayCheckHelp();
             return 1;
         }
         else
@@ -375,7 +375,7 @@ int handleCheckCommand(int argc, char** argv, int argOffset)
     if (files.empty())
     {
         fprintf(stderr, "Error: No files specified for 'check' command.\n\n");
-        displayCheckHelp(argv[0]);
+        displayCheckHelp();
         return 1;
     }
 
@@ -393,7 +393,7 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
 
         if (strcmp(currentArg, "-h") == 0 || strcmp(currentArg, "--help") == 0)
         {
-            displayCompileHelp(argv[0]);
+            displayCompileHelp();
             return 0;
         }
         else if (inputFilePath.empty())
@@ -407,7 +407,7 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
         else
         {
             fprintf(stderr, "Error: Too many arguments for 'compile' command.\n\n");
-            displayCompileHelp(argv[0]);
+            displayCompileHelp();
             return 1;
         }
     }
@@ -415,7 +415,7 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
     if (inputFilePath.empty())
     {
         fprintf(stderr, "Error: No input file specified for 'compile' command.\n\n");
-        displayCompileHelp(argv[0]);
+        displayCompileHelp();
         return 1;
     }
 
@@ -445,12 +445,12 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
 #endif
     }
 
-    return compileScript(inputFilePath, outputFilePath, argv[0]);
+    return compileScript(inputFilePath, outputFilePath);
 }
 
-int handleCliCommand(CliCommandResult result, int program_argc, char** program_argv, char* argv0)
+int handleCliCommand(CliCommandResult result, int program_argc, char** program_argv)
 {
-    Runtime runtime(argv0);
+    Runtime runtime;
     lua_State* L = setupCliState(runtime);
 
     std::string bytecode = Luau::compile(std::string(result.contents), copts());
@@ -461,10 +461,10 @@ int cliMain(int argc, char** argv)
 {
     Luau::assertHandler() = assertionHandler;
 
-    AppendedBytecodeResult embedded = checkForAppendedBytecode(argv[0]);
+    AppendedBytecodeResult embedded = checkForAppendedBytecode();
     if (embedded.found)
     {
-        Runtime runtime(argv[0]);
+        Runtime runtime;
         lua_State* GL = setupCliState(runtime);
 
         bool success = runBytecode(runtime, embedded.BytecodeData, "=__EMBEDDED__", GL, argc, argv);
@@ -479,7 +479,7 @@ int cliMain(int argc, char** argv)
     if (argc < 2)
     {
         // TODO: REPL?
-        displayHelp(argv[0]);
+        displayHelp();
         return 0;
     }
 
@@ -488,7 +488,7 @@ int cliMain(int argc, char** argv)
 
     if (strcmp(command, "run") == 0)
     {
-        return handleRunCommand(argc, argv, argv[0], argOffset);
+        return handleRunCommand(argc, argv, argOffset);
     }
     else if (strcmp(command, "check") == 0)
     {
@@ -500,7 +500,7 @@ int cliMain(int argc, char** argv)
     }
     else if (strcmp(command, "-h") == 0 || strcmp(command, "--help") == 0)
     {
-        displayHelp(argv[0]);
+        displayHelp();
         return 0;
     }
     else if (strcmp(command, "--version") == 0)
@@ -510,12 +510,12 @@ int cliMain(int argc, char** argv)
     }
     else if (std::optional<CliCommandResult> result = getCliCommand(command); result)
     {
-        return handleCliCommand(*result, argc - argOffset, &argv[argOffset], argv[0]);
+        return handleCliCommand(*result, argc - argOffset, &argv[argOffset]);
     }
     else
     {
         // Default to 'run' command
         argOffset = 1;
-        return handleRunCommand(argc, argv, argv[0], argOffset);
+        return handleRunCommand(argc, argv, argOffset);
     }
 }

--- a/lute/cli/src/compile.cpp
+++ b/lute/cli/src/compile.cpp
@@ -1,17 +1,32 @@
 #include "lute/compile.h"
 
 #include "lute/options.h"
+#include "lute/process.h"
 #include "uv.h"
 
 #include <fstream>
+#include <string>
 
 const char MAGIC_FLAG[] = "LUTEBYTE";
 const size_t MAGIC_FLAG_SIZE = sizeof(MAGIC_FLAG) - 1;
 const size_t BYTECODE_SIZE_FIELD_SIZE = sizeof(uint64_t);
 
-AppendedBytecodeResult checkForAppendedBytecode(const std::string& executablePath)
+AppendedBytecodeResult checkForAppendedBytecode()
 {
     AppendedBytecodeResult result;
+
+    std::string executablePath;
+    {
+        std::string error;
+        std::optional<std::string> execPathOpt = process::getExecPath(&error);
+        if (!execPathOpt)
+        {
+            fprintf(stderr, "Could not get path to executable: %s\n", error.c_str());
+            return result;
+        }
+        executablePath = *execPathOpt;
+    }
+
     std::ifstream exeFile(executablePath, std::ios::binary | std::ios::ate);
     if (!exeFile)
     {
@@ -54,8 +69,21 @@ AppendedBytecodeResult checkForAppendedBytecode(const std::string& executablePat
     return result;
 }
 
-int compileScript(const std::string& inputFilePath, const std::string& outputFilePath, const std::string& currentExecutablePath)
+int compileScript(const std::string& inputFilePath, const std::string& outputFilePath)
 {
+    std::string currentExecutablePath;
+    ;
+    {
+        std::string error;
+        std::optional<std::string> execPathOpt = process::getExecPath(&error);
+        if (!execPathOpt)
+        {
+            fprintf(stderr, "Could not get path to current executable: %s\n", error.c_str());
+            return 1;
+        }
+        currentExecutablePath = *execPathOpt;
+    }
+
     std::optional<std::string> source = readFile(inputFilePath);
     if (!source)
     {

--- a/lute/cli/src/compile.cpp
+++ b/lute/cli/src/compile.cpp
@@ -72,7 +72,6 @@ AppendedBytecodeResult checkForAppendedBytecode()
 int compileScript(const std::string& inputFilePath, const std::string& outputFilePath)
 {
     std::string currentExecutablePath;
-    ;
     {
         std::string error;
         std::optional<std::string> execPathOpt = process::getExecPath(&error);

--- a/lute/process/include/lute/process.h
+++ b/lute/process/include/lute/process.h
@@ -3,6 +3,9 @@
 #include "lua.h"
 #include "lualib.h"
 
+#include <optional>
+#include <string>
+
 // open the library as a standard global luau library
 int luaopen_process(lua_State* L);
 // open the library as a table on top of the stack
@@ -18,6 +21,7 @@ int cwd(lua_State* L);
 
 int exitFunc(lua_State* L);
 
+std::optional<std::string> getExecPath(std::string* error);
 int execpath(lua_State* L);
 
 static const luaL_Reg lib[] = {

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -1,15 +1,26 @@
 #include "lute/process.h"
 #include "lute/runtime.h"
-#include <uv.h>
-#include <string>
-#include <vector>
-#include <memory>
-#include <functional>
-#include <map>
+
 #include "Luau/Common.h"
 
 #include "lua.h"
 #include "lualib.h"
+
+#include <uv.h>
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <climits> // IWYU pragma: keep
+#ifdef PATH_MAX
+#define LUTE_PATH_MAX PATH_MAX
+#else
+#define LUTE_PATH_MAX 8192
+#endif
 
 namespace process
 {
@@ -474,9 +485,36 @@ int cwd(lua_State* L)
     return 1;
 };
 
+std::optional<std::string> getExecPath(std::string* error)
+{
+    // Executable path is not expected to change during process lifetime, so we
+    // can safely cache it after the first retrieval.
+    static std::optional<std::string> cachedPath = std::nullopt;
+    if (cachedPath)
+        return *cachedPath;
+
+    char buf[LUTE_PATH_MAX];
+    size_t len = sizeof(buf);
+
+    if (int status = uv_exepath(buf, &len); status < 0)
+    {
+        if (error)
+            *error = uv_strerror(status);
+        return std::nullopt;
+    }
+
+    cachedPath = std::string(buf, len);
+    return *cachedPath;
+}
+
 int execpath(lua_State* L)
 {
-    lua_pushstring(L, getRuntime(L)->execPath.c_str());
+    std::string error;
+    std::optional<std::string> execPath = getExecPath(&error);
+    if (!execPath)
+        luaL_error(L, "Failed to get executable path: %s", error.c_str());
+
+    lua_pushlstring(L, execPath->c_str(), execPath->size());
     return 1;
 }
 

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -40,7 +40,7 @@ using RuntimeStep = Luau::Variant<StepSuccess, StepErr, StepEmpty>;
 
 struct Runtime
 {
-    Runtime(const char* argv0 = nullptr);
+    Runtime();
     ~Runtime();
 
     bool runToCompletion();
@@ -80,8 +80,6 @@ struct Runtime
     std::unique_ptr<lua_State, void (*)(lua_State*)> dataCopy;
 
     std::vector<ThreadToContinue> runningThreads;
-
-    std::string execPath;
 
 private:
     std::mutex continuationMutex;

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -9,13 +9,6 @@
 
 #include <string>
 #include <assert.h>
-#include <climits> // IWYU pragma: keep
-
-#ifdef PATH_MAX
-#define LUTE_PATH_MAX PATH_MAX
-#else
-#define LUTE_PATH_MAX 8192
-#endif
 
 static void lua_close_checked(lua_State* L)
 {
@@ -23,21 +16,9 @@ static void lua_close_checked(lua_State* L)
         lua_close(L);
 }
 
-static std::string getExecPath(const char* argv0)
-{
-    char buf[LUTE_PATH_MAX];
-    size_t len = sizeof(buf);
-    if (uv_exepath(buf, &len) == 0)
-        return {buf, len};
-    if (argv0)
-        return argv0;
-    return {};
-}
-
-Runtime::Runtime(const char* argv0)
+Runtime::Runtime()
     : globalState(nullptr, lua_close_checked)
     , dataCopy(nullptr, lua_close_checked)
-    , execPath(getExecPath(argv0))
 {
     stop.store(false);
     activeTokens.store(0);

--- a/lute/vm/src/spawn.cpp
+++ b/lute/vm/src/spawn.cpp
@@ -200,7 +200,7 @@ int lua_spawn(lua_State* L)
 {
     const char* file = luaL_checkstring(L, 1);
 
-    auto child = std::make_shared<Runtime>(getRuntime(L)->execPath.c_str());
+    auto child = std::make_shared<Runtime>();
 
     setupState(
         *child,


### PR DESCRIPTION
Follow-up work to #455. We shouldn't need to store global state like the executable name in `Runtime` itself. The only Luau-facing API that needs that value is the new `process.execpath` API, so the implementation is moved to `process.cpp`.

While refactoring some files after removing `argv0` from the `Runtime` constructor, I realized that we pass around `argv[0]` in many places where we don't need to. I've removed it entirely from helper functions like `displayCheckHelp`.

There are only two functions that actually need the executable name: `checkForAppendedBytecode` and `compileScript`. Rather than passing it in, we instead call into `Lute.Process`'s new `getExecPath` API to retrieve it.