### PR TITLE
runtime: implement `system.tmpdir` to provide access to the temporary files directory.

### DIFF
--- a/definitions/system.luau
+++ b/definitions/system.luau
@@ -21,6 +21,10 @@ function system.hostname(): string
 	error("unimplemented")
 end
 
+function system.tmpdir(): string
+	error("unimplemented")
+end
+
 function system.totalmemory(): number
 	error("unimplemented")
 end

--- a/lute/system/include/lute/system.h
+++ b/lute/system/include/lute/system.h
@@ -21,6 +21,7 @@ int lua_freememory(lua_State* L);
 int lua_totalmemory(lua_State* L);
 int lua_hostname(lua_State* L);
 int lua_uptime(lua_State* L);
+int lua_tmpdir(lua_State* L);
 
 static const luaL_Reg lib[] = {
     {"cpus", lua_cpus},
@@ -29,6 +30,7 @@ static const luaL_Reg lib[] = {
     {"totalmemory", lua_totalmemory},
     {"hostname", lua_hostname},
     {"uptime", lua_uptime},
+    {"tmpdir", lua_tmpdir},
 
     {nullptr, nullptr}
 };

--- a/lute/system/src/system.cpp
+++ b/lute/system/src/system.cpp
@@ -123,6 +123,30 @@ int lua_uptime(lua_State* L)
 
     return 1;
 }
+
+int lua_tmpdir(lua_State* L)
+{
+    size_t size = 255;
+    std::string tmpdir;
+    tmpdir.reserve(size);
+
+    int res = uv_os_tmpdir(tmpdir.data(), &size);
+    if (res == UV_ENOBUFS)
+    {
+        tmpdir.reserve(size); // libuv updates the size to what's required
+        res = uv_os_tmpdir(tmpdir.data(), &size);
+    }
+
+    if (res != 0)
+    {
+        luaL_error(L, "libuv error: %s", uv_strerror(res));
+    }
+
+    lua_pushstring(L, tmpdir.c_str());
+
+    return 1;
+    
+}
 } // namespace libsystem
 
 int luaopen_system(lua_State* L)


### PR DESCRIPTION
Varying OSes provide different preferred locations for temporary files, and libuv provides an API by which we can get at that. We should make that available so that people can build cross-platform code that interacts with these directories safely.