### PR TITLE
stdlib: path join shouldn't mutate argument objects

### DIFF
--- a/lute/std/libs/path/posix/init.luau
+++ b/lute/std/libs/path/posix/init.luau
@@ -102,7 +102,7 @@ local function joinHelper(path: path, addend: pathlike): ()
 end
 
 function posix.join(...: pathlike): path
-	local parts = { ... }
+	local parts: { pathlike } = { ... }
 	if #parts == 0 then
 		return {
 			parts = {},
@@ -110,7 +110,15 @@ function posix.join(...: pathlike): path
 		}
 	end
 
-	local path = posix.parse(parts[1])
+	local path: path
+	if typeof(parts[1]) == "string" then
+		path = posix.parse(parts[1])
+	else
+		path = {
+			parts = table.clone((parts[1] :: path).parts),
+			absolute = (parts[1] :: path).absolute,
+		}
+	end
 
 	for i = 2, #parts do
 		joinHelper(path, parts[i])

--- a/lute/std/libs/path/win32/init.luau
+++ b/lute/std/libs/path/win32/init.luau
@@ -144,7 +144,16 @@ function win32.join(...: pathlike): path
 		}
 	end
 
-	local path = win32.parse(parts[1])
+	local path: path
+	if typeof(parts[1]) == "string" then
+		path = win32.parse(parts[1])
+	else
+		path = {
+			parts = table.clone((parts[1] :: path).parts),
+			kind = (parts[1] :: path).kind,
+			driveLetter = (parts[1] :: path).driveLetter,
+		}
+	end
 
 	for i = 2, #parts do
 		joinHelper(path, parts[i])

--- a/tests/path.posix.test.luau
+++ b/tests/path.posix.test.luau
@@ -454,6 +454,10 @@ test.suite("PathPosixJoinSuite", function(suite)
 		assert.eq(result.parts[2], "user")
 		assert.eq(result.parts[3], "documents")
 		assert.eq(result.parts[4], "file.txt")
+		assert.eq(#pathobj.parts, 2) -- original pathobj should be unchanged
+		assert.eq(pathobj.parts[1], "home")
+		assert.eq(pathobj.parts[2], "user")
+		assert.eq(pathobj.absolute, true)
 	end)
 
 	suite:case("join_error_on_absolute_addend", function(assert)

--- a/tests/path.win32.test.luau
+++ b/tests/path.win32.test.luau
@@ -553,6 +553,11 @@ test.suite("PathWin32JoinSuite", function(suite)
 		assert.eq(result.parts[2], "username")
 		assert.eq(result.parts[3], "Documents")
 		assert.eq(result.parts[4], "file.txt")
+		assert.eq(#pathobj.parts, 2) -- original pathobj should be unchanged
+		assert.eq(pathobj.parts[1], "Users")
+		assert.eq(pathobj.parts[2], "username")
+		assert.eq(pathobj.kind, "absolute")
+		assert.eq(pathobj.driveLetter, "C")
 	end)
 
 	suite:case("join_error_on_absolute_addend", function(assert)


### PR DESCRIPTION
Separating this out from a different PR so the fix can get in sooner (resolves #463)