### PR TITLE
fix: clang-cl build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,8 +110,9 @@ if(MSVC)
     list(APPEND LUTE_OPTIONS /D_CRT_SECURE_NO_WARNINGS) # We need to use the portable CRT functions.
     list(APPEND LUTE_OPTIONS "/we4018") # Signed/unsigned mismatch
     list(APPEND LUTE_OPTIONS "/we4388") # Also signed/unsigned mismatch
-    list(APPEND LUTE_OPTIONS "/Zc:externConstexpr") # MSVC does not comply with C++ standard by default
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        list(APPEND LUTE_OPTIONS "/Zc:externConstexpr") # MSVC does not comply with C++ standard by default
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         list(APPEND LUTE_OPTIONS "/EHsc") # The CMake clang-cl target doesn't enable exceptions by default
     endif()
     # FIXME: list(APPEND LUTE_OPTIONS /WX) # Warnings are errors

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -302,6 +302,7 @@ local function generateStdLibFilesIfNeeded()
 				for _, line in lines do
 					local escapedLine = string.gsub(line, "\\", "\\\\")
 					escapedLine = string.gsub(escapedLine, '"', '\\"')
+					escapedLine = string.gsub(escapedLine, "\r", "")
 					table.insert(generatedLines, `"{escapedLine}\\n"`)
 				end
 				fs.write(cpp, `\n    \{"{aliasedPath}", {table.concat(generatedLines, "\n")}},\n`)
@@ -483,6 +484,7 @@ local function generateCliCommandsFilesIfNeeded()
 				for _, line in lines do
 					local escapedLine = string.gsub(line, "\\", "\\\\")
 					escapedLine = string.gsub(escapedLine, '"', '\\"')
+					escapedLine = string.gsub(escapedLine, "\r", "")
 					table.insert(generatedLines, `"{escapedLine}\\n"`)
 				end
 				fs.write(cpp, `\n    \{"{aliasedPath}", {table.concat(generatedLines, "\n")}},\n`)


### PR DESCRIPTION
Fixes the build to work with clang-cl.

- `clang-cl` errored out on the generated strings, because they had `\r` at the end (from the default Windows line endings[^1]).
- `/Zc:externConstexpr` is unsupported/not needed on `clang-cl`

[^1]: Might be worth to have something like a `splitlines` that works with both LF and CRLF.