### PR TITLE
refactor: StaticRequireTracer should be reworked to use the resolveRequire api

### DIFF
--- a/lute/cli/include/lute/compile.h
+++ b/lute/cli/include/lute/compile.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "lute/reporter.h"
+
 #include "Luau/DenseHash.h"
 #include "Luau/FileUtils.h"
-#include "lute/reporter.h"
 
 #include <string_view>
 
@@ -38,7 +39,7 @@ struct LuteEncodeResult
 struct LuteExePayload
 {
     LuteExePayload(LuteReporter& reporter);
-    void add(const std::string& luauFilePath);
+    void add(const std::string& bundlePath, const std::string& sourcePath);
 
     std::optional<LuteEncodeResult> encode();
     static std::optional<LuteDecodeResult> decode(const std::string_view binary, LuteReporter& reporter);
@@ -50,6 +51,7 @@ private:
     LuteReporter& reporter;
     bool parseFromDecompressedBundle(std::string_view decompressedBundle);
     std::vector<std::string> filePaths;
+    Luau::DenseHashMap<std::string, std::string> sourceToBundlePath{""};
 };
 
 struct LuteDecodeResult

--- a/lute/cli/include/lute/staticrequires.h
+++ b/lute/cli/include/lute/staticrequires.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Luau/DenseHash.h"
-
 #include "lute/reporter.h"
+
+#include "Luau/DenseHash.h"
 
 #include <optional>
 #include <string>
@@ -14,31 +14,35 @@ public:
     StaticRequireTracer(LuteReporter& reporter);
 
     // Trace dependencies starting from an entry point file
-    // rootDirectory: Base directory for resolving all requires
-    // entryPoint: Path to entry point file (relative to rootDirectory)
-    // Returns list of all files in dependency order (entry point first)
-    std::vector<std::string> trace(const std::string& rootDirectory, const std::string& entryPoint);
+    // entryPoint: absolute path to entry point file
+    void trace(const std::string& entryPoint);
 
-    // Get the require graph built during the last trace
-    // Maps each file to the list of files it requires
-    const Luau::DenseHashMap<std::string, std::vector<std::string>>& getRequireGraph() const
+    // Get discovered files as pairs of (bundlePath, absolutePath)
+    // bundlePath is the absolute path with the lowest common prefix stripped
+    std::vector<std::pair<std::string, std::string>> getStaticRequirePairs() const;
+
+    // Check if an absolute path exists in the discovered files
+    bool containsAbsolute(const std::string& absolutePath) const;
+
+    const std::string& getLowestCommonRoot() const
     {
-        return requireGraph;
+        return lowestCommonRoot;
     }
 
     void printRequireGraph() const;
+    // Find the lowest common root directory from a collection of absolute paths
+    static std::string findLowestCommonRoot(const std::vector<std::string>& paths);
 
 private:
     Luau::DenseHashSet<std::string> visited{""};
-    std::vector<std::string> discovered;
-    Luau::DenseHashMap<std::string, std::vector<std::string>> requireGraph{""};
-    std::string rootDirectory;
+    std::vector<std::string> discovered;                                        // Absolute paths
+    Luau::DenseHashMap<std::string, std::vector<std::string>> requireGraph{""}; // Absolute paths
+    std::string lowestCommonRoot;
 
     // Extract all require() paths from source code
     std::vector<std::string> extractRequires(const std::string& source);
 
     // Resolve a require path relative to the requiring file
     std::optional<std::string> resolveRequire(const std::string& requirer, const std::string& required);
-
     LuteReporter& reporter;
 };

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -485,19 +485,27 @@ int handleCompileCommand(int argc, char** argv, int argOffset, LuteReporter& rep
         return 1;
     }
 
