### PR TITLE
stdlib: fix memory leak in luau.compile

### DIFF
--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -2649,7 +2649,7 @@ int compile_luau(lua_State* L)
         sizeof(std::string),
         [](void* ptr)
         {
-            static_cast<std::string*>(ptr)->~basic_string();
+            static_cast<std::string*>(ptr)->~std::basic_string();
         }
     ));
 

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -2644,7 +2644,14 @@ int compile_luau(lua_State* L)
 
     std::string bytecode = Luau::compile(std::string(source, source_size), opts);
 
-    std::string* userdata = static_cast<std::string*>(lua_newuserdatatagged(L, sizeof(std::string), kCompilerResultTag));
+    std::string* userdata = static_cast<std::string*>(lua_newuserdatadtor(
+        L,
+        sizeof(std::string),
+        [](void* ptr)
+        {
+            static_cast<std::string*>(ptr)->~basic_string();
+        }
+    ));
 
     new (userdata) std::string(std::move(bytecode));
 

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -17,6 +17,7 @@
 #include <cstddef>
 #include <cstring>
 #include <iterator>
+#include <string>
 
 const char* COMPILE_RESULT_TYPE = "CompileResult";
 
@@ -2649,7 +2650,7 @@ int compile_luau(lua_State* L)
         sizeof(std::string),
         [](void* ptr)
         {
-            static_cast<std::string*>(ptr)->~std::basic_string();
+            static_cast<std::string*>(ptr)->std::string::~string();
         }
     ));
 

--- a/lute/runtime/include/lute/userdatas.h
+++ b/lute/runtime/include/lute/userdatas.h
@@ -1,7 +1,6 @@
 #pragma once
 
 // all tags count down from 128
-constexpr int kDurationTag       = 127;
-constexpr int kInstantTag        = 126;
-constexpr int kCompilerResultTag = 125;
-constexpr int kWatchHandleTag    = 124;
+constexpr int kDurationTag = 127;
+constexpr int kInstantTag = 126;
+constexpr int kWatchHandleTag = 125;

--- a/lute/std/libs/system/init.luau
+++ b/lute/std/libs/system/init.luau
@@ -14,6 +14,7 @@ end
 return table.freeze({
 	os = system.os,
 	arch = system.arch,
+	tmpdir = tmpdir,
 
 	-- function re-exports
 	threadcount = system.threadcount,

--- a/tests/compile.test.luau
+++ b/tests/compile.test.luau
@@ -1,0 +1,52 @@
+local fs = require("@std/fs")
+local process = require("@std/process")
+local path = require("@std/path")
+local system = require("@std/system")
+local test = require("@std/test")
+
+local COMPILER_CONTENTS = [[
+local luau = require("@lute/luau")
+local fs = require("@std/fs")
+
+local args = { ... }
+assert(#args == 2, "Expected one argument: path to Luau script to compile")
+
+local handle = fs.open(args[2], "r")
+local contents = fs.read(handle)
+fs.close(handle)
+luau.compile(contents)
+print(`SUCCESS`)
+]]
+
+local COMPILEE_CONTENTS = [[return "Hello world"]]
+
+local lutePath = process.execpath()
+local tmpDir = system.tmpdir()
+
+test.suite("Lute CLI", function(suite)
+	suite:case("help1", function(check)
+		-- Setup
+		-- Create files
+		local compilerPath = path.join(tmpDir, "compiler.luau")
+		local compilerFile = fs.open(compilerPath, "w+")
+		fs.write(compilerFile, COMPILER_CONTENTS)
+		fs.close(compilerFile)
+
+		local compileePath = path.join(tmpDir, "compilee.luau")
+		local compileeFile = fs.open(compileePath, "w+")
+		fs.write(compileeFile, COMPILEE_CONTENTS)
+		fs.close(compileeFile)
+
+		local result = process.run({ path.format(lutePath), path.format(compilerPath), path.format(compileePath) })
+		-- Compilation should work with no memory leaks
+		check.eq(result.stderr, "")
+		check.eq(result.stdout, "SUCCESS\n")
+		check.eq(result.exitcode, 0)
+
+		-- -- Cleanup
+		fs.remove(compilerPath)
+		fs.remove(compileePath)
+	end)
+end)
+
+test.run()


### PR DESCRIPTION
Fixed a memory leak which was causing GC for my other changes to fail. Specifically, there was a `std::string` which wasn't being freed because it was being moved into a userdata object, so I attached a destructor to it. I also got rid of the tag which was being applied to the userdata object being constructed because it wasn't being checked, and we were already applying a type-specific metatable to it. Thanks @~vrn-sn for helping me come up the fix!

Also added a missing export for `system.tmpdir`.