### PR TITLE
stdlib: add `__tostring` to paths

### DIFF
--- a/lute/std/libs/path/init.luau
+++ b/lute/std/libs/path/init.luau
@@ -1,11 +1,11 @@
-local pathlib = {}
-
 local platforminfo = require("@std/system/platforminfo")
 
 local posix = require("@self/posix")
 local win32 = require("@self/win32")
 
 local pathtypes = require("@self/types")
+
+local pathlib = {}
 
 type PathInterface = {
 	__tostring: () -> string,
@@ -82,10 +82,8 @@ end
 
 function pathlib.resolve(...: pathlike): path
 	if onWindows then
-		-- return win32.resolve(...)
 		return setmetatable(win32.resolve(...), pathlib)
 	else
-		-- return posix.resolve(...)
 		return setmetatable(posix.resolve(...), pathlib)
 	end
 end

--- a/lute/std/libs/path/init.luau
+++ b/lute/std/libs/path/init.luau
@@ -7,12 +7,8 @@ local pathtypes = require("@self/types")
 
 local pathlib = {}
 
-type PathInterface = {
-	__tostring: () -> string,
-}
-
-export type path = setmetatable<pathtypes.path, PathInterface>
-export type pathlike = setmetatable<pathtypes.pathlike, PathInterface>
+export type path = pathtypes.path
+export type pathlike = pathtypes.pathlike
 
 local onWindows = platforminfo.win32
 
@@ -90,13 +86,5 @@ end
 
 pathlib.win32 = win32
 pathlib.posix = posix
-
-function pathlib:__tostring(): string
-	if onWindows then
-		return win32.format(self :: path)
-	else
-		return posix.format(self :: path)
-	end
-end
 
 return table.freeze(pathlib)

--- a/lute/std/libs/path/init.luau
+++ b/lute/std/libs/path/init.luau
@@ -54,33 +54,33 @@ end
 
 function pathlib.join(...: pathlike): path
 	if onWindows then
-		return setmetatable(win32.join(...), pathlib)
+		return win32.join(...)
 	else
-		return setmetatable(posix.join(...), pathlib)
+		return posix.join(...)
 	end
 end
 
 function pathlib.normalize(path: pathlike): path
 	if onWindows then
-		return setmetatable(win32.normalize(path :: win32.pathlike), pathlib)
+		return win32.normalize(path :: win32.pathlike)
 	else
-		return setmetatable(posix.normalize(path :: posix.pathlike), pathlib)
+		return posix.normalize(path :: posix.pathlike)
 	end
 end
 
 function pathlib.parse(path: pathlike): path
 	if onWindows then
-		return setmetatable(win32.parse(path :: win32.pathlike), pathlib)
+		return win32.parse(path :: win32.pathlike)
 	else
-		return setmetatable(posix.parse(path :: posix.pathlike), pathlib)
+		return posix.parse(path :: posix.pathlike)
 	end
 end
 
 function pathlib.resolve(...: pathlike): path
 	if onWindows then
-		return setmetatable(win32.resolve(...), pathlib)
+		return win32.resolve(...)
 	else
-		return setmetatable(posix.resolve(...), pathlib)
+		return posix.resolve(...)
 	end
 end
 

--- a/lute/std/libs/path/init.luau
+++ b/lute/std/libs/path/init.luau
@@ -1,3 +1,5 @@
+local pathlib = {}
+
 local platforminfo = require("@std/system/platforminfo")
 
 local posix = require("@self/posix")
@@ -5,10 +7,12 @@ local win32 = require("@self/win32")
 
 local pathtypes = require("@self/types")
 
-local pathlib = {}
+type PathInterface = {
+	__tostring: () -> string,
+}
 
-export type path = pathtypes.path
-export type pathlike = pathtypes.pathlike
+export type path = setmetatable<pathtypes.path, PathInterface>
+export type pathlike = setmetatable<pathtypes.pathlike, PathInterface>
 
 local onWindows = platforminfo.win32
 
@@ -54,37 +58,47 @@ end
 
 function pathlib.join(...: pathlike): path
 	if onWindows then
-		return win32.join(...)
+		return setmetatable(win32.join(...), pathlib)
 	else
-		return posix.join(...)
+		return setmetatable(posix.join(...), pathlib)
 	end
 end
 
 function pathlib.normalize(path: pathlike): path
 	if onWindows then
-		return win32.normalize(path :: win32.pathlike)
+		return setmetatable(win32.normalize(path :: win32.pathlike), pathlib)
 	else
-		return posix.normalize(path :: posix.pathlike)
+		return setmetatable(posix.normalize(path :: posix.pathlike), pathlib)
 	end
 end
 
 function pathlib.parse(path: pathlike): path
 	if onWindows then
-		return win32.parse(path :: win32.pathlike)
+		return setmetatable(win32.parse(path :: win32.pathlike), pathlib)
 	else
-		return posix.parse(path :: posix.pathlike)
+		return setmetatable(posix.parse(path :: posix.pathlike), pathlib)
 	end
 end
 
 function pathlib.resolve(...: pathlike): path
 	if onWindows then
-		return win32.resolve(...)
+		-- return win32.resolve(...)
+		return setmetatable(win32.resolve(...), pathlib)
 	else
-		return posix.resolve(...)
+		-- return posix.resolve(...)
+		return setmetatable(posix.resolve(...), pathlib)
 	end
 end
 
 pathlib.win32 = win32
 pathlib.posix = posix
+
+function pathlib:__tostring(): string
+	if onWindows then
+		return win32.format(self :: path)
+	else
+		return posix.format(self :: path)
+	end
+end
 
 return table.freeze(pathlib)

--- a/lute/std/libs/path/posix/init.luau
+++ b/lute/std/libs/path/posix/init.luau
@@ -113,16 +113,16 @@ function posix.join(...: pathlike): path
 
 	local path: path = if typeof(parts[1]) == "string"
 		then posix.parse(parts[1])
-		else {
+		else setmetatable({
 			parts = table.clone((parts[1] :: path).parts),
 			absolute = (parts[1] :: path).absolute,
-		}
+		}, path_mt)
 
 	for i = 2, #parts do
 		joinHelper(path, parts[i])
 	end
 
-	return setmetatable(path, path_mt)
+	return path
 end
 
 function posix.normalize(path: pathlike): path
@@ -224,7 +224,7 @@ function posix.resolve(...: pathlike): path
 		path = cwd
 	end
 
-	return setmetatable(posix.normalize(path), path_mt)
+	return posix.normalize(path)
 end
 
 function path_mt:__tostring(): string

--- a/lute/std/libs/path/posix/init.luau
+++ b/lute/std/libs/path/posix/init.luau
@@ -1,8 +1,12 @@
 local process = require("@lute/process")
 local posixtypes = require("@self/types")
 
-export type path = posixtypes.path
-export type pathlike = posixtypes.pathlike
+type PathInterface = {
+	__tostring: () -> string,
+}
+
+export type path = setmetatable<posixtypes.path, PathInterface>
+export type pathlike = setmetatable<posixtypes.pathlike, PathInterface>
 
 local posix = {}
 
@@ -121,7 +125,7 @@ function posix.join(...: pathlike): path
 		joinHelper(path, parts[i])
 	end
 
-	return path
+	return setmetatable(path, posix)
 end
 
 function posix.normalize(path: pathlike): path
@@ -151,10 +155,10 @@ function posix.normalize(path: pathlike): path
 		end
 	end
 
-	return {
+	return setmetatable({
 		parts = newParts,
 		absolute = path.absolute,
-	}
+	}, posix)
 end
 
 function posix.parse(path: pathlike): path
@@ -188,10 +192,10 @@ function posix.parse(path: pathlike): path
 		end
 	end
 
-	return {
+	return setmetatable({
 		parts = parts,
 		absolute = isAbs,
-	}
+	}, posix)
 end
 
 function posix.resolve(...: pathlike): path
@@ -223,7 +227,11 @@ function posix.resolve(...: pathlike): path
 		path = cwd
 	end
 
-	return posix.normalize(path)
+	return setmetatable(posix.normalize(path), posix)
+end
+
+function posix:__tostring(): string
+	return posix.format(self :: path)
 end
 
 return table.freeze(posix)

--- a/lute/std/libs/path/posix/init.luau
+++ b/lute/std/libs/path/posix/init.luau
@@ -1,14 +1,11 @@
 local process = require("@lute/process")
 local posixtypes = require("@self/types")
 
-type PathInterface = {
-	__tostring: () -> string,
-}
-
-export type path = setmetatable<posixtypes.path, PathInterface>
-export type pathlike = setmetatable<posixtypes.pathlike, PathInterface>
+export type path = setmetatable<posixtypes.path, posixtypes.pathinterface>
+export type pathlike = posixtypes.pathlike
 
 local posix = {}
+local path_mt = {}
 
 function posix.basename(path: pathlike): string?
 	if typeof(path) == "string" then
@@ -108,10 +105,10 @@ end
 function posix.join(...: pathlike): path
 	local parts: { pathlike } = { ... }
 	if #parts == 0 then
-		return {
+		return setmetatable({
 			parts = {},
 			absolute = false,
-		}
+		}, path_mt)
 	end
 
 	local path: path = if typeof(parts[1]) == "string"
@@ -125,7 +122,7 @@ function posix.join(...: pathlike): path
 		joinHelper(path, parts[i])
 	end
 
-	return setmetatable(path, posix)
+	return setmetatable(path, path_mt)
 end
 
 function posix.normalize(path: pathlike): path
@@ -158,12 +155,12 @@ function posix.normalize(path: pathlike): path
 	return setmetatable({
 		parts = newParts,
 		absolute = path.absolute,
-	}, posix)
+	}, path_mt)
 end
 
 function posix.parse(path: pathlike): path
 	if typeof(path) == "table" then