-    // Validate file exists
-    std::optional<std::string> validPath = getValidPath(filePath);
-    if (!validPath)
+    std::string absoluteEntryPoint;
+    if (isAbsolutePath(filePath))
     {
-        reporter.formatError("Error: File '%s' does not exist.", filePath.c_str());
-        return 1;
+        absoluteEntryPoint = filePath;
+    }
+    else
+    {
+        std::optional<std::string> cwd = getCurrentWorkingDirectory();
+        if (!cwd)
+        {
+            reporter.reportError("Error: Failed to get current working directory.\n");
+            return 1;
+        }
+        absoluteEntryPoint = normalizePath(joinPaths(*cwd, filePath));
     }
 
     // Set default output path if not specified
     if (outputPath.empty())
     {
         // Extract base name from input file (remove directory and extension)
-        std::string baseName = *validPath;
+        std::string baseName = filePath;
 
         // Remove directory path
         size_t lastSlash = baseName.find_last_of("/\\");
@@ -515,46 +523,24 @@ int handleCompileCommand(int argc, char** argv, int argOffset, LuteReporter& rep
 #endif
     }
 
-    // Normalize paths to be relative to working directory
-    std::string normalizedEntry = normalizePath(*validPath);
-
-    // Split into directory and filename for cleaner trace output
-    std::string rootDirectory;
-    std::string entryFilename;
-
-    size_t lastSlash = normalizedEntry.find_last_of("/\\");
-    if (lastSlash != std::string::npos)
-    {
-        rootDirectory = normalizedEntry.substr(0, lastSlash);
-        entryFilename = normalizedEntry.substr(lastSlash + 1);
-    }
-    else
-    {
-        rootDirectory = ".";
-        entryFilename = normalizedEntry;
-    }
-
     // Perform static require trace
     StaticRequireTracer tracer{reporter};
-    std::vector<std::string> discoveredFiles = tracer.trace(rootDirectory, entryFilename);
-
-    if (discoveredFiles.empty())
-    {
-        reporter.reportError("Error: No files discovered during require trace.");
-        return 1;
-    }
+    tracer.trace(absoluteEntryPoint);
 
     if (showRequireGraph)
         tracer.printRequireGraph();
 
     // Create payload and add all discovered files
     LuteExePayload payload{reporter};
-    for (const auto& file : discoveredFiles)
+    auto staticRequirePairs = tracer.getStaticRequirePairs();
+    // Add file with absolute path for reading and rooted path for bundle
+    // We don't want to leak your entire directory path in the bundle, so we
+    // try to pick the lowest common ancestor and keep that as the root.
+    for (const auto& [bundle, absolute] : staticRequirePairs)
     {
-        // Construct full path from root directory and relative file path
-        std::string fullPath = joinPaths(rootDirectory, file);
-        payload.add(fullPath);
+        payload.add(bundle, absolute);
     }
+
 
     // Encode the payload
     reporter.reportOutput("Compiling and bundling bytecode...");
@@ -569,7 +555,7 @@ int handleCompileCommand(int argc, char** argv, int argOffset, LuteReporter& rep
     if (bundleStats)
     {
         reporter.reportOutput("\nBundle Statistics:");
-        reporter.formatOutput("\tFiles bundled: %zu", discoveredFiles.size());
+        reporter.formatOutput("\tFiles bundled: %zu", staticRequirePairs.size());
         reporter.formatOutput("\tUncompressed size: %zu bytes", encodeResult->uncompressedPayloadSizeBytes);
         reporter.formatOutput("\tCompressed size: %zu bytes", encodeResult->compressedPayloadSizeBytes);
         reporter.formatOutput(

--- a/lute/cli/src/compile.cpp
+++ b/lute/cli/src/compile.cpp
@@ -23,13 +23,17 @@ LuteExePayload::LuteExePayload(LuteReporter& reporter)
 {
 }
 
-void LuteExePayload::add(const std::string& luauFilePath)
+void LuteExePayload::add(const std::string& bundlePath, const std::string& sourcePath)
 {
     // First file added becomes the entry point
     if (filePaths.empty())
-        entryPointPath = luauFilePath;
+        entryPointPath = bundlePath;
 
-    filePaths.push_back(luauFilePath);
+    // Store the source path for reading files
+    filePaths.push_back(sourcePath);
+
+    // Map source path to bundle path
+    sourceToBundlePath[sourcePath] = bundlePath;
 }
 
 std::optional<LuteEncodeResult> LuteExePayload::encode()
@@ -45,13 +49,17 @@ std::optional<LuteEncodeResult> LuteExePayload::encode()
     // Step 1: Build uncompressed bytecode bundle
     // Format: For each file, append [path_len][path][bytecode_size][bytecode]
     std::string uncompressedBundle;
-    for (const auto& filePath : filePaths)
+    for (const auto& sourcePath : filePaths)
     {
-        // Read source file from disk
-        std::optional<std::string> source = readFile(filePath);
+        // Get the bundle path (rooted path for the bundle)
+        const std::string* bundlePathPtr = sourceToBundlePath.find(sourcePath);
+        const std::string& bundlePath = bundlePathPtr ? *bundlePathPtr : sourcePath;
+
+        // Read source file from disk using absolute source path
+        std::optional<std::string> source = readFile(sourcePath);
         if (!source)
         {
-            reporter.formatError("Encode failed: Could not read file '%s'", filePath.c_str());
+            reporter.formatError("Encode failed: Could not read file '%s'\n", sourcePath.c_str());
             return std::nullopt;
         }
 
@@ -59,18 +67,19 @@ std::optional<LuteEncodeResult> LuteExePayload::encode()
         std::string bytecode = Luau::compile(*source, copts());
         if (bytecode.empty())
         {
-            reporter.formatError("Encode failed: Could not compile file '%s' to bytecode", filePath.c_str());
+            reporter.formatError("Encode failed: Could not compile file '%s' to bytecode", sourcePath.c_str());
             return std::nullopt;
         }
 
-        filePathToBytecode[filePath] = bytecode;
+        // Store bytecode with bundle path (rooted path)
+        filePathToBytecode[bundlePath] = bytecode;
 
-        // Append path_length field (uint32_t, 4 bytes)
-        uint32_t pathLength = static_cast<uint32_t>(filePath.size());
+        // Append path_length field (uint32_t, 4 bytes) - use bundle path
+        uint32_t pathLength = static_cast<uint32_t>(bundlePath.size());
         uncompressedBundle.append(reinterpret_cast<const char*>(&pathLength), sizeof(uint32_t));
 
-        // Append path_string field (variable length)
-        uncompressedBundle.append(filePath);
+        // Append path_string field (variable length) - use bundle path
+        uncompressedBundle.append(bundlePath);
 
         // Append bytecode_size field (uint64_t, 8 bytes)
         uint64_t bytecodeSize = bytecode.size();

--- a/lute/cli/src/staticrequires.cpp
+++ b/lute/cli/src/staticrequires.cpp
@@ -1,12 +1,15 @@
 #include "lute/staticrequires.h"
 
 #include "lute/modulepath.h"
+#include "lute/resolverequire.h"
+#include "lute/staticrequires.h"
 
 #include "Luau/Ast.h"
 #include "Luau/FileUtils.h"
 #include "Luau/Parser.h"
 #include "Luau/VecDeque.h"
 
+#include <algorithm>
 #include <cstdio>
 
 // AST visitor to extract require() calls
@@ -36,12 +39,17 @@ StaticRequireTracer::StaticRequireTracer(LuteReporter& reporter)
 {
 }
 
-std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirectory, const std::string& entryPoint)
+void StaticRequireTracer::trace(const std::string& entryPoint)
 {
     visited.clear();
     discovered.clear();
     requireGraph.clear();
-    this->rootDirectory = rootDirectory;
+
+    if (!isAbsolutePath(entryPoint))
+    {
+        fprintf(stderr, "Error: %s isn't an absolute path\n", entryPoint.c_str());
+        return;
+    }
 
     Luau::VecDeque<std::string> toProcess;
     toProcess.push_back(entryPoint);
@@ -51,19 +59,15 @@ std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirec
         std::string filePath = toProcess.front();
         toProcess.pop_front();
 
-        // Get normalized path for visited tracking
-        std::string fullPath = joinPaths(rootDirectory, filePath);
-        std::string absPath = normalizePath(fullPath);
-
         // Skip if already visited (handles circular dependencies)
-        if (visited.contains(absPath))
+        if (visited.contains(filePath))
             continue;
 
-        visited.insert(absPath);
-        std::optional<std::string> source = readFile(fullPath);
+        visited.insert(filePath);
+        std::optional<std::string> source = readFile(filePath);
         if (!source)
         {
-            reporter.formatError("Warning: Could not read file '%s'\n", fullPath.c_str());
+            reporter.formatError("Warning: Could not read file '%s'\n", filePath.c_str());
             continue;
         }
 
@@ -76,7 +80,14 @@ std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirec
 
         for (const auto& req : requiresInFile)
         {
-            std::optional<std::string> resolvedPath = resolveRequire(filePath, req);
+            // Skip warning for built-in libraries (@std and @lute)
+            // The new and improved requireResolver is really good - it'll even handle std/lute aliases that we've built in.
+            // For now, we can just explicitly skip these, since they are provided by the runtime
+            if (req.find("@std/") == 0 || req.find("@lute/") == 0)
+                continue;
+            std::string err = "";
+            std::optional<std::string> resolvedPath = ::resolveRequire(req, "@" + filePath, &err);
+
             if (resolvedPath)
             {
                 toProcess.push_back(*resolvedPath);
@@ -87,9 +98,9 @@ std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirec
                 // Skip warning for built-in libraries (@std and @lute)
                 bool isBuiltinLibrary = req.rfind("@std/", 0) == 0 || req.rfind("@lute/", 0) == 0;
                 if (!isBuiltinLibrary)
-                {
                     reporter.formatError("Warning: Could not resolve require('%s') from '%s'\n", req.c_str(), filePath.c_str());
-                }
+                if (!err.empty())
+                    reporter.formatError("Warning: Could not resolve require('%s') from '%s':\n\t%s\n", req.c_str(), filePath.c_str(), err.c_str());
             }
         }
 
@@ -97,7 +108,7 @@ std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirec
         requireGraph[filePath] = std::move(resolvedDeps);
     }
 
-    return discovered;
+    lowestCommonRoot = findLowestCommonRoot(discovered);
 }
 
 std::vector<std::string> StaticRequireTracer::extractRequires(const std::string& source)
@@ -121,109 +132,105 @@ std::vector<std::string> StaticRequireTracer::extractRequires(const std::string&
     return extractor.requirePaths;
 }
 
-std::optional<std::string> StaticRequireTracer::resolveRequire(const std::string& requirer, const std::string& required)
+std::vector<std::pair<std::string, std::string>> StaticRequireTracer::getStaticRequirePairs() const
 {
-    // Get the directory containing the requiring file (relative to rootDirectory)
-    std::string requirerDir;
-    size_t lastSlash = requirer.find_last_of("/\\");
-    if (lastSlash != std::string::npos)
+    std::vector<std::pair<std::string, std::string>> pairs;
+    pairs.reserve(discovered.size());
+
+    size_t commonRootLen = lowestCommonRoot.empty() ? 0 : lowestCommonRoot.length() + 1; // +1 for the trailing slash
+
+    for (const auto& absolutePath : discovered)
     {
-        requirerDir = requirer.substr(0, lastSlash);
-    }
-    else
-    {
-        requirerDir = "";
-    }
-
-    // Helper functions for ModulePath - paths are relative to rootDirectory
-    auto isFileFunc = [this](const std::string& path) -> bool
-    {
-        std::string fullPath = joinPaths(rootDirectory, path);
-        return isFile(fullPath);
-    };
-
-    auto isDir = [this](const std::string& path) -> bool
-    {
-        std::string fullPath = joinPaths(rootDirectory, path);
-        return isDirectory(fullPath);
-    };
-
-    // Create a ModulePath with root as rootDirectory, starting at requirer's directory
-    // This allows us to navigate up with .. beyond requirerDir, but not beyond rootDirectory
-    std::optional<ModulePath> modulePath = ModulePath::create(
-        "",          // Root is empty (relative path base)
-        requirerDir, // Start at the requirer's directory
-        isFileFunc,
-        isDir
-    );
-
-    if (!modulePath)
-        return std::nullopt;
-
-    // Navigate according to the require path
-    // Split require path by '/' and navigate
-    std::string reqPath = required;
-    size_t pos = 0;
-
-    while (pos < reqPath.size())
-    {
-        size_t nextSlash = reqPath.find('/', pos);
-        std::string component;
-
-        if (nextSlash == std::string::npos)
-        {
-            component = reqPath.substr(pos);
-            pos = reqPath.size();
-        }
+        std::string bundlePath;
+        if (commonRootLen > 0 && absolutePath.length() > commonRootLen)
+            bundlePath = absolutePath.substr(commonRootLen);
         else
-        {
-            component = reqPath.substr(pos, nextSlash - pos);
-            pos = nextSlash + 1;
-        }
+            bundlePath = absolutePath;
 
-        if (component.empty() || component == ".")
-            continue;
-
-        if (component == "..")
-        {
-            if (modulePath->toParent() != NavigationStatus::Success)
-                return std::nullopt;
-        }
-        else
-        {
-            if (modulePath->toChild(component) != NavigationStatus::Success)
-                return std::nullopt;
-        }
+        pairs.emplace_back(bundlePath, absolutePath);
     }
 
-    // Get the resolved path (relative to rootDirectory)
-    ResolvedRealPath resolved = modulePath->getRealPath();
-    if (resolved.status != NavigationStatus::Success)
-        return std::nullopt;
+    return pairs;
+}
 
-    // Strip leading slash if present (occurs when root is empty)
-    std::string result = resolved.realPath;
-    if (!result.empty() && result[0] == '/')
-        result = result.substr(1);
-
-    return result;
+bool StaticRequireTracer::containsAbsolute(const std::string& absolutePath) const
+{
+    return visited.contains(absolutePath);
 }
 
 void StaticRequireTracer::printRequireGraph() const
 {
-    printf("\nRequire dependency graph:\n");
+    reporter.reportOutput("\nRequire dependency graph:");
+
+    size_t commonRootLen = lowestCommonRoot.empty() ? 0 : lowestCommonRoot.length() + 1;
+
     for (const auto& [file, deps] : requireGraph)
     {
-        printf("\t%s\n", file.c_str());
+        // Convert absolute path to bundle path for display
+        std::string displayFile;
+        if (commonRootLen > 0 && file.length() > commonRootLen)
+            displayFile = file.substr(commonRootLen);
+        else
+            displayFile = file;
+
+        reporter.formatOutput("\t%s", displayFile.c_str());
         for (const auto& dep : deps)
         {
-            printf("\t\t -> %s\n", dep.c_str());
-        }
+            // Convert absolute path to bundle path for display
+            std::string displayDep;
+            if (commonRootLen > 0 && dep.length() > commonRootLen)
+                displayDep = dep.substr(commonRootLen);
+            else
+                displayDep = dep;
 
+            reporter.formatOutput("\t\t -> %s", displayDep.c_str());
+        }
         if (deps.empty())
         {
-            printf("\t\t(no dependencies)\n");
+            reporter.reportOutput("\t\t(no dependencies)");
         }
     }
-    printf("\n");
+    reporter.reportOutput("");
+}
+
+std::string StaticRequireTracer::findLowestCommonRoot(const std::vector<std::string>& paths)
+{
+    if (paths.empty())
+        return "";
+
+    if (paths.size() == 1)
+    {
+        // For a single file, return its directory
+        size_t lastSlash = paths[0].find_last_of("/\\");
+        if (lastSlash != std::string::npos)
+            return paths[0].substr(0, lastSlash);
+        return "";
+    }
+
+    // Sort the paths - the first and last will have the maximum difference
+    std::vector<std::string> sortedPaths = paths;
+    std::sort(sortedPaths.begin(), sortedPaths.end());
+
+    const std::string& first = sortedPaths.front();
+    const std::string& last = sortedPaths.back();
+
+    // Find common prefix between first and last
+    size_t i = 0;
+    while (i < first.length() && i < last.length() && first[i] == last[i])
+    {
+        i++;
+    }
+
+    // Back up to the last directory separator
+    std::string commonPrefix = first.substr(0, i);
+    size_t lastSlash = commonPrefix.find_last_of("/\\");
+    if (lastSlash != std::string::npos)
+    {
+        // Special case: if the slash is at position 0, we're at the root directory
+        if (lastSlash == 0)
+            return "/";
+        return commonPrefix.substr(0, lastSlash);
+    }
+
+    return "";
 }

--- a/tests/src/compile.test.cpp
+++ b/tests/src/compile.test.cpp
@@ -1,5 +1,6 @@
-#include "lute/climain.h"
 #include "lute/compile.h"
+
+#include "lute/climain.h"
 
 #include "Luau/FileUtils.h"
 
@@ -20,7 +21,7 @@ TEST_CASE_FIXTURE(LuteFixture, "lutepayload_single_file_roundtrip")
 
     // Create payload and add file
     LuteExePayload originalPayload{getReporter()};
-    originalPayload.add(testFilePath);
+    originalPayload.add(testFilePath, testFilePath);
 
     // Encode
     auto encodeResult = originalPayload.encode();
@@ -71,7 +72,7 @@ TEST_CASE_FIXTURE(LuteFixture, "lutepayload_multiple_files_roundtrip")
     LuteExePayload originalPayload{getReporter()};
     for (const auto& file : testFiles)
     {
-        originalPayload.add(file);
+        originalPayload.add(file, file);
     }
 
     // First file should be the entry point
@@ -129,7 +130,7 @@ TEST_CASE_FIXTURE(LuteFixture, "lutepayload_corrupted_metadata")
 
     // Create valid payload
     LuteExePayload originalPayload{getReporter()};
-    originalPayload.add(testFilePath);
+    originalPayload.add(testFilePath, testFilePath);
     auto encodeResult = originalPayload.encode();
     REQUIRE(encodeResult.has_value());
 
@@ -161,8 +162,8 @@ TEST_CASE_FIXTURE(LuteFixture, "lutepayload_entry_point_is_first_added")
     std::string secondFile = joinPaths(testDir, "utils.luau");
 
     LuteExePayload payload{getReporter()};
-    payload.add(firstFile);
-    payload.add(secondFile);
+    payload.add(firstFile, firstFile);
+    payload.add(secondFile, secondFile);
 
     // Entry point should be the first file added
     CHECK(payload.entryPointPath == firstFile);
@@ -174,7 +175,7 @@ TEST_CASE_FIXTURE(LuteFixture, "lutepayload_nonexistent_file")
     std::string nonExistentFile = joinPaths(luteProjectRoot, "tests/src/this_file_does_not_exist.luau");
 
     LuteExePayload payload{getReporter()};
-    payload.add(nonExistentFile);
+    payload.add(nonExistentFile, nonExistentFile);
 
     // Encoding should fail because file doesn't exist
     auto encodeResult = payload.encode();
@@ -198,7 +199,7 @@ TEST_CASE_FIXTURE(LuteFixture, "lutepayload_compression_effectiveness")
     std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
 
     LuteExePayload payload{getReporter()};
-    payload.add(testFilePath);
+    payload.add(testFilePath, testFilePath);
 
     auto encodeResult = payload.encode();
     REQUIRE(encodeResult.has_value());
@@ -219,12 +220,12 @@ TEST_CASE_FIXTURE(LuteFixture, "lutepayload_bytecode_integrity")
 
     // Create two separate payloads with the same file
     LuteExePayload payload1{getReporter()};
-    payload1.add(testFilePath);
+    payload1.add(testFilePath, testFilePath);
     auto encode1 = payload1.encode();
     REQUIRE(encode1.has_value());
 
     LuteExePayload payload2{getReporter()};
-    payload2.add(testFilePath);
+    payload2.add(testFilePath, testFilePath);
     auto encode2 = payload2.encode();
     REQUIRE(encode2.has_value());
 
@@ -246,7 +247,7 @@ TEST_CASE_FIXTURE(LuteFixture, "lutepayload_validates_numfiles_metadata")
 
     // Create and encode a valid payload
     LuteExePayload payload{getReporter()};
-    payload.add(testFilePath);
+    payload.add(testFilePath, testFilePath);
     auto encodeResult = payload.encode();
     REQUIRE(encodeResult.has_value());
 
@@ -292,7 +293,7 @@ TEST_CASE_FIXTURE(LuteFixture, "luteexecutable_single_file_roundtrip")
 
     // Create payload with a test file
     LuteExePayload originalPayload{getReporter()};
-    originalPayload.add(testFilePath);
+    originalPayload.add(testFilePath, testFilePath);
 
     // Create LuteExecutable and write it out
     std::string outputExePath = joinPaths(luteProjectRoot, "tests/temp_output_exe");
@@ -352,7 +353,7 @@ TEST_CASE_FIXTURE(LuteFixture, "luteexecutable_multiple_files_roundtrip")
     LuteExePayload originalPayload{getReporter()};
     for (const auto& file : testFiles)
     {
-        originalPayload.add(file);
+        originalPayload.add(file, file);
     }
 
     // First file should be the entry point
@@ -433,7 +434,7 @@ TEST_CASE_FIXTURE(LuteFixture, "luteexecutable_extract_preserves_original_execut
 
     // Create payload and executable
     LuteExePayload payload{getReporter()};
-    payload.add(testFilePath);
+    payload.add(testFilePath, testFilePath);
 
     std::string outputExePath = joinPaths(luteProjectRoot, "tests/temp_output_exe_preserve");
     LuteExecutable executable{dummyExePath, getReporter()};

--- a/tests/src/staticrequires.test.cpp
+++ b/tests/src/staticrequires.test.cpp
@@ -14,23 +14,25 @@ TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_simple_dependencies")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+    std::string entryPoint = joinPaths(testDir, "main.luau");
 
     StaticRequireTracer tracer{getReporter()};
-    std::vector<std::string> deps = tracer.trace(testDir, "main.luau");
+    tracer.trace(entryPoint);
+
+    auto pairs = tracer.getStaticRequirePairs();
 
     // Should find: main.luau, utils.luau, lib/helper.luau, shared.luau
-    REQUIRE(deps.size() == 4);
+    REQUIRE(pairs.size() == 4);
 
     // Entry point should be first
-    CHECK(deps[0] == "main.luau");
+    CHECK(pairs[0].first == "main.luau");
 
-    // Verify all expected files are present (paths are relative to testDir)
     std::vector<std::string> expectedFiles = {"main.luau", "utils.luau", "lib/helper.luau", "shared.luau"};
 
     for (const auto& expected : expectedFiles)
     {
-        bool found = std::find(deps.begin(), deps.end(), expected) != deps.end();
-        CHECK(found);
+        std::string absolutePath = joinPaths(tracer.getLowestCommonRoot(), expected);
+        CHECK(tracer.containsAbsolute(absolutePath));
     }
 }
 
@@ -38,88 +40,180 @@ TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_circular_dependencies")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+    std::string entryPoint = joinPaths(testDir, "circular_a.luau");
 
     StaticRequireTracer tracer{getReporter()};
-    std::vector<std::string> deps = tracer.trace(testDir, "circular_a.luau");
+    tracer.trace(entryPoint);
+
+    auto pairs = tracer.getStaticRequirePairs();
 
     // Should find both circular_a and circular_b without infinite loop
-    REQUIRE(deps.size() == 2);
+    REQUIRE(pairs.size() == 2);
 
     // Entry point should be first
-    CHECK(deps[0] == "circular_a.luau");
+    CHECK(pairs[0].first == "circular_a.luau");
 
-    // Both files should be in the list
-    bool hasA = std::find(deps.begin(), deps.end(), "circular_a.luau") != deps.end();
-    bool hasB = std::find(deps.begin(), deps.end(), "circular_b.luau") != deps.end();
+    // Both files should be in the list using absolute paths
+    std::string absoluteA = joinPaths(tracer.getLowestCommonRoot(), "circular_a.luau");
+    std::string absoluteB = joinPaths(tracer.getLowestCommonRoot(), "circular_b.luau");
 
-    CHECK(hasA);
-    CHECK(hasB);
+    CHECK(tracer.containsAbsolute(absoluteA));
+    CHECK(tracer.containsAbsolute(absoluteB));
 }
 
 TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_no_dependencies")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+    std::string entryPoint = joinPaths(testDir, "utils.luau");
 
     StaticRequireTracer tracer{getReporter()};
-    std::vector<std::string> deps = tracer.trace(testDir, "utils.luau");
+    tracer.trace(entryPoint);
+
+    auto pairs = tracer.getStaticRequirePairs();
 
     // utils.luau has no requires, should only return itself
-    REQUIRE(deps.size() == 1);
-    CHECK(deps[0] == "utils.luau");
+    REQUIRE(pairs.size() == 1);
+    CHECK(pairs[0].first == "utils.luau");
 }
 
 TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_relative_paths")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+    std::string entryPoint = joinPaths(testDir, "lib/helper.luau");
 
     StaticRequireTracer tracer{getReporter()};
