### PR TITLE
feature: Introduce a multifile payload format for embedding into the lute binary

### DIFF
--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -37,8 +37,8 @@ target_sources(Lute.CLI.lib PRIVATE
 )
 
 target_compile_features(Lute.CLI.lib PUBLIC cxx_std_17)
-target_include_directories(Lute.CLI.lib PUBLIC include ${CLI_GENERATED_INCLUDE_DIR})
-target_link_libraries(Lute.CLI.lib PRIVATE Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Require Lute.Runtime Luau.CLI.lib)
+target_include_directories(Lute.CLI.lib PUBLIC include ${CLI_GENERATED_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR})
+target_link_libraries(Lute.CLI.lib PRIVATE Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Require Lute.Runtime Luau.CLI.lib zlibstatic)
 target_compile_options(Lute.CLI.lib PRIVATE ${LUTE_OPTIONS})
 
 add_executable(Lute.CLI)

--- a/lute/cli/include/lute/compile.h
+++ b/lute/cli/include/lute/compile.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "Luau/DenseHash.h"
 #include "Luau/FileUtils.h"
+
+#include <string_view>
 
 struct AppendedBytecodeResult
 {
@@ -11,3 +14,56 @@ struct AppendedBytecodeResult
 AppendedBytecodeResult checkForAppendedBytecode();
 
 int compileScript(const std::string& inputFilePath, const std::string& outputFilePath);
+
+struct LuteDecodeResult;
+
+struct LuteEncodeResult
+{
+    std::string payload;
+    size_t bytesWritten = 0;
+    size_t compressedPayloadSizeBytes = 0;
+    size_t uncompressedPayloadSizeBytes = 0;
+};
+
+/**
+ * Represents a bundle of compiled Luau files ready for injection.
+ *
+ * Uncompressed bundle format (before compression):
+ *   For each file:
+ *     [path_length: uint32_t]
+ *     [path_string: char[path_length]]
+ *     [bytecode_size: uint64_t]
+ *     [bytecode_data: byte[bytecode_size]]
+ *
+ * Injectable payload format (after compression, what goes into executable):
+ *   [compressed_bundle_data: byte[compressed_size]]
+ *   [compressed_size: uint64_t]
+ *   [uncompressed_size: uint64_t]
+ *   [num_files: uint32_t]
+ *   [entry_point_path_string: char[entry_point_path_length]]
+ *   [entry_point_path_length: uint32_t]
+
+ */
+struct LuteExePayload
+{
+    LuteExePayload() = default;
+    void add(const std::string& luauFilePath);
+
+    std::optional<LuteEncodeResult> encode();
+    static std::optional<LuteDecodeResult> decode(const std::string_view binary);
+
+    std::string entryPointPath;
+    Luau::DenseHashMap<std::string, std::string> filePathToBytecode{""}; // path -> bytecode
+
+private:
+    bool parseFromDecompressedBundle(std::string_view decompressedBundle);
+    std::vector<std::string> filePaths;
+};
+
+struct LuteDecodeResult
+{
+    LuteExePayload payload;
+    size_t bytesRead = 0;
+    size_t compressedPayloadSizeBytes = 0;
+    size_t uncompressedPayloadSizeBytes = 0;
+};

--- a/lute/cli/src/compile.cpp
+++ b/lute/cli/src/compile.cpp
@@ -159,9 +159,7 @@ void LuteExePayload::add(const std::string& luauFilePath)
 {
     // First file added becomes the entry point
     if (filePaths.empty())
-    {
         entryPointPath = luauFilePath;
-    }
 
     filePaths.push_back(luauFilePath);
 }

--- a/lute/cli/src/compile.cpp
+++ b/lute/cli/src/compile.cpp
@@ -6,9 +6,10 @@
 #include "uv.h"
 #include "zlib.h"
 
+#include <cstring>
 #include <fstream>
 #include <string>
-#include <cstring>
+#include <type_traits>
 
 #ifndef _WIN32
 #include <sys/stat.h>
@@ -296,59 +297,60 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
         return std::nullopt;
     }
 
