### PR TITLE
std/json: distinguish more explicitly between array and object

### DIFF
--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -1,12 +1,15 @@
 local json = {
 	--- Not actually a nil value, a newproxy stand-in for a null value since Luau has no actual representation of `null`
-	NULL = newproxy() :: nil,
+	null = newproxy() :: nil,
 }
 
-type JSONPrimitive = nil | number | string | boolean
-type Object = { [string]: Value }
-type Array = { Value }
-export type Value = JSONPrimitive | Array | Object
+type jsonprimitive = nil | number | string | boolean
+type object = { [string]: value }
+type array = { [number]: value }
+export type value = jsonprimitive | array | object
+
+-- a unique key to identify an object vs a table
+local object_key = newproxy()
 
 -- serialization
 
@@ -66,7 +69,7 @@ local function writeString(state: SerializerState, str: string)
 	state.cursor += #str
 end
 
-local serializeAny: (SerializerState, (Array | Object | boolean | number | string)?) -> ()
+local serializeAny: (SerializerState, (array | object | boolean | number | string)?) -> ()
 
 local ESCAPE_MAP = {
 	[0x5C] = string.byte("\\"), -- 5C = '\'
@@ -107,7 +110,7 @@ local function serializeString(state: SerializerState, str: string)
 	writeByte(state, string.byte('"'))
 end
 
-local function serializeArray(state: SerializerState, array: Array)
+local function serializeArray(state: SerializerState, array: array)
 	state.depth += 1
 
 	writeByte(state, string.byte("["))
@@ -142,7 +145,7 @@ local function serializeArray(state: SerializerState, array: Array)
 	writeByte(state, string.byte("]"))
 end
 
-local function serializeTable(state: SerializerState, object: Object)
+local function serializeTable(state: SerializerState, object: object)
 	writeByte(state, string.byte("{"))
 
 	if state.prettyPrint then
@@ -184,10 +187,10 @@ local function serializeTable(state: SerializerState, object: Object)
 	writeByte(state, string.byte("}"))
 end
 
-serializeAny = function(state: SerializerState, value: Value)
+serializeAny = function(state: SerializerState, value: value)
 	local valueType = type(value)
 
-	if value == json.NULL then
+	if value == json.null then
 		writeString(state, "null")
 	elseif valueType == "boolean" then
 		writeString(state, if value then "true" else "false")
@@ -197,9 +200,9 @@ serializeAny = function(state: SerializerState, value: Value)
 		serializeString(state, value :: string)
 	elseif valueType == "table" then
 		if #(value :: {}) == 0 and next(value :: { [unknown]: unknown }) ~= nil then
-			serializeTable(state, value :: Object)
+			serializeTable(state, value :: object)
 		else
-			serializeArray(state, value :: Array)
+			serializeArray(state, value :: array)
 		end
 	else
 		error("Unknown value", 2)
@@ -329,12 +332,12 @@ local function deserializeString(state: DeserializerState): string
 	return deserializerError(state, "Unterminated string")
 end
 
-local deserialize: (DeserializerState) -> (Array | Object | boolean | number | string)?
+local deserialize: (DeserializerState) -> (array | object | boolean | number | string)?
 
-local function deserializeArray(state: DeserializerState): Array
+local function deserializeArray(state: DeserializerState): array
 	state.cursor += 1
 
-	local current: Array = {}
+	local current: array = {}
 
 	local expectingValue = false
 	while state.cursor < #state.src do
@@ -369,7 +372,7 @@ local function deserializeArray(state: DeserializerState): Array
 	return current
 end
 
-local function deserializeObject(state: DeserializerState): Object
+local function deserializeObject(state: DeserializerState): object
 	state.cursor += 1
 
 	local current = {}
@@ -429,14 +432,14 @@ local function deserializeObject(state: DeserializerState): Object
 	return current
 end
 
-deserialize = function(state: DeserializerState): Value
+deserialize = function(state: DeserializerState): value
 	skipWhitespace(state)
 
 	local fourChars = string.sub(state.src, state.cursor, state.cursor + 3)
 
 	if fourChars == "null" then
 		state.cursor += 4
-		return json.NULL
+		return json.null
 	elseif fourChars == "true" then
 		state.cursor += 4
 		return true
@@ -459,7 +462,7 @@ end
 
 -- user-facing
 
-json.serialize = function(value: Value, prettyPrint: boolean?)
+function json.serialize(value: value, prettyPrint: boolean?)
 	local state: SerializerState = {
 		buf = buffer.create(1024),
 		cursor = 0,
@@ -472,13 +475,39 @@ json.serialize = function(value: Value, prettyPrint: boolean?)
 	return buffer.readstring(state.buf, 0, state.cursor)
 end
 
-json.deserialize = function(src: string)
+function json.deserialize(src: string)
 	local state = {
 		src = src,
 		cursor = 0,
 	}
 
 	return deserialize(state)
+end
+
+function json.object(props: { [string]: value }): object
+	local res: object = { [object_key] = true }
+
+	for key, value in props do
+		res[key] = value
+	end
+
+	return res
+end
+
+function json.asobject(value: value): object?
+	if typeof(value) == "table" and value[object_key] then
+		return value :: object
+	end
+
+	return nil
+end
+
+function json.asarray(value: value): array?
+	if typeof(value) == "table" and not value[object_key] then
+		return value :: array
+	end
+
+	return nil
 end
 
 return table.freeze(json)

--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -3,10 +3,9 @@ local json = {
 	null = newproxy() :: nil,
 }
 
-type jsonprimitive = nil | number | string | boolean
-type object = { [string]: value }
-type array = { [number]: value }
-export type value = jsonprimitive | array | object
+export type object = { [string]: value }
+export type array = { [number]: value }
+export type value = nil | number | string | boolean | array | object
 
 -- a unique key to identify an object vs a table
 local object_key = newproxy()

--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -156,6 +156,10 @@ local function serializeTable(state: SerializerState, object: object)
 
 	local first = true
 	for key, value in object do
+		if key == object_key then
+			continue
+		end
+
 		if not first then
 			writeByte(state, string.byte(","))
 			writeByte(state, string.byte(" "))


### PR DESCRIPTION
We got some useful feedback from @vocksel about not being able to get a clean refinement between array and object with the existing types setup, and the correct solution to this problem here is for us to leverage another newproxy as a key to distinguish between objects and arrays. We've provided some additional functions to the interface of `json` both to construct `object`s and to test against values being `object`s or `array`s. There's also some clean up in here for json as a library generally, including correcting its casing now that it's a standard library and including `object` and `array` as part of the exported types as well.