-    std::vector<std::string> deps = tracer.trace(testDir, "lib/helper.luau");
+    tracer.trace(entryPoint);
+
+    auto pairs = tracer.getStaticRequirePairs();
 
     // helper.luau requires ../shared, should resolve correctly
-    REQUIRE(deps.size() == 2);
+    REQUIRE(pairs.size() == 2);
 
-    CHECK(deps[0] == "lib/helper.luau");
+    CHECK(pairs[0].first == "lib/helper.luau");
 
-    bool hasShared = std::find(deps.begin(), deps.end(), "shared.luau") != deps.end();
-    CHECK(hasShared);
+    std::string absoluteShared = joinPaths(tracer.getLowestCommonRoot(), "shared.luau");
+    CHECK(tracer.containsAbsolute(absoluteShared));
 }
 
 TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_require_graph")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+    StaticRequireTracer tracer{getReporter()};
+    std::string entryPoint = joinPaths(testDir, "main.luau");
+
+    tracer.trace(entryPoint);
+
+    // Build absolute paths
+    std::string mainPath = joinPaths(testDir, "main.luau");
+    std::string utilsPath = joinPaths(testDir, "utils.luau");
+    std::string helperPath = joinPaths(testDir, "lib/helper.luau");
+    std::string sharedPath = joinPaths(testDir, "shared.luau");
+
+    // Verify all expected files were discovered
+    CHECK(tracer.containsAbsolute(mainPath));
+    CHECK(tracer.containsAbsolute(utilsPath));
+    CHECK(tracer.containsAbsolute(helperPath));
+    CHECK(tracer.containsAbsolute(sharedPath));
+
+    // Verify the graph can be printed without errors (visual inspection of output)
+    tracer.printRequireGraph();
+}
+
+TEST_CASE("staticrequiretracer_find_lowest_common_root")
+{
+    SUBCASE("single_file")
+    {
+        std::vector<std::string> paths = {"/home/user/project/src/main.luau"};
+        std::string root = StaticRequireTracer::findLowestCommonRoot(paths);
+        CHECK(root == "/home/user/project/src");
+    }
+
+    SUBCASE("same_directory")
+    {
+        std::vector<std::string> paths = {
+            "/home/user/project/src/main.luau", "/home/user/project/src/utils.luau", "/home/user/project/src/helper.luau"
+        };
+        std::string root = StaticRequireTracer::findLowestCommonRoot(paths);
+        CHECK(root == "/home/user/project/src");
+    }
+
+    SUBCASE("nested_directories")
+    {
+        std::vector<std::string> paths = {
+            "/home/user/project/src/main.luau", "/home/user/project/src/utils.luau", "/home/user/project/src/lib/helper.luau"
+        };
+        std::string root = StaticRequireTracer::findLowestCommonRoot(paths);
+        CHECK(root == "/home/user/project/src");
+    }
+
+    SUBCASE("different_subdirectories")
+    {
+        std::vector<std::string> paths = {"/home/user/project/tests/src/main.luau", "/home/user/project/tests/lib/helper.luau"};
+        std::string root = StaticRequireTracer::findLowestCommonRoot(paths);
+        CHECK(root == "/home/user/project/tests");
+    }
+
+    SUBCASE("no_common_root")
+    {
+        std::vector<std::string> paths = {"/home/user/project1/main.luau", "/var/lib/project2/utils.luau"};
+        std::string root = StaticRequireTracer::findLowestCommonRoot(paths);
+        // Should find at least the root directory "/"
+        CHECK(!root.empty());
+    }
+
+    SUBCASE("empty_vector")
+    {
+        std::vector<std::string> paths = {};
+        std::string root = StaticRequireTracer::findLowestCommonRoot(paths);
+        CHECK(root.empty());
+    }
+}
+
+TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_bundle_paths_and_contains")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+    std::string entryPoint = joinPaths(testDir, "main.luau");
 
     StaticRequireTracer tracer{getReporter()};
