### PR TITLE
refactor: rename exprifelse field names

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -233,7 +233,7 @@ export type AstStatElseIf = {
 	elseifkeyword: Token<"elseif">,
 	condition: AstExpr,
 	thenkeyword: Token<"then">,
-	consequent: AstStatBlock,
+	thenblock: AstStatBlock,
 }
 
 export type AstStatIf = {
@@ -241,10 +241,10 @@ export type AstStatIf = {
 	ifkeyword: Token<"if">,
 	condition: AstExpr,
 	thenkeyword: Token<"then">,
-	consequent: AstStatBlock,
+	thenblock: AstStatBlock,
 	elseifs: { AstStatElseIf },
 	elsekeyword: Token<"else">?, -- TODO: this could be elseif!
-	antecedent: AstStatBlock?,
+	elseblock: AstStatBlock?,
 	endkeyword: Token<"end">,
 }
 

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -229,7 +229,7 @@ export type AstStatBlock = {
 	statements: { AstStat },
 }
 
-export type AstStatElseIf = {
+type AstStatElseIf = {
 	elseifkeyword: Token<"elseif">,
 	condition: AstExpr,
 	thenkeyword: Token<"then">,

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -186,11 +186,11 @@ export type AstExprTypeAssertion = {
 	annotation: AstType,
 }
 
-export type AstExprIfElseIfs = {
+type AstExprIfElseIfs = {
 	elseifkeyword: Token<"elseif">,
 	condition: AstExpr,
 	thenkeyword: Token<"then">,
-	consequent: AstExpr,
+	trueexpr: AstExpr,
 }
 
 export type AstExprIfElse = {
@@ -198,10 +198,10 @@ export type AstExprIfElse = {
 	ifkeyword: Token<"if">,
 	condition: AstExpr,
 	thenkeyword: Token<"then">,
-	consequent: AstExpr,
+	trueexpr: AstExpr,
 	elseifs: { AstExprIfElseIfs },
 	elsekeyword: Token<"else">,
-	antecedent: AstExpr,
+	falseexpr: AstExpr,
 }
 
 export type AstExpr =

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -186,11 +186,11 @@ export type AstExprTypeAssertion = {
 	annotation: AstType,
 }
 
-type AstExprIfElseIfs = {
+export type AstExprIfElseIfs = {
 	elseifkeyword: Token<"elseif">,
 	condition: AstExpr,
 	thenkeyword: Token<"then">,
-	trueexpr: AstExpr,
+	thenexpr: AstExpr,
 }
 
 export type AstExprIfElse = {
@@ -198,10 +198,10 @@ export type AstExprIfElse = {
 	ifkeyword: Token<"if">,
 	condition: AstExpr,
 	thenkeyword: Token<"then">,
-	trueexpr: AstExpr,
+	thenexpr: AstExpr,
 	elseifs: { AstExprIfElseIfs },
 	elsekeyword: Token<"else">,
-	falseexpr: AstExpr,
+	elseexpr: AstExpr,
 }
 
 export type AstExpr =
@@ -229,7 +229,7 @@ export type AstStatBlock = {
 	statements: { AstStat },
 }
 
-type AstStatElseIf = {
+export type AstStatElseIf = {
 	elseifkeyword: Token<"elseif">,
 	condition: AstExpr,
 	thenkeyword: Token<"then">,

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -1045,7 +1045,7 @@ struct AstSerialize : public Luau::AstVisitor
         }
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "consequent");
+        lua_setfield(L, -2, "trueexpr");
 
         lua_createtable(L, 0, preambleSize + 4);
         int i = 0;
@@ -1070,7 +1070,7 @@ struct AstSerialize : public Luau::AstVisitor
             }
             else
                 lua_pushnil(L);
-            lua_setfield(L, -2, "consequent");
+            lua_setfield(L, -2, "trueexpr");
 
             lua_rawseti(L, -2, i + 1);
             i++;
@@ -1085,7 +1085,7 @@ struct AstSerialize : public Luau::AstVisitor
         }
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "antecedent");
+        lua_setfield(L, -2, "falseexpr");
     }
 
     void serialize(Luau::AstExprInterpString* node)

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -1166,7 +1166,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "thenkeyword");
 
         node->thenbody->visit(this);
-        lua_setfield(L, -2, "consequent");
+        lua_setfield(L, -2, "thenblock");
 
         lua_createtable(L, 0, 0);
         int i = 0;
@@ -1185,7 +1185,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "thenkeyword");
 
             elseif->thenbody->visit(this);
-            lua_setfield(L, -2, "consequent");
+            lua_setfield(L, -2, "thenblock");
 
             lua_rawseti(L, -2, i + 1);
             node = elseif;
@@ -1200,7 +1200,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "elsekeyword");
 
             node->elsebody->visit(this);
-            lua_setfield(L, -2, "antecedent");
+            lua_setfield(L, -2, "elseblock");
 
             serializeToken(node->elsebody->location.end, "end");
             lua_setfield(L, -2, "endkeyword");
@@ -1211,7 +1211,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "elsekeyword");
 
             lua_pushnil(L);
-            lua_setfield(L, -2, "antecedent");
+            lua_setfield(L, -2, "elseblock");
 
             serializeToken(node->thenbody->location.end, "end");
             lua_setfield(L, -2, "endkeyword");

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -1045,7 +1045,7 @@ struct AstSerialize : public Luau::AstVisitor
         }
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "trueexpr");
+        lua_setfield(L, -2, "thenexpr");
 
         lua_createtable(L, 0, preambleSize + 4);
         int i = 0;
