### PR TITLE
Fix CI and pin foreman lute version

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -25,10 +25,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Set checkout path as LUTE_ROOT_DIR
-      shell: bash
-      run: echo "LUTE_ROOT_DIR=$(pwd)" >> $GITHUB_ENV
-
     - name: Install tools
       uses: Roblox/setup-foreman@v3
       with:

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,3 +1,3 @@
 [tools]
 stylua = { github = "JohnnyMorganz/StyLua", version = "2.3.0" }
-lute = { github = "luau-lang/lute", version = "0.1.0-nightly.20251003" }
+lute = { github = "luau-lang/lute", version = "=0.1.0-nightly.20251023" }


### PR DESCRIPTION
Foreman auto upgrades if you don't pin the version, the output is pretty deceiving, too.