### PR TITLE
stdlib: add kinds to ast types

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -36,6 +36,7 @@ export type Token<Kind = string> = {
 	position: Position,
 	text: Kind,
 	trailingtrivia: { Trivia },
+	istoken: true,
 }
 
 export type Eof = Token<""> & { tag: "eof" }
@@ -44,6 +45,7 @@ export type Pair<T, Separator> = { node: T, separator: Token<Separator>? }
 export type Punctuated<T, Separator = ","> = { Pair<T, Separator> }
 
 export type AstLocal = {
+	kind: "local",
 	name: Token<string>,
 	colon: Token<":">?,
 	annotation: AstType?,
@@ -134,6 +136,7 @@ export type AstExprAnonymousFunction = {
 	body: AstFunctionBody,
 }
 
+-- helper type for items contained in an AstExprTable, not actually an AstExpr itself
 export type AstExprTableItem =
 	| { kind: "list", value: AstExpr, separator: Token<"," | ";">? }
 	| {
@@ -186,6 +189,7 @@ export type AstExprTypeAssertion = {
 	annotation: AstType,
 }
 
+-- helper type for elseif clauses of an if-else expression, not actually an AstExpr itself
 export type AstExprIfElseIfs = {
 	elseifkeyword: Token<"elseif">,
 	condition: AstExpr,
@@ -204,8 +208,8 @@ export type AstExprIfElse = {
 	elseexpr: AstExpr,
 }
 
-export type AstExpr =
-	| AstExprGroup
+export type AstExpr = { kind: "expr" } & (
+	AstExprGroup
 	| AstExprConstantNil
 	| AstExprConstantBool
 	| AstExprConstantNumber
@@ -223,6 +227,7 @@ export type AstExpr =
 	| AstExprInterpString
 	| AstExprTypeAssertion
 	| AstExprIfElse
+)
 
 export type AstStatBlock = {
 	tag: "block",
@@ -328,7 +333,7 @@ export type AstStatCompoundAssign = {
 	value: AstExpr,
 }
 
-export type AstAttribute = Token<"@checked" | "@native" | "@deprecated"> & { tag: "attribute" }
+export type AstAttribute = Token<"@checked" | "@native" | "@deprecated"> & { kind: "attribute" }
 
 export type AstStatFunction = {
 	tag: "function",
@@ -369,8 +374,8 @@ export type AstStatTypeFunction = {
 	body: AstFunctionBody,
 }
 
-export type AstStat =
-	| AstStatBlock
+export type AstStat = { kind: "stat" } & (
+	AstStatBlock
 	| AstStatIf
 	| AstStatWhile
 	| AstStatRepeat
@@ -387,6 +392,7 @@ export type AstStat =
 	| AstStatLocalFunction
 	| AstStatTypeAlias
 	| AstStatTypeFunction
+)
 
 export type AstGenericType = {
 	tag: "generic",
@@ -519,8 +525,8 @@ export type AstTypeFunction = {
 	returntypes: AstTypePack,
 }
 
-export type AstType =
-	| AstTypeReference
+export type AstType = { kind: "type" } & (
+	AstTypeReference
 	| AstTypeSingletonBool
 	| AstTypeSingletonString
 	| AstTypeTypeof
@@ -531,6 +537,7 @@ export type AstType =
 	| AstTypeArray
 	| AstTypeTable
 	| AstTypeFunction
+)
 
 export type AstTypePackExplicit = {
 	tag: "explicit",
@@ -553,7 +560,9 @@ export type AstTypePackVariadic = {
 	type: AstType,
 }
 
-export type AstTypePack = AstTypePackExplicit | AstTypePackGeneric | AstTypePackVariadic
+export type AstTypePack = { kind: "typepack" } & (AstTypePackExplicit | AstTypePackGeneric | AstTypePackVariadic)
+
+export type AstNode = { location: Location } & (AstExpr | AstStat | AstType | AstTypePack | AstLocal | AstAttribute)
 
 export type ParseResult = {
 	root: AstStatBlock,

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -136,25 +136,28 @@ export type AstExprAnonymousFunction = {
 	body: AstFunctionBody,
 }
 
--- helper type for items contained in an AstExprTable, not actually an AstExpr itself
-export type AstExprTableItem =
-	| { kind: "list", value: AstExpr, separator: Token<"," | ";">? }
-	| {
-		kind: "record",
-		key: Token<string>,
-		equals: Token<"=">,
-		value: AstExpr,
-		separator: Token<"," | ";">?,
-	}
-	| {
-		kind: "general",
-		indexeropen: Token<"[">,
-		key: AstExpr,
-		indexerclose: Token<"]">,
-		equals: Token<"=">,
-		value: AstExpr,
-		separator: Token<"," | ";">?,
-	}
+-- helper types for items contained in an AstExprTable, not actually AstExprs themselves
+export type AstExprTableItemList = { kind: "list", value: AstExpr, separator: Token<"," | ";">? }
+
+export type AstExprTableItemRecord = {
+	kind: "record",
+	key: Token<string>,
+	equals: Token<"=">,
+	value: AstExpr,
+	separator: Token<"," | ";">?,
+}
+
+export type AstExprTableItemGeneral = {
+	kind: "general",
+	indexeropen: Token<"[">,
+	key: AstExpr,
+	indexerclose: Token<"]">,
+	equals: Token<"=">,
+	value: AstExpr,
+	separator: Token<"," | ";">?,
+}
+
+export type AstExprTableItem = AstExprTableItemList | AstExprTableItemRecord | AstExprTableItemGeneral
 
 export type AstExprTable = {
 	tag: "table",
@@ -441,7 +444,7 @@ export type AstTypeGroup = {
 	tag: "group",
 	openparens: Token<"(">,
 	type: AstType,
-	closeparens: Token<">">,
+	closeparens: Token<")">,
 }
 
 export type AstTypeOptional = Token<"?"> & { tag: "optional" }
@@ -467,36 +470,38 @@ export type AstTypeArray = {
 	closebrace: Token<"}">,
 }
 
-export type AstTypeTableItem =
-	{
-		kind: "indexer",
-		access: Token<"read" | "write">?,
-		indexeropen: Token<"[">,
-		key: AstType,
-		indexerclose: Token<"]">,
-		colon: Token<":">,
-		value: AstType,
-		separator: Token<"," | ";">?,
-	}
-	| {
-		kind: "stringproperty",
-		access: Token<"read" | "write">?,
-		indexeropen: Token<"[">,
-		key: AstTypeSingletonString,
-		indexerclose: Token<"]">,
-		colon: Token<":">,
-		value: AstType,
-		separator: Token<"," | ";">?,
-	}
-	| {
-		kind: "property",
-		access: Token<"read" | "write">?,
-		key: AstTypeSingletonString,
-		indexerclose: Token<"]">,
-		colon: Token<":">,
-		value: AstType,
-		separator: Token<"," | ";">?,
-	}
+export type AstTypeTableItemIndexer = {
+	kind: "indexer",
+	access: Token<"read" | "write">?,
+	indexeropen: Token<"[">,
+	key: AstType,
+	indexerclose: Token<"]">,
+	colon: Token<":">,
+	value: AstType,
+	separator: Token<"," | ";">?,
+}
+
+export type AstTypeTableItemStringProperty = {
+	kind: "stringproperty",
+	access: Token<"read" | "write">?,
+	indexeropen: Token<"[">,
+	key: AstTypeSingletonString,
+	indexerclose: Token<"]">,
+	colon: Token<":">,
+	value: AstType,
+	separator: Token<"," | ";">?,
+}
+
+export type AstTypeTableItemProperty = {
+	kind: "property",
+	access: Token<"read" | "write">?,
+	key: Token,
+	colon: Token<":">,
+	value: AstType,
+	separator: Token<"," | ";">?,
+}
+
+export type AstTypeTableItem = AstTypeTableItemIndexer | AstTypeTableItemStringProperty | AstTypeTableItemProperty
 
 export type AstTypeTable = {
 	tag: "table",

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -193,7 +193,7 @@ export type AstExprTypeAssertion = {
 }
 
 -- helper type for elseif clauses of an if-else expression, not actually an AstExpr itself
-export type AstExprIfElseIfs = {
+export type AstElseIfExpr = {
 	elseifkeyword: Token<"elseif">,
 	condition: AstExpr,
 	thenkeyword: Token<"then">,
@@ -206,13 +206,13 @@ export type AstExprIfElse = {
 	condition: AstExpr,
 	thenkeyword: Token<"then">,
 	thenexpr: AstExpr,
-	elseifs: { AstExprIfElseIfs },
+	elseifs: { AstElseIfExpr },
 	elsekeyword: Token<"else">,
 	elseexpr: AstExpr,
 }
 
 export type AstExpr = { kind: "expr" } & (
-	AstExprGroup
+	| AstExprGroup
 	| AstExprConstantNil
 	| AstExprConstantBool
 	| AstExprConstantNumber
@@ -237,7 +237,7 @@ export type AstStatBlock = {
 	statements: { AstStat },
 }
 
-export type AstStatElseIf = {
+export type AstElseIfStat = {
 	elseifkeyword: Token<"elseif">,
 	condition: AstExpr,
 	thenkeyword: Token<"then">,
@@ -250,7 +250,7 @@ export type AstStatIf = {
 	condition: AstExpr,
 	thenkeyword: Token<"then">,
 	thenblock: AstStatBlock,
-	elseifs: { AstStatElseIf },
+	elseifs: { AstElseIfStat },
 	elsekeyword: Token<"else">?, -- TODO: this could be elseif!
 	elseblock: AstStatBlock?,
 	endkeyword: Token<"end">,
@@ -378,7 +378,7 @@ export type AstStatTypeFunction = {
 }
 
 export type AstStat = { kind: "stat" } & (
-	AstStatBlock
+	| AstStatBlock
 	| AstStatIf
 	| AstStatWhile
 	| AstStatRepeat
@@ -531,7 +531,7 @@ export type AstTypeFunction = {
 }
 
 export type AstType = { kind: "type" } & (
-	AstTypeReference
+	| AstTypeReference
 	| AstTypeSingletonBool
 	| AstTypeSingletonString
 	| AstTypeTypeof

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -1772,6 +1772,9 @@ struct AstSerialize : public Luau::AstVisitor
                         auto initialPosition = item.stringPosition;
                         serializeToken(item.stringPosition, item.stringInfo->sourceString.data);
 
+                        lua_pushstring(L, "string");
+                        lua_setfield(L, -2, "tag");
+
                         switch (item.stringInfo->quoteStyle)
                         {
                         case Luau::CstExprConstantString::QuotedSingle:

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -319,7 +319,12 @@ struct AstSerialize : public Luau::AstVisitor
         if (lua_isnil(L, -1))
         {
             lua_pop(L, 1);
-            lua_createtable(L, 0, 4);
+            lua_createtable(L, 0, 6);
+
+            lua_pushlstring(L, "local", 5);
+            lua_setfield(L, -2, "kind");
+
+            withLocation(local->location);
 
             // set up reference for this local into the local table
             lua_pushlightuserdata(L, local);
@@ -435,13 +440,16 @@ struct AstSerialize : public Luau::AstVisitor
     }
 
     // preambleSize should encode the size of the fields we're setting up for _all_ nodes.
-    static const size_t preambleSize = 2;
-    void serializeNodePreamble(Luau::AstNode* node, const char* tag)
+    static const size_t preambleSize = 3;
+    void serializeNodePreamble(Luau::AstNode* node, const char* tag, const char* kind)
     {
         lua_rawcheckstack(L, 2);
 
         lua_pushstring(L, tag);
         lua_setfield(L, -2, "tag");
+
+        lua_pushstring(L, kind);
+        lua_setfield(L, -2, "kind");
 
         withLocation(node->location);
     }
@@ -483,7 +491,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeToken(Luau::Position position, const char* text, int nrec = 0)
     {
         lua_rawcheckstack(L, 3);
-        lua_createtable(L, 0, nrec + 4);
+        lua_createtable(L, 0, nrec + 5);
 
         const auto trivia = extractTrivia(position);
         if (lastTokenRef != LUA_NOREF)
@@ -517,6 +525,9 @@ struct AstSerialize : public Luau::AstVisitor
 
         lua_createtable(L, 0, 0);
         lua_setfield(L, -2, "trailingtrivia");
+
+        lua_pushboolean(L, 1);
+        lua_setfield(L, -2, "istoken");
 
         lastTokenRef = lua_ref(L, -1);
     }
@@ -635,7 +646,12 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeAttribute(Luau::AstAttr* node)
     {
         serializeToken(node->location.begin, ("@" + std::string(node->name.value)).c_str());
-        serializeNodePreamble(node, "attribute");
+        lua_rawcheckstack(L, 2);
+
+        lua_pushstring(L, "attribute");
+        lua_setfield(L, -2, "kind");
+
+        withLocation(node->location);
     }
 
     void serializeEof(Luau::Position eofPosition)
@@ -649,9 +665,9 @@ struct AstSerialize : public Luau::AstVisitor
     void serialize(Luau::AstExprGroup* node)
     {
         lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 3);
+        lua_createtable(L, 0, preambleSize + 4);
 
-        serializeNodePreamble(node, "group");
+        serializeNodePreamble(node, "group", "expr");
 
         serializeToken(node->location.begin, "(");
         lua_setfield(L, -2, "openparens");
@@ -666,13 +682,13 @@ struct AstSerialize : public Luau::AstVisitor
     void serialize(Luau::AstExprConstantNil* node)
     {
         serializeToken(node->location.begin, "nil", preambleSize);
-        serializeNodePreamble(node, "nil");
+        serializeNodePreamble(node, "nil", "expr");
     }
 
     void serialize(Luau::AstExprConstantBool* node)
     {
         serializeToken(node->location.begin, node->value ? "true" : "false", preambleSize + 1);
-        serializeNodePreamble(node, "boolean");
+        serializeNodePreamble(node, "boolean", "expr");
 
         lua_pushboolean(L, node->value);
         lua_setfield(L, -2, "value");
@@ -683,7 +699,7 @@ struct AstSerialize : public Luau::AstVisitor
         const auto cstNode = lookupCstNode<Luau::CstExprConstantNumber>(node);
 
         serializeToken(node->location.begin, cstNode->value.data, preambleSize + 1);
-        serializeNodePreamble(node, "number");
+        serializeNodePreamble(node, "number", "expr");
 
         lua_pushnumber(L, node->value);
         lua_setfield(L, -2, "value");
@@ -693,7 +709,7 @@ struct AstSerialize : public Luau::AstVisitor
     {
         const auto cstNode = lookupCstNode<Luau::CstExprConstantString>(node);
         serializeToken(node->location.begin, cstNode->sourceString.data, preambleSize + 2);
-        serializeNodePreamble(node, "string");
+        serializeNodePreamble(node, "string", "expr");
 
         switch (cstNode->quoteStyle)
         {
@@ -726,7 +742,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
-        serializeNodePreamble(node, "local");
+        serializeNodePreamble(node, "local", "expr");
 
         serializeToken(node->location.begin, node->local->name.value);
         lua_setfield(L, -2, "token"),
@@ -743,7 +759,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 1);
 
-        serializeNodePreamble(node, "global");
+        serializeNodePreamble(node, "global", "expr");
 
         serializeToken(node->location.begin, node->name.value);
         lua_setfield(L, -2, "name");
@@ -752,7 +768,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serialize(Luau::AstExprVarargs* node)
     {
         serializeToken(node->location.begin, "...", preambleSize);
-        serializeNodePreamble(node, "vararg");
+        serializeNodePreamble(node, "vararg", "expr");
     }
 
     void serialize(Luau::AstExprCall* node)
@@ -762,7 +778,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 6);
 
-        serializeNodePreamble(node, "call");
+        serializeNodePreamble(node, "call", "expr");
 
         node->func->visit(this);
         lua_setfield(L, -2, "func");
@@ -794,7 +810,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 4);
 
-        serializeNodePreamble(node, "indexname");
+        serializeNodePreamble(node, "indexname", "expr");
 
         node->expr->visit(this);
         lua_setfield(L, -2, "expression");
@@ -815,7 +831,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 4);
 
-        serializeNodePreamble(node, "index");
+        serializeNodePreamble(node, "index", "expr");
 
         node->expr->visit(this);
         lua_setfield(L, -2, "expression");
@@ -921,7 +937,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 3);
         lua_createtable(L, 0, preambleSize + 3);
 
-        serializeNodePreamble(node, "function");
+        serializeNodePreamble(node, "function", "expr");
 
         serializeAttributes(node->attributes);
         lua_setfield(L, -2, "attributes");
@@ -942,7 +958,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 3);
         lua_createtable(L, 0, preambleSize + 3);
 
-        serializeNodePreamble(node, "table");
+        serializeNodePreamble(node, "table", "expr");
 
         serializeToken(node->location.begin, "{");
         lua_setfield(L, -2, "openbrace");
@@ -964,7 +980,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
-        serializeNodePreamble(node, "unary");
+        serializeNodePreamble(node, "unary", "expr");
 
         const auto cstNode = lookupCstNode<Luau::CstExprOp>(node);
         serializeToken(cstNode->opPosition, toString(node->op).data());
@@ -979,7 +995,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
-        serializeNodePreamble(node, "binary");
+        serializeNodePreamble(node, "binary", "expr");
 
         node->left->visit(this);
         lua_setfield(L, -2, "lhsoperand");
@@ -997,7 +1013,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
-        serializeNodePreamble(node, "cast");
+        serializeNodePreamble(node, "cast", "expr");
 
         node->expr->visit(this);
         lua_setfield(L, -2, "operand");
@@ -1017,7 +1033,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 7);
 
-        serializeNodePreamble(node, "conditional");
+        serializeNodePreamble(node, "conditional", "expr");
 
         serializeToken(node->location.begin, "if");
         lua_setfield(L, -2, "ifkeyword");
@@ -1084,7 +1100,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 3);
         lua_createtable(L, 0, preambleSize + 2);
 
-        serializeNodePreamble(node, "interpolatedstring");
+        serializeNodePreamble(node, "interpolatedstring", "expr");
 
         lua_createtable(L, node->strings.size, 0);
         lua_createtable(L, node->expressions.size, 0);
@@ -1119,7 +1135,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
-        serializeNodePreamble(node, "error");
+        serializeNodePreamble(node, "error", "expr");
 
         serializeExprs(node->expressions);
         lua_setfield(L, -2, "expressions");
@@ -1132,7 +1148,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 1);
 
-        serializeNodePreamble(node, "block");
+        serializeNodePreamble(node, "block", "stat");
 
         serializeStats(node->body);
         lua_setfield(L, -2, "statements");
@@ -1143,7 +1159,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 8);
 
-        serializeNodePreamble(node, "conditional");
+        serializeNodePreamble(node, "conditional", "stat");
 
         serializeToken(node->location.begin, "if");
         lua_setfield(L, -2, "ifkeyword");
@@ -1212,7 +1228,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 5);
 
-        serializeNodePreamble(node, "while");
+        serializeNodePreamble(node, "while", "stat");
 
         serializeToken(node->location.begin, "while");
         lua_setfield(L, -2, "whilekeyword");
@@ -1238,7 +1254,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 4);
 
-        serializeNodePreamble(node, "repeat");
+        serializeNodePreamble(node, "repeat", "stat");
 
         serializeToken(node->location.begin, "repeat");
         lua_setfield(L, -2, "repeatKeyword");
@@ -1258,14 +1274,14 @@ struct AstSerialize : public Luau::AstVisitor
     {
         lua_rawcheckstack(L, 2);
         serializeToken(node->location.begin, "break", preambleSize);
-        serializeNodePreamble(node, "break");
+        serializeNodePreamble(node, "break", "stat");
     }
 
     void serializeStat(Luau::AstStatContinue* node)
     {
         lua_rawcheckstack(L, 2);
         serializeToken(node->location.begin, "continue", preambleSize);
-        serializeNodePreamble(node, "continue");
+        serializeNodePreamble(node, "continue", "stat");
     }
 
     void serializeStat(Luau::AstStatReturn* node)
@@ -1273,7 +1289,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
-        serializeNodePreamble(node, "return");
+        serializeNodePreamble(node, "return", "stat");
 
         serializeToken(node->location.begin, "return");
         lua_setfield(L, -2, "returnkeyword");
@@ -1288,7 +1304,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 1);
 
-        serializeNodePreamble(node, "expression");
+        serializeNodePreamble(node, "expression", "stat");
 
         node->expr->visit(this);
         lua_setfield(L, -2, "expression");
@@ -1299,7 +1315,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 4);
 
-        serializeNodePreamble(node, "local");
+        serializeNodePreamble(node, "local", "stat");
 
         serializeToken(node->location.begin, "local");
         lua_setfield(L, -2, "localkeyword");
@@ -1325,7 +1341,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         const auto cstNode = lookupCstNode<Luau::CstStatFor>(node);
 
-        serializeNodePreamble(node, "for");
+        serializeNodePreamble(node, "for", "stat");
 
         serializeToken(node->location.begin, "for");
         lua_setfield(L, -2, "forkeyword");
@@ -1377,7 +1393,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         const auto cstNode = lookupCstNode<Luau::CstStatForIn>(node);
 
-        serializeNodePreamble(node, "forin");
+        serializeNodePreamble(node, "forin", "stat");
 
         serializeToken(node->location.begin, "for");
         lua_setfield(L, -2, "forkeyword");
@@ -1414,7 +1430,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         const auto cstNode = lookupCstNode<Luau::CstStatAssign>(node);
 
-        serializeNodePreamble(node, "assign");
+        serializeNodePreamble(node, "assign", "stat");
 
         serializePunctuated(node->vars, cstNode->varsCommaPositions, ",");
         lua_setfield(L, -2, "variables");
@@ -1431,7 +1447,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
-        serializeNodePreamble(node, "compoundassign");
+        serializeNodePreamble(node, "compoundassign", "stat");
 
         node->var->visit(this);
         lua_setfield(L, -2, "variable");
@@ -1449,7 +1465,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 4);
 
-        serializeNodePreamble(node, "function");
+        serializeNodePreamble(node, "function", "stat");
 
         const auto cstNode = lookupCstNode<Luau::CstStatFunction>(node);
 
@@ -1471,7 +1487,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 5);
 
-        serializeNodePreamble(node, "localfunction");
+        serializeNodePreamble(node, "localfunction", "stat");
 
         serializeAttributes(node->func->attributes);
         lua_setfield(L, -2, "attributes");
@@ -1503,7 +1519,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 9);
 
-        serializeNodePreamble(node, "typealias");
+        serializeNodePreamble(node, "typealias", "stat");
 
         const auto cstNode = lookupCstNode<Luau::CstStatTypeAlias>(node);
 
@@ -1549,7 +1565,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         const auto cstNode = lookupCstNode<Luau::CstStatTypeFunction>(node);
 
-        serializeNodePreamble(node, "typefunction");
+        serializeNodePreamble(node, "typefunction", "stat");
 
         if (node->exported)
             serializeToken(node->location.begin, "export");
@@ -1590,7 +1606,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
-        serializeNodePreamble(node, "error");
+        serializeNodePreamble(node, "error", "stat");
 
         serializeExprs(node->expressions);
         lua_setfield(L, -2, "expressions");
@@ -1606,7 +1622,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 6);
 
-        serializeNodePreamble(node, "reference");
+        serializeNodePreamble(node, "reference", "type");
 
         const auto cstNode = node->prefix || node->hasParameterList ? lookupCstNode<Luau::CstTypeReference>(node).get() : nullptr;
 
@@ -1648,7 +1664,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_rawcheckstack(L, 2);
             lua_createtable(L, 0, preambleSize + 4);
 
-            serializeNodePreamble(node, "array");
+            serializeNodePreamble(node, "array", "type");
 
             serializeToken(node->location.begin, "{");
             lua_setfield(L, -2, "openbrace");
@@ -1674,7 +1690,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
-        serializeNodePreamble(node, "table");
+        serializeNodePreamble(node, "table", "type");
 
         serializeToken(node->location.begin, "{");
         lua_setfield(L, -2, "openbrace");
@@ -1816,7 +1832,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 10);
 
-        serializeNodePreamble(node, "function");
+        serializeNodePreamble(node, "function", "type");
 
         const auto cstNode = lookupCstNode<Luau::CstTypeFunction>(node);
 
@@ -1896,7 +1912,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 4);
 
-        serializeNodePreamble(node, "typeof");
+        serializeNodePreamble(node, "typeof", "type");
 
         serializeToken(node->location.begin, "typeof");
         lua_setfield(L, -2, "typeof");
@@ -1919,7 +1935,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
-        serializeNodePreamble(node, "union");
+        serializeNodePreamble(node, "union", "type");
 
         if (cstNode->leadingPosition)
             serializeToken(*cstNode->leadingPosition, "|");
@@ -1970,7 +1986,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
-        serializeNodePreamble(node, "intersection");
+        serializeNodePreamble(node, "intersection", "type");
 
         if (cstNode->leadingPosition)
             serializeToken(*cstNode->leadingPosition, "&");
@@ -1985,7 +2001,7 @@ struct AstSerialize : public Luau::AstVisitor
     void serializeType(Luau::AstTypeSingletonBool* node)
     {
         serializeToken(node->location.begin, node->value ? "true" : "false", preambleSize + 1);
-        serializeNodePreamble(node, "boolean");
+        serializeNodePreamble(node, "boolean", "type");
 
         lua_pushboolean(L, node->value);
         lua_setfield(L, -2, "value");
@@ -1995,7 +2011,7 @@ struct AstSerialize : public Luau::AstVisitor
     {
         const auto cstNode = lookupCstNode<Luau::CstTypeSingletonString>(node);
         serializeToken(node->location.begin, cstNode->sourceString.data, preambleSize + 1);
-        serializeNodePreamble(node, "string");
+        serializeNodePreamble(node, "string", "type");
 
         switch (cstNode->quoteStyle)
         {
@@ -2021,7 +2037,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
-        serializeNodePreamble(node, "group");
+        serializeNodePreamble(node, "group", "type");
 
         serializeToken(node->location.begin, "(");
         lua_setfield(L, -2, "openparens");
@@ -2038,7 +2054,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 3);
 
-        serializeNodePreamble(node, "generic");
+        serializeNodePreamble(node, "generic", "type");
 
         const auto cstNode = lookupCstNode<Luau::CstGenericType>(node);
 
@@ -2063,7 +2079,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 4);
 
-        serializeNodePreamble(node, "generic");
+        serializeNodePreamble(node, "generic", "typepack");
 
         const auto cstNode = lookupCstNode<Luau::CstGenericTypePack>(node);
 
@@ -2096,7 +2112,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 4);
 
-        serializeNodePreamble(node, "explicit");
+        serializeNodePreamble(node, "explicit", "typepack");
 
         const auto cstNode = lookupCstNode<Luau::CstTypePackExplicit>(node);
 
@@ -2127,7 +2143,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
-        serializeNodePreamble(node, "generic");
+        serializeNodePreamble(node, "generic", "typepack");
 
         serializeToken(node->location.begin, node->genericName.value);
         lua_setfield(L, -2, "name");
@@ -2142,7 +2158,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 2);
 
-        serializeNodePreamble(node, "variadic");
+        serializeNodePreamble(node, "variadic", "typepack");
 
         if (!forVarArg)
             serializeToken(node->location.begin, "...");

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -50,6 +50,12 @@ export type AstFunctionBody = luteLuau.AstFunctionBody
 
 export type AstExprAnonymousFunction = luteLuau.AstExprAnonymousFunction
 
+export type AstExprTableItemList = luteLuau.AstExprTableItemList
+
+export type AstExprTableItemRecord = luteLuau.AstExprTableItemRecord
+
+export type AstExprTableItemGeneral = luteLuau.AstExprTableItemGeneral
+
 export type AstExprTableItem = luteLuau.AstExprTableItem
 
 export type AstExprTable = luteLuau.AstExprTable
@@ -129,6 +135,12 @@ export type AstTypeUnion = luteLuau.AstTypeUnion
 export type AstTypeIntersection = luteLuau.AstTypeIntersection
 
 export type AstTypeArray = luteLuau.AstTypeArray
+
+export type AstTypeTableItemIndexer = luteLuau.AstTypeTableItemIndexer
+
+export type AstTypeTableItemStringProperty = luteLuau.AstTypeTableItemStringProperty
+
+export type AstTypeTableItemProperty = luteLuau.AstTypeTableItemProperty
 
 export type AstTypeTableItem = luteLuau.AstTypeTableItem
 

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -68,7 +68,7 @@ export type AstExprInterpString = luteLuau.AstExprInterpString
 
 export type AstExprTypeAssertion = luteLuau.AstExprTypeAssertion
 
-export type AstExprIfElseIfs = luteLuau.AstExprIfElseIfs
+export type AstElseIfExpr = luteLuau.AstElseIfExpr
 
 export type AstExprIfElse = luteLuau.AstExprIfElse
 
@@ -76,7 +76,7 @@ export type AstExpr = luteLuau.AstExpr
 
 export type AstStatBlock = luteLuau.AstStatBlock
 
-export type AstStatElseIf = luteLuau.AstStatElseIf
+export type AstElseIfStat = luteLuau.AstElseIfStat
 
 export type AstStatIf = luteLuau.AstStatIf
 

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -148,6 +148,8 @@ export type AstTypePackVariadic = luteLuau.AstTypePackVariadic
 
 export type AstTypePack = luteLuau.AstTypePack
 
+export type AstNode = luteLuau.AstNode
+
 export type ParseResult = luteLuau.ParseResult
 
 export type Bytecode = luteLuau.Bytecode

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -520,22 +520,22 @@ test.suite("parse", function(suite)
 		assert.eq(ifStat.ifkeyword.text, "if")
 		assert.eq(ifStat.condition.tag, "binary")
 		assert.eq(ifStat.thenkeyword.text, "then")
-		checkIsBlock(ifStat.consequent, assert)
+		checkIsBlock(ifStat.thenblock, assert)
 
-		local consequentBlock = ifStat.consequent
-		assert.eq(#consequentBlock.statements, 1)
+		local thenBlock = ifStat.thenblock
+		assert.eq(#thenBlock.statements, 1)
 
 		assert.eq(#ifStat.elseifs, 1)
 		local elseIf = ifStat.elseifs[1]
 		assert.eq(elseIf.elseifkeyword.text, "elseif")
 		assert.eq(elseIf.condition.tag, "binary")
 		assert.eq(elseIf.thenkeyword.text, "then")
-		checkIsBlock(elseIf.consequent, assert)
+		checkIsBlock(elseIf.thenblock, assert)
 
 		assert.neq(ifStat.elsekeyword, nil)
 		assert.eq((ifStat.elsekeyword :: luau.Token<"else">).text, "else")
-		assert.neq(ifStat.antecedent, nil)
-		checkIsBlock(ifStat.antecedent, assert)
+		assert.neq(ifStat.elseblock, nil)
+		checkIsBlock(ifStat.elseblock, assert)
 		assert.eq(ifStat.endkeyword.text, "end")
 
 		block = parser.parse("if condition then doSomething() end")
@@ -545,11 +545,11 @@ test.suite("parse", function(suite)
 		assert.eq(simpleIfStat.ifkeyword.text, "if")
 		assert.eq(simpleIfStat.condition.tag, "global")
 		assert.eq(simpleIfStat.thenkeyword.text, "then")
-		checkIsBlock(simpleIfStat.consequent, assert)
-		assert.eq(#simpleIfStat.consequent.statements, 1)
+		checkIsBlock(simpleIfStat.thenblock, assert)
+		assert.eq(#simpleIfStat.thenblock.statements, 1)
 		assert.eq(#simpleIfStat.elseifs, 0)
 		assert.eq(simpleIfStat.elsekeyword, nil)
-		assert.eq(simpleIfStat.antecedent, nil)
+		assert.eq(simpleIfStat.elseblock, nil)
 		assert.eq(simpleIfStat.endkeyword.text, "end")
 	end)
 

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -835,4 +835,306 @@ test.suite("parse", function(suite)
 	end)
 end)
 
+test.suite("parse types", function(suite)
+	-- AstGenericType and AstGenericTypePack are tested in parseExprAnonymousFunction
+	suite:case("testTypeReference", function(assert)
+		local block = parser.parse("type MyString = string")
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "reference")
+
+		local typeRef = typeAlias.type :: luau.AstTypeReference
+		assert.eq(typeRef.prefix, nil)
+		assert.eq(typeRef.prefixpoint, nil)
+		assert.eq(typeRef.name.text, "string")
+		assert.eq(typeRef.openparameters, nil)
+		assert.eq(typeRef.parameters, nil)
+		assert.eq(typeRef.closeparameters, nil)
+
+		block = parser.parse("type MyTable = MyModule.Table<number, string>")
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "reference")
+
+		typeRef = typeAlias.type :: luau.AstTypeReference
+		assert.neq(typeRef.prefix, nil)
+		assert.eq((typeRef.prefix :: luau.Token<string>).text, "MyModule")
+		assert.neq(typeRef.prefixpoint, nil)
+		assert.eq((typeRef.prefixpoint :: luau.Token<".">).text, ".")
+		assert.eq(typeRef.name.text, "Table")
+		assert.neq(typeRef.openparameters, nil)
+		assert.eq((typeRef.openparameters :: luau.Token<"<">).text, "<")
+		assert.neq(typeRef.parameters, nil)
+		assert.eq(#typeRef.parameters :: luau.Punctuated<luau.AstType>, 2)
+		assert.eq((typeRef.parameters :: luau.Punctuated<luau.AstType>)[1].node.tag, "reference")
+		assert.eq((typeRef.parameters :: luau.Punctuated<luau.AstType>)[2].node.tag, "reference")
+		assert.neq(typeRef.closeparameters, nil)
+		assert.eq((typeRef.closeparameters :: luau.Token<">">).text, ">")
+	end)
+
+	suite:case("testTypeSingletonBoolean", function(assert)
+		local block = parser.parse("type TrueType = true")
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "boolean")
+
+		local singletonBool = typeAlias.type :: luau.AstTypeSingletonBool
+		assert.eq(singletonBool.text, "true")
+		assert.eq(singletonBool.value, true)
+
+		block = parser.parse("type FalseType = false")
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "boolean")
+
+		singletonBool = typeAlias.type :: luau.AstTypeSingletonBool
+		assert.eq(singletonBool.text, "false")
+		assert.eq(singletonBool.value, false)
+	end)
+
+	suite:case("testTypeSingletonString", function(assert)
+		local block = parser.parse("type HelloType = 'hello'")
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "string")
+
+		local singletonStr = typeAlias.type :: luau.AstTypeSingletonString
+		assert.eq(singletonStr.text, "hello")
+		assert.eq(singletonStr.quotestyle, "single")
+
+		block = parser.parse('type WorldType = "world"')
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "string")
+
+		singletonStr = typeAlias.type :: luau.AstTypeSingletonString
+		assert.eq(singletonStr.text, "world")
+		assert.eq(singletonStr.quotestyle, "double")
+	end)
+
+	suite:case("testTypeTypeof", function(assert)
+		local block = parser.parse("type T = typeof(someVariable)")
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "typeof")
+
+		local typeofType = typeAlias.type :: luau.AstTypeTypeof
+		assert.eq(typeofType.typeof.text, "typeof")
+		assert.eq(typeofType.openparens.text, "(")
+		assert.eq(typeofType.expression.tag, "global")
+		assert.eq(typeofType.closeparens.text, ")")
+	end)
+
+	suite:case("testTypeGroup", function(assert)
+		local block = parser.parse("type T = (string)")
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "group")
+
+		local groupType = typeAlias.type :: luau.AstTypeGroup
+		assert.eq(groupType.openparens.text, "(")
+		assert.eq(groupType.type.tag, "reference")
+		assert.eq(groupType.closeparens.text, ")")
+	end)
+
+	suite:case("testTypeUnion", function(assert)
+		local block = parser.parse("type T = string | number | boolean")
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "union")
+
+		local unionType = typeAlias.type :: luau.AstTypeUnion
+		assert.eq(unionType.leading, nil)
+		assert.eq(#unionType.types, 3)
+		assert.eq(unionType.types[1].node.tag, "reference")
+		assert.eq(unionType.types[2].node.tag, "reference")
+		assert.eq(unionType.types[3].node.tag, "reference")
+
+		block = parser.parse("type T = | number?")
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "union")
+
+		unionType = typeAlias.type :: luau.AstTypeUnion
+		assert.neq(unionType.leading, nil)
+		assert.eq((unionType.leading :: luau.Token<"|">).text, "|")
+		assert.eq(#unionType.types, 2)
+		assert.eq(unionType.types[1].node.tag, "reference")
+		assert.eq(unionType.types[2].node.tag, "optional")
+		assert.eq((unionType.types[2].node :: luau.AstTypeOptional).text, "?")
+	end)
+
+	suite:case("testTypeIntersection", function(assert)
+		local block = parser.parse("type T = A & B & C")
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "intersection")
+
+		local intersectionType = typeAlias.type :: luau.AstTypeIntersection
+		assert.eq(intersectionType.leading, nil)
+		assert.eq(#intersectionType.types, 3)
+		assert.eq(intersectionType.types[1].node.tag, "reference")
+		assert.eq(intersectionType.types[2].node.tag, "reference")
+		assert.eq(intersectionType.types[3].node.tag, "reference")
+
+		block = parser.parse("type T = & B")
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "intersection")
+
+		intersectionType = typeAlias.type :: luau.AstTypeIntersection
+		assert.neq(intersectionType.leading, nil)
+		assert.eq((intersectionType.leading :: luau.Token<"&">).text, "&")
+		assert.eq(#intersectionType.types, 1)
+		assert.eq(intersectionType.types[1].node.tag, "reference")
+	end)
+
+	suite:case("testTypeArray", function(assert)
+		local block = parser.parse("type T = { number }")
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "array")
+
+		local arrayType = typeAlias.type :: luau.AstTypeArray
+		assert.eq(arrayType.openbrace.text, "{")
+		assert.eq(arrayType.access, nil)
+		assert.eq(arrayType.type.tag, "reference")
+		assert.eq(arrayType.closebrace.text, "}")
+
+		block = parser.parse("type T = { read string }")
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "array")
+
+		arrayType = typeAlias.type :: luau.AstTypeArray
+		assert.neq(arrayType.access, nil)
+		assert.eq((arrayType.access :: luau.Token<"read" | "write">).text, "read")
+
+		block = parser.parse("type T = { write number }")
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "array")
+
+		arrayType = typeAlias.type :: luau.AstTypeArray
+		assert.neq(arrayType.access, nil)
+		assert.eq((arrayType.access :: luau.Token<"read" | "write">).text, "write")
+	end)
+
+	suite:case("parseTypeTable", function(assert)
+		local block = parser.parse("type T = {}")
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "table")
+
+		local tableType = typeAlias.type :: luau.AstTypeTable
+		assert.eq(tableType.openbrace.text, "{")
+		assert.eq(#tableType.entries, 0)
+		assert.eq(tableType.closebrace.text, "}")
+
+		block = parser.parse("type T = {[number] : string}")
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "table")
+
+		tableType = typeAlias.type :: luau.AstTypeTable
+		assert.eq(#tableType.entries, 1)
+		local tableTypeItem: any = tableType.entries[1]
+		assert.eq(tableTypeItem.kind, "indexer")
+		assert.eq(tableTypeItem.access, nil)
+		assert.eq(tableTypeItem.indexeropen.text, "[")
+		assert.eq(tableTypeItem.key.tag, "reference")
+		assert.eq(tableTypeItem.indexerclose.text, "]")
+		assert.eq(tableTypeItem.colon.text, ":")
+		assert.eq(tableTypeItem.value.tag, "reference")
+		assert.eq(tableTypeItem.separator, nil)
+
+		block = parser.parse("type T = {['hello'] : 'world', read ['foo'] : number; write ['bar'] : boolean}")
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "table")
+		tableType = typeAlias.type :: luau.AstTypeTable
+		assert.eq(#tableType.entries, 3)
+		tableTypeItem = tableType.entries[1]
+		assert.eq(tableTypeItem.kind, "stringproperty")
+		assert.eq(tableTypeItem.access, nil)
+		assert.eq(tableTypeItem.indexeropen.text, "[")
+		assert.eq((tableTypeItem.key :: luau.AstTypeSingletonString).tag, "string")
+		assert.eq((tableTypeItem.key :: luau.AstTypeSingletonString).text, "hello")
+		assert.eq(tableTypeItem.indexerclose.text, "]")
+		assert.eq(tableTypeItem.colon.text, ":")
+		assert.eq(tableTypeItem.value.tag, "string")
+		assert.neq(tableTypeItem.separator, nil)
+		assert.eq((tableTypeItem.separator :: luau.Token<"," | ";">).text, ",")
+
+		tableTypeItem = tableType.entries[2]
+		assert.eq(tableTypeItem.kind, "stringproperty")
+		assert.neq(tableTypeItem.access, nil)
+		assert.eq((tableTypeItem.access :: luau.Token<"read" | "write">).text, "read")
+		assert.neq(tableTypeItem.separator, nil)
+		assert.eq((tableTypeItem.separator :: luau.Token<"," | ";">).text, ";")
+
+		tableTypeItem = tableType.entries[3]
+		assert.eq(tableTypeItem.kind, "stringproperty")
+		assert.neq(tableTypeItem.access, nil)
+		assert.eq((tableTypeItem.access :: luau.Token<"read" | "write">).text, "write")
+		assert.eq(tableTypeItem.separator, nil)
+
+		block = parser.parse("type T = { hello: 'world'; read foo: number, write bar: boolean }")
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "table")
+		tableType = typeAlias.type :: luau.AstTypeTable
+		assert.eq(#tableType.entries, 3)
+		tableTypeItem = tableType.entries[1]
+		assert.eq(tableTypeItem.kind, "property")
+		assert.eq(tableTypeItem.access, nil)
+		assert.eq((tableTypeItem.key :: luau.Token).text, "hello")
+		assert.eq(tableTypeItem.colon.text, ":")
+		assert.eq(tableTypeItem.value.tag, "string")
+		assert.neq(tableTypeItem.separator, nil)
+		assert.eq((tableTypeItem.separator :: luau.Token<"," | ";">).text, ";")
+
+		tableTypeItem = tableType.entries[2]
+		assert.eq(tableTypeItem.kind, "property")
+		assert.neq(tableTypeItem.access, nil)
+		assert.eq((tableTypeItem.access :: luau.Token<"read" | "write">).text, "read")
+		assert.neq(tableTypeItem.separator, nil)
+		assert.eq((tableTypeItem.separator :: luau.Token<"," | ";">).text, ",")
+
+		tableTypeItem = tableType.entries[3]
+		assert.eq(tableTypeItem.kind, "property")
+		assert.neq(tableTypeItem.access, nil)
+		assert.eq((tableTypeItem.access :: luau.Token<"read" | "write">).text, "write")
+		assert.eq(tableTypeItem.separator, nil)
+	end)
+
+	suite:case("parseTypeFunction", function(assert)
+		local block = parser.parse("type T = (n : number, string) -> boolean")
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "function")
+
+		local funcType = typeAlias.type :: luau.AstTypeFunction
+		assert.eq(funcType.opengenerics, nil)
+		assert.eq(funcType.generics, nil)
+		assert.eq(funcType.genericpacks, nil)
+		assert.eq(funcType.closegenerics, nil)
+		assert.eq(funcType.openparens.text, "(")
+		assert.eq(#funcType.parameters, 2)
+
+		local param = funcType.parameters[1].node
+		assert.neq(param.name, nil)
+		assert.eq((param.name :: luau.Token<string>).text, "n")
+		assert.neq(param.colon, nil)
+		assert.eq((param.colon :: luau.Token<":">).text, ":")
+		assert.eq(param.type.tag, "reference")
+
+		param = funcType.parameters[2].node
+		assert.eq(param.name, nil)
+		assert.eq(param.colon, nil)
+		assert.eq(param.type.tag, "reference")
+
+		assert.eq(funcType.vararg, nil)
+		assert.eq(funcType.closeparens.text, ")")
+		assert.eq(funcType.returnarrow.text, "->")
+		assert.eq(funcType.returntypes.kind, "typepack")
+
+		block = parser.parse("type T = <T, U...> (item: T, ...U) -> ()")
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "function")
+
+		funcType = typeAlias.type :: luau.AstTypeFunction
+		assert.neq(funcType.opengenerics, nil)
+		assert.eq((funcType.opengenerics :: luau.Token<"<">).text, "<")
+		assert.neq(funcType.generics, nil)
+		assert.eq(#funcType.generics :: luau.Punctuated<luau.AstGenericType>, 1)
+		assert.neq(funcType.genericpacks, nil)
+		assert.eq(#funcType.genericpacks :: luau.Punctuated<luau.AstGenericTypePack>, 1)
+		assert.neq(funcType.closegenerics, nil)
+		assert.eq((funcType.closegenerics :: luau.Token<">">).text, ">")
+		assert.neq(funcType.vararg, nil)
+		assert.eq((funcType.vararg :: luau.AstTypePack).kind, "typepack")
+	end)
+end)
+
 test.run()

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -1130,10 +1130,28 @@ test.suite("parse types", function(suite)
 		assert.eq(#funcType.generics :: luau.Punctuated<luau.AstGenericType>, 1)
 		assert.neq(funcType.genericpacks, nil)
 		assert.eq(#funcType.genericpacks :: luau.Punctuated<luau.AstGenericTypePack>, 1)
+		assert.eq((funcType.genericpacks :: luau.Punctuated<luau.AstGenericTypePack>)[1].node.tag, "generic")
+
+		local genericTypePack = (funcType.genericpacks :: luau.Punctuated<luau.AstGenericTypePack>)[1].node
+		assert.eq(genericTypePack.name.text, "U")
+		assert.eq(genericTypePack.ellipsis.text, "...")
+
 		assert.neq(funcType.closegenerics, nil)
 		assert.eq((funcType.closegenerics :: luau.Token<">">).text, ">")
 		assert.neq(funcType.vararg, nil)
 		assert.eq((funcType.vararg :: luau.AstTypePack).kind, "typepack")
+
+		block = parser.parse("type T = () -> ...number")
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "function")
+
+		funcType = typeAlias.type :: luau.AstTypeFunction
+		assert.eq(funcType.returntypes.kind, "typepack")
+		assert.eq(funcType.returntypes.tag, "variadic")
+		local variadicType: luau.AstTypePackVariadic = funcType.returntypes :: any
+		assert.neq(variadicType.ellipsis, nil)
+		assert.eq((variadicType.ellipsis :: luau.Token<"...">).text, "...")
+		assert.eq(variadicType.type.tag, "reference")
 	end)
 end)
 

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -498,4 +498,341 @@ test.suite("parseExpr", function(suite)
 	end)
 end)
 