+    // Helper to read fixed-size values backwards
+    auto readValue = [&binary](size_t& pos, const char* fieldName, auto& value) -> bool
+    {
+        // We need this because the auto& parameter acts like a generic and we would like to strip out the & here
+        using T = std::decay_t<decltype(value)>;
+        if (pos < sizeof(T))
+        {
+            fprintf(stderr, "Decode failed: Incomplete %s field\n", fieldName);
+            return false;
+        }
+        pos -= sizeof(T);
+        memcpy(&value, binary.data() + pos, sizeof(T));
+        return true;
+    };
+
+    // Helper to read variable-length bytes backwards
+    auto readBytes = [&binary](size_t& pos, size_t length, const char* fieldName) -> std::optional<std::string> {
+        if (pos < length)
+        {
+            fprintf(stderr, "Decode failed: Incomplete %s field\n", fieldName);
+            return std::nullopt;
+        }
+        pos -= length;
+        return std::string(binary.data() + pos, length);
+    };
 
     // Read metadata from LUTEBYTE back to entry_point_path_length: [entry_point_path_length][entry_point_path][num_files][uncompressed_size][compressed_size][compressed_data]...[LUTEBYTE]
     size_t pos = binary.size() - MAGIC_FLAG_SIZE;
 
     // Read entry_point_path_length
-    if (pos < sizeof(uint32_t))
-    {
-        fprintf(stderr, "Decode failed: Incomplete entry point path length field\n");
-        return std::nullopt;
-    }
-    pos -= sizeof(uint32_t);
     uint32_t entryPointPathLength;
-    memcpy(&entryPointPathLength, binary.data() + pos, sizeof(uint32_t));
+    if (!readValue(pos, "entry_point_path_length", entryPointPathLength))
+        return std::nullopt;
 
     // Read entry_point_path
-    if (pos < entryPointPathLength)
-    {
-        fprintf(stderr, "Decode failed: Incomplete entry point path field\n");
+    auto entryPointPath = readBytes(pos, entryPointPathLength, "entry_point_path");
+    if (!entryPointPath)
         return std::nullopt;
-    }
-
-    pos -= entryPointPathLength;
-    result.payload.entryPointPath = std::string(binary.data() + pos, entryPointPathLength);
+    result.payload.entryPointPath = *entryPointPath;
 
     // Read num_files
-    if (pos < sizeof(uint32_t))
-    {
-        fprintf(stderr, "Decode failed: Incomplete num_files field\n");
-        return std::nullopt;
-    }
-    pos -= sizeof(uint32_t);
     uint32_t numFiles;
-    memcpy(&numFiles, binary.data() + pos, sizeof(uint32_t));
+    if (!readValue(pos, "num_files", numFiles))
+        return std::nullopt;
 
     // Read uncompressed_size
-    if (pos < sizeof(uint64_t))
-    {
-        fprintf(stderr, "Decode failed: Incomplete uncompressed_size field\n");
-        return std::nullopt;
-    }
-    pos -= sizeof(uint64_t);
     uint64_t uncompressedSize;
-    memcpy(&uncompressedSize, binary.data() + pos, sizeof(uint64_t));
+    if (!readValue(pos, "uncompressed_size", uncompressedSize))
+        return std::nullopt;
 
     // Read compressed_size
-    if (pos < sizeof(uint64_t))
-    {
-        fprintf(stderr, "Decode failed: Incomplete compressed_size field\n");
-        return std::nullopt;
-    }
-    pos -= sizeof(uint64_t);
     uint64_t compressedSize;
-    memcpy(&compressedSize, binary.data() + pos, sizeof(uint64_t));
+    if (!readValue(pos, "compressed_size", compressedSize))
+        return std::nullopt;
 
     // Read compressed data
     if (pos < compressedSize)

--- a/lute/cli/src/compile.cpp
+++ b/lute/cli/src/compile.cpp
@@ -170,7 +170,8 @@ std::optional<LuteEncodeResult> LuteExePayload::encode()
     // Encoding an empty payload is an error
     if (filePaths.empty())
     {
-        return std::nullopt;        
+        fprintf(stderr, "Encode failed: No files added to payload\n");
+        return std::nullopt;
     }
 
     LuteEncodeResult result;
@@ -182,12 +183,18 @@ std::optional<LuteEncodeResult> LuteExePayload::encode()
         // Read source file from disk
         std::optional<std::string> source = readFile(filePath);
         if (!source)
+        {
+            fprintf(stderr, "Encode failed: Could not read file '%s'\n", filePath.c_str());
             return std::nullopt;
+        }
 
         // Compile Luau source to bytecode
         std::string bytecode = Luau::compile(*source, copts());
         if (bytecode.empty())
