### PR TITLE
Change base URL in VitePress config

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vitepress'
 export default defineConfig({
   title: "Lute",
   description: "Luau for General-Purpose Programming",
-  base: "/lute/",
+  base: "/",
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [


### PR DESCRIPTION
We changed the domain to not be under a folder, but be under a subdomain (`lute.luau.org`, instead of `luau-lang.github.io/lute/`), so we need to update the vitepress default.