### PR TITLE
Fix race condition in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,8 +163,10 @@ jobs:
           prerelease: ${{ github.event.inputs.nightly || github.event_name == 'schedule' }}
           files: release/*.zip
 
+      - name: Wait for Tag Creation in GitHub
+        run: sleep 5
+
       - name: Publish Release
-        uses: luau-lang/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.tag_release.outputs.tag }}
-          draft: false
+        run: gh release edit "${{ steps.tag_release.outputs.tag }}" --draft=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For the `0.1.0-nightly.20251018` release, there was a race condition between the "Create Draft Release" and "Publish Release" steps of the release workflow.

We successfully created the draft release with all the built binaries:
<img width="696" height="158" alt="image" src="https://github.com/user-attachments/assets/c7f18bc4-4207-4bb0-8746-b61f1cdb3a90" />

However, when the release was being published, GitHub was still internally registering the new release tag. Rather than publishing the draft release, the publish step was unable to find the still-registering tag, so it instead published a brand-new release. This one wasn't set to a prerelease, and it had none of the binaries attached since the draft release's settings didn't carry over.

<img width="693" height="266" alt="image" src="https://github.com/user-attachments/assets/2b326998-2286-4632-be30-cdcd9d5a9d7c" />

I've since deleted both of these since releases being immutable makes it difficult to fix this retroactively. To avoid this in the future, I've added a short `sleep` to our release workflow; even 1 second seems to have prevented this issue in all other nightly releases, but I've put 5 seconds to be safe. I've also replaced our final release step with a call to `gh release edit`, which will immediately fail if the tag cannot be found (couldn't find an analogue in `luau-lang/action-gh-release@v2`).