### PR TITLE
infra: set LUTE_ROOT_DIR in CI to the checkout

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -26,6 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Set checkout path as LUTE_ROOT_DIR
+      shell: bash
       run: echo "LUTE_ROOT_DIR=$(pwd)" >> $GITHUB_ENV
 
     - name: Install tools

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -25,6 +25,9 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Set checkout path as LUTE_ROOT_DIR
+      run: echo "LUTE_ROOT_DIR=$(pwd)" >> $GITHUB_ENV
+
     - name: Install tools
       uses: Roblox/setup-foreman@v3
       with:


### PR DESCRIPTION
We suddenly started getting CI failures for `getSourceRoot`, but we can set the environment variable instead to make sure it works consistently.