### PR TITLE
Use visitor pattern for exhaustivity in IO stream handling

### DIFF
--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -37,7 +37,7 @@ struct IOHandle
         return Luau::visit(
             [](auto& stream) -> uv_stream_t*
             {
-                return (uv_stream_t*)&stream;
+                return static_cast<uv_stream_t*>(&stream);
             },
             streamVariant
         );

--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -34,11 +34,13 @@ struct IOHandle
     }
 
     uv_stream_t* getStream() {
-        if (auto* tty = streamVariant.get_if<uv_tty_t>())
-            return (uv_stream_t*)tty;
-        if (auto* pipe = streamVariant.get_if<uv_pipe_t>())
-            return (uv_stream_t*)pipe;
-        return nullptr;
+        return Luau::visit(
+            [](auto& stream) -> uv_stream_t*
+            {
+                return (uv_stream_t*)&stream;
+            },
+            streamVariant
+        );
     }
 };
 

--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -37,7 +37,7 @@ struct IOHandle
         return Luau::visit(
             [](auto& stream) -> uv_stream_t*
             {
-                return static_cast<uv_stream_t*>(&stream);
+                return (uv_stream_t*)&stream;
             },
             streamVariant
         );


### PR DESCRIPTION
There are many other places where this pattern would be safer than `get_if`, but this is the only one where the overload pattern isn't needed (since all variants are handled identically). I'll need to think on how we want to introduce the overload pattern (either somewhere central in Lute or in the Luau repo itself).