### PR TITLE
refactor: Add some utilities for reading and writing Lute Executables in a more systematic fashion

### DIFF
--- a/lute/cli/include/lute/compile.h
+++ b/lute/cli/include/lute/compile.h
@@ -67,3 +67,27 @@ struct LuteDecodeResult
     size_t compressedPayloadSizeBytes = 0;
     size_t uncompressedPayloadSizeBytes = 0;
 };
+
+/**
+ * Manages creating and reading Lute executables with embedded bytecode bundles.
+ *
+ * Binary format (from end of file, reading backward):
+ *   [lute runtime executable's bytes]
+ *   [compressed bundle data]
+ *   [compressed_size: uint64_t]
+ *   [uncompressed_size: uint64_t]
+ *   [num_files: uint32_t]
+ *   [entry_point_path_string: char[entry_point_path_length]]
+ *   [entry_point_path_length: uint32_t]
+ *   [MAGIC_FLAG: "LUTEBYTE" (8 bytes)]
+ */
+struct LuteExecutable
+{
+    LuteExecutable(const std::string& luteRuntimePath);
+
+    bool create(const std::string& outputPath, LuteExePayload& payload);
+    std::optional<LuteExePayload> extract();
+
+    std::string executablePath;
+};
+

--- a/lute/cli/src/compile.cpp
+++ b/lute/cli/src/compile.cpp
@@ -451,3 +451,95 @@ bool LuteExePayload::parseFromDecompressedBundle(std::string_view decompressedBu
 
     return true;
 }
+
+LuteExecutable::LuteExecutable(const std::string& luteRuntimePath)
+    : executablePath(luteRuntimePath)
+{
+}
+
+bool LuteExecutable::create(const std::string& outputPath, LuteExePayload& payload)
+{
+    // Read the current executable (lute runtime)
+    std::ifstream sourceExe(executablePath, std::ios::binary | std::ios::ate);
+    if (!sourceExe)
+    {
+        fprintf(stderr, "Error: Failed to read executable '%s'\n", executablePath.c_str());
+        return false;
+    }
+
+    std::streampos exeSize = sourceExe.tellg();
+    if (exeSize < 0)
+        return false;
+
+    sourceExe.seekg(0, std::ios::beg);
+    std::vector<char> exeData(exeSize);
+    if (!sourceExe.read(exeData.data(), exeSize))
+        return false;
+
+    // Encode the payload
+    std::optional<LuteEncodeResult> encodeResult = payload.encode();
+
+    if (!encodeResult)
+    {
+        fprintf(stderr, "Error: Failed to encode payload\n");
+        return false;
+    }
+
+    // Write output file: executable + payload
+    std::ofstream outputFile(outputPath, std::ios::binary);
+    if (!outputFile)
+    {
+        fprintf(stderr, "Error: Failed to create output file '%s'\n", outputPath.c_str());
+        return false;
+    }
+
+    // Write original executable
+    outputFile.write(exeData.data(), exeData.size());
+
+    // Write encoded payload
+    outputFile.write(encodeResult->payload.data(), encodeResult->payload.size());
+
+    // Set executable permissions (using libuv's permission constants)
+#ifndef _WIN32
+    chmod(outputPath.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH);
+#endif
+
+    return true;
+}
+
+std::optional<LuteExePayload> LuteExecutable::extract()
+{
+    if (isDirectory(executablePath))
+        return std::nullopt;
+
+    std::ifstream exeFile(executablePath, std::ios::binary | std::ios::ate);
+
+    if (!exeFile)
+        return std::nullopt;
+
+    // Get file size
+    std::streampos fileSize = exeFile.tellg();
+    if (fileSize < 0)
+        return std::nullopt;
+
+    // Read entire file
+    exeFile.seekg(0, std::ios::beg);
+    std::vector<char> fileData(fileSize);
+    if (!exeFile.read(fileData.data(), fileSize))
+        return std::nullopt;
+
+    // Early check for LUTEBYTE magic flag before attempting decode
+    if (fileData.size() < MAGIC_FLAG_SIZE)
+        return std::nullopt;
+
+    size_t magicOffset = fileData.size() - MAGIC_FLAG_SIZE;
+    if (memcmp(fileData.data() + magicOffset, MAGIC_FLAG, MAGIC_FLAG_SIZE) != 0)
+        return std::nullopt;
+
+    // Decode the payload
+    std::optional<LuteDecodeResult> decodedPayload = LuteExePayload::decode(std::string_view(fileData.data(), fileData.size()));
+    if (!decodedPayload)
+        return std::nullopt;
+
+    return decodedPayload->payload;
+}

