### PR TITLE
stdlib: lute test shouldn't point to xpcall for error msg

### DIFF
--- a/lute/std/libs/test.luau
+++ b/lute/std/libs/test.luau
@@ -57,8 +57,8 @@ end
 -- Test Reporting
 type FailedTest = {
 	test: string, -- name of the test case that failed
-	assertion: string, -- name of the assertion that failed (e.g., "assert.eq")
-	error: string, -- the error message from the assertion
+	assertion: string?, -- name of the assertion that failed (e.g., "assert.eq")
+	error: string?, -- the error message from the assertion
 	filename: string, -- source file where the failure occurred
 	linenumber: number, -- line number of the failure
 }
@@ -73,7 +73,9 @@ type TestRunResult = {
 local function printFailedTest(failed: FailedTest)
 	print(`❌ {failed.test}`)
 	print(`   {failed.filename}:{failed.linenumber}`)
-	print(`   	{failed.assertion}: {failed.error}`)
+	if failed.assertion ~= nil and failed.error ~= nil then
+		print(`   	{failed.assertion}: {failed.error}`)
+	end
 	print()
 end
 
@@ -213,10 +215,14 @@ function test.run()
 			local fileName, lineNumber = debug.info(4, "sl")
 			local assertName = debug.info(3, "n")
 
+			if assertName == "xpcall" then
+				fileName, lineNumber = debug.info(2, "sl")
+			end
+
 			local failedtest: FailedTest = {
 				test = tc.name,
-				assertion = assertName,
-				error = err.msg,
+				assertion = if assertName == "xpcall" then nil else assertName,
+				error = if assertName == "xpcall" then nil else err.msg,
 				filename = fileName,
 				linenumber = lineNumber,
 			}
@@ -248,10 +254,14 @@ function test.run()
 				local fileName, lineNumber = debug.info(4, "sl")
 				local assertName = debug.info(3, "n")
 
+				if assertName == "xpcall" then
+					fileName, lineNumber = debug.info(2, "sl")
+				end
+
 				local failedtest: FailedTest = {
 					test = testFullName,
-					assertion = assertName,
-					error = err.msg,
+					assertion = if assertName == "xpcall" then nil else assertName,
+					error = if assertName == "xpcall" then nil else err.msg,
 					filename = fileName,
 					linenumber = lineNumber,
 				}

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -61,7 +61,8 @@ test.run()
 		-- Check that the output doesn't include xpcall
 		assert.eq(result.exitcode, 1)
 		assert.eq(result.stdout:find("xpcall", 1, true), nil)
-		assert.neq(result.stdout:find(tostring(testFilePath), 1, true), nil)
+		-- Check that the error points to filepath + correct line number
+		assert.neq(result.stdout:find(`{tostring(testFilePath)}:6`, 1, true), nil)
 
 		fs.remove(testFilePath)
 	end)
@@ -91,7 +92,8 @@ test.run()
 		-- Check that the output doesn't include xpcall
 		assert.eq(result.exitcode, 1)
 		assert.eq(result.stdout:find("xpcall", 1, true), nil)
-		assert.neq(result.stdout:find(tostring(testFilePath), 1, true), nil)
+		-- Check that the error points to filepath + correct line number
+		assert.neq(result.stdout:find(`{tostring(testFilePath)}:5`, 1, true), nil)
 
 		fs.remove(testFilePath)
 	end)

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -1,8 +1,11 @@
+local fs = require("@std/fs")
 local path = require("@std/path")
 local process = require("@std/process")
+local system = require("@std/system")
 local test = require("@std/test")
 
 local lutePath = path.format(process.execpath())
+local tmpDir = system.tmpdir()
 
 test.suite("lute test", function(suite)
 	suite:case("lute test help message", function(assert)
@@ -29,6 +32,68 @@ test.suite("lute test", function(suite)
 		-- Check that it discovers test files (.test.luau and .spec.luau)
 		assert.eq(result.exitcode, 0)
 		assert.neq(result.stdout:find("Found 2 test files", 1, true), nil)
+	end)
+
+	suite:case("lute doesn't report xpcall as error when accessing field of nil in suite", function(assert)
+		-- Setup
+		local testFilePath = path.join(tmpDir, "nil_field_access_test.test.luau")
+		local handle = fs.open(testFilePath, "w+")
+		fs.write(
+			handle,
+			[[
+local test = require("@std/test")
+
+test.suite("nil_field_suite", function(suite)
+	suite:case("access_field_of_nil", function(assert)
+		local t = nil
+		local value = t.field -- This will cause an error
+	end)
+end)
+
+test.run()
+			]]
+		)
+		fs.close(handle)
+
+		-- Run lute on the created test file
+		local result = process.run({ lutePath, tostring(testFilePath) })
+
+		-- Check that the output doesn't include xpcall
+		assert.eq(result.exitcode, 1)
+		assert.eq(result.stdout:find("xpcall", 1, true), nil)
+		assert.neq(result.stdout:find(tostring(testFilePath), 1, true), nil)
+
+		fs.remove(testFilePath)
+	end)
+
+	suite:case("lute doesn't report xpcall as error when accessing field of nil in case", function(assert)
+		-- Setup
+		local testFilePath = path.join(tmpDir, "nil_field_access_test.test.luau")
+		local handle = fs.open(testFilePath, "w+")
+		fs.write(
+			handle,
+			[[
+local test = require("@std/test")
+
+test.case("access_field_of_nil", function(assert)
+	local t = nil
+	local value = t.field -- This will cause an error
+end)
+
+test.run()
+			]]
+		)
+		fs.close(handle)
+
+		-- Run lute on the created test file
+		local result = process.run({ lutePath, tostring(testFilePath) })
+
+		-- Check that the output doesn't include xpcall
+		assert.eq(result.exitcode, 1)
+		assert.eq(result.stdout:find("xpcall", 1, true), nil)
+		assert.neq(result.stdout:find(tostring(testFilePath), 1, true), nil)
+
+		fs.remove(testFilePath)
 	end)
 end)
 


### PR DESCRIPTION
While working on tests for something else, I noticed that in cases where a test case fails for reasons other than an assertion, the testing harness reports the source of the error as an `xpcall` call in the lute's test implementation. After discussing with @~Vighnesh-V, I've implemented a small workaround where we look lower down in the stack for the source of the error, so that we can actually point to the test case causing the failure in failure reporting.