+local function checkIsBlock(node: any, assert: asserts.Asserts)
+	assert.eq(node.kind, "stat")
+	assert.eq(node.tag, "block")
+end
+
+test.suite("parse", function(suite)
+	suite:case("parseEmptyProgram", function(assert)
+		local block = parser.parse("")
+		checkIsBlock(block, assert)
+		assert.eq(#block.statements, 0)
+	end)
+
+	suite:case("parseIfStatement", function(assert)
+		local block =
+			parser.parse("if x > 0 then print('positive') elseif x < 0 then print('negative') else print('zero') end")
+		assert.eq(#block.statements, 1)
+
+		local ifStat = block.statements[1] :: luau.AstStatIf
+		assert.eq(ifStat.tag, "conditional")
+		assert.eq(ifStat.ifkeyword.text, "if")
+		assert.eq(ifStat.condition.tag, "binary")
+		assert.eq(ifStat.thenkeyword.text, "then")
+		checkIsBlock(ifStat.consequent, assert)
+
+		local consequentBlock = ifStat.consequent
+		assert.eq(#consequentBlock.statements, 1)
+
+		assert.eq(#ifStat.elseifs, 1)
+		local elseIf = ifStat.elseifs[1]
+		assert.eq(elseIf.elseifkeyword.text, "elseif")
+		assert.eq(elseIf.condition.tag, "binary")
+		assert.eq(elseIf.thenkeyword.text, "then")
+		checkIsBlock(elseIf.consequent, assert)
+
+		assert.neq(ifStat.elsekeyword, nil)
+		assert.eq((ifStat.elsekeyword :: luau.Token<"else">).text, "else")
+		assert.neq(ifStat.antecedent, nil)
+		checkIsBlock(ifStat.antecedent, assert)
+		assert.eq(ifStat.endkeyword.text, "end")
+
+		block = parser.parse("if condition then doSomething() end")
+		assert.eq(#block.statements, 1)
+		local simpleIfStat = block.statements[1] :: luau.AstStatIf
+		assert.eq(simpleIfStat.tag, "conditional")
+		assert.eq(simpleIfStat.ifkeyword.text, "if")
+		assert.eq(simpleIfStat.condition.tag, "global")
+		assert.eq(simpleIfStat.thenkeyword.text, "then")
+		checkIsBlock(simpleIfStat.consequent, assert)
+		assert.eq(#simpleIfStat.consequent.statements, 1)
+		assert.eq(#simpleIfStat.elseifs, 0)
+		assert.eq(simpleIfStat.elsekeyword, nil)
+		assert.eq(simpleIfStat.antecedent, nil)
+		assert.eq(simpleIfStat.endkeyword.text, "end")
+	end)
+
+	suite:case("parseStatWhile", function(assert)
+		local block = parser.parse("while i <= 10 do print(i); i = i + 1 end")
+		checkIsBlock(block, assert)
+		assert.eq(#block.statements, 1)
+
+		local whileStat = block.statements[1] :: luau.AstStatWhile
+		assert.eq(whileStat.tag, "while")
+		assert.eq(whileStat.whilekeyword.text, "while")
+		assert.eq(whileStat.condition.tag, "binary")
+		assert.eq(whileStat.dokeyword.text, "do")
+		checkIsBlock(whileStat.body, assert)
+		assert.eq(#whileStat.body.statements, 2)
+		assert.eq(whileStat.endkeyword.text, "end")
+
+		block = parser.parse("while true do break end")
+		checkIsBlock(block, assert)
+		assert.eq(#block.statements, 1)
+
+		whileStat = block.statements[1] :: luau.AstStatWhile
+		assert.eq(whileStat.tag, "while")
+		assert.eq(whileStat.whilekeyword.text, "while")
+		assert.eq(whileStat.condition.tag, "boolean")
+		assert.eq(whileStat.dokeyword.text, "do")
+		checkIsBlock(whileStat.body, assert)
+		assert.eq(#whileStat.body.statements, 1)
+
+		local breakStat = whileStat.body.statements[1] :: luau.AstStat
+		assert.eq(breakStat.kind, "stat")
+		breakStat = breakStat :: luau.AstStatBreak
+		assert.eq(breakStat.tag, "break")
+		assert.eq(breakStat.text, "break")
+
+		assert.eq(whileStat.endkeyword.text, "end")
+
+		block = parser.parse("while true do continue end")
+		checkIsBlock(block, assert)
+		assert.eq(#block.statements, 1)
+
+		whileStat = block.statements[1] :: luau.AstStatWhile
+		assert.eq(whileStat.tag, "while")
+		assert.eq(whileStat.whilekeyword.text, "while")
+		assert.eq(whileStat.condition.tag, "boolean")
+		assert.eq(whileStat.dokeyword.text, "do")
+		checkIsBlock(whileStat.body, assert)
+		assert.eq(#whileStat.body.statements, 1)
+
+		local continueStat = whileStat.body.statements[1] :: luau.AstStat
+		assert.eq(continueStat.kind, "stat")
+		continueStat = continueStat :: luau.AstStatContinue
+		assert.eq(continueStat.tag, "continue")
+		assert.eq(continueStat.text, "continue")
+
+		assert.eq(whileStat.endkeyword.text, "end")
+	end)
+
+	suite:case("parseStatRepeat", function(assert)
+		local block = parser.parse("repeat i = i + 1; print(i) until i > 5")
+		checkIsBlock(block, assert)
+		assert.eq(#block.statements, 1)
+
+		local repeatStat = block.statements[1] :: luau.AstStatRepeat
+		assert.eq(repeatStat.tag, "repeat")
+		assert.eq(repeatStat.repeatKeyword.text, "repeat")
+		checkIsBlock(repeatStat.body, assert)
+		assert.eq(#repeatStat.body.statements, 2)
+		assert.eq(repeatStat.untilKeyword.text, "until")
+		assert.eq(repeatStat.condition.tag, "binary")
+	end)
+
+	suite:case("parseStatLocal", function(assert)
+		local block = parser.parse("local b, c = 1, 2")
+		checkIsBlock(block, assert)
+		assert.eq(#block.statements, 1)
+		assert.eq(block.statements[1].kind, "stat")
+
+		local l = block.statements[1] :: luau.AstStatLocal
+		assert.eq(l.tag, "local")
+		assert.eq(l.localkeyword.text, "local")
+		assert.eq(#l.variables, 2)
+		assert.eq(l.variables[1].node.name.text, "b")
+		assert.neq(l.variables[1].separator, nil)
+		assert.eq((l.variables[1].separator :: luau.Token<",">).text, ",")
+		assert.eq(l.variables[2].node.name.text, "c")
+		assert.eq(l.variables[2].separator, nil)
+		assert.neq(l.equals, nil)
+		assert.eq((l.equals :: luau.Token<"=">).text, "=")
+		assert.eq(#l.values, 2)
+		assert.eq(l.values[1].node.tag, "number")
+		assert.neq(l.values[1].separator, nil)
+		assert.eq((l.values[1].separator :: luau.Token<",">).text, ",")
+		assert.eq(l.values[2].node.tag, "number")
+		assert.eq(l.values[2].separator, nil)
+
+		block = parser.parse("local x")
+		checkIsBlock(block, assert)
+		assert.eq(#block.statements, 1)
+		assert.eq(block.statements[1].kind, "stat")
+
+		l = block.statements[1] :: luau.AstStatLocal
+		assert.eq(l.tag, "local")
+		assert.eq(l.localkeyword.text, "local")
+		assert.eq(#l.variables, 1)
+		assert.eq(l.variables[1].node.name.text, "x")
+		assert.eq(l.variables[1].separator, nil)
+		assert.eq(l.equals, nil)
+		assert.eq(#l.values, 0)
+	end)
+
+	suite:case("parseStatFor", function(assert)
+		local block = parser.parse("for i = 1, 10, 2 do print(i) end")
+		assert.eq(block.tag, "block")
+		assert.eq(#block.statements, 1)
+
+		local forStat = block.statements[1] :: luau.AstStatFor
+		assert.eq(forStat.tag, "for")
+		assert.eq(forStat.forkeyword.text, "for")
+		assert.eq(forStat.variable.name.text, "i")
+		assert.eq(forStat.equals.text, "=")
+		assert.eq(forStat.from.tag, "number")
+		assert.eq(forStat.tocomma.text, ",")
+		assert.eq(forStat.to.tag, "number")
+		assert.neq(forStat.stepcomma, nil)
+		assert.eq((forStat.stepcomma :: luau.Token<",">).text, ",")
+		assert.neq(forStat.step, nil)
+		assert.eq(((forStat.step :: any) :: luau.AstExpr).tag, "number")
+		assert.eq(forStat.dokeyword.text, "do")
+		checkIsBlock(forStat.body, assert)
+		assert.eq(#forStat.body.statements, 1)
+		assert.eq(forStat.endkeyword.text, "end")
+
+		block = parser.parse("for j = 0, 5 do print(j) end")
+		assert.eq(block.tag, "block")
+		assert.eq(#block.statements, 1)
+
+		forStat = block.statements[1] :: luau.AstStatFor
+		assert.eq(forStat.tag, "for")
+		assert.eq(forStat.forkeyword.text, "for")
+		assert.eq(forStat.variable.name.text, "j")
+		assert.eq(forStat.equals.text, "=")
+		assert.eq(forStat.from.tag, "number")
+		assert.eq(forStat.tocomma.text, ",")
+		assert.eq(forStat.to.tag, "number")
+		assert.eq(forStat.stepcomma, nil)
+		assert.eq(forStat.step, nil)
+		assert.eq(forStat.dokeyword.text, "do")
+		checkIsBlock(forStat.body, assert)
+		assert.eq(#forStat.body.statements, 1)
+		assert.eq(forStat.endkeyword.text, "end")
+	end)
+
+	suite:case("parseForInLoop", function(assert)
+		local block = parser.parse("for key, value in arr do print(key, value) end")
+		assert.eq(block.tag, "block")
+		assert.eq(#block.statements, 1)
+
+		local forInStat = block.statements[1] :: luau.AstStatForIn
+		assert.eq(forInStat.tag, "forin")
+		assert.eq(forInStat.forkeyword.text, "for")
+		assert.eq(#forInStat.variables, 2)
+		assert.eq(forInStat.variables[1].node.name.text, "key")
+		assert.eq(forInStat.variables[2].node.name.text, "value")
+		assert.eq(forInStat.inkeyword.text, "in")
+		assert.eq(#forInStat.values, 1)
+		assert.eq(forInStat.values[1].node.tag, "global")
+		assert.eq(forInStat.dokeyword.text, "do")
+		checkIsBlock(forInStat.body, assert)
+		assert.eq(#forInStat.body.statements, 1)
+		assert.eq(forInStat.endkeyword.text, "end")
+	end)
+
+	suite:case("parseStatAssign", function(assert)
+		local block = parser.parse("x = 1")
+		assert.eq(block.tag, "block")
+		assert.eq(#block.statements, 1)
+
+		local assign = block.statements[1] :: luau.AstStatAssign
+		assert.eq(assign.tag, "assign")
+		assert.eq(#assign.variables, 1)
+		assert.eq(assign.variables[1].node.tag, "global")
+		assert.eq(assign.equals.text, "=")
+		assert.eq(#assign.values, 1)
+		assert.eq(assign.values[1].node.tag, "number")
+	end)
+
+	suite:case("parseStatCompoundAssign", function(assert)
+		local block = parser.parse("x += 5")
+		assert.eq(block.tag, "block")
+		assert.eq(#block.statements, 1)
+
+		local compound = block.statements[1] :: luau.AstStatCompoundAssign
+		assert.eq(compound.tag, "compoundassign")
+		assert.eq(compound.variable.tag, "global")
+		assert.eq(compound.operand.text, "+=")
+		assert.eq(compound.value.tag, "number")
+	end)
+
+	suite:case("parseStatFunction", function(assert)
+		local block = parser.parse("@checked @native @deprecated function add(a, b) return a + b end")
+		checkIsBlock(block, assert)
+		assert.eq(#block.statements, 1)
+
+		local funcStat = block.statements[1] :: luau.AstStatFunction
+		assert.eq(funcStat.tag, "function")
+		assert.eq(#funcStat.attributes, 3)
+		assert.eq((funcStat.attributes[1] :: luau.AstAttribute).text, "@checked")
+		assert.eq((funcStat.attributes[2] :: luau.AstAttribute).text, "@native")
+		assert.eq((funcStat.attributes[3] :: luau.AstAttribute).text, "@deprecated")
+		assert.eq(funcStat.functionkeyword.text, "function")
+		assert.eq(funcStat.name.tag, "global")
+		assert.eq((funcStat.name :: luau.AstExprGlobal).name.text, "add")
+		-- body parsing tested in parseExprAnonymousFunction
+	end)
+
+	suite:case("parseStatLocalFunction", function(assert)
+		local block = parser.parse("local function multiply(x, y) return x * y end")
+		checkIsBlock(block, assert)
+		assert.eq(#block.statements, 1)
+
+		local localFuncStat = block.statements[1] :: luau.AstStatLocalFunction
+		assert.eq(localFuncStat.tag, "localfunction")
+		assert.eq(#localFuncStat.attributes, 0)
+		assert.eq(localFuncStat.localkeyword.text, "local")
+		assert.eq(localFuncStat.functionkeyword.text, "function")
+		assert.eq(localFuncStat.name.name.text, "multiply")
+	end)
+
+	suite:case("parseStatTypeAlias", function(assert)
+		local block = parser.parse("type Vector3 = {x: number, y: number, z: number}")
+		assert.eq(block.tag, "block")
+		assert.eq(#block.statements, 1)
+
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.tag, "typealias")
+		assert.eq(typeAlias.export, nil)
+		assert.eq(typeAlias.typeToken.text, "type")
+		assert.eq(typeAlias.name.text, "Vector3")
+		assert.eq(typeAlias.opengenerics, nil)
+		assert.eq(typeAlias.generics, nil)
+		assert.eq(typeAlias.closegenerics, nil)
+		assert.eq(typeAlias.equals.text, "=")
+		assert.eq(typeAlias.type.kind, "type")
+		assert.eq(typeAlias.type.tag, "table")
+
+		block = parser.parse("export type Point<T, U...> = {x: T, y: T, f: (U...) -> ()}")
+		checkIsBlock(block, assert)
+		assert.eq(#block.statements, 1)
+
+		typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.neq(typeAlias.export, nil)
+		assert.eq((typeAlias.export :: luau.Token<"export">).text, "export")
+		assert.neq(typeAlias.opengenerics, nil)
+		assert.eq((typeAlias.opengenerics :: luau.Token<"<">).text, "<")
+		assert.neq(typeAlias.generics, nil)
+		assert.eq(#typeAlias.generics :: luau.Punctuated<luau.AstGenericType>, 1)
+		assert.neq(typeAlias.genericpacks, nil)
+		assert.eq(#typeAlias.genericpacks :: luau.Punctuated<luau.AstGenericTypePack>, 1)
+		assert.neq(typeAlias.closegenerics, nil)
+		assert.eq((typeAlias.closegenerics :: luau.Token<">">).text, ">")
+	end)
+
+	suite:case("parseStatTypeFunction", function(assert)
+		local block = parser.parse("type function foo() return types.number end")
+		assert.eq(block.tag, "block")
+		assert.eq(#block.statements, 1)
+
+		local typeFunc = block.statements[1] :: luau.AstStatTypeFunction
+		assert.eq(typeFunc.tag, "typefunction")
+		assert.eq(typeFunc.export, nil)
+		assert.eq(typeFunc.type.text, "type")
+		assert.eq(typeFunc.functionkeyword.text, "function")
+		assert.eq(typeFunc.name.text, "foo")
+
+		block = parser.parse("export type function foo() return types.number end")
+		assert.eq(block.tag, "block")
+		assert.eq(#block.statements, 1)
+
+		typeFunc = block.statements[1] :: luau.AstStatTypeFunction
+		assert.neq(typeFunc.export, nil)
+		assert.eq((typeFunc.export :: luau.Token<"export">).text, "export")
+	end)
+end)
+
 test.run()

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -108,11 +108,11 @@ test.suite("Parser", function(suite)
 
 		local trailingToken: luau.AstExpr = (firstStmt :: luau.AstStatLocal).values[1].node
 		assert.eq(trailingToken.tag, "string")
-		trailingToken = trailingToken :: luau.AstExprConstantString
-		assert.eq(#trailingToken.trailingtrivia, 3)
-		assert.eq(trailingToken.trailingtrivia[1].text, " ")
-		assert.eq(trailingToken.trailingtrivia[2].text, "-- comment")
-		assert.eq(trailingToken.trailingtrivia[3].text, "\n")
+		local expr = trailingToken :: luau.AstExprConstantString
+		assert.eq(#expr.trailingtrivia, 3)
+		assert.eq(expr.trailingtrivia[1].text, " ")
+		assert.eq(expr.trailingtrivia[2].text, "-- comment")
+		assert.eq(expr.trailingtrivia[3].text, "\n")
 
 		local secondStmt = block.statements[2]
 		assert.eq(secondStmt.tag, "local")
@@ -187,6 +187,314 @@ test.suite("Parser", function(suite)
 			local lf = l :: luau.AstStatLocalFunction
 			assert.eq(lf.attributes[1].text, subcase.attr)
 		end
+	end)
+end)
+
+test.suite("parseExpr", function(suite)
+	suite:case("parseExprGroup", function(assert)
+		local groupExpr = parser.parseexpr("(x)")
+		assert.eq(groupExpr.tag, "group")
+		assert.eq(groupExpr.kind, "expr")
+		local expr = groupExpr :: luau.AstExprGroup
+		assert.eq(expr.openparens.text, "(")
+		assert.eq(expr.closeparens.text, ")")
+		assert.eq(expr.expression.tag, "global")
+	end)
+
+	suite:case("parseExprNil", function(assert)
+		local expr = parser.parseexpr("nil")
+		assert.eq(expr.tag, "nil")
+		assert.eq(expr.kind, "expr")
+		assert.eq((expr :: luau.AstExprConstantNil).text, "nil")
+	end)
+
+	suite:case("parseExprBoolean", function(assert)
+		local trueExpr = parser.parseexpr("true")
+		assert.eq(trueExpr.tag, "boolean")
+		assert.eq(trueExpr.kind, "expr")
+		assert.eq((trueExpr :: luau.AstExprConstantBool).text, "true")
+		assert.eq((trueExpr :: luau.AstExprConstantBool).value, true)
+
+		local falseExpr = parser.parseexpr("false")
+		assert.eq(falseExpr.tag, "boolean")
+		assert.eq(falseExpr.kind, "expr")
+		assert.eq((falseExpr :: luau.AstExprConstantBool).text, "false")
+		assert.eq((falseExpr :: luau.AstExprConstantBool).value, false)
+	end)
+
+	suite:case("parseExprNumber", function(assert)
+		local numberExpr = parser.parseexpr("42")
+		assert.eq(numberExpr.tag, "number")
+		assert.eq(numberExpr.kind, "expr")
+		assert.eq((numberExpr :: luau.AstExprConstantNumber).text, "42")
+		assert.eq((numberExpr :: luau.AstExprConstantNumber).value, 42)
+
+		local floatExpr = parser.parseexpr("3.14")
+		assert.eq(floatExpr.tag, "number")
+		assert.eq(floatExpr.kind, "expr")
+		assert.eq((floatExpr :: luau.AstExprConstantNumber).text, "3.14")
+		assert.eq((floatExpr :: luau.AstExprConstantNumber).value, 3.14)
+	end)
+
+	suite:case("parseExprString", function(assert)
+		local singleQuoteExpr = parser.parseexpr("'hello'")
+		assert.eq(singleQuoteExpr.tag, "string")
+		assert.eq(singleQuoteExpr.kind, "expr")
+		assert.eq((singleQuoteExpr :: luau.AstExprConstantString).text, "hello")
+		assert.eq((singleQuoteExpr :: luau.AstExprConstantString).quotestyle, "single")
+
+		local doubleQuoteExpr = parser.parseexpr('"world"')
+		assert.eq(doubleQuoteExpr.tag, "string")
+		assert.eq(doubleQuoteExpr.kind, "expr")
+		assert.eq((doubleQuoteExpr :: luau.AstExprConstantString).text, "world")
+		assert.eq((doubleQuoteExpr :: luau.AstExprConstantString).quotestyle, "double")
+
+		local blockQuoteExpr = parser.parseexpr("[[world]]")
+		assert.eq(blockQuoteExpr.tag, "string")
+		assert.eq(blockQuoteExpr.kind, "expr")
+		assert.eq((blockQuoteExpr :: luau.AstExprConstantString).text, "world")
+		assert.eq((blockQuoteExpr :: luau.AstExprConstantString).quotestyle, "block")
+
+		local interpExpr = parser.parseexpr("`foobar`")
+		assert.eq(interpExpr.tag, "string")
+		assert.eq(interpExpr.kind, "expr")
+		assert.eq((interpExpr :: luau.AstExprConstantString).text, "foobar")
+		assert.eq((interpExpr :: luau.AstExprConstantString).quotestyle, "interp")
+	end)
+
+	suite:case("parseExprLocal", function(assert)
+		local localExpr = parser.parseexpr("x")
+		assert.eq(localExpr.tag, "global")
+		assert.eq(localExpr.kind, "expr")
+		assert.eq((localExpr :: luau.AstExprGlobal).name.text, "x")
+	end)
+
+	suite:case("parseExprGlobal", function(assert)
+		local globalExpr = parser.parseexpr("_G")
+		assert.eq(globalExpr.tag, "global")
+		assert.eq(globalExpr.kind, "expr")
+		assert.eq((globalExpr :: luau.AstExprGlobal).name.text, "_G")
+	end)
+
+	suite:case("parseExprVarargs", function(assert)
+		local varargsExpr = parser.parseexpr("...")
+		assert.eq(varargsExpr.tag, "vararg")
+		assert.eq(varargsExpr.kind, "expr")
+		assert.eq((varargsExpr :: luau.AstExprVarargs).text, "...")
+	end)
+
+	suite:case("parseExprCall", function(assert)
+		local callExpr = parser.parseexpr("foo()")
+		assert.eq(callExpr.tag, "call")
+		assert.eq(callExpr.kind, "expr")
+		assert.eq((callExpr :: luau.AstExprCall).func.tag, "global")
+		assert.eq(((callExpr :: luau.AstExprCall).func :: luau.AstExprGlobal).name.text, "foo")
+		assert.eq((callExpr :: luau.AstExprCall).self, false)
+		assert.eq(#(callExpr :: luau.AstExprCall).arguments, 0)
+
+		local callWithArgsExpr = parser.parseexpr("bar(1, 2)")
+		assert.eq(callWithArgsExpr.tag, "call")
+		assert.eq(callWithArgsExpr.kind, "expr")
+		assert.eq(#(callWithArgsExpr :: luau.AstExprCall).arguments, 2)
+		assert.eq((callWithArgsExpr :: luau.AstExprCall).arguments[1].node.tag, "number")
+		assert.eq((callWithArgsExpr :: luau.AstExprCall).arguments[2].node.tag, "number")
+	end)
+
+	suite:case("parseExprIndexName", function(assert)
+		local indexExpr = parser.parseexpr("obj.field")
+		assert.eq(indexExpr.tag, "indexname")
+		assert.eq(indexExpr.kind, "expr")
+		assert.eq((indexExpr :: luau.AstExprIndexName).expression.tag, "global")
+		assert.eq((indexExpr :: luau.AstExprIndexName).accessor.text, ".")
+		assert.eq((indexExpr :: luau.AstExprIndexName).index.text, "field")
+	end)
+
+	suite:case("parseExprIndexExpr", function(assert)
+		local indexExpr = parser.parseexpr("arr[1]")
+		assert.eq(indexExpr.tag, "index")
+		assert.eq(indexExpr.kind, "expr")
+		assert.eq((indexExpr :: luau.AstExprIndexExpr).expression.tag, "global")
+		assert.eq((indexExpr :: luau.AstExprIndexExpr).index.tag, "number")
+		assert.eq((indexExpr :: luau.AstExprIndexExpr).openbrackets.text, "[")
+		assert.eq((indexExpr :: luau.AstExprIndexExpr).closebrackets.text, "]")
+	end)
+
+	suite:case("parseExprAnonymousFunction", function(assert)
+		local anonFuncExpr = parser.parseexpr("function(a, b) return a + b end")
+		assert.eq(anonFuncExpr.tag, "function")
+		assert.eq(anonFuncExpr.kind, "expr")
+
+		local funcExpr = anonFuncExpr :: luau.AstExprAnonymousFunction
+		assert.eq(#funcExpr.attributes, 0)
+		assert.eq(funcExpr.functionkeyword.text, "function")
+
+		local funcBody = funcExpr.body
+		assert.eq(funcBody.opengenerics, nil)
+		assert.eq(funcBody.generics, nil)
+		assert.eq(funcBody.genericpacks, nil)
+		assert.eq(funcBody.closegenerics, nil)
+		assert.eq(funcBody.self, nil)
+		assert.eq(funcBody.openparens.text, "(")
+		assert.eq(#funcBody.parameters, 2)
+		assert.eq(funcBody.parameters[1].node.name.text, "a")
+		assert.eq(funcBody.parameters[2].node.name.text, "b")
+		assert.eq(funcBody.vararg, nil)
+		assert.eq(funcBody.varargcolon, nil)
+		assert.eq(funcBody.varargannotation, nil)
+		assert.eq(funcBody.closeparens.text, ")")
+		assert.eq(funcBody.returnspecifier, nil)
+		assert.eq(funcBody.returnannotation, nil)
+		assert.eq(funcBody.endkeyword.text, "end")
+
+		anonFuncExpr = parser.parseexpr("function<A, B...>(a: A, ...: B...): A return a end")
+		assert.eq(anonFuncExpr.tag, "function")
+		assert.eq(anonFuncExpr.kind, "expr")
+
+		funcExpr = anonFuncExpr :: luau.AstExprAnonymousFunction
+		assert.eq(#funcExpr.attributes, 0)
+		assert.eq(funcExpr.functionkeyword.text, "function")
+
+		funcBody = funcExpr.body
+		assert.neq(funcBody.opengenerics, nil)
+		assert.neq(funcBody.generics, nil)
+
+		assert.eq(#funcBody.generics :: luau.Punctuated<luau.AstGenericType>, 1)
+		local gen = (funcBody.generics :: luau.Punctuated<luau.AstGenericType>)[1].node
+		assert.eq(gen.name.text, "A")
+		assert.eq(gen.equals, nil)
+		assert.eq(gen.default, nil)
+
+		assert.neq(funcBody.genericpacks, nil)
+		assert.eq(#funcBody.genericpacks :: luau.Punctuated<luau.AstGenericTypePack>, 1)
+		local genPack = (funcBody.genericpacks :: luau.Punctuated<luau.AstGenericTypePack>)[1].node
+		assert.eq(genPack.name.text, "B")
+		assert.eq(genPack.ellipsis.text, "...")
+		assert.eq(genPack.equals, nil)
+		assert.eq(genPack.default, nil)
+
+		assert.neq(funcBody.closegenerics, nil)
+		assert.eq((funcBody.closegenerics :: luau.Token<">">).text, ">")
+
+		assert.eq(funcBody.openparens.text, "(")
+		assert.eq(#funcBody.parameters, 1)
+
+		local param = funcBody.parameters[1].node
+		assert.eq(param.name.text, "a")
+		assert.neq(param.colon, nil)
+		assert.eq((param.colon :: luau.Token<":">).text, ":")
+		assert.neq(param.annotation, nil)
+		assert.eq((param.annotation :: luau.AstType).tag, "reference")
+
+		assert.neq(funcBody.vararg, nil)
+		assert.eq((funcBody.vararg :: luau.Token<"...">).text, "...")
+		assert.neq(funcBody.varargcolon, nil)
+		assert.eq((funcBody.varargcolon :: luau.Token<":">).text, ":")
+		assert.neq(funcBody.varargannotation, nil)
+		assert.eq((funcBody.varargannotation :: luau.AstTypePack).tag, "generic")
+
+		assert.eq(funcBody.closeparens.text, ")")
+		assert.neq(funcBody.returnspecifier, nil)
+		assert.eq((funcBody.returnspecifier :: luau.Token<":">).text, ":")
+		assert.neq(funcBody.returnannotation, nil)
+		assert.eq((funcBody.returnannotation :: luau.AstTypePack).tag, "explicit")
+	end)
+
+	suite:case("parseExprTable", function(assert)
+		local emptyTableExpr = parser.parseexpr("{}")
+		assert.eq(emptyTableExpr.tag, "table")
+		assert.eq(emptyTableExpr.kind, "expr")
+		local tableExpr = emptyTableExpr :: luau.AstExprTable
+		assert.eq(tableExpr.openbrace.text, "{")
+		assert.eq(tableExpr.closebrace.text, "}")
+		assert.eq(#tableExpr.entries, 0)
+
+		local mixedTable = parser.parseexpr("{1, foo = bar; [2] = baz}")
+		assert.eq(mixedTable.tag, "table")
+		assert.eq(mixedTable.kind, "expr")
+		local mixedTableExpr = mixedTable :: luau.AstExprTable
+		assert.eq(#mixedTableExpr.entries, 3)
+
+		local entry1 = mixedTableExpr.entries[1]
+		assert.eq(entry1.kind, "list")
+		assert.eq(entry1.value.tag, "number")
+		assert.neq(entry1.separator, nil)
+		assert.eq((entry1.separator :: luau.Token<"," | ";">).text, ",")
+
+		local entry2: any = mixedTableExpr.entries[2]
+		assert.eq(entry2.kind, "record")
+		assert.eq(entry2.key.text, "foo")
+		assert.eq(entry2.equals.text, "=")
+		assert.eq(entry2.value.tag, "global")
+		assert.neq(entry2.separator, nil)
+		assert.eq((entry2.separator :: luau.Token<"," | ";">).text, ";")
+
+		local entry3: any = mixedTableExpr.entries[3]
+		assert.eq(entry3.kind, "general")
+		assert.eq(entry3.indexeropen.text, "[")
+		assert.eq(entry3.key.tag, "number")
+		assert.eq(entry3.indexerclose.text, "]")
+		assert.eq(entry3.equals.text, "=")
+		assert.eq(entry3.value.tag, "global")
+		assert.eq(entry3.separator, nil)
+	end)
+
+	suite:case("parseExprUnary", function(assert)
+		local notExpr = parser.parseexpr("not x")
+		assert.eq(notExpr.tag, "unary")
+		assert.eq(notExpr.kind, "expr")
+		local expr = notExpr :: luau.AstExprUnary
+		assert.eq(expr.operator.text, "not")
+		assert.eq(expr.operand.tag, "global")
+
+		local negExpr = parser.parseexpr("-42")
+		assert.eq(negExpr.tag, "unary")
+		assert.eq(negExpr.kind, "expr")
+		expr = negExpr :: luau.AstExprUnary
+		assert.eq(expr.operator.text, "-")
+		assert.eq(expr.operand.tag, "number")
+
+		local lenExpr = parser.parseexpr("#str")
+		assert.eq(lenExpr.tag, "unary")
+		assert.eq(lenExpr.kind, "expr")
+		expr = lenExpr :: luau.AstExprUnary
+		assert.eq(expr.operator.text, "#")
+		assert.eq(expr.operand.tag, "global")
+	end)
+
+	suite:case("parseExprBinary", function(assert)
+		local addExpr = parser.parseexpr("1 + 2")
+		assert.eq(addExpr.tag, "binary")
+		assert.eq(addExpr.kind, "expr")
+		local expr = addExpr :: luau.AstExprBinary
+		assert.eq(expr.lhsoperand.tag, "number")
+		assert.eq(expr.operator.text, "+")
+		assert.eq(expr.rhsoperand.tag, "number")
+	end)
+
+	suite:case("parseExprInterpString", function(assert)
+		local interpExpr = parser.parseexpr("`Hello, {name}! Today is {dayOfWeek}.`")
+		assert.eq(interpExpr.tag, "interpolatedstring")
+		assert.eq(interpExpr.kind, "expr")
+		local expr = interpExpr :: luau.AstExprInterpString
+		assert.eq(#expr.strings, 3)
+
+		assert.eq(expr.strings[1].text, "Hello, ")
+		assert.eq(expr.strings[2].text, "! Today is ")
+		assert.eq(expr.strings[3].text, ".")
+
+		assert.eq(#expr.expressions, 2)
+		assert.eq(expr.expressions[1].tag, "global")
+		assert.eq(expr.expressions[2].tag, "global")
+	end)
+
+	suite:case("parseExprTypeAssertion", function(assert)
+		local castExpr = parser.parseexpr("x :: string")
+		assert.eq(castExpr.tag, "cast")
+		assert.eq(castExpr.kind, "expr")
+		local expr = castExpr :: luau.AstExprTypeAssertion
+		assert.eq(expr.operand.tag, "global")
+		assert.eq(expr.operator.text, "::")
+		assert.eq(expr.annotation.tag, "reference")
 	end)
 end)
 


### PR DESCRIPTION
This PR adds kinds to AST types, which lets us do nice things with refinements like:
```luau
if node.kind == "expr" then
    if node.tag == "conditional" then
        node. -- we get autocomplete for things like 'condition' here
    end
end
```

This also required updating the serialization implementation of the parser.