--- a/lute/cli/src/compile.cpp
+++ b/lute/cli/src/compile.cpp
@@ -522,18 +522,22 @@ std::optional<LuteExePayload> LuteExecutable::extract()
     if (fileSize < 0)
         return std::nullopt;
 
-    // Read entire file
+    // Early check: validate LUTEBYTE magic flag at end before reading entire file
+    if (fileSize < static_cast<std::streampos>(MAGIC_FLAG_SIZE))
+        return std::nullopt;
+
+    exeFile.seekg(-static_cast<std::streamoff>(MAGIC_FLAG_SIZE), std::ios::end);
+    char magicBuffer[MAGIC_FLAG_SIZE];
+    if (!exeFile.read(magicBuffer, MAGIC_FLAG_SIZE))
+        return std::nullopt;
+
+    if (memcmp(magicBuffer, MAGIC_FLAG, MAGIC_FLAG_SIZE) != 0)
+        return std::nullopt;
+
+    // Magic flag found, now read entire file
     exeFile.seekg(0, std::ios::beg);
     std::vector<char> fileData(fileSize);
     if (!exeFile.read(fileData.data(), fileSize))
-        return std::nullopt;
-
-    // Early check for LUTEBYTE magic flag before attempting decode
-    if (fileData.size() < MAGIC_FLAG_SIZE)
-        return std::nullopt;
-
-    size_t magicOffset = fileData.size() - MAGIC_FLAG_SIZE;
-    if (memcmp(fileData.data() + magicOffset, MAGIC_FLAG, MAGIC_FLAG_SIZE) != 0)
         return std::nullopt;
 
     // Decode the payload

--- a/tests/src/compile.test.cpp
+++ b/tests/src/compile.test.cpp
@@ -271,3 +271,188 @@ TEST_CASE("lutepayload_validates_numfiles_metadata")
     auto decodeResult = LuteExePayload::decode(corruptedPayload);
     CHECK(!decodeResult.has_value());
 }