-    std::vector<std::string> deps = tracer.trace(testDir, "main.luau");
+    tracer.trace(entryPoint);
 
-    const auto& graph = tracer.getRequireGraph();
+    // Get the lowest common root
+    std::string commonRoot = tracer.getLowestCommonRoot();
+    CHECK(commonRoot == testDir);
 
-    // main.luau should require utils.luau and lib/helper.luau
-    REQUIRE(graph.contains("main.luau"));
-    const auto* mainDeps = graph.find("main.luau");
-    REQUIRE(mainDeps != nullptr);
-    REQUIRE(mainDeps->size() == 2);
-    CHECK(std::find(mainDeps->begin(), mainDeps->end(), "utils.luau") != mainDeps->end());
-    CHECK(std::find(mainDeps->begin(), mainDeps->end(), "lib/helper.luau") != mainDeps->end());
+    // Get discovered files as pairs
+    auto pairs = tracer.getStaticRequirePairs();
+    REQUIRE(pairs.size() == 4);
 
-    // lib/helper.luau should require shared.luau
-    REQUIRE(graph.contains("lib/helper.luau"));
-    const auto* helperDeps = graph.find("lib/helper.luau");
-    REQUIRE(helperDeps != nullptr);
-    REQUIRE(helperDeps->size() == 1);
-    CHECK((*helperDeps)[0] == "shared.luau");
+    // Verify bundle paths (without common prefix)
+    std::vector<std::string> expectedBundlePaths = {"main.luau", "utils.luau", "lib/helper.luau", "shared.luau"};
 
