### PR TITLE
fix: rename `io.read()` in definitions

### DIFF
--- a/definitions/io.luau
+++ b/definitions/io.luau
@@ -1,6 +1,6 @@
 local io = {}
 
-function io.input(): string
+function io.read(): string
 	error("unimplemented")
 end
 


### PR DESCRIPTION
Forgot to rename the `.read()` call in `definitions/io.luau` when renaming the `input` to `read` in `io.cpp` in https://github.com/luau-lang/lute/pull/437 and was causing a type error