### PR TITLE
stdlib: wrap tmpdir result in path

### DIFF
--- a/lute/std/libs/path/init.luau
+++ b/lute/std/libs/path/init.luau
@@ -1,4 +1,4 @@
-local system = require("@std/system")
+local platforminfo = require("@std/system/platforminfo")
 
 local posix = require("@self/posix")
 local win32 = require("@self/win32")
@@ -8,7 +8,7 @@ local pathtypes = require("@self/types")
 export type path = pathtypes.path
 export type pathlike = pathtypes.pathlike
 
-local onWindows = system.win32
+local onWindows = platforminfo.win32
 
 local function basename(path: pathlike): string?
 	if onWindows then

--- a/lute/std/libs/system.luau
+++ b/lute/std/libs/system.luau
@@ -5,12 +5,19 @@
 
 local system = require("@lute/system")
 
+local path = (require)("@std/path") -- trickery to avoid circular dependency
+local pathTypes = require("@std/path/types")
+
 local osName = string.lower(system.os)
 
 local win32 = osName == "windows_nt"
 local linux = osName == "linux"
 local macos = osName == "darwin"
 local unix = macos or linux or osName == "unix" or osName == "posix"
+
+local function tmpdir(): pathTypes.path
+	return path.parse(system.tmpdir())
+end
 
 return table.freeze({
 	os = system.os,

--- a/lute/std/libs/system/init.luau
+++ b/lute/std/libs/system/init.luau
@@ -4,18 +4,10 @@
 -- Provides re-exports of `@lute/system` and boolean properties for OS detection
 
 local system = require("@lute/system")
+local path = require("@std/path")
+local platforminfo = require("@self/platforminfo")
 
-local path = (require)("@std/path") -- trickery to avoid circular dependency
-local pathTypes = require("@std/path/types")
-
-local osName = string.lower(system.os)
-
-local win32 = osName == "windows_nt"
-local linux = osName == "linux"
-local macos = osName == "darwin"
-local unix = macos or linux or osName == "unix" or osName == "posix"
-
-local function tmpdir(): pathTypes.path
+local function tmpdir(): path.path
 	return path.parse(system.tmpdir())
 end
 
@@ -32,8 +24,8 @@ return table.freeze({
 	cpus = system.cpus,
 
 	-- boolean properties
-	win32 = win32,
-	linux = linux,
-	macos = macos,
-	unix = unix,
+	win32 = platforminfo.win32,
+	linux = platforminfo.linux,
+	macos = platforminfo.macos,
+	unix = platforminfo.unix,
 })

--- a/lute/std/libs/system/platforminfo.luau
+++ b/lute/std/libs/system/platforminfo.luau
@@ -1,0 +1,10 @@
+local system = require("@lute/system")
+
+local osName = string.lower(system.os)
+
+local win32 = osName == "windows_nt"
+local linux = osName == "linux"
+local macos = osName == "darwin"
+local unix = macos or linux or osName == "unix" or osName == "posix"
+
+return table.freeze({ win32 = win32, linux = linux, macos = macos, unix = unix })


### PR DESCRIPTION
Wrap `system.tmpdir` in path to make our stdlib interfaces more consistent