-    // utils.luau should have no dependencies
-    REQUIRE(graph.contains("utils.luau"));
-    const auto* utilsDeps = graph.find("utils.luau");
-    REQUIRE(utilsDeps != nullptr);
-    CHECK(utilsDeps->empty());
+    for (const auto& expected : expectedBundlePaths)
+    {
+        bool found = false;
+        for (const auto& [bundlePath, absolutePath] : pairs)
+        {
+            if (bundlePath == expected)
+            {
+                found = true;
+                break;
+            }
+        }
+        CHECK(found);
+    }
 
-    // shared.luau should have no dependencies
-    REQUIRE(graph.contains("shared.luau"));
-    const auto* sharedDeps = graph.find("shared.luau");
-    REQUIRE(sharedDeps != nullptr);
-    CHECK(sharedDeps->empty());
+    // Test containsAbsolute() method with absolute paths
+    std::string mainAbsolute = joinPaths(commonRoot, "main.luau");
+    CHECK(tracer.containsAbsolute(mainAbsolute));
+
+    std::string helperAbsolute = joinPaths(commonRoot, "lib/helper.luau");
+    CHECK(tracer.containsAbsolute(helperAbsolute));
+
+    // Test non-existent module
+    std::string nonExistentAbsolute = joinPaths(commonRoot, "nonexistent.luau");
+    CHECK(!tracer.containsAbsolute(nonExistentAbsolute));
 }