@@ -1070,7 +1070,7 @@ struct AstSerialize : public Luau::AstVisitor
             }
             else
                 lua_pushnil(L);
-            lua_setfield(L, -2, "trueexpr");
+            lua_setfield(L, -2, "thenexpr");
 
             lua_rawseti(L, -2, i + 1);
             i++;
@@ -1085,7 +1085,7 @@ struct AstSerialize : public Luau::AstVisitor
         }
         else
             lua_pushnil(L);
-        lua_setfield(L, -2, "falseexpr");
+        lua_setfield(L, -2, "elseexpr");
     }
 
     void serialize(Luau::AstExprInterpString* node)

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -62,11 +62,15 @@ export type AstExprInterpString = luteLuau.AstExprInterpString
 
 export type AstExprTypeAssertion = luteLuau.AstExprTypeAssertion
 
+export type AstExprIfElseIfs = luteLuau.AstExprIfElseIfs
+
 export type AstExprIfElse = luteLuau.AstExprIfElse
 
 export type AstExpr = luteLuau.AstExpr
 
 export type AstStatBlock = luteLuau.AstStatBlock
+
+export type AstStatElseIf = luteLuau.AstStatElseIf
 
 export type AstStatIf = luteLuau.AstStatIf
 

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -68,8 +68,6 @@ export type AstExpr = luteLuau.AstExpr
 
 export type AstStatBlock = luteLuau.AstStatBlock
 
-export type AstStatElseIf = luteLuau.AstStatElseIf
-
 export type AstStatIf = luteLuau.AstStatIf
 
 export type AstStatWhile = luteLuau.AstStatWhile

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -62,8 +62,6 @@ export type AstExprInterpString = luteLuau.AstExprInterpString
 
 export type AstExprTypeAssertion = luteLuau.AstExprTypeAssertion
 
-export type AstExprIfElseIfs = luteLuau.AstExprIfElseIfs
-
 export type AstExprIfElse = luteLuau.AstExprIfElse
 
 export type AstExpr = luteLuau.AstExpr

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -168,18 +168,18 @@ local function visitIf(node: luau.AstStatIf, visitor: Visitor)
 		visitToken(node.ifkeyword, visitor)
 		visitExpression(node.condition, visitor)
 		visitToken(node.thenkeyword, visitor)
-		visitBlock(node.consequent, visitor)
+		visitBlock(node.thenblock, visitor)
 		for _, elseifNode in node.elseifs do
 			visitToken(elseifNode.elseifkeyword, visitor)
 			visitExpression(elseifNode.condition, visitor)
 			visitToken(elseifNode.thenkeyword, visitor)
-			visitBlock(elseifNode.consequent, visitor)
+			visitBlock(elseifNode.thenblock, visitor)
 		end
 		if node.elsekeyword then
 			visitToken(node.elsekeyword, visitor)
 		end
-		if node.antecedent then
-			visitBlock(node.antecedent, visitor)
+		if node.elseblock then
+			visitBlock(node.elseblock, visitor)
 		end
 		visitToken(node.endkeyword, visitor)
 	end

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -554,15 +554,15 @@ local function visitIfExpression(node: luau.AstExprIfElse, visitor: Visitor)
 		visitToken(node.ifkeyword, visitor)
 		visitExpression(node.condition, visitor)
 		visitToken(node.thenkeyword, visitor)
-		visitExpression(node.consequent, visitor)
+		visitExpression(node.trueexpr, visitor)
 		for _, elseifs in node.elseifs do
 			visitToken(elseifs.elseifkeyword, visitor)
 			visitExpression(elseifs.condition, visitor)
 			visitToken(elseifs.thenkeyword, visitor)
-			visitExpression(elseifs.consequent, visitor)
+			visitExpression(elseifs.trueexpr, visitor)
 		end
 		visitToken(node.elsekeyword, visitor)
-		visitExpression(node.antecedent, visitor)
+		visitExpression(node.falseexpr, visitor)
 	end
 end
 

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -554,15 +554,15 @@ local function visitIfExpression(node: luau.AstExprIfElse, visitor: Visitor)
 		visitToken(node.ifkeyword, visitor)
 		visitExpression(node.condition, visitor)
 		visitToken(node.thenkeyword, visitor)
-		visitExpression(node.trueexpr, visitor)
+		visitExpression(node.thenexpr, visitor)
 		for _, elseifs in node.elseifs do
 			visitToken(elseifs.elseifkeyword, visitor)
 			visitExpression(elseifs.condition, visitor)
 			visitToken(elseifs.thenkeyword, visitor)
-			visitExpression(elseifs.trueexpr, visitor)
+			visitExpression(elseifs.thenexpr, visitor)
 		end
 		visitToken(node.elsekeyword, visitor)
-		visitExpression(node.falseexpr, visitor)
+		visitExpression(node.elseexpr, visitor)
 	end
 end
 


### PR DESCRIPTION
These field names are [misleading](https://home.sandiego.edu/~baber/logic/conditionals), so rename them to match what we have in our C++ Ast types. Also, stop exporting AstExprIfElseIfs, because it's more like a utility type rather than an actual AST node.