-		return path
+		return setmetatable(path, path_mt)
 	end
 	if typeof(path) ~= "string" then
 		error("Expected string or path")
@@ -195,7 +192,7 @@ function posix.parse(path: pathlike): path
 	return setmetatable({
 		parts = parts,
 		absolute = isAbs,
-	}, posix)
+	}, path_mt)
 end
 
 function posix.resolve(...: pathlike): path
@@ -227,10 +224,10 @@ function posix.resolve(...: pathlike): path
 		path = cwd
 	end
 
-	return setmetatable(posix.normalize(path), posix)
+	return setmetatable(posix.normalize(path), path_mt)
 end
 
-function posix:__tostring(): string
+function path_mt:__tostring(): string
 	return posix.format(self :: path)
 end
 

--- a/lute/std/libs/path/posix/types.luau
+++ b/lute/std/libs/path/posix/types.luau
@@ -1,3 +1,7 @@
+export type pathinterface = {
+	__tostring: () -> string,
+}
+
 export type path = {
 	parts: { string },
 	absolute: boolean,

--- a/lute/std/libs/path/win32/init.luau
+++ b/lute/std/libs/path/win32/init.luau
@@ -5,7 +5,7 @@ type PathInterface = {
 	__tostring: () -> string,
 }
 
-export type pathkind = setmetatable<win32types.pathkind, PathInterface>
+export type pathkind = win32types.pathkind
 export type path = setmetatable<win32types.path, PathInterface>
 export type pathlike = setmetatable<win32types.pathlike, PathInterface>
 

--- a/lute/std/libs/path/win32/init.luau
+++ b/lute/std/libs/path/win32/init.luau
@@ -147,17 +147,17 @@ function win32.join(...: pathlike): path
 
 	local path: path = if typeof(parts[1]) == "string"
 		then win32.parse(parts[1])
-		else {
+		else setmetatable({
 			parts = table.clone((parts[1] :: path).parts),
 			kind = (parts[1] :: path).kind,
 			driveLetter = (parts[1] :: path).driveLetter,
-		}
+		}, path_mt)
 
 	for i = 2, #parts do
 		joinHelper(path, parts[i])
 	end
 
-	return setmetatable(path, path_mt)
+	return path
 end
 
 function win32.normalize(path: pathlike): path
@@ -278,7 +278,7 @@ function win32.resolve(...: pathlike): path
 		path = cwd
 	end
 
-	return setmetatable(win32.normalize(path), path_mt)
+	return win32.normalize(path)
 end
 
 function path_mt:__tostring(): string

--- a/lute/std/libs/path/win32/init.luau
+++ b/lute/std/libs/path/win32/init.luau
@@ -1,15 +1,12 @@
 local process = require("@lute/process")
 local win32types = require("@self/types")
 
-type PathInterface = {
-	__tostring: () -> string,
-}
-
 export type pathkind = win32types.pathkind
-export type path = setmetatable<win32types.path, PathInterface>
-export type pathlike = setmetatable<win32types.pathlike, PathInterface>
+export type path = setmetatable<win32types.path, win32types.pathinterface>
+export type pathlike = win32types.pathlike
 
 local win32 = {}
+local path_mt = {}
 
 function win32.basename(path: pathlike): string?
 	if typeof(path) == "string" then
@@ -141,11 +138,11 @@ end
 function win32.join(...: pathlike): path
 	local parts = { ... }
 	if #parts == 0 then
-		return {
+		return setmetatable({
 			parts = {},
 			kind = "relative",
 			driveLetter = nil,
-		}
+		}, path_mt)
 	end
 
 	local path: path = if typeof(parts[1]) == "string"
@@ -160,7 +157,7 @@ function win32.join(...: pathlike): path
 		joinHelper(path, parts[i])
 	end
 
-	return setmetatable(path, win32)
+	return setmetatable(path, path_mt)
 end
 
 function win32.normalize(path: pathlike): path
@@ -194,12 +191,12 @@ function win32.normalize(path: pathlike): path
 		parts = newParts,
 		kind = path.kind,
 		driveLetter = path.driveLetter,
-	}, win32)
+	}, path_mt)
 end
 
 function win32.parse(path: pathlike): path
 	if typeof(path) == "table" then
