### PR TITLE
docs fix: use lute lib instead of std for `reference.luau`

### DIFF
--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -1,5 +1,5 @@
-local fs = require("@std/fs")
-local process = require("@std/process")
+local fs = require("@lute/fs")
+local process = require("@lute/process")
 
 local function projectRelative(...)
 	local cwd = process.cwd()


### PR DESCRIPTION
reverting the `fs` and `process` of `reference.luau` for docs gen to use `@lute` instead of `@std` because it uses `table.concat` on the `string` version of cwd
fixes failing build for docs

reverted both just for consistency in the requires for this file (that will hopefully be replaced with another version of doc gen soon)