+        {
+            fprintf(stderr, "Encode failed: Could not compile file '%s' to bytecode\n", filePath.c_str());
             return std::nullopt;
+        }
 
         filePathToBytecode[filePath] = bytecode;
 
@@ -223,7 +230,10 @@ std::optional<LuteEncodeResult> LuteExePayload::encode()
     );
 
     if (compressResult != Z_OK)
+    {
+        fprintf(stderr, "Encode failed: Compression error (zlib error %d)\n", compressResult);
         return std::nullopt;
+    }
     result.payload.clear();
     size_t totalBytes = compressedSize            // Size of compressed data
                         + sizeof(uint64_t)        // Length of compressed data (uint64_t)
@@ -273,12 +283,18 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
 
     // Check minimum size for magic flag
     if (binary.size() < MAGIC_FLAG_SIZE + sizeof(uint32_t))
+    {
+        fprintf(stderr, "Decode failed: Binary too small (%zu bytes) to contain valid payload\n", binary.size());
         return std::nullopt;
+    }
 
     // Check for LUTEBYTE magic flag at the end
     size_t magicOffset = binary.size() - MAGIC_FLAG_SIZE;
     if (memcmp(binary.data() + magicOffset, MAGIC_FLAG, MAGIC_FLAG_SIZE) != 0)
+    {
+        fprintf(stderr, "Decode failed: LUTEBYTE magic flag not found\n");
         return std::nullopt;
+    }
 
 
     // Read metadata from LUTEBYTE back to entry_point_path_length: [entry_point_path_length][entry_point_path][num_files][uncompressed_size][compressed_size][compressed_data]...[LUTEBYTE]
@@ -287,6 +303,7 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
     // Read entry_point_path_length
     if (pos < sizeof(uint32_t))
     {
+        fprintf(stderr, "Decode failed: Incomplete entry point path length field\n");
         return std::nullopt;
     }
     pos -= sizeof(uint32_t);
@@ -296,7 +313,8 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
     // Read entry_point_path
     if (pos < entryPointPathLength)
     {
-        return std::nullopt;        
+        fprintf(stderr, "Decode failed: Incomplete entry point path field\n");
+        return std::nullopt;
     }
 
     pos -= entryPointPathLength;
@@ -305,6 +323,7 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
     // Read num_files
     if (pos < sizeof(uint32_t))
     {
+        fprintf(stderr, "Decode failed: Incomplete num_files field\n");
         return std::nullopt;
     }
     pos -= sizeof(uint32_t);
@@ -314,6 +333,7 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
     // Read uncompressed_size
     if (pos < sizeof(uint64_t))
     {
+        fprintf(stderr, "Decode failed: Incomplete uncompressed_size field\n");
         return std::nullopt;
     }
     pos -= sizeof(uint64_t);
@@ -323,6 +343,7 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
     // Read compressed_size
     if (pos < sizeof(uint64_t))
     {
+        fprintf(stderr, "Decode failed: Incomplete compressed_size field\n");
         return std::nullopt;
     }
     pos -= sizeof(uint64_t);
@@ -332,6 +353,7 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
     // Read compressed data
     if (pos < compressedSize)
     {
+        fprintf(stderr, "Decode failed: Incomplete compressed data (expected %llu bytes)\n", static_cast<unsigned long long>(compressedSize));
         return std::nullopt;
     }
     pos -= compressedSize;
@@ -348,6 +370,7 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
 
     if (zlibResult != Z_OK)
     {
+        fprintf(stderr, "Decode failed: Decompression error (zlib error %d)\n", zlibResult);
         return std::nullopt;
     }
 
@@ -355,12 +378,16 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
     std::string_view decompressedBundle(reinterpret_cast<const char*>(uncompressedData.data()), actualUncompressedSize);
     if (!result.payload.parseFromDecompressedBundle(decompressedBundle))
     {
+        fprintf(stderr, "Decode failed: Failed to parse decompressed bundle\n");
         return std::nullopt;
     }
 
     // Validate that the number of parsed files matches the metadata
     if (result.payload.filePathToBytecode.size() != numFiles)
+    {
+        fprintf(stderr, "Decode failed: Expected %u files but parsed %zu\n", numFiles, result.payload.filePathToBytecode.size());
         return std::nullopt;
+    }
 
     // Populate result metrics
     result.bytesRead = binary.size();

--- a/lute/cli/src/compile.cpp
+++ b/lute/cli/src/compile.cpp
@@ -2,10 +2,17 @@
 
 #include "lute/options.h"
 #include "lute/process.h"
