### PR TITLE
lute transform: add exhaustive match back

### DIFF
--- a/lute/cli/commands/transform/init.luau
+++ b/lute/cli/commands/transform/init.luau
@@ -6,6 +6,10 @@ local arguments = require("@self/lib/arguments")
 local files = require("@self/lib/files")
 local types = require("@self/lib/types")
 
+local function exhaustiveMatch(value: never): never
+	error(`Unknown value in exhaustive match: {value}`)
+end
+
 local function loadMigration(path: string): types.Migration
 	local success, loaded = pcall(luau.loadbypath, path)
 	assert(success, `{path} failed to require: {loaded}`)

--- a/tests/transform.test.luau
+++ b/tests/transform.test.luau
@@ -1,6 +1,7 @@
-local fs = require("@lute/fs")
+local fs = require("@std/fs")
 local path = require("@std/path")
 local process = require("@lute/process")
+local system = require("@std/system")
 local test = require("@std/test")
 
 local TRANSFORMEE_CONTENT = [[
@@ -9,39 +10,25 @@ local b = x ~= x
 ]]
 
 local lutePath = process.execpath()
+local tmpDir = system.tmpdir()
 
 test.suite("lute transform", function(suite)
-	local transformTestDir = path.format(path.join("build", "transform_tests"))
-
-	suite:beforeall(function()
-		-- Make a temp folder in the build directory
-		if not fs.exists("build") then
-			fs.mkdir("build")
-		end
-
-		if not fs.exists(transformTestDir) then
-			fs.mkdir(transformTestDir)
-		end
-	end)
-
 	suite:case("transform visitor style", function(assert)
 		-- Setup
 		-- Copy examples/transformer.luau to build/transform_tests/transformer.luau
 		local transformerExample = path.format(path.join("examples", "transformer.luau"))
-		local transformerDest = path.format(path.join(transformTestDir, "transformer.luau"))
+		local transformerDest = path.format(path.join(tmpDir, "transformer.luau"))
 		fs.copy(transformerExample, transformerDest)
 
 		-- Create a transformee file
-		local transformeePath = path.format(path.join(transformTestDir, "transformee.luau"))
+		local transformeePath = path.format(path.join(tmpDir, "transformee.luau"))
 		local transformeeHandle = fs.open(transformeePath, "w+")
 		fs.write(transformeeHandle, TRANSFORMEE_CONTENT)
 		fs.close(transformeeHandle)
 
 		-- Do
 		-- Run the transformer on the transformee
-		local result = process.run({ lutePath, "transform", transformerDest, transformeePath }, {
-			cwd = process.cwd(),
-		})
+		local result = process.run({ lutePath, "transform", transformerDest, transformeePath })
 
 		-- Check
 		assert.eq(result.exitcode, 0)
@@ -55,13 +42,6 @@ test.suite("lute transform", function(suite)
 		-- Teardown
 		fs.remove(transformerDest)
 		fs.remove(transformeePath)
-	end)
-
-	suite:afterall(function()
-		for _, file in fs.listdir(transformTestDir) do
-			fs.remove(path.format(path.join(transformTestDir, file.name)))
-		end
-		fs.rmdir(transformTestDir)
 	end)
 end)
 


### PR DESCRIPTION
`exhaustiveMatch` got accidentally deleted in a previous PR. Also took the chance to update the transform test since we have `tempDir` now. The migration processing code is already written in a way that `exhaustiveMatch` is never actually reachable right now, but it's a good check to have in case we expand the migration API in the future.