### PR TITLE
Feature: lute test subcommand

### DIFF
--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -1,0 +1,44 @@
+local function printHelp()
+	print([[
+Usage: lute test [OPTIONS] [PATHS...]
+
+Run tests discovered in .test.luau and .spec.luau files.
+
+OPTIONS:
+  -h, --help              Show this help message
+  --list                  List all discovered test cases without running them
+  --filter=PATTERN        Run only tests matching PATTERN
+                          Examples:
+                            --filter=SuiteName           (run all tests in suite)
+                            --filter=SuiteName.testname  (run specific test)
+                            --filter=testname            (run anonymous test)
+  --reporter=REPORTER     Choose test reporter (default: rich)
+                          Options:
+                            rich    - Color output with visual diffs
+                            simple  - Plain text output
+                            <path>  - Custom reporter from file path
+
+PATHS:
+  Directories or files to search for tests (default: ./tests)
+
+EXAMPLES:
+  lute test                                    Run all tests in ./tests
+  lute test --list                             List all test cases
+  lute test --filter=MyTestSuite               Run all tests in MyTestSuite
+  lute test --reporter=simple src/             Run tests with simple reporter
+]])
+end
+
+local function main(...: string)
+	local args = { ... }
+
+	-- Check for help flag
+	for _, arg in args do
+		if arg == "-h" or arg == "--help" then
+			printHelp()
+			return
+		end
+	end
+end
+
+main(...)

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -1,7 +1,8 @@
-local process = require("@lute/process")
+local path = require("@std/path")
+local process = require("@std/process")
 local test = require("@std/test")
 
-local lutePath = process.execpath()
+local lutePath = path.format(process.execpath())
 
 test.suite("lute test", function(suite)
 	suite:case("lute test help message", function(assert)

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -1,0 +1,25 @@
+local process = require("@lute/process")
+local test = require("@std/test")
+
+local lutePath = process.execpath()
+
+test.suite("lute test", function(suite)
+	suite:case("lute test help message", function(assert)
+		-- Run lute test with -h flag
+		local result = process.run({ lutePath, "test", "-h" })
+
+		-- Check that it exits successfully and prints help
+		assert.eq(result.exitcode, 0)
+		assert.neq(result.stdout:find("Usage:", 1, true), nil)
+	end)
+
+	suite:case("lute test runs successfully", function(assert)
+		-- Run lute test without arguments
+		local result = process.run({ lutePath, "test" })
+
+		-- Check that it succeeds
+		assert.eq(result.exitcode, 0)
+	end)
+end)
+
+test.run()


### PR DESCRIPTION
This PR introduces a skeleton for the `lute test` subcommand. In future PR's I'll build out the functionality described in the help message, e.g. `--list, --filter, --reporter = ...`