### PR TITLE
stdlib: expose test environment from test library

### DIFF
--- a/lute/std/libs/test.luau
+++ b/lute/std/libs/test.luau
@@ -128,7 +128,7 @@ function test.suite(name: string, registerFn: (TestSuite) -> ())
 end
 
 -- get all registered tests without running them (internal)
-function test._getregistered()
+function test._registered()
 	return table.freeze({ anonymous = env.anonymous, suites = env.suites })
 end
 

--- a/lute/std/libs/test.luau
+++ b/lute/std/libs/test.luau
@@ -127,6 +127,11 @@ function test.suite(name: string, registerFn: (TestSuite) -> ())
 	table.insert(env.suites, suite)
 end
 
+-- get all registered tests without running them (internal)
+function test._getregistered()
+	return table.freeze({ anonymous = env.anonymous, suites = env.suites })
+end
+
 -- run all the tests
 function test.run()
 	local failures: { FailedTest } = {}


### PR DESCRIPTION
This exposes a method in std/test to grab the registered test cases out of the internal environment.