-		return path
+		return setmetatable(path, path_mt)
 	end
 	if typeof(path) ~= "string" then
 		error("Expected string or path")
@@ -249,7 +246,7 @@ function win32.parse(path: pathlike): path
 		parts = parts,
 		kind = kind,
 		driveLetter = driveLetter,
-	}, win32)
+	}, path_mt)
 end
 
 function win32.resolve(...: pathlike): path
@@ -281,10 +278,10 @@ function win32.resolve(...: pathlike): path
 		path = cwd
 	end
 
-	return setmetatable(win32.normalize(path), win32)
+	return setmetatable(win32.normalize(path), path_mt)
 end
 
-function win32:__tostring(): string
+function path_mt:__tostring(): string
 	return win32.format(self :: path)
 end
 

--- a/lute/std/libs/path/win32/init.luau
+++ b/lute/std/libs/path/win32/init.luau
@@ -1,9 +1,13 @@
 local process = require("@lute/process")
 local win32types = require("@self/types")
 
-export type pathkind = win32types.pathkind
-export type path = win32types.path
-export type pathlike = win32types.pathlike
+type PathInterface = {
+	__tostring: () -> string,
+}
+
+export type pathkind = setmetatable<win32types.pathkind, PathInterface>
+export type path = setmetatable<win32types.path, PathInterface>
+export type pathlike = setmetatable<win32types.pathlike, PathInterface>
 
 local win32 = {}
 