### PR DESCRIPTION
This PR makes use of the resolverequire api exposed in https://github.com/luau-lang/lute/pull/496 to perform static require tracing. This will handle static resolution of aliases for free during compilation - a followup PR will actually handle loading bundled files when they are required via aliases.

Because the `resolverequire` code operates in terms of absolute paths, all static require tracing is now done in terms of absolute paths as well. This has some knock on consequences for how creating Lute Payloads works, which requires me to refactor this in the same PR.

Prior, the `LuteExePayload::add(file path)` method used to take a relative path to the source file being embedded, and all embedded files would be resolved relative to this path. This path was used as both a key in the bundle, as well as the filepath to the script. For example:
```
lute compile tests/staticrequires/src/main.luau
```
would embed:
```
tests/staticrequires/src/main.luau
tests/staticrequires/src/utils.luau
tests/staticrequires/src/deps/dep1.luau
tests/staticrequires/src/deps/dep2.luau
```

However, static require tracing now strips off the longest common prefix of paths, in order to a) save some bytes and b) avoid exposing the directory structure any more than necessary.

This means that the bundle will look like:
```
main.luau
utils.luau
deps/dep1.luau
deps/dep2.luau
```

However, passing just these as keys is insufficient information for the `LuteExePayload` to be able to find and compile these scripts. That's why the `add` method now takes both a `bundleName` e.g. `main.luau` and a filepath, e.g. `/path/to/main.luau`.