### PR TITLE
Use `std::destroy_at` instead of manually invoking destructors

### DIFF
--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -35,6 +35,7 @@
 #endif
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -45,7 +46,7 @@ void* createCliRequireContext(lua_State* L)
         sizeof(RequireCtx),
         [](void* ptr)
         {
-            static_cast<RequireCtx*>(ptr)->~RequireCtx();
+            std::destroy_at(static_cast<RequireCtx*>(ptr));
         }
     );
 

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -1050,9 +1050,7 @@ static void initalizeFS(lua_State* L)
         kWatchHandleTag,
         [](lua_State* L, void* ud)
         {
-            auto* handle = static_cast<fs::WatchHandle*>(ud);
-
-            handle->~WatchHandle();
+            std::destroy_at(static_cast<fs::WatchHandle*>(ud));
         }
     );
 

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -14,9 +14,11 @@
 
 #include "lua.h"
 #include "lualib.h"
+
 #include <cstddef>
 #include <cstring>
 #include <iterator>
+#include <memory>
 #include <string>
 
 const char* COMPILE_RESULT_TYPE = "CompileResult";
@@ -2650,7 +2652,7 @@ int compile_luau(lua_State* L)
         sizeof(std::string),
         [](void* ptr)
         {
-            static_cast<std::string*>(ptr)->std::string::~string();
+            std::destroy_at(static_cast<std::string*>(ptr));
         }
     ));
 

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -41,8 +41,6 @@ struct ProcessHandle
     std::shared_ptr<ProcessHandle> self;
     std::atomic<int> pendingCloses{0};
 
-    ~ProcessHandle() {}
-
     void closeHandles()
     {
         auto closeCb = [](uv_handle_t* handle)
@@ -604,7 +602,7 @@ static int envIter(lua_State* L)
         sizeof(EnvIter),
         [](void* ptr)
         {
-            static_cast<EnvIter*>(ptr)->~EnvIter();
+            std::destroy_at(static_cast<EnvIter*>(ptr));
         }
     );
 

--- a/lute/vm/src/spawn.cpp
+++ b/lute/vm/src/spawn.cpp
@@ -178,7 +178,7 @@ static void* createChildVmRequireContext(lua_State* L)
         sizeof(RequireCtx),
         [](void* ptr)
         {
-            static_cast<RequireCtx*>(ptr)->~RequireCtx();
+            std::destroy_at(static_cast<RequireCtx*>(ptr));
         }
     );
 
@@ -255,7 +255,7 @@ int lua_spawn(lua_State* L)
             );
 
             // Remove the Ref we have in current VM, now it will not cause the actual lua_unref
-            target->~TargetFunction();
+            std::destroy_at(target);
         }
     );
 


### PR DESCRIPTION
C++17 introduces `std::destroy_at` under the `<memory>` header, which prevents confusion about which destructor to use when paired with placement new. For many cases, choosing the correct destructor is trivial, but for type names that are inside a namespace or aliased, it can be somewhat confusing which destructor to call. Using `std::destroy_at` automatically compiles the call to the correct destructor based on the pointer type.