@@ -156,7 +160,7 @@ function win32.join(...: pathlike): path
 		joinHelper(path, parts[i])
 	end
 
-	return path
+	return setmetatable(path, win32)
 end
 
 function win32.normalize(path: pathlike): path
@@ -186,11 +190,11 @@ function win32.normalize(path: pathlike): path
 		end
 	end
 
-	return {
+	return setmetatable({
 		parts = newParts,
 		kind = path.kind,
 		driveLetter = path.driveLetter,
-	}
+	}, win32)
 end
 
 function win32.parse(path: pathlike): path
@@ -241,11 +245,11 @@ function win32.parse(path: pathlike): path
 		end
 	end
 
-	return {
+	return setmetatable({
 		parts = parts,
 		kind = kind,
 		driveLetter = driveLetter,
-	}
+	}, win32)
 end
 
 function win32.resolve(...: pathlike): path
@@ -277,7 +281,11 @@ function win32.resolve(...: pathlike): path
 		path = cwd
 	end
 
-	return win32.normalize(path)
+	return setmetatable(win32.normalize(path), win32)
+end
+
+function win32:__tostring(): string
+	return win32.format(self :: path)
 end
 
 return table.freeze(win32)

--- a/lute/std/libs/path/win32/types.luau
+++ b/lute/std/libs/path/win32/types.luau
@@ -1,5 +1,9 @@
 export type pathkind = "unc" | "absolute" | "relative"
 
+export type pathinterface = {
+	__tostring: () -> string,
+}
+
 export type path = {
 	parts: { string },
 	kind: pathkind,

--- a/tests/std/path/path.posix.test.luau
+++ b/tests/std/path/path.posix.test.luau
@@ -535,4 +535,18 @@ test.suite("PathPosixResolveSuite", function(suite)
 	end)
 end)
 
+test.suite("PathPosixToStringSuite", function(suite)
+	suite:case("toString_posix_absolute_path", function(assert)
+		local pathobj: posix.path = posix.parse("/home/user/documents/file.txt")
+		local result = tostring(pathobj)
+		assert.eq(result, "/home/user/documents/file.txt")
+	end)
+
+	suite:case("toString_posix_relative_path", function(assert)
+		local pathobj: posix.path = posix.parse("documents/file.txt")
+		local result = tostring(pathobj)
+		assert.eq(result, "documents/file.txt")
+	end)
+end)
+
 test.run()

--- a/tests/std/path/path.posix.test.luau
+++ b/tests/std/path/path.posix.test.luau
@@ -537,15 +537,17 @@ end)
 
 test.suite("PathPosixToStringSuite", function(suite)
 	suite:case("toString_posix_absolute_path", function(assert)
-		local pathobj: posix.path = posix.parse("/home/user/documents/file.txt")
+		local filePath = "/home/user/documents/file.txt"
+		local pathobj: posix.path = posix.parse(filePath)
 		local result = tostring(pathobj)
-		assert.eq(result, "/home/user/documents/file.txt")
+		assert.eq(result, filePath)
 	end)
 
 	suite:case("toString_posix_relative_path", function(assert)
-		local pathobj: posix.path = posix.parse("documents/file.txt")
+		local filePath = "documents/file.txt"
+		local pathobj: posix.path = posix.parse(filePath)
 		local result = tostring(pathobj)
-		assert.eq(result, "documents/file.txt")
+		assert.eq(result, filePath)
 	end)
 end)
 

--- a/tests/std/path/path.win32.test.luau
+++ b/tests/std/path/path.win32.test.luau
@@ -685,4 +685,18 @@ test.suite("PathWin32ResolveSuite", function(suite)
 	end)
 end)
 
+test.suite("PathWin32ToStringSuite", function(suite)
+	suite:case("toString_windows_absolute_path", function(assert)
+		local pathobj: win32.path = win32.parse("C:\\Users\\username\\Documents\\file.txt")
+		local result = tostring(pathobj)
+		assert.eq(result, "C:\\Users\\username\\Documents\\file.txt")
+	end)
+
+	suite:case("toString_windows_relative_path", function(assert)
+		local pathobj: win32.path = win32.parse("Documents\\file.txt")
+		local result = tostring(pathobj)
+		assert.eq(result, "Documents\\file.txt")
+	end)
+end)
+
 test.run()

--- a/tests/std/path/path.win32.test.luau
+++ b/tests/std/path/path.win32.test.luau
@@ -687,15 +687,17 @@ end)
 
 test.suite("PathWin32ToStringSuite", function(suite)
 	suite:case("toString_windows_absolute_path", function(assert)
-		local pathobj: win32.path = win32.parse("C:\\Users\\username\\Documents\\file.txt")
-		local result = tostring(pathobj)
-		assert.eq(result, "C:\\Users\\username\\Documents\\file.txt")
+		local filePath = "C:\\Users\\username\\Documents\\file.txt"
+		local pathObj: win32.path = win32.parse(filePath)
+		local result = tostring(pathObj)
+		assert.eq(result, filePath)
 	end)
 
 	suite:case("toString_windows_relative_path", function(assert)
-		local pathobj: win32.path = win32.parse("Documents\\file.txt")
-		local result = tostring(pathobj)
-		assert.eq(result, "Documents\\file.txt")
+		local filePath = "C:\\Users\\username\\Documents\\file.txt"
+		local pathObj: win32.path = path.win32.parse(filePath)
+		local result = tostring(pathObj)
+		assert.eq(result, filePath)
 	end)
 end)
 


### PR DESCRIPTION
### Problem

Paths didn't have a default way of parsing between a `path` or `pathlike` and a string other than using `.format`

### Solution

We add `__tostring` to paths so users can now just `print(path)` or `tostring(path)` to get the string version of a path

part of https://github.com/luau-lang/lute/pull/491!