### PR TITLE
[old] refactor: update `stdlib` module files to follow format in lute `definitions/`

### DIFF
--- a/examples/system_lib.luau
+++ b/examples/system_lib.luau
@@ -1,4 +1,4 @@
-local system = require("@lute/system")
+local system = require("@std/system")
 
 print(
 	string.format(
@@ -7,7 +7,7 @@ print(
 		system.os,
 		system.arch,
 		system.threadcount(),
-		system.uptime(),
+		tostring(system.uptime()),
 		system.freememory(),
 		system.totalmemory()
 	)

--- a/examples/task-wait.luau
+++ b/examples/task-wait.luau
@@ -1,8 +1,8 @@
 local task = require("@lute/task")
-local time = require("@lute/time")
+local time = require("@std/time")
 
 print(task.wait(1))
-print(task.wait(time.duration.seconds(1)))
+print(task.wait(time.seconds(1)))
 print(task.wait())
 
 -- while true do

--- a/examples/transformer.luau
+++ b/examples/transformer.luau
@@ -1,12 +1,12 @@
 local parser = require("@std/syntax/parser")
 local printer = require("@std/syntax/printer")
 local visitor = require("@std/syntax/visitor")
-local luau = require("@lute/luau")
+local luau = require("@std/luau")
 
 function transformation(ctx)
 	local parsedResult = parser.parsefile(ctx.source)
 
-	local v = visitor.createVisitor()
+	local v = visitor.createvisitor()
 
 	v.visitBinary = function(node: luau.AstExprBinary)
 		if node.operator.text ~= "~=" then
@@ -80,7 +80,7 @@ function transformation(ctx)
 		return false
 	end
 
-	visitor.visitBlock(parsedResult.root, v)
+	visitor.visitblock(parsedResult.root, v)
 
 	return printer.printfile(parsedResult)
 end

--- a/lute/std/libs/assert.luau
+++ b/lute/std/libs/assert.luau
@@ -1,3 +1,7 @@
+--!strict
+-- @std/assert
+-- Standard assertion library for Luau
+
 local assertions = {}
 
 function assertions.eq<T>(lhs: T, rhs: T)

--- a/lute/std/libs/fs.luau
+++ b/lute/std/libs/fs.luau
@@ -6,6 +6,8 @@
 local fs = require("@lute/fs")
 local pathlib = require("@std/path")
 
+local fslib = {}
+
 export type handlemode = fs.HandleMode
 export type filehandle = fs.FileHandle
 export type filetype = fs.FileType
@@ -19,76 +21,75 @@ export type createdirectoryoptions = {
 	makeparents: boolean?,
 }
 
-local function open(path: pathlike, mode: handlemode?): filehandle
+function fslib.open(path: pathlike, mode: handlemode?): filehandle
 	return fs.open(pathlib.format(path), mode)
 end
 
-local function read(handle: filehandle): string
+function fslib.read(handle: filehandle): string
 	return fs.read(handle)
 end
 
-local function write(handle: filehandle, contents: string): ()
+function fslib.write(handle: filehandle, contents: string): ()
 	return fs.write(handle, contents)
 end
 
-local function close(handle: filehandle): ()
+function fslib.close(handle: filehandle): ()
 	return fs.close(handle)
 end
 
-local function remove(path: pathlike): ()
+function fslib.remove(path: pathlike): ()
 	return fs.remove(pathlib.format(path))
 end
 
-local function stat(path: pathlike): filemetadata
+function fslib.stat(path: pathlike): filemetadata
 	return fs.stat(pathlib.format(path))
 end
 
-local function type(path: pathlike): filetype
+function fslib.type(path: pathlike): filetype
 	return fs.type(pathlib.format(path))
 end
 
-local function link(src: pathlike, dest: pathlike): ()
+function fslib.link(src: pathlike, dest: pathlike): ()
 	return fs.link(pathlib.format(src), pathlib.format(dest))
 end
 
-local function symlink(src: pathlike, dest: pathlike): ()
-	-- make sure our path is absolute path for symlink and if your os is
+function fslib.symlink(src: pathlike, dest: pathlike): ()
 	return fs.symlink(pathlib.format(src), pathlib.format(dest))
 end
 
-local function watch(path: pathlike, callback: (filename: pathlike, event: watchevent) -> ()): watchhandle
+function fslib.watch(path: pathlike, callback: (filename: pathlike, event: watchevent) -> ()): watchhandle
 	return fs.watch(pathlib.format(path), callback)
 end
 
-local function exists(path: pathlike): boolean
+function fslib.exists(path: pathlike): boolean
 	return fs.exists(pathlib.format(path))
 end
 
-local function copy(src: pathlike, dest: pathlike): ()
+function fslib.copy(src: pathlike, dest: pathlike): ()
 	return fs.copy(pathlib.format(src), pathlib.format(dest))
 end
 
-local function listdir(path: pathlike): { directoryentry }
+function fslib.listdir(path: pathlike): { directoryentry }
 	return fs.listdir(pathlib.format(path))
 end
 
-local function rmdir(path: pathlike): ()
+function fslib.rmdir(path: pathlike): ()
 	return fs.rmdir(pathlib.format(path))
 end
 
-local function readfiletostring(filepath: pathlike): string
+function fslib.readfiletostring(filepath: pathlike): string
 	return fs.readfiletostring(pathlib.format(filepath))
 end
 
-local function writestringtofile(filepath: pathlike, contents: string): ()
+function fslib.writestringtofile(filepath: pathlike, contents: string): ()
 	return fs.writestringtofile(pathlib.format(filepath), contents)
 end
 
-local function readasync(filepath: pathlike): string
+function fslib.readasync(filepath: pathlike): string
 	return fs.readasync(pathlib.format(filepath))
 end
 
-local function createdirectory(path: pathlike, options: createdirectoryoptions?): ()
+function fslib.createdirectory(path: pathlike, options: createdirectoryoptions?): ()
 	if options and options.makeparents then
 		local parts: { string } = pathlib.parse(path).parts
 
@@ -99,7 +100,7 @@ local function createdirectory(path: pathlike, options: createdirectoryoptions?)
 
 		for _, part in parts do
 			subdir = pathlib.join(subdir, part)
-			if not exists(subdir) then
+			if not fslib.exists(subdir) then
 				fs.mkdir(pathlib.format(subdir))
 			end
 		end
@@ -108,23 +109,4 @@ local function createdirectory(path: pathlike, options: createdirectoryoptions?)
 	end
 end
 
-return table.freeze({
-	open = open,
-	read = read,
-	write = write,
-	close = close,
-	remove = remove,
-	stat = stat,
-	type = type,
-	link = link,
-	symlink = symlink,
-	watch = watch,
-	exists = exists,
-	copy = copy,
-	listdir = listdir,
-	rmdir = rmdir,
-	readfiletostring = readfiletostring,
-	writestringtofile = writestringtofile,
-	readasync = readasync,
-	createdirectory = createdirectory,
-})
+return table.freeze(fslib)

--- a/lute/std/libs/io.luau
+++ b/lute/std/libs/io.luau
@@ -5,8 +5,10 @@
 
 local io = require("@lute/io")
 
+local iolib = {}
+
 -- User input can be provided via command line stdin, piped input, or redirection from a file. See `examples/user_input.luau`.
-function input(prompt: string?): string
+function iolib.input(prompt: string?): string
 	if prompt then
 		-- We temporarily use `print` for prompt until we have proper stdout support, so there is a `\n` between prompt and input.
 		print(prompt)
@@ -14,6 +16,4 @@ function input(prompt: string?): string
 	return io.read()
 end
 
-return table.freeze({
-	input = input,
-})
+return table.freeze(iolib)

--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -1,3 +1,7 @@
+--!strict
+-- @std/json
+-- JSON serialization and deserialization library
+
 local json = {
 	--- Not actually a nil value, a newproxy stand-in for a null value since Luau has no actual representation of `null`
 	null = newproxy() :: nil,

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -1,3 +1,8 @@
+--!strict
+-- @std/luau
+-- stdlib for `@lute/luau`
+-- Provides utilities for parsing and compiling Luau source code
+
 local luteLuau = require("@lute/luau")
 
 local fs = require("@lute/fs")

--- a/lute/std/libs/process.luau
+++ b/lute/std/libs/process.luau
@@ -6,37 +6,35 @@
 local process = require("@lute/process")
 local pathlib = require("@std/path")
 
+local processlib = {}
+
 export type stdiokind = process.StdioKind
 export type processrunoptions = process.ProcessRunOptions
 export type processresult = process.ProcessResult
 export type path = pathlib.path
 export type pathlike = pathlib.pathlike
 
-local function homedir(): path
+function processlib.homedir(): path
 	return pathlib.parse(process.homedir())
 end
 
-local function cwd(): path
+function processlib.cwd(): path
 	return pathlib.parse(process.cwd())
 end
 
-local function run(args: string | { string }, options: processrunoptions?): processresult
+function processlib.run(args: string | { string }, options: processrunoptions?): processresult
 	return process.run(args, options)
 end
 
-local function exit(exitcode: number): never
+function processlib.exit(exitcode: number): never
 	return process.exit(exitcode)
 end
 
-local function execpath(): path
+function processlib.execpath(): path
 	return pathlib.parse(process.execpath())
 end
 
-return table.freeze({
-	env = process.env,
-	homedir = homedir,
-	cwd = cwd,
-	run = run,
-	exit = exit,
-	execpath = execpath,
-})
+-- re-exports
+processlib.env = process.env
+
+return table.freeze(processlib)

--- a/lute/std/libs/string.luau
+++ b/lute/std/libs/string.luau
@@ -1,3 +1,8 @@
+--!strict
+-- @std/string
+-- stdlib for the built-in string library in Luau
+-- Provides additional utility functions for string operations
+
 local strings = {}
 
 function strings.startswith(str: string, prefix: string): boolean
@@ -33,27 +38,21 @@ function strings.trim(str: string): string
 	return str:match("^%s*(.-)%s*$") :: string
 end
 
-return table.freeze({
-	startswith = strings.startswith,
-	removeprefix = strings.removeprefix,
-	endswith = strings.endswith,
-	removesuffix = strings.removesuffix,
-	trim = strings.trim,
+-- re-exports
+strings.byte = string.byte
+strings.char = string.char
+strings.find = string.find
+strings.format = string.format
+strings.gmatch = string.gmatch
+strings.gsub = string.gsub
+strings.len = string.len
+strings.lower = string.lower
+strings.match = string.match
+strings.pack = string.pack
+strings.packsize = string.packsize
+strings.rep = string.rep
+strings.reverse = string.reverse
+strings.split = string.split
+strings.sub = string.sub
 
-	-- re-exports of the table library
-	byte = string.byte,
-	char = string.char,
-	find = string.find,
-	format = string.format,
-	gmatch = string.gmatch,
-	gsub = string.gsub,
-	len = string.len,
-	lower = string.lower,
-	match = string.match,
-	pack = string.pack,
-	packsize = string.packsize,
-	rep = string.rep,
-	reverse = string.reverse,
-	split = string.split,
-	sub = string.sub,
-})
+return table.freeze(strings)

--- a/lute/std/libs/syntax/parser.luau
+++ b/lute/std/libs/syntax/parser.luau
@@ -1,13 +1,17 @@
 --!strict
+-- @std/syntax/parser
+-- Parser for Luau source code into Luau AST nodes
 
 local luau = require("@std/luau")
 
+local parser = {}
+
 --- Parses Luau source code into an AstStatBlock
-local function parse(source: string): luau.AstStatBlock
+function parser.parse(source: string): luau.AstStatBlock
 	return luau.parse(source).root
 end
 
-local function parseexpr(source: string): luau.AstExpr
+function parser.parseexpr(source: string): luau.AstExpr
 	return luau.parseexpr(source)
 end
 
@@ -16,13 +20,9 @@ export type ParseResult = {
 	eof: luau.Eof,
 }
 
-local function parsefile(source: string): ParseResult
+function parser.parsefile(source: string): ParseResult
 	local result = luau.parse(source)
 	return { root = result.root, eof = result.eof }
 end
 
-return {
-	parse = parse,
-	parseexpr = parseexpr,
-	parsefile = parsefile,
-}
+return table.freeze(parser)

--- a/lute/std/libs/syntax/printer.luau
+++ b/lute/std/libs/syntax/printer.luau
@@ -81,7 +81,7 @@ type PrintVisitor = visitor.Visitor & {
 }
 
 local function printVisitor()
-	local printer = visitor.createVisitor() :: PrintVisitor
+	local printer = visitor.createvisitor() :: PrintVisitor
 
 	printer.result = buffer.create(1024)
 	printer.cursor = 0
@@ -135,23 +135,23 @@ end
 
 --- Returns a string representation of an AstExpr
 function printer.printexpr(expr: luau.AstExpr): string
-	return printNode(expr, visitor.visitExpression)
+	return printNode(expr, visitor.visitexpression)
 end
 
 --- Returns a string representation of an AstStat
 function printer.printstatement(statement: luau.AstStat): string
-	return printNode(statement, visitor.visitStatement)
+	return printNode(statement, visitor.visitstatement)
 end
 
 -- Returns a string representation of an AstType
 function printer.printtype(type: luau.AstType): string
-	return printNode(type, visitor.visitType)
+	return printNode(type, visitor.visittype)
 end
 
 function printer.printfile(result: { root: luau.AstStatBlock, eof: luau.Eof }): string
 	local printer = printVisitor()
-	visitor.visitBlock(result.root, printer)
-	visitor.visitToken(result.eof, printer)
+	visitor.visitblock(result.root, printer)
+	visitor.visittoken(result.eof, printer)
 	return buffer.readstring(printer.result, 0, printer.cursor)
 end
 

--- a/lute/std/libs/syntax/printer.luau
+++ b/lute/std/libs/syntax/printer.luau
@@ -1,6 +1,10 @@
 --!strict
+-- @std/syntax/printer
+
 local luau = require("@std/luau")
 local visitor = require("./visitor")
+
+local printer = {}
 
 local function exhaustiveMatch(value: never): never
 	error(`Unknown value in exhaustive match: {value}`)
@@ -64,7 +68,7 @@ local function printInterpolatedString(expr: luau.AstExprInterpString): string
 		else
 			result ..= "{"
 			result ..= printTriviaList(expr.strings[i].trailingtrivia)
-			result ..= printExpr(expr.expressions[i])
+			result ..= printer.printexpr(expr.expressions[i])
 		end
 	end
 
@@ -130,30 +134,25 @@ function printNode<T>(node: T, visit: (node: T, visitor: visitor.Visitor) -> ())
 end
 
 --- Returns a string representation of an AstExpr
-function printExpr(expr: luau.AstExpr): string
+function printer.printexpr(expr: luau.AstExpr): string
 	return printNode(expr, visitor.visitExpression)
 end
 
 --- Returns a string representation of an AstStat
-local function printStatement(statement: luau.AstStat): string
+function printer.printstatement(statement: luau.AstStat): string
 	return printNode(statement, visitor.visitStatement)
 end
 
 -- Returns a string representation of an AstType
-function printType(type: luau.AstType): string
+function printer.printtype(type: luau.AstType): string
 	return printNode(type, visitor.visitType)
 end
 
-function printFile(result: { root: luau.AstStatBlock, eof: luau.Eof }): string
+function printer.printfile(result: { root: luau.AstStatBlock, eof: luau.Eof }): string
 	local printer = printVisitor()
 	visitor.visitBlock(result.root, printer)
 	visitor.visitToken(result.eof, printer)
 	return buffer.readstring(printer.result, 0, printer.cursor)
 end
 
-return {
-	printexpr = printExpr,
-	printstatement = printStatement,
-	printtype = printType,
-	printfile = printFile,
-}
+return table.freeze(printer)

--- a/lute/std/libs/syntax/query.luau
+++ b/lute/std/libs/syntax/query.luau
@@ -1,10 +1,15 @@
-local luau = require("@lute/luau")
+--!strict
+-- @std/syntax/query
+-- Provides utility functions for querying Luau AST nodes
 
+local luau = require("@lute/luau")
 local visitor = require("./visitor")
+
+local query = {}
 
 --- Selects a list of expressions from the provided block that match the provided predicate.
 --- Useful for defining declarative-based programs, where the matched nodes are mutated for the migration
-local function selectif<T>(block: luau.AstStatBlock, predicate: (luau.AstExpr) -> T?): { T }
+function query.selectif<T>(block: luau.AstStatBlock, predicate: (luau.AstExpr) -> T?): { T }
 	local nodes = {}
 	local finder = visitor.createVisitor()
 
@@ -22,6 +27,4 @@ local function selectif<T>(block: luau.AstStatBlock, predicate: (luau.AstExpr) -
 	return nodes
 end
 
-return {
-	selectif = selectif,
-}
+return table.freeze(query)

--- a/lute/std/libs/syntax/query.luau
+++ b/lute/std/libs/syntax/query.luau
@@ -2,7 +2,7 @@
 -- @std/syntax/query
 -- Provides utility functions for querying Luau AST nodes
 
-local luau = require("@lute/luau")
+local luau = require("@std/luau")
 local visitor = require("./visitor")
 
 local query = {}
@@ -11,7 +11,7 @@ local query = {}
 --- Useful for defining declarative-based programs, where the matched nodes are mutated for the migration
 function query.selectif<T>(block: luau.AstStatBlock, predicate: (luau.AstExpr) -> T?): { T }
 	local nodes = {}
-	local finder = visitor.createVisitor()
+	local finder = visitor.createvisitor()
 
 	finder.visitExpression = function(node)
 		local result = predicate(node)
@@ -22,7 +22,7 @@ function query.selectif<T>(block: luau.AstStatBlock, predicate: (luau.AstExpr) -
 		return true
 	end
 
-	visitor.visitBlock(block, finder)
+	visitor.visitblock(block, finder)
 
 	return nodes
 end

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -1,6 +1,10 @@
 --!strict
+-- @std/syntax/visitor
+-- Visitor pattern implementation for traversing Luau AST nodes
 
 local luau = require("@std/luau")
+
+local visitorlib = {}
 
 export type Visitor = {
 	visitBlock: (luau.AstStatBlock) -> boolean,
@@ -877,12 +881,12 @@ local function createVisitor()
 	return table.clone(defaultVisitor)
 end
 
-return {
-	createVisitor = createVisitor,
-	visitBlock = visitBlock,
-	visitStatement = visitStatement,
-	visitExpression = visitExpression,
-	visitType = visitType,
-	visitTypePack = visitTypePack,
-	visitToken = visitToken,
-}
+visitorlib.createVisitor = createVisitor
+visitorlib.visitBlock = visitBlock
+visitorlib.visitStatement = visitStatement
+visitorlib.visitExpression = visitExpression
+visitorlib.visitType = visitType
+visitorlib.visitTypePack = visitTypePack
+visitorlib.visitToken = visitToken
+
+return table.freeze(visitorlib)

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -881,12 +881,12 @@ local function createVisitor()
 	return table.clone(defaultVisitor)
 end
 
-visitorlib.createVisitor = createVisitor
-visitorlib.visitBlock = visitBlock
-visitorlib.visitStatement = visitStatement
-visitorlib.visitExpression = visitExpression
-visitorlib.visitType = visitType
-visitorlib.visitTypePack = visitTypePack
-visitorlib.visitToken = visitToken
+visitorlib.createvisitor = createVisitor
+visitorlib.visitblock = visitBlock
+visitorlib.visitstatement = visitStatement
+visitorlib.visitexpression = visitExpression
+visitorlib.visittype = visitType
+visitorlib.visittypepack = visitTypePack
+visitorlib.visittoken = visitToken
 
 return table.freeze(visitorlib)

--- a/lute/std/libs/system/init.luau
+++ b/lute/std/libs/system/init.luau
@@ -7,26 +7,27 @@ local system = require("@lute/system")
 local path = require("@std/path")
 local platforminfo = require("@self/platforminfo")
 
-local function tmpdir(): path.path
+local systemlib = {}
+
+function systemlib.tmpdir(): path.path
 	return path.parse(system.tmpdir())
 end
 
-return table.freeze({
-	os = system.os,
-	arch = system.arch,
-	tmpdir = tmpdir,
+-- re-exports
+systemlib.os = system.os
+systemlib.arch = system.arch
 
-	-- function re-exports
-	threadcount = system.threadcount,
-	hostname = system.hostname,
-	totalmemory = system.totalmemory,
-	freememory = system.freememory,
-	uptime = system.uptime,
-	cpus = system.cpus,
+systemlib.threadcount = system.threadcount
+systemlib.hostname = system.hostname
+systemlib.totalmemory = system.totalmemory
+systemlib.freememory = system.freememory
+systemlib.uptime = system.uptime
+systemlib.cpus = system.cpus
 
-	-- boolean properties
-	win32 = platforminfo.win32,
-	linux = platforminfo.linux,
-	macos = platforminfo.macos,
-	unix = platforminfo.unix,
-})
+-- boolean properties
+systemlib.win32 = platforminfo.win32
+systemlib.linux = platforminfo.linux
+systemlib.macos = platforminfo.macos
+systemlib.unix = platforminfo.unix
+
+return table.freeze(systemlib)

--- a/lute/std/libs/table.luau
+++ b/lute/std/libs/table.luau
@@ -1,7 +1,14 @@
+--!strict
+-- @std/table
+-- stdlib for the built-in table library in Luau
+-- Provides additional utility functions for table operations
+
+local tablelib = {}
+
 export type array<T> = { T }
 export type dictionary<T> = { [string]: T }
 
-local function map<K, A, B>(table: { [K]: A }, f: (A) -> B): { [K]: B }
+function tablelib.map<K, A, B>(table: { [K]: A }, f: (A) -> B): { [K]: B }
 	local new = {}
 
 	for k, v in table do
@@ -11,7 +18,7 @@ local function map<K, A, B>(table: { [K]: A }, f: (A) -> B): { [K]: B }
 	return new
 end
 
-local function filter<K, V>(table: { [K]: V }, predicate: (V) -> boolean): { [K]: V }
+function tablelib.filter<K, V>(table: { [K]: V }, predicate: (V) -> boolean): { [K]: V }
 	local new = {}
 
 	for k, v in table do
@@ -23,7 +30,7 @@ local function filter<K, V>(table: { [K]: V }, predicate: (V) -> boolean): { [K]
 	return new
 end
 
-local function fold<K, V, A>(table: { [K]: V }, f: (A, V) -> A, initial: A): A
+function tablelib.fold<K, V, A>(table: { [K]: V }, f: (A, V) -> A, initial: A): A
 	local acc = initial
 
 	for _, v in table do
@@ -33,32 +40,26 @@ local function fold<K, V, A>(table: { [K]: V }, f: (A, V) -> A, initial: A): A
 	return acc
 end
 
-local function extend<T>(tbl: array<T>, other: array<T>)
+function tablelib.extend<T>(tbl: array<T>, other: array<T>)
 	for _, entry in other do
 		table.insert(tbl, entry)
 	end
 end
 
-return table.freeze({
-	-- std extension for table
-	map = map,
-	filter = filter,
-	fold = fold,
-	extend = extend,
+-- re-exports
+tablelib.clear = table.clear
+tablelib.clone = table.clone
+tablelib.concat = table.concat
+tablelib.create = table.create
+tablelib.find = table.find
+tablelib.freeze = table.freeze
+tablelib.insert = table.insert
+tablelib.isfrozen = table.isfrozen
+tablelib.maxn = table.maxn
+tablelib.move = table.move
+tablelib.pack = table.pack
+tablelib.remove = table.remove
+tablelib.sort = table.sort
+tablelib.unpack = table.unpack
 
-	-- re-exports of the table library
-	clear = table.clear,
-	clone = table.clone,
-	concat = table.concat,
-	create = table.create,
-	find = table.find,
-	freeze = table.freeze,
-	insert = table.insert,
-	isfrozen = table.isfrozen,
-	maxn = table.maxn,
-	move = table.move,
-	pack = table.pack,
-	remove = table.remove,
-	sort = table.sort,
-	unpack = table.unpack,
-})
+return table.freeze(tablelib)

--- a/lute/std/libs/task.luau
+++ b/lute/std/libs/task.luau
@@ -1,4 +1,11 @@
+--!strict
+-- @std/task
+-- stdlib for `@lute/task`
+-- Provides utilities for creating and managing asynchronous tasks
+
 local task = require("@lute/task")
+
+local tasklib = {}
 
 export type task = {
 	success: boolean?,
@@ -6,7 +13,7 @@ export type task = {
 	co: thread,
 }
 
-local function create(f, ...): task
+function tasklib.create(f, ...): task
 	local data = {}
 
 	data.co = coroutine.create(function(...)
@@ -20,7 +27,7 @@ local function create(f, ...): task
 	return data :: task
 end
 
-local function await(t: task)
+function tasklib.await(t: task)
 	if not t.co then
 		error(`await: argument 1 is not a task`)
 	end
@@ -36,7 +43,7 @@ local function await(t: task)
 	end
 end
 
-local function awaitall(...: task)
+function tasklib.awaitall(...: task)
 	local tasks = table.pack(...)
 
 	for i, v in ipairs(tasks) do
@@ -70,8 +77,4 @@ local function awaitall(...: task)
 	return table.unpack(results)
 end
 
-return table.freeze({
-	create = create,
-	await = await,
-	awaitall = awaitall,
-})
+return table.freeze(tasklib)

--- a/lute/std/libs/test.luau
+++ b/lute/std/libs/test.luau
@@ -1,4 +1,7 @@
 --!strict
+-- @std/test
+-- A testing framework for Luau
+
 local ps = require("@std/process")
 local assert = require("@std/assert")
 -- Test Types

--- a/lute/std/libs/time.luau
+++ b/lute/std/libs/time.luau
@@ -1,3 +1,7 @@
+--!strict
+-- @std/time
+-- Provides utility functions for time durations
+
 local NANOS_PER_SEC = 1_000_000_000
 local NANOS_PER_MILLI = 1_000_000
 local NANOS_PER_MICRO = 1_000
@@ -164,6 +168,4 @@ function duration.__tostring(self: duration): string
 	return string.format("%d.%09d", self._seconds, self._nanoseconds)
 end
 
-return table.freeze({
-	duration = duration,
-})
+return table.freeze(duration)

--- a/lute/std/libs/vector.luau
+++ b/lute/std/libs/vector.luau
@@ -1,36 +1,38 @@
-local function withx(vec: vector, x: number): vector
+--!strict
+-- @std/vector
+-- stdlib for the built-in vector library in Luau
+-- Provides additional utility functions for vector operations
+
+local vectorlib = {}
+
+function vectorlib.withx(vec: vector, x: number): vector
 	return vector.create(x, vec.y, vec.z)
 end
 
-local function withy(vec: vector, y: number): vector
+function vectorlib.withy(vec: vector, y: number): vector
 	return vector.create(vec.x, y, vec.z)
 end
 
-local function withz(vec: vector, z: number): vector
+function vectorlib.withz(vec: vector, z: number): vector
 	return vector.create(vec.x, vec.y, z)
 end
 
-return table.freeze({
-	-- std extensions for vector
-	withx = withx,
-	withy = withy,
-	withz = withz,
+-- re-exports
+vectorlib.create = vector.create
+vectorlib.magnitude = vector.magnitude
+vectorlib.normalize = vector.normalize
+vectorlib.cross = vector.cross
+vectorlib.vector = vector.dot
+vectorlib.angle = vector.angle
+vectorlib.floor = vector.floor
+vectorlib.ceil = vector.ceil
+vectorlib.abs = vector.abs
+vectorlib.sign = vector.sign
+vectorlib.clamp = vector.clamp
+vectorlib.max = vector.max
+vectorlib.min = vector.min
 
-	-- re-exports of the vector library
-	create = vector.create,
-	magnitude = vector.magnitude,
-	normalize = vector.normalize,
-	cross = vector.cross,
-	vector = vector.dot,
-	angle = vector.angle,
-	floor = vector.floor,
-	ceil = vector.ceil,
-	abs = vector.abs,
-	sign = vector.sign,
-	clamp = vector.clamp,
-	max = vector.max,
-	min = vector.min,
+vectorlib.zero = vector.zero
+vectorlib.one = vector.one
 
-	zero = vector.zero,
-	one = vector.one,
-})
+return table.freeze(vectorlib)

--- a/tests/cli/loadbypath.test.luau
+++ b/tests/cli/loadbypath.test.luau
@@ -41,7 +41,7 @@ test.suite("Lute CLI Run", function(suite)
 		fs.write(requireeFile, REQUIREE_CONTENTS)
 		fs.close(requireeFile)
 
-		local result = process.run({ tostring(lutePath), tostring(requirerPath), tostring(requireePath) })
+		local result = process.run({ tostring(lutePath), requirerPath, requireePath })
 		check.eq(result.exitcode, 0)
 		check.eq(result.stdout, "Success\n")
 

--- a/tests/cli/loadbypath.test.luau
+++ b/tests/cli/loadbypath.test.luau
@@ -1,5 +1,5 @@
-local fs = require("@lute/fs")
-local process = require("@lute/process")
+local fs = require("@std/fs")
+local process = require("@std/process")
 local path = require("@std/path")
 local system = require("@std/system")
 local test = require("@std/test")
@@ -24,7 +24,7 @@ local testDirStr = path.format(testDir)
 test.suite("Lute CLI Run", function(suite)
 	suite:beforeall(function()
 		if not fs.exists(testDirStr) then
-			fs.mkdir(testDirStr)
+			fs.createdirectory(testDirStr)
 		end
 	end)
 
@@ -41,7 +41,7 @@ test.suite("Lute CLI Run", function(suite)
 		fs.write(requireeFile, REQUIREE_CONTENTS)
 		fs.close(requireeFile)
 
-		local result = process.run({ lutePath, requirerPath, requireePath })
+		local result = process.run({ tostring(lutePath), tostring(requirerPath), tostring(requireePath) })
 		check.eq(result.exitcode, 0)
 		check.eq(result.stdout, "Success\n")
 


### PR DESCRIPTION
### Problem

The file structure before in`@std` is a little inconsistent when we're writing the modules so it's a bit hard to know how to structure a new addition in our std lib. It also means we can't extend our current doc generator for the lute definitions to the stdlib because the [regex matching](https://github.com/luau-lang/lute/blob/primary/docs/scripts/reference.luau#L17) doesn't detect the different structures in these files. 

### Solution

We update the std lib files to follow the format of the lute `definitions/` library ([example](https://github.com/luau-lang/lute/blob/primary/definitions/task.luau)) to standardize how we write modules and help with adding the std lib to our docs site :) 

The file structure (in `lute/std/libs/...`) is now hopefully something like:

file name: `modulename.luau`
```
--!strict
-- @std/modulename (path to use the module)
-- description of the purpose of the module

local modulename = {}

-- types & export types -- 
type nonExportedType = ...
export type exportedType = ...

-- local functions and/or user-facing functions (only user-facing functions should be added to the returned table) --
local function nonuserfacingfunction(): returntype
    ...
end

function modulename.functiontoreturn(): returntype
    ...
end

-- re-exports if extended from another library and other non-functions --

return table.freeze(modulename)
```
