### PR TITLE
bugfix: UAF in fs callbacks

### DIFF
--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -457,7 +457,7 @@ static void defaultCallback(uv_fs_t* req)
 
     if (err)
     {
-        token->fail(uv_strerror(req->result));
+        token->fail(uv_strerror(err));
         return;
     }
 


### PR DESCRIPTION
There is a UAF bug in the `defaultCallback` where we access the result of a uv_fs_t handle after delete'ing it.