### PR TITLE
feature: list all discovered tests

### DIFF
--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -1,4 +1,7 @@
 local finder = require("@self/finder")
+local luau = require("@std/luau")
+local path = require("@std/path")
+local test = require("@std/test")
 
 local function printHelp()
 	print([[
@@ -31,22 +34,78 @@ EXAMPLES:
 ]])
 end
 
+--[[
+ Any of the tests we load will use the instance of std/test initialized in this module (cli/commands/test/init.luau)
+ Tests that run via lute test don't need to explicitly call test.run, so we'll pass an empty run function so that we don't
+ execute any tests, while giving us time to remove unecessary run() calls (doing this because this doesn't support running tests just yet)
+ The reason we have to inject a custom require here is because each `loadbypath` on a test file will return the "@std/test" instance provided by
+ the EmbeddedStdVFS. However, running `lute test` from the root of the lute repo will use a distinct @std/test instance, which is provided by the .luaurc when running
+ this file, which means the test environment won't get populated. The consequence of this is that `lute test` will work perfectly everywhere except inside of
+ the lute repo, which sucks. Intercepting @std/test requires works correctly and ensures that the correct @std/test instance gets populated
+]]
+--
+local function lutetestrequire(req: string)
+	if req == "@std/test" then
+		return table.freeze({ case = test.case, suite = test.suite, run = function() end })
+	end
+	return require(req) :: any
+end
+
+local function loadtests(testfiles: { path.path })
+	local fenv: { [unknown]: unknown } = setmetatable({ ["require"] = lutetestrequire }, { __index = _G })
+	-- Load all test files first
+	for _, p in testfiles do
+		local success, err = pcall(luau.loadbypath, p, fenv)
+
+		if not success then
+			print(`Error loading {path.format(p)}: {err}`)
+		end
+	end
+end
+
+local function listtests()
+	-- Gets all registered tests using the shared test instance
+	local registered = test._registered()
+	local totalTests = #registered.anonymous
+
+	for _, suite in registered.suites do
+		totalTests += #suite.cases
+	end
+
+	print("Anonymous:")
+	for _, tc in registered.anonymous do
+		print(`\t{tc.name}`)
+	end
+
+	for _, suite in registered.suites do
+		print(`{suite.name}:`)
+		for _, tc in suite.cases do
+			print(`\t{tc.name}`)
+		end
+	end
+end
+
 local function main(...: string)
 	local args = { ... }
+	local testPaths = {}
+	local isListMode = false
 
-	-- Check for help flag
 	for _, arg in args do
 		if arg == "-h" or arg == "--help" then
 			printHelp()
 			return
+		elseif arg == "--list" then
+			isListMode = true
+		else
+			table.insert(testPaths, arg)
 		end
 	end
+	local searchpath = if #testPaths > 0 then testPaths else { "./tests" }
+	loadtests(finder.findtestfiles(searchpath))
 
-	local searchpath = if #args > 0 then args else { "./tests" }
-
-	local files = finder.findtestfiles(searchpath)
-
-	print(`Found {#files} test files`)
+	if isListMode then
+		listtests()
+	end
 end
 
 main(...)

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -187,7 +187,7 @@ function luau.load(bytecode: Bytecode, chunkname: string?, env: { [any]: any }?)
 	return luteLuau.load(bytecode, if chunkname ~= nil then `@{chunkname}` else "=luau.load", env)
 end
 
-function luau.loadbypath(requirePath: path.pathlike): any
+function luau.loadbypath(requirePath: path.pathlike, env: { [any]: any }?): any
 	local requirePathStr = if typeof(requirePath) == "string" then requirePath else path.format(requirePath)
 
 	local migrationHandle = fs.open(requirePathStr, "r")
@@ -196,7 +196,7 @@ function luau.loadbypath(requirePath: path.pathlike): any
 
 	fs.close(migrationHandle)
 
-	return luau.load(migrationBytecode, requirePathStr)()
+	return luau.load(migrationBytecode, requirePathStr, env)()
 end
 
 return luau

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -3,9 +3,18 @@ local path = require("@std/path")
 local process = require("@std/process")
 local system = require("@std/system")
 local test = require("@std/test")
-
+local fs = require("@std/fs")
 local lutePath = path.format(process.execpath())
 local tmpDir = system.tmpdir()
+
+local expected = [[Anonymous:
+	Passing
+ExampleSuite:
+	should pass
+SmokeSuite:
+	make_fail
+	make_pass
+]]
 
 test.suite("lute test", function(suite)
 	suite:case("lute test help message", function(assert)
@@ -27,11 +36,11 @@ test.suite("lute test", function(suite)
 
 	suite:case("lute test discovers test files in custom directory", function(assert)
 		-- Run lute test with custom directory path
-		local result = process.run({ lutePath, "test", "tests/cli/discovery" })
+		local result = process.run({ lutePath, "test", "--list", "tests/cli/discovery" })
 
 		-- Check that it discovers test files (.test.luau and .spec.luau)
 		assert.eq(result.exitcode, 0)
-		assert.neq(result.stdout:find("Found 2 test files", 1, true), nil)
+		assert.eq(expected, result.stdout)
 	end)
 
 	suite:case("lute doesn't report xpcall as error when accessing field of nil in suite", function(assert)


### PR DESCRIPTION
This PR adds support for discovering and eventually running test cases. Using the loadbypath api, we can load all the discovered test files and eventually run them (future PR). This PR just implements a simple list all test cases command, much like `doctest`.

In order to populate the test environment, I've overridden `require` with one that intercepts calls to "@std/test" and returns the version of std/test require'd by the `test` subcommand itself. This ensures that loading modules registers tests in a way that makes them visible by the subcommand.