+
 #include "uv.h"
+#include "zlib.h"
 
 #include <fstream>
 #include <string>
+#include <cstring>
+
+#ifndef _WIN32
+#include <sys/stat.h>
+#endif
 
 const char MAGIC_FLAG[] = "LUTEBYTE";
 const size_t MAGIC_FLAG_SIZE = sizeof(MAGIC_FLAG) - 1;
@@ -145,4 +152,275 @@ int compileScript(const std::string& inputFilePath, const std::string& outputFil
 #endif
 
     return 0;
+}
+
+void LuteExePayload::add(const std::string& luauFilePath)
+{
+    // First file added becomes the entry point
+    if (filePaths.empty())
+    {
+        entryPointPath = luauFilePath;
+    }
+
+    filePaths.push_back(luauFilePath);
+}
+
+std::optional<LuteEncodeResult> LuteExePayload::encode()
+{
+    // Encoding an empty payload is an error
+    if (filePaths.empty())
+    {
+        return std::nullopt;        
+    }
+
+    LuteEncodeResult result;
+    // Step 1: Build uncompressed bytecode bundle
+    // Format: For each file, append [path_len][path][bytecode_size][bytecode]
+    std::string uncompressedBundle;
+    for (const auto& filePath : filePaths)
+    {
+        // Read source file from disk
+        std::optional<std::string> source = readFile(filePath);
+        if (!source)
+            return std::nullopt;
+
+        // Compile Luau source to bytecode
+        std::string bytecode = Luau::compile(*source, copts());
+        if (bytecode.empty())
+            return std::nullopt;
+
+        filePathToBytecode[filePath] = bytecode;
+
+        // Append path_length field (uint32_t, 4 bytes)
+        uint32_t pathLength = static_cast<uint32_t>(filePath.size());
+        uncompressedBundle.append(reinterpret_cast<const char*>(&pathLength), sizeof(uint32_t));
+
+        // Append path_string field (variable length)
+        uncompressedBundle.append(filePath);
+
+        // Append bytecode_size field (uint64_t, 8 bytes)
+        uint64_t bytecodeSize = bytecode.size();
+        uncompressedBundle.append(reinterpret_cast<const char*>(&bytecodeSize), sizeof(uint64_t));
+
+        // Append bytecode_data field (variable length)
+        uncompressedBundle.append(bytecode);
+    }
+
+    // Step 2: Compress the bundled bytecode using zlib
+    uLong uncompressedSize = uncompressedBundle.size();
+
+    // Calculate maximum possible compressed size
+    uLong compressedSize = compressBound(uncompressedSize);
+    std::vector<Bytef> compressedData(compressedSize);
+
+    // Compress with maximum compression level
+    int compressResult = compress2(
+        compressedData.data(),           // destination buffer
+        &compressedSize,                 // in/out: buffer size / actual compressed size
+        reinterpret_cast<const Bytef*>(uncompressedBundle.data()),  // source data
+        uncompressedSize,                // source size
+        Z_BEST_COMPRESSION               // compression level (9)
+    );
+
+    if (compressResult != Z_OK)
+        return std::nullopt;
+    result.payload.clear();
+    size_t totalBytes = compressedSize            // Size of compressed data
+                        + sizeof(uint64_t)        // Length of compressed data (uint64_t)
+                        + sizeof(uint64_t)        // Lengths of uncompressed data (uint64_t)
+                        + sizeof(uint32_t)        // Number of modules(files) in the bundle (uint32_t)
+                        + entryPointPath.length() // Module entry point path length
+                        + sizeof(uint32_t)        // Length of entry point field
+                        + MAGIC_FLAG_SIZE;        // LUTEBYTE - the magic flag that tells us to decode the bundled modules
+    result.payload.reserve(totalBytes);
+    // Step 3: Append the metadata needed
+    // Append compressed_data field (variable length, compressedSize bytes)
+    result.payload.append(reinterpret_cast<const char*>(compressedData.data()), compressedSize);
+
+    // Append compressed_size field (uint64_t, 8 bytes)
+    uint64_t compressedSizeField = compressedSize;
+    result.payload.append(reinterpret_cast<const char*>(&compressedSizeField), sizeof(uint64_t));
+
+    // Append uncompressed_size field (uint64_t, 8 bytes)
+    uint64_t uncompressedSizeField = uncompressedSize;
+    result.payload.append(reinterpret_cast<const char*>(&uncompressedSizeField), sizeof(uint64_t));
+
+    // Append num_files field (uint32_t, 4 bytes)
+    uint32_t numFiles = static_cast<uint32_t>(filePaths.size());
+    result.payload.append(reinterpret_cast<const char*>(&numFiles), sizeof(uint32_t));
+
+    // Append entry_point_path_string field (variable length)
+    result.payload.append(entryPointPath);
+
+    // Append entry_point_path_length field (uint32_t, 4 bytes)
+    uint32_t entryPointPathLength = static_cast<uint32_t>(entryPointPath.size());
+    result.payload.append(reinterpret_cast<const char*>(&entryPointPathLength), sizeof(uint32_t));
+
+    // Step 4: Append the LUTE BYTE
+    result.payload.append(MAGIC_FLAG, MAGIC_FLAG_SIZE);
+
+    result.bytesWritten = result.payload.size();
+    result.compressedPayloadSizeBytes = compressedSize;
+    result.uncompressedPayloadSizeBytes = uncompressedSize;
+    
+    return result;
+}
+
+std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view binary)
+{
+    LuteDecodeResult result;
+    result.payload.filePathToBytecode.clear();
+
+    // Check minimum size for magic flag
+    if (binary.size() < MAGIC_FLAG_SIZE + sizeof(uint32_t))
+        return std::nullopt;
+
+    // Check for LUTEBYTE magic flag at the end
+    size_t magicOffset = binary.size() - MAGIC_FLAG_SIZE;
+    if (memcmp(binary.data() + magicOffset, MAGIC_FLAG, MAGIC_FLAG_SIZE) != 0)
+        return std::nullopt;
+
+
+    // Read metadata from LUTEBYTE back to entry_point_path_length: [entry_point_path_length][entry_point_path][num_files][uncompressed_size][compressed_size][compressed_data]...[LUTEBYTE]
+    size_t pos = binary.size() - MAGIC_FLAG_SIZE;
+
+    // Read entry_point_path_length
+    if (pos < sizeof(uint32_t))
+    {
+        return std::nullopt;
+    }
+    pos -= sizeof(uint32_t);
+    uint32_t entryPointPathLength;
+    memcpy(&entryPointPathLength, binary.data() + pos, sizeof(uint32_t));
+
+    // Read entry_point_path
+    if (pos < entryPointPathLength)
+    {
+        return std::nullopt;        
+    }
+
+    pos -= entryPointPathLength;
+    result.payload.entryPointPath = std::string(binary.data() + pos, entryPointPathLength);
+
+    // Read num_files
+    if (pos < sizeof(uint32_t))
+    {
+        return std::nullopt;
+    }
+    pos -= sizeof(uint32_t);
+    uint32_t numFiles;
+    memcpy(&numFiles, binary.data() + pos, sizeof(uint32_t));
+
+    // Read uncompressed_size
+    if (pos < sizeof(uint64_t))
+    {
+        return std::nullopt;
+    }
+    pos -= sizeof(uint64_t);
+    uint64_t uncompressedSize;
+    memcpy(&uncompressedSize, binary.data() + pos, sizeof(uint64_t));
+
+    // Read compressed_size
+    if (pos < sizeof(uint64_t))
+    {
+        return std::nullopt;
+    }
+    pos -= sizeof(uint64_t);
+    uint64_t compressedSize;
+    memcpy(&compressedSize, binary.data() + pos, sizeof(uint64_t));
+
+    // Read compressed data
+    if (pos < compressedSize)
+    {
+        return std::nullopt;
+    }
+    pos -= compressedSize;
+
+    // Decompress the bundle
+    std::vector<Bytef> uncompressedData(uncompressedSize);
+    uLongf actualUncompressedSize = uncompressedSize;
+    int zlibResult = uncompress(
+        uncompressedData.data(),
+        &actualUncompressedSize,
+        reinterpret_cast<const Bytef*>(binary.data() + pos),
+        compressedSize
+    );
+
+    if (zlibResult != Z_OK)
+    {
+        return std::nullopt;
+    }
+
+    // Parse the decompressed bundle
+    std::string_view decompressedBundle(reinterpret_cast<const char*>(uncompressedData.data()), actualUncompressedSize);
+    if (!result.payload.parseFromDecompressedBundle(decompressedBundle))
+    {
+        return std::nullopt;
+    }
+
+    // Validate that the number of parsed files matches the metadata
+    if (result.payload.filePathToBytecode.size() != numFiles)
+        return std::nullopt;
+
+    // Populate result metrics
+    result.bytesRead = binary.size();
+    result.compressedPayloadSizeBytes = compressedSize;
+    result.uncompressedPayloadSizeBytes = actualUncompressedSize;
+    return result;
+}
+
+bool LuteExePayload::parseFromDecompressedBundle(std::string_view decompressedBundle)
+{
+    size_t offset = 0;
+    filePathToBytecode.clear();
+
+    while (offset < decompressedBundle.size())
+    {
+        // Read path length
+        if (offset + sizeof(uint32_t) > decompressedBundle.size())
+        {
+            fprintf(stderr, "Invalid bundle: incomplete path length field\n");
+            return false;
+        }
+
+        uint32_t pathLength;
+        memcpy(&pathLength, decompressedBundle.data() + offset, sizeof(uint32_t));
+        offset += sizeof(uint32_t);
+
+        // Read path string
+        if (offset + pathLength > decompressedBundle.size())
+        {
+            fprintf(stderr, "Invalid bundle: incomplete path string\n");
+            return false;
+        }
+
+        std::string filePath(decompressedBundle.data() + offset, pathLength);
+        offset += pathLength;
+
+        // Read bytecode size
+        if (offset + sizeof(uint64_t) > decompressedBundle.size())
+        {
+            fprintf(stderr, "Invalid bundle: incomplete bytecode size field\n");
+            return false;
+        }
+
+        uint64_t bytecodeSize;
+        memcpy(&bytecodeSize, decompressedBundle.data() + offset, sizeof(uint64_t));
+        offset += sizeof(uint64_t);
+
+        // Read bytecode
+        if (offset + bytecodeSize > decompressedBundle.size())
+        {
+            fprintf(stderr, "Invalid bundle: incomplete bytecode data\n");
+            return false;
+        }
+
+        std::string bytecode(decompressedBundle.data() + offset, bytecodeSize);
+        offset += bytecodeSize;
+
+        // Store in map
+        filePathToBytecode[filePath] = bytecode;
+    }
+
+    return true;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,9 @@ target_sources(Lute.Test PRIVATE
     src/modulepath.test.cpp
     src/require.test.cpp
     src/stdsystem.test.cpp
-    src/staticrequires.test.cpp)
+    src/staticrequires.test.cpp
+    src/stdsystem.test.cpp
+    src/compile.test.cpp)
 
 set_target_properties(Lute.Test PROPERTIES OUTPUT_NAME lute-tests)
 target_compile_features(Lute.Test PUBLIC cxx_std_17)

--- a/tests/src/compile.test.cpp
+++ b/tests/src/compile.test.cpp
@@ -1,0 +1,273 @@
+#include "Luau/FileUtils.h"
+#include "doctest.h"
+#include "lute/compile.h"
+#include "luteprojectroot.h"
+
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+TEST_CASE("lutepayload_single_file_roundtrip")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
+
+    // Create payload and add file
+    LuteExePayload originalPayload;
+    originalPayload.add(testFilePath);
+
+    // Encode
+    auto encodeResult = originalPayload.encode();
+    REQUIRE(encodeResult.has_value());
+    REQUIRE(encodeResult->bytesWritten > 0);
+    REQUIRE(encodeResult->compressedPayloadSizeBytes > 0);
+    REQUIRE(encodeResult->uncompressedPayloadSizeBytes > 0);
+    REQUIRE(!encodeResult->payload.empty());
+
+    // Verify compression is working (compressed should be smaller than uncompressed)
+    CHECK(encodeResult->compressedPayloadSizeBytes <= encodeResult->uncompressedPayloadSizeBytes);
+
+    // Decode
+    auto decodeResult = LuteExePayload::decode(encodeResult->payload);
+    REQUIRE(decodeResult.has_value());
+
+    // Verify metrics match
+    CHECK(decodeResult->bytesRead == encodeResult->bytesWritten);
+    CHECK(decodeResult->compressedPayloadSizeBytes == encodeResult->compressedPayloadSizeBytes);
+    CHECK(decodeResult->uncompressedPayloadSizeBytes == encodeResult->uncompressedPayloadSizeBytes);
+
+    // Verify entry point
+    CHECK(decodeResult->payload.entryPointPath == testFilePath);
+    CHECK(decodeResult->payload.entryPointPath == originalPayload.entryPointPath);
+
+    // Verify bytecode map has one entry
+    REQUIRE(decodeResult->payload.filePathToBytecode.size() == 1);
+
+    // Verify bytecode matches
+    auto it = decodeResult->payload.filePathToBytecode.find(testFilePath);
+    REQUIRE(it != nullptr);
+    auto originalIt = originalPayload.filePathToBytecode.find(testFilePath);
+    REQUIRE(originalIt != nullptr);
+    CHECK(*it == *originalIt);
+}
+
+TEST_CASE("lutepayload_multiple_files_roundtrip")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+
+    std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+
+    std::vector<std::string> testFiles = {
+        joinPaths(testDir, "main.luau"),
+        joinPaths(testDir, "utils.luau"),
+        joinPaths(testDir, "lib/helper.luau"),
+        joinPaths(testDir, "shared.luau")
+    };
+
+    // Create payload with multiple files
+    LuteExePayload originalPayload;
+    for (const auto& file : testFiles)
+    {
+        originalPayload.add(file);
+    }
+
+    // First file should be the entry point
+    CHECK(originalPayload.entryPointPath == testFiles[0]);
+
+    auto encodeResult = originalPayload.encode();
+    REQUIRE(encodeResult.has_value());
+    REQUIRE(!encodeResult->payload.empty());
+
+    auto decodeResult = LuteExePayload::decode(encodeResult->payload);
+    REQUIRE(decodeResult.has_value());
+
+    // Verify entry point
+    CHECK(decodeResult->payload.entryPointPath == testFiles[0]);
+
+    // Verify all files are present
+    REQUIRE(decodeResult->payload.filePathToBytecode.size() == testFiles.size());
+
+    for (const auto& file : testFiles)
+    {
+        auto decodedIt = decodeResult->payload.filePathToBytecode.find(file);
+        REQUIRE(decodedIt != nullptr);
+
+        auto originalIt = originalPayload.filePathToBytecode.find(file);
+        REQUIRE(originalIt != nullptr);
+
+        // Verify bytecode matches
+        CHECK(*decodedIt == *originalIt);
+    }
+}
+
+TEST_CASE("lutepayload_invalid_magic_flag")
+{
+    // Create a payload with invalid magic flag
+    std::string invalidPayload = "INVALID_";
+    invalidPayload.append(100, 'X'); // Add some data
+
+    auto decodeResult = LuteExePayload::decode(invalidPayload);
+    CHECK(!decodeResult.has_value());
+}
+
+TEST_CASE("lutepayload_too_small_payload")
+{
+    // Payload smaller than minimum size
+    std::string tinyPayload = "TINY";
+
+    auto decodeResult = LuteExePayload::decode(tinyPayload);
+    CHECK(!decodeResult.has_value());
+}
+
+TEST_CASE("lutepayload_corrupted_metadata")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
+
+    // Create valid payload
+    LuteExePayload originalPayload;
+    originalPayload.add(testFilePath);
+    auto encodeResult = originalPayload.encode();
+    REQUIRE(encodeResult.has_value());
+
+    // Corrupt the payload by modifying bytes near the end (metadata area)
+    std::string corruptedPayload = encodeResult->payload;
+    size_t corruptPos = corruptedPayload.size() - 20;
+    if (corruptPos < corruptedPayload.size())
+    {
+        corruptedPayload[corruptPos] = ~corruptedPayload[corruptPos];
+        corruptedPayload[corruptPos + 1] = ~corruptedPayload[corruptPos + 1];
+    }
+
+    // Attempt to decode corrupted payload
+    auto decodeResult = LuteExePayload::decode(corruptedPayload);
+    // Should either fail or produce different results
+    if (decodeResult.has_value())
+    {
+        // If it doesn't fail outright, the data should be corrupted
+        CHECK(decodeResult->payload.entryPointPath != originalPayload.entryPointPath);
+    }
+}
+
+TEST_CASE("lutepayload_entry_point_is_first_added")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+
+    std::string firstFile = joinPaths(testDir, "main.luau");
+    std::string secondFile = joinPaths(testDir, "utils.luau");
+
+    LuteExePayload payload;
+    payload.add(firstFile);
+    payload.add(secondFile);
+
+    // Entry point should be the first file added
+    CHECK(payload.entryPointPath == firstFile);
+}
+
+TEST_CASE("lutepayload_nonexistent_file")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string nonExistentFile = joinPaths(luteProjectRoot, "tests/src/this_file_does_not_exist.luau");
+
+    LuteExePayload payload;
+    payload.add(nonExistentFile);
+
+    // Encoding should fail because file doesn't exist
+    auto encodeResult = payload.encode();
+    CHECK(!encodeResult.has_value());
+}
+
+TEST_CASE("lutepayload_empty_payload")
+{
+    // Create payload without adding any files
+    LuteExePayload emptyPayload;
+    CHECK(emptyPayload.entryPointPath.empty());
+
+    // Encoding an empty payload should fail
+    auto encodeResult = emptyPayload.encode();
+    CHECK(!encodeResult.has_value());
+}
+
+TEST_CASE("lutepayload_compression_effectiveness")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
+
+    LuteExePayload payload;
+    payload.add(testFilePath);
+
+    auto encodeResult = payload.encode();
+    REQUIRE(encodeResult.has_value());
+
+    // Verify that compression is actually reducing size
+    // compressed should be smaller than uncompressed (barring any weird edge cases)
+    CHECK(encodeResult->compressedPayloadSizeBytes <= encodeResult->uncompressedPayloadSizeBytes);
+
+    // Verify the total payload includes overhead for metadata
+    // Total = compressed data + metadata (sizes, counts, paths, magic flag)
+    CHECK(encodeResult->bytesWritten >= encodeResult->compressedPayloadSizeBytes);
+}
+
+TEST_CASE("lutepayload_bytecode_integrity")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
+
+    // Create two separate payloads with the same file
+    LuteExePayload payload1;
+    payload1.add(testFilePath);
+    auto encode1 = payload1.encode();
+    REQUIRE(encode1.has_value());
+
+    LuteExePayload payload2;
+    payload2.add(testFilePath);
+    auto encode2 = payload2.encode();
+    REQUIRE(encode2.has_value());
+
+    // The bytecode for the same file should be identical
+    auto it1 = payload1.filePathToBytecode.find(testFilePath);
+    auto it2 = payload2.filePathToBytecode.find(testFilePath);
+    REQUIRE(it1 != nullptr);
+    REQUIRE(it2 != nullptr);
+    CHECK(*it1 == *it2);
+
+    // The encoded payloads should be identical (deterministic encoding)
+    CHECK(encode1->payload == encode2->payload);
+}
+
+TEST_CASE("lutepayload_validates_numfiles_metadata")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
+
+    // Create and encode a valid payload
+    LuteExePayload payload;
+    payload.add(testFilePath);
+    auto encodeResult = payload.encode();
+    REQUIRE(encodeResult.has_value());
+
+    // Corrupt the numFiles field (located before entry point path)
+    // Format: [...][compressed_size][uncompressed_size][num_files][entry_point_path][entry_point_path_length][LUTEBYTE]
+    std::string corruptedPayload = encodeResult->payload;
+
+    // Find the numFiles field: 8 bytes (magic) + 4 bytes (entry path len) + entry path len + 4 bytes (num_files)
+    size_t magicSize = 8; // "LUTEBYTE"
+
+    // Read entry point path length from the correct position
+    size_t entryPathLenPos = corruptedPayload.size() - magicSize - sizeof(uint32_t);
+    uint32_t entryPathLen;
+    memcpy(&entryPathLen, corruptedPayload.data() + entryPathLenPos, sizeof(uint32_t));
+
+    // numFiles is right before the entry point path
+    size_t numFilesPos = corruptedPayload.size() - magicSize - sizeof(uint32_t) - entryPathLen - sizeof(uint32_t);
+
+    // Change numFiles from 1 to 99
+    uint32_t fakeNumFiles = 99;
+    memcpy(corruptedPayload.data() + numFilesPos, &fakeNumFiles, sizeof(uint32_t));
+
+    // Decoding should fail due to numFiles mismatch
+    auto decodeResult = LuteExePayload::decode(corruptedPayload);
+    CHECK(!decodeResult.has_value());
+}


### PR DESCRIPTION
This PR is an incremental step towards supporting multi-file bytecode compilation. This PR defines a `LuteExePayload`, for encoding and decoding the multi file bytecode bundles that will be appended to the `lute` binary when shipping executables.

Once this PR is in, we can start writing the glue code that will let us produce a lute executable with multiple .luau files embedded.