+
+TEST_CASE("luteexecutable_single_file_roundtrip")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
+
+    // Create a temporary dummy executable as the base runtime
+    std::string dummyExePath = joinPaths(luteProjectRoot, "tests/temp_dummy_exe");
+    {
+        std::ofstream dummyExe(dummyExePath, std::ios::binary);
+        REQUIRE(dummyExe.is_open());
+        // Write some dummy data to simulate an executable
+        std::string dummyContent = "FAKE_EXECUTABLE_HEADER_DATA";
+        dummyExe.write(dummyContent.data(), dummyContent.size());
+        dummyExe.close();
+    }
+
+    // Create payload with a test file
+    LuteExePayload originalPayload;
+    originalPayload.add(testFilePath);
+
+    // Create LuteExecutable and write it out
+    std::string outputExePath = joinPaths(luteProjectRoot, "tests/temp_output_exe");
+    LuteExecutable executable(dummyExePath);
+
+    bool createSuccess = executable.create(outputExePath, originalPayload);
+    REQUIRE(createSuccess);
+
+    // Verify output file was created
+    std::ifstream checkFile(outputExePath, std::ios::binary);
+    REQUIRE(checkFile.is_open());
+    checkFile.close();
+
+    // Extract the payload from the created executable
+    LuteExecutable readExecutable(outputExePath);
+    auto extractedPayload = readExecutable.extract();
+    REQUIRE(extractedPayload.has_value());
+
+    // Verify entry point matches
+    CHECK(extractedPayload->entryPointPath == originalPayload.entryPointPath);
+
+    // Verify the file count matches
+    REQUIRE(extractedPayload->filePathToBytecode.size() == 1);
+
+    // Verify bytecode matches
+    auto originalBytecodeIt = originalPayload.filePathToBytecode.find(testFilePath);
+    auto extractedBytecodeIt = extractedPayload->filePathToBytecode.find(testFilePath);
+    REQUIRE(originalBytecodeIt != nullptr);
+    REQUIRE(extractedBytecodeIt != nullptr);
+    CHECK(*originalBytecodeIt == *extractedBytecodeIt);
+
+    // Clean up temporary files
+    std::remove(dummyExePath.c_str());
+    std::remove(outputExePath.c_str());
+}
+
+TEST_CASE("luteexecutable_multiple_files_roundtrip")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+
+    std::vector<std::string> testFiles = {
+        joinPaths(testDir, "main.luau"),
+        joinPaths(testDir, "utils.luau"),
+        joinPaths(testDir, "lib/helper.luau"),
+        joinPaths(testDir, "shared.luau")
+    };
+
+    // Create a temporary dummy executable
+    std::string dummyExePath = joinPaths(luteProjectRoot, "tests/temp_dummy_exe_multi");
+    {
+        std::ofstream dummyExe(dummyExePath, std::ios::binary);
+        REQUIRE(dummyExe.is_open());
+        std::string dummyContent = "FAKE_EXECUTABLE_WITH_LONGER_HEADER_TO_TEST_MULTI_FILE";
+        dummyExe.write(dummyContent.data(), dummyContent.size());
+        dummyExe.close();
+    }
+
+    // Create payload with multiple files
+    LuteExePayload originalPayload;
+    for (const auto& file : testFiles)
+    {
+        originalPayload.add(file);
+    }
+
+    // First file should be the entry point
+    CHECK(originalPayload.entryPointPath == testFiles[0]);
+
+    // Create the executable
+    std::string outputExePath = joinPaths(luteProjectRoot, "tests/temp_output_exe_multi");
+    LuteExecutable executable(dummyExePath);
+
+    bool createSuccess = executable.create(outputExePath, originalPayload);
+    REQUIRE(createSuccess);
+
+    // Extract the payload
+    LuteExecutable readExecutable(outputExePath);
+    auto extractedPayload = readExecutable.extract();
+    REQUIRE(extractedPayload.has_value());
+
+    // Verify entry point
+    CHECK(extractedPayload->entryPointPath == testFiles[0]);
+
+    // Verify all files are present
+    REQUIRE(extractedPayload->filePathToBytecode.size() == testFiles.size());
+
+    // Verify each file's bytecode matches
+    for (const auto& file : testFiles)
+    {
+        auto extractedIt = extractedPayload->filePathToBytecode.find(file);
+        REQUIRE(extractedIt != nullptr);
+
+        auto originalIt = originalPayload.filePathToBytecode.find(file);
+        REQUIRE(originalIt != nullptr);
+
+        CHECK(*extractedIt == *originalIt);
+    }
+
+    // Clean up
+    std::remove(dummyExePath.c_str());
+    std::remove(outputExePath.c_str());
+}
+
+TEST_CASE("luteexecutable_extract_from_plain_executable")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+
+    // Create a plain executable without any embedded payload
+    std::string plainExePath = joinPaths(luteProjectRoot, "tests/temp_plain_exe");
+    {
+        std::ofstream plainExe(plainExePath, std::ios::binary);
+        REQUIRE(plainExe.is_open());
+        std::string content = "PLAIN_EXECUTABLE_NO_PAYLOAD";
+        plainExe.write(content.data(), content.size());
+        plainExe.close();
+    }
+
+    // Attempt to extract - should return nullopt since there's no payload
+    LuteExecutable executable(plainExePath);
+    auto extractedPayload = executable.extract();
+    CHECK(!extractedPayload.has_value());
+
+    // Clean up
+    std::remove(plainExePath.c_str());
+}
+
+TEST_CASE("luteexecutable_extract_preserves_original_executable")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
+
+    // Create dummy executable with specific content
+    std::string dummyExePath = joinPaths(luteProjectRoot, "tests/temp_dummy_exe_preserve");
+    std::string originalExeContent = "ORIGINAL_EXE_CONTENT_12345";
+    {
+        std::ofstream dummyExe(dummyExePath, std::ios::binary);
+        REQUIRE(dummyExe.is_open());
+        dummyExe.write(originalExeContent.data(), originalExeContent.size());
+        dummyExe.close();
+    }
+
+    // Create payload and executable
+    LuteExePayload payload;
+    payload.add(testFilePath);
+
+    std::string outputExePath = joinPaths(luteProjectRoot, "tests/temp_output_exe_preserve");
+    LuteExecutable executable(dummyExePath);
+    bool createSuccess = executable.create(outputExePath, payload);
+    REQUIRE(createSuccess);
+
+    // Read the output file and verify the original executable content is at the beginning
+    std::ifstream outputFile(outputExePath, std::ios::binary);
+    REQUIRE(outputFile.is_open());
+
+    std::vector<char> buffer(originalExeContent.size());
+    outputFile.read(buffer.data(), buffer.size());
+    outputFile.close();
+
+    std::string extractedPrefix(buffer.begin(), buffer.end());
+    CHECK(extractedPrefix == originalExeContent);
+
+    // Clean up
+    std::remove(dummyExePath.c_str());
+    std::remove(outputExePath.c_str());
+}


### PR DESCRIPTION
This PR adds a `LuteExecutable` wrapper, that handles extracting the `LuteExePayload` out of a binary and also creating a valid `lute` executable with the payload injected in correctly. This will set us up to be able to do cross compilation a bit easier, by separating the `payload` from the actual act of manipulating an executable file.