### PR TITLE
refactor: Suppress printing to stdout in test cases by logging to a reporter

### DIFF
--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(Lute.CLI.lib PRIVATE
     include/lute/climain.h
     include/lute/compile.h
     include/lute/luauflags.h
+    include/lute/reporter.h
     include/lute/staticrequires.h
     include/lute/tc.h
     include/lute/uvstate.h
@@ -46,6 +47,9 @@ target_compile_options(Lute.CLI.lib PRIVATE ${LUTE_OPTIONS})
 add_executable(Lute.CLI)
 
 target_sources(Lute.CLI PRIVATE
+    include/lute/clireporter.h
+
+    src/clireporter.cpp
     src/main.cpp
 )
 

--- a/lute/cli/include/lute/climain.h
+++ b/lute/cli/include/lute/climain.h
@@ -4,7 +4,16 @@
 
 struct lua_State;
 struct Runtime;
+class LuteReporter;
 
 lua_State* setupCliState(Runtime& runtime, std::function<void(lua_State*)> preSandboxInit = nullptr);
-int cliMain(int argc, char** argv);
-bool runBytecode(Runtime& runtime, const std::string& bytecode, const std::string& chunkname, lua_State* GL, int program_argc, char** program_argv);
+int cliMain(int argc, char** argv, LuteReporter& reporter);
+bool runBytecode(
+    Runtime& runtime,
+    const std::string& bytecode,
+    const std::string& chunkname,
+    lua_State* GL,
+    int program_argc,
+    char** program_argv,
+    LuteReporter& reporter
+);

--- a/lute/cli/include/lute/clireporter.h
+++ b/lute/cli/include/lute/clireporter.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "lute/reporter.h"
+
+// Standard CLI reporter that writes to stderr and stdout
+class CLIReporter : public LuteReporter
+{
+public:
+    void reportError(const std::string& message) override;
+    void reportOutput(const std::string& message) override;
+};

--- a/lute/cli/include/lute/compile.h
+++ b/lute/cli/include/lute/compile.h
@@ -2,6 +2,7 @@
 
 #include "Luau/DenseHash.h"
 #include "Luau/FileUtils.h"
+#include "lute/reporter.h"
 
 #include <string_view>
 
@@ -36,22 +37,24 @@ struct LuteEncodeResult
  */
 struct LuteExePayload
 {
-    LuteExePayload() = default;
+    LuteExePayload(LuteReporter& reporter);
     void add(const std::string& luauFilePath);
 
     std::optional<LuteEncodeResult> encode();
-    static std::optional<LuteDecodeResult> decode(const std::string_view binary);
+    static std::optional<LuteDecodeResult> decode(const std::string_view binary, LuteReporter& reporter);
 
     std::string entryPointPath;
     Luau::DenseHashMap<std::string, std::string> filePathToBytecode{""}; // path -> bytecode
 
 private:
+    LuteReporter& reporter;
     bool parseFromDecompressedBundle(std::string_view decompressedBundle);
     std::vector<std::string> filePaths;
 };
 
 struct LuteDecodeResult
 {
+    LuteDecodeResult(LuteReporter& reporter);
     LuteExePayload payload;
     size_t bytesRead = 0;
     size_t compressedPayloadSizeBytes = 0;
@@ -73,10 +76,11 @@ struct LuteDecodeResult
  */
 struct LuteExecutable
 {
-    LuteExecutable(const std::string& luteRuntimePath);
+    LuteExecutable(const std::string& luteRuntimePath, LuteReporter& reporter);
 
     bool create(const std::string& outputPath, LuteExePayload& payload);
     std::optional<LuteExePayload> extract();
 
     std::string executablePath;
+    LuteReporter& reporter;
 };

--- a/lute/cli/include/lute/reporter.h
+++ b/lute/cli/include/lute/reporter.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+// Interface for reporting output and errors from CLI operations
+class LuteReporter
+{
+public:
+    virtual ~LuteReporter() = default;
+
+    // Report an error message (typically to stderr)
+    virtual void reportError(const std::string& message) = 0;
+
+    // Report normal output (typically to stdout)
+    virtual void reportOutput(const std::string& message) = 0;
+
+    // Variadic template version for formatted error messages using printf-style format specifiers
+    template<typename... Args>
+    void formatError(const char* format, Args&&... args)
+    {
+        reportError(formatMessage(format, std::forward<Args>(args)...));
+    }
+
+    // Variadic template version for formatted output messages using printf-style format specifiers
+    template<typename... Args>
+    void formatOutput(const char* format, Args&&... args)
+    {
+        reportOutput(formatMessage(format, std::forward<Args>(args)...));
+    }
+
+private:
+    // Format implementation using snprintf
+    template<typename... Args>
+    static std::string formatMessage(const char* format, Args&&... args)
+    {
+        // Calculate required buffer size
+        int size = std::snprintf(nullptr, 0, format, args...);
+
+        if (size > 0)
+        {
+            // Allocate buffer and format the string
+            std::vector<char> buffer(size + 1);
+            std::snprintf(buffer.data(), buffer.size(), format, args...);
+
+            return std::string(buffer.data(), size);
+        }
+
+        // Fallback if formatting fails
+        return std::string(format);
+    }
+};

--- a/lute/cli/include/lute/staticrequires.h
+++ b/lute/cli/include/lute/staticrequires.h
@@ -2,6 +2,8 @@
 
 #include "Luau/DenseHash.h"
 
+#include "lute/reporter.h"
+
 #include <optional>
 #include <string>
 #include <vector>
@@ -9,7 +11,7 @@
 class StaticRequireTracer
 {
 public:
-    StaticRequireTracer() = default;
+    StaticRequireTracer(LuteReporter& reporter);
 
     // Trace dependencies starting from an entry point file
     // rootDirectory: Base directory for resolving all requires
@@ -37,4 +39,6 @@ private:
 
     // Resolve a require path relative to the requiring file
     std::optional<std::string> resolveRequire(const std::string& requirer, const std::string& required);
+
+    LuteReporter& reporter;
 };

--- a/lute/cli/include/lute/tc.h
+++ b/lute/cli/include/lute/tc.h
@@ -4,4 +4,6 @@
 #include "Luau/FileUtils.h"
 #include "Luau/Frontend.h"
 
-int typecheck(const std::vector<std::string>& sourceFiles);
+#include "lute/reporter.h"
+
+int typecheck(const std::vector<std::string>& sourceFiles, LuteReporter& reporter);

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -13,6 +13,7 @@
 #include "lute/options.h"
 #include "lute/process.h"
 #include "lute/ref.h"
+#include "lute/reporter.h"
 #include "lute/require.h"
 #include "lute/runtime.h"
 #include "lute/staticrequires.h"
@@ -43,6 +44,60 @@
 #include <memory>
 #include <string>
 #include <vector>
+
+static const char* HELP_STRING = R"(Usage: lute <command> [options] [arguments...]
+
+Commands:
+	run (default)   Run a Luau script.
+	check           Type check Luau files.
+	compile         Compile a Luau script into a standalone executable.
+	setup           Generate type definition files for the language server.
+
+Run Options (when using 'run' or no command):
+	lute [run] <script.luau> [args...]
+		Executes the script, passing [args...] to it.
+
+Check Options:
+	lute check <file1.luau> [file2.luau...]
+		Performs a type check on the specified files.
+
+Compile Options:
+	lute compile <entry.luau> [--output <executable>]
+		Compiles entry point and auto-discovered dependencies into a standalone executable.
+
+Setup Options:
+	lute setup
+		Generates type definition files for the language server.
+			--with-luaurc Defines aliases to the type definition files in the working directory's luaurc file.
+
+General Options:
+	-h, --help    Display this usage message.
+		--version Show the lute version.
+)";
+
+static const char* VERSION_STRING = LUTE_VERSION_FULL;
+
+static const char* RUN_HELP_STRING = R"(Usage: lute run <script.luau> [args...]
+
+Run Options:
+	-h, --help    Display this usage message.
+)";
+
+static const char* CHECK_HELP_STRING = R"(Usage: lute check <file1.luau> [file2.luau...]
+
+Check Options:
+	-h, --help    Display this usage message.
+)";
+
+static const char* COMPILE_HELP_STRING = R"(Usage: lute compile <entry.luau> [options]
+
+Compile Options:
+	--output <path>         Name for the compiled executable.
+		Defaults to entry file's base name (with .exe on Windows).
+	--bundle-stats          Display bundle size and compression statistics.
+	--show-require-graph    Print the require dependency graph.
+	-h, --help              Display this usage message.
+)";
 
 void* createCliRequireContext(lua_State* L)
 {
@@ -162,7 +217,15 @@ static bool setupArguments(lua_State* L, int argc, char** argv)
     return true;
 }
 
-bool runBytecode(Runtime& runtime, const std::string& bytecode, const std::string& chunkname, lua_State* GL, int program_argc, char** program_argv)
+bool runBytecode(
+    Runtime& runtime,
+    const std::string& bytecode,
+    const std::string& chunkname,
+    lua_State* GL,
+    int program_argc,
+    char** program_argv,
+    LuteReporter& reporter
+)
 {
     // module needs to run in a new thread, isolated from the rest
     lua_State* L = lua_newthread(GL);
@@ -173,9 +236,9 @@ bool runBytecode(Runtime& runtime, const std::string& bytecode, const std::strin
     if (luau_load(L, chunkname.c_str(), bytecode.data(), bytecode.size(), 0) != 0)
     {
         if (const char* str = lua_tostring(L, -1))
-            fprintf(stderr, "%s", str);
+            reporter.reportError(str);
         else
-            fprintf(stderr, "Failed to load bytecode");
+            reporter.reportError("Failed to load bytecode");
 
         lua_pop(GL, 1);
         return false;
@@ -189,7 +252,7 @@ bool runBytecode(Runtime& runtime, const std::string& bytecode, const std::strin
 
     if (!setupArguments(L, program_argc, program_argv))
     {
-        fprintf(stderr, "Failed to pass arguments to Luau");
+        reporter.reportError("Failed to pass arguments to Luau");
         lua_pop(GL, 1);
         return false;
     }
@@ -202,18 +265,18 @@ bool runBytecode(Runtime& runtime, const std::string& bytecode, const std::strin
     return runtime.runToCompletion();
 }
 
-static bool runFile(Runtime& runtime, const char* name, lua_State* GL, int program_argc, char** program_argv)
+static bool runFile(Runtime& runtime, const char* name, lua_State* GL, int program_argc, char** program_argv, LuteReporter& reporter)
 {
     if (isDirectory(name))
     {
-        fprintf(stderr, "Error: %s is a directory\n", name);
+        reporter.formatError("Error: %s is a directory", name);
         return false;
     }
 
     std::optional<std::string> source = readFile(name);
     if (!source)
     {
-        fprintf(stderr, "Error opening %s\n", name);
+        reporter.formatError("Error opening %s", name);
         return false;
     }
 
@@ -221,73 +284,7 @@ static bool runFile(Runtime& runtime, const char* name, lua_State* GL, int progr
 
     std::string bytecode = Luau::compile(*source, copts());
 
-    return runBytecode(runtime, bytecode, chunkname, GL, program_argc, program_argv);
-}
-
-static void displayHelp()
-{
-    printf("Usage: lute <command> [options] [arguments...]\n");
-    printf("\n");
-    printf("Commands:\n");
-    printf("  run (default)   Run a Luau script.\n");
-    printf("  check           Type check Luau files.\n");
-    printf("  compile         Compile a Luau script into a standalone executable.\n");
-    printf("  setup           Generate type definition files for the language server.");
-    printf("\n");
-    printf("Run Options (when using 'run' or no command):\n");
-    printf("  lute [run] <script.luau> [args...]\n");
-    printf("    Executes the script, passing [args...] to it.\n");
-    printf("\n");
-    printf("Check Options:\n");
-    printf("  lute check <file1.luau> [file2.luau...]\n");
-    printf("    Performs a type check on the specified files.\n");
-    printf("\n");
-    printf("Compile Options:\n");
-    printf("  lute compile <entry.luau> [--output <executable>]\n");
-    printf("    Compiles entry point and auto-discovered dependencies into a standalone executable.\n");
-    printf("\n");
-    printf("Setup Options:\n");
-    printf("  lute setup");
-    printf("    Generates type definition files for the language server.\n");
-    printf("      --with-luaurc Defines aliases to the type definition files in the working directory's luaurc file.\n");
-    printf("\n");
-    printf("General Options:\n");
-    printf("  -h, --help    Display this usage message.\n");
-    printf("      --version Show the lute version.\n");
-}
-
-static void displayVersion()
-{
-    printf("%s\n", LUTE_VERSION_FULL);
-}
-
-static void displayRunHelp()
-{
-    printf("Usage: lute run <script.luau> [args...]\n");
-    printf("\n");
-    printf("Run Options:\n");
-    printf("  -h, --help    Display this usage message.\n");
-}
-
-static void displayCheckHelp()
-{
-    printf("Usage: lute check <file1.luau> [file2.luau...]\n");
-    printf("\n");
-    printf("Check Options:\n");
-    printf("  -h, --help    Display this usage message.\n");
-}
-
-static void displayCompileHelp()
-{
-    printf("Usage: lute compile <entry.luau> [options]\n");
-    printf("\n");
-    printf("Compile Options:\n");
-    printf("\t--output <path>         Name for the compiled executable.\n");
-    printf("\t\tDefaults to entry file's base name (with .exe on Windows).\n");
-    printf("\t--bundle-stats          Display bundle size and compression statistics.\n");
-    printf("\t--show-require-graph    Print the require dependency graph.\n");
-    printf("\t-h, --help              Display this usage message.\n");
-    printf("\n");
+    return runBytecode(runtime, bytecode, chunkname, GL, program_argc, program_argv, reporter);
 }
 
 static int assertionHandler(const char* expr, const char* file, int line, const char* function)
@@ -346,7 +343,7 @@ static std::optional<std::string> getValidPath(std::string filePath)
     return std::nullopt;
 }
 
-int handleRunCommand(int argc, char** argv, int argOffset)
+int handleRunCommand(int argc, char** argv, int argOffset, LuteReporter& reporter)
 {
     std::string filePath;
     int program_argc = 0;
@@ -358,13 +355,13 @@ int handleRunCommand(int argc, char** argv, int argOffset)
 
         if (strcmp(currentArg, "-h") == 0 || strcmp(currentArg, "--help") == 0)
         {
-            displayRunHelp();
+            reporter.reportOutput(RUN_HELP_STRING);
             return 0;
         }
         else if (currentArg[0] == '-')
         {
-            fprintf(stderr, "Error: Unrecognized option '%s' for 'run' command.\n\n", currentArg);
-            displayRunHelp();
+            reporter.formatError("Error: Unrecognized option '%s' for 'run' command.", currentArg);
+            reporter.reportOutput(RUN_HELP_STRING);
             return 1;
         }
         else
@@ -378,8 +375,8 @@ int handleRunCommand(int argc, char** argv, int argOffset)
 
     if (filePath.empty())
     {
-        fprintf(stderr, "Error: No file specified for 'run' command.\n\n");
-        displayRunHelp();
+        reporter.reportError("Error: No file specified for 'run' command.");
+        reporter.reportOutput(RUN_HELP_STRING);
         return 1;
     }
 
@@ -389,15 +386,15 @@ int handleRunCommand(int argc, char** argv, int argOffset)
     std::optional<std::string> validPath = getValidPath(filePath);
     if (!validPath)
     {
-        std::cerr << "Error: File '" << filePath << "' does not exist.\n";
+        reporter.formatError("Error: File '%s' does not exist.", filePath.c_str());
         return 1;
     }
 
-    bool success = runFile(runtime, validPath->c_str(), L, program_argc, program_argv);
+    bool success = runFile(runtime, validPath->c_str(), L, program_argc, program_argv, reporter);
     return success ? 0 : 1;
 }
 
-int handleCheckCommand(int argc, char** argv, int argOffset)
+int handleCheckCommand(int argc, char** argv, int argOffset, LuteReporter& reporter)
 {
     std::vector<std::string> files;
 
@@ -407,13 +404,13 @@ int handleCheckCommand(int argc, char** argv, int argOffset)
 
         if (strcmp(currentArg, "-h") == 0 || strcmp(currentArg, "--help") == 0)
         {
-            displayCheckHelp();
+            reporter.reportOutput(CHECK_HELP_STRING);
             return 0;
         }
         else if (currentArg[0] == '-')
         {
-            fprintf(stderr, "Error: Unrecognized option '%s' for 'check' command.\n\n", currentArg);
-            displayCheckHelp();
+            reporter.formatError("Error: Unrecognized option '%s' for 'check' command.", currentArg);
+            reporter.reportOutput(CHECK_HELP_STRING);
             return 1;
         }
         else
@@ -424,15 +421,15 @@ int handleCheckCommand(int argc, char** argv, int argOffset)
 
     if (files.empty())
     {
-        fprintf(stderr, "Error: No files specified for 'check' command.\n\n");
-        displayCheckHelp();
+        reporter.reportError("Error: No files specified for 'check' command.");
+        reporter.reportOutput(CHECK_HELP_STRING);
         return 1;
     }
 
-    return typecheck(files);
+    return typecheck(files, reporter);
 }
 
-int handleCompileCommand(int argc, char** argv, int argOffset)
+int handleCompileCommand(int argc, char** argv, int argOffset, LuteReporter& reporter)
 {
     std::string filePath;
     std::string outputPath;
@@ -446,15 +443,15 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
 
         if (strcmp(currentArg, "-h") == 0 || strcmp(currentArg, "--help") == 0)
         {
-            displayCompileHelp();
+            reporter.reportOutput(COMPILE_HELP_STRING);
             return 0;
         }
         else if (strcmp(currentArg, "--output") == 0)
         {
             if (i + 1 >= argc)
             {
-                fprintf(stderr, "Error: --output requires a path argument.\n\n");
-                displayCompileHelp();
+                reporter.reportError("Error: --output requires a path argument.");
+                reporter.reportOutput(COMPILE_HELP_STRING);
                 return 1;
             }
             outputPath = argv[++i];
@@ -465,8 +462,8 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
             showRequireGraph = true;
         else if (currentArg[0] == '-')
         {
-            fprintf(stderr, "Error: Unrecognized option '%s' for 'compile' command.\n\n", currentArg);
-            displayCompileHelp();
+            reporter.formatError("Error: Unrecognized option '%s' for 'compile' command.", currentArg);
+            reporter.reportOutput(COMPILE_HELP_STRING);
             return 1;
         }
         else if (filePath.empty())
@@ -475,16 +472,16 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
         }
         else
         {
-            fprintf(stderr, "Error: Unexpected argument '%s'.\n\n", currentArg);
-            displayCompileHelp();
+            reporter.reportError("Error: Too many arguments for 'compile' command.");
+            reporter.reportOutput(COMPILE_HELP_STRING);
             return 1;
         }
     }
 
     if (filePath.empty())
     {
-        fprintf(stderr, "Error: No file specified for 'compile' command.\n\n");
-        displayCompileHelp();
+        reporter.reportError("Error: No input file specified for 'compile' command.");
+        reporter.reportOutput(COMPILE_HELP_STRING);
         return 1;
     }
 
@@ -492,7 +489,7 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
     std::optional<std::string> validPath = getValidPath(filePath);
     if (!validPath)
     {
-        fprintf(stderr, "Error: File '%s' does not exist.\n", filePath.c_str());
+        reporter.formatError("Error: File '%s' does not exist.", filePath.c_str());
         return 1;
     }
 
@@ -538,12 +535,12 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
     }
 
     // Perform static require trace
-    StaticRequireTracer tracer;
+    StaticRequireTracer tracer{reporter};
     std::vector<std::string> discoveredFiles = tracer.trace(rootDirectory, entryFilename);
 
     if (discoveredFiles.empty())
     {
-        fprintf(stderr, "Error: No files discovered during require trace.\n");
+        reporter.reportError("Error: No files discovered during require trace.");
         return 1;
     }
 
@@ -551,7 +548,7 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
         tracer.printRequireGraph();
 
     // Create payload and add all discovered files
-    LuteExePayload payload;
+    LuteExePayload payload{reporter};
     for (const auto& file : discoveredFiles)
     {
         // Construct full path from root directory and relative file path
@@ -560,30 +557,30 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
     }
 
     // Encode the payload
-    printf("Compiling and bundling bytecode...\n");
+    reporter.reportOutput("Compiling and bundling bytecode...");
     std::optional<LuteEncodeResult> encodeResult = payload.encode();
     if (!encodeResult)
     {
-        fprintf(stderr, "Error: Failed to encode bundle\n");
+        reporter.reportError("Error: Failed to encode bundle");
         return 1;
     }
 
     // Show bundle stats if requested
     if (bundleStats)
     {
-        printf("\nBundle Statistics:\n");
-        printf("  Files bundled: %zu\n", discoveredFiles.size());
-        printf("  Uncompressed size: %zu bytes\n", encodeResult->uncompressedPayloadSizeBytes);
-        printf("  Compressed size: %zu bytes\n", encodeResult->compressedPayloadSizeBytes);
-        printf(
-            "  Space saved: %.2f%%\n",
+        reporter.reportOutput("\nBundle Statistics:");
+        reporter.formatOutput("\tFiles bundled: %zu", discoveredFiles.size());
+        reporter.formatOutput("\tUncompressed size: %zu bytes", encodeResult->uncompressedPayloadSizeBytes);
+        reporter.formatOutput("\tCompressed size: %zu bytes", encodeResult->compressedPayloadSizeBytes);
+        reporter.formatOutput(
+            "\tSpace saved: %.2f%%",
             100.0 * (1.0 - (double)encodeResult->compressedPayloadSizeBytes / (double)encodeResult->uncompressedPayloadSizeBytes)
         );
-        printf(
-            "  Compression ratio: %.2f:1\n", (double)encodeResult->uncompressedPayloadSizeBytes / (double)encodeResult->compressedPayloadSizeBytes
+        reporter.formatOutput(
+            "\tCompression ratio: %.2f:1", (double)encodeResult->uncompressedPayloadSizeBytes / (double)encodeResult->compressedPayloadSizeBytes
         );
-        printf("  Total payload size: %zu bytes\n", encodeResult->bytesWritten);
-        printf("\n");
+        reporter.formatOutput("\tTotal payload size: %zu bytes", encodeResult->bytesWritten);
+        reporter.reportOutput("");
     }
 
     // Get current executable path
@@ -591,32 +588,32 @@ int handleCompileCommand(int argc, char** argv, int argOffset)
     std::optional<std::string> exePath = process::getExecPath(&errorMsg);
     if (!exePath)
     {
-        fprintf(stderr, "Error: Failed to get executable path: %s\n", errorMsg.c_str());
+        reporter.formatError("Error: Failed to get executable path: %s", errorMsg.c_str());
         return 1;
     }
 
     // Create the executable with embedded payload
-    LuteExecutable executable(*exePath);
+    LuteExecutable executable{*exePath, reporter};
     if (!executable.create(outputPath, payload))
     {
-        fprintf(stderr, "Error: Failed to create executable.\n");
+        reporter.reportError("Error: Failed to create executable.");
         return 1;
     }
 
-    printf("Created executable '%s'\n", outputPath.c_str());
+    reporter.formatOutput("Created executable '%s'", outputPath.c_str());
     return 0;
 }
 
-int handleCliCommand(CliCommandResult result, int program_argc, char** program_argv)
+int handleCliCommand(CliCommandResult result, int program_argc, char** program_argv, LuteReporter& reporter)
 {
     Runtime runtime;
     lua_State* L = setupCliState(runtime);
 
     std::string bytecode = Luau::compile(std::string(result.contents), copts());
-    return runBytecode(runtime, bytecode, "@" + result.path, L, program_argc, program_argv) ? 0 : 1;
+    return runBytecode(runtime, bytecode, "@" + result.path, L, program_argc, program_argv, reporter) ? 0 : 1;
 }
 
-int cliMain(int argc, char** argv)
+int cliMain(int argc, char** argv, LuteReporter& reporter)
 {
     Luau::assertHandler() = assertionHandler;
     setLuauFlags();
@@ -624,18 +621,17 @@ int cliMain(int argc, char** argv)
     std::string err = "";
     if (auto exePath = process::getExecPath(&err))
     {
-        LuteExecutable exe{*exePath};
+        LuteExecutable exe{*exePath, reporter};
         if (auto payload = exe.extract())
         {
             Runtime runtime;
 
             lua_State* GL = setupBundleState(runtime, payload->filePathToBytecode);
-
             std::string entryPoint = payload->entryPointPath;
             auto entryModule = payload->filePathToBytecode.find(entryPoint);
             if (entryModule != nullptr)
             {
-                bool success = runBytecode(runtime, *entryModule, "@@bundle/" + entryPoint, GL, argc, argv);
+                bool success = runBytecode(runtime, *entryModule, "@@bundle/" + entryPoint, GL, argc, argv, reporter);
                 return success ? 0 : 1;
             }
         }
@@ -648,7 +644,7 @@ int cliMain(int argc, char** argv)
     if (argc < 2)
     {
         // TODO: REPL?
-        displayHelp();
+        reporter.reportOutput(HELP_STRING);
         return 0;
     }
 
@@ -657,34 +653,34 @@ int cliMain(int argc, char** argv)
 
     if (strcmp(command, "run") == 0)
     {
-        return handleRunCommand(argc, argv, argOffset);
+        return handleRunCommand(argc, argv, argOffset, reporter);
     }
     else if (strcmp(command, "check") == 0)
     {
-        return handleCheckCommand(argc, argv, argOffset);
+        return handleCheckCommand(argc, argv, argOffset, reporter);
     }
     else if (strcmp(command, "compile") == 0)
     {
-        return handleCompileCommand(argc, argv, argOffset);
+        return handleCompileCommand(argc, argv, argOffset, reporter);
     }
     else if (strcmp(command, "-h") == 0 || strcmp(command, "--help") == 0)
     {
-        displayHelp();
+        reporter.reportOutput(HELP_STRING);
         return 0;
     }
     else if (strcmp(command, "--version") == 0)
     {
-        displayVersion();
+        reporter.reportOutput(VERSION_STRING);
         return 0;
     }
     else if (std::optional<CliCommandResult> result = getCliCommand(command); result)
     {
-        return handleCliCommand(*result, argc - argOffset, &argv[argOffset]);
+        return handleCliCommand(*result, argc - argOffset, &argv[argOffset], reporter);
     }
     else
     {
         // Default to 'run' command
         argOffset = 1;
-        return handleRunCommand(argc, argv, argOffset);
+        return handleRunCommand(argc, argv, argOffset, reporter);
     }
 }

--- a/lute/cli/src/clireporter.cpp
+++ b/lute/cli/src/clireporter.cpp
@@ -1,0 +1,13 @@
+#include "lute/clireporter.h"
+
+#include <cstdio>
+
+void CLIReporter::reportError(const std::string& message)
+{
+    fprintf(stderr, "%s\n", message.c_str());
+}
+
+void CLIReporter::reportOutput(const std::string& message)
+{
+    fprintf(stdout, "%s\n", message.c_str());
+}

--- a/lute/cli/src/compile.cpp
+++ b/lute/cli/src/compile.cpp
@@ -18,6 +18,11 @@
 const char MAGIC_FLAG[] = "LUTEBYTE";
 const size_t MAGIC_FLAG_SIZE = sizeof(MAGIC_FLAG) - 1;
 
+LuteExePayload::LuteExePayload(LuteReporter& reporter)
+    : reporter(reporter)
+{
+}
+
 void LuteExePayload::add(const std::string& luauFilePath)
 {
     // First file added becomes the entry point
@@ -32,7 +37,7 @@ std::optional<LuteEncodeResult> LuteExePayload::encode()
     // Encoding an empty payload is an error
     if (filePaths.empty())
     {
-        fprintf(stderr, "Encode failed: No files added to payload\n");
+        reporter.reportError("Encode failed: No files added to payload");
         return std::nullopt;
     }
 
@@ -46,7 +51,7 @@ std::optional<LuteEncodeResult> LuteExePayload::encode()
         std::optional<std::string> source = readFile(filePath);
         if (!source)
         {
-            fprintf(stderr, "Encode failed: Could not read file '%s'\n", filePath.c_str());
+            reporter.formatError("Encode failed: Could not read file '%s'", filePath.c_str());
             return std::nullopt;
         }
 
@@ -54,7 +59,7 @@ std::optional<LuteEncodeResult> LuteExePayload::encode()
         std::string bytecode = Luau::compile(*source, copts());
         if (bytecode.empty())
         {
-            fprintf(stderr, "Encode failed: Could not compile file '%s' to bytecode\n", filePath.c_str());
+            reporter.formatError("Encode failed: Could not compile file '%s' to bytecode", filePath.c_str());
             return std::nullopt;
         }
 
@@ -93,7 +98,7 @@ std::optional<LuteEncodeResult> LuteExePayload::encode()
 
     if (compressResult != Z_OK)
     {
-        fprintf(stderr, "Encode failed: Compression error (zlib error %d)\n", compressResult);
+        reporter.formatError("Encode failed: Compression error (zlib error %d)", compressResult);
         return std::nullopt;
     }
     result.payload.clear();
@@ -138,15 +143,15 @@ std::optional<LuteEncodeResult> LuteExePayload::encode()
     return result;
 }
 
-std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view binary)
+std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view binary, LuteReporter& reporter)
 {
-    LuteDecodeResult result;
+    LuteDecodeResult result{reporter};
     result.payload.filePathToBytecode.clear();
 
     // Check minimum size for magic flag
     if (binary.size() < MAGIC_FLAG_SIZE + sizeof(uint32_t))
     {
-        fprintf(stderr, "Decode failed: Binary too small (%zu bytes) to contain valid payload\n", binary.size());
+        reporter.formatError("Decode failed: Binary too small (%zu bytes) to contain valid payload", binary.size());
         return std::nullopt;
     }
 
@@ -154,18 +159,18 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
     size_t magicOffset = binary.size() - MAGIC_FLAG_SIZE;
     if (memcmp(binary.data() + magicOffset, MAGIC_FLAG, MAGIC_FLAG_SIZE) != 0)
     {
-        fprintf(stderr, "Decode failed: LUTEBYTE magic flag not found\n");
+        reporter.reportError("Decode failed: LUTEBYTE magic flag not found");
         return std::nullopt;
     }
 
     // Helper to read fixed-size values backwards
-    auto readValue = [&binary](size_t& pos, const char* fieldName, auto& value) -> bool
+    auto readValue = [&binary, &reporter](size_t& pos, const char* fieldName, auto& value) -> bool
     {
         // We need this because the auto& parameter acts like a generic and we would like to strip out the & here
         using T = std::decay_t<decltype(value)>;
         if (pos < sizeof(T))
         {
-            fprintf(stderr, "Decode failed: Incomplete %s field\n", fieldName);
+            reporter.formatError("Decode failed: Incomplete %s field", fieldName);
             return false;
         }
         pos -= sizeof(T);
@@ -174,11 +179,11 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
     };
 
     // Helper to read variable-length bytes backwards
-    auto readBytes = [&binary](size_t& pos, size_t length, const char* fieldName) -> std::optional<std::string>
+    auto readBytes = [&binary, &reporter](size_t& pos, size_t length, const char* fieldName) -> std::optional<std::string>
     {
         if (pos < length)
         {
-            fprintf(stderr, "Decode failed: Incomplete %s field\n", fieldName);
+            reporter.formatError("Decode failed: Incomplete %s field", fieldName);
             return std::nullopt;
         }
         pos -= length;
@@ -218,7 +223,7 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
     // Read compressed data
     if (pos < compressedSize)
     {
-        fprintf(stderr, "Decode failed: Incomplete compressed data (expected %llu bytes)\n", static_cast<unsigned long long>(compressedSize));
+        reporter.formatError("Decode failed: Incomplete compressed data (expected %llu bytes)", static_cast<unsigned long long>(compressedSize));
         return std::nullopt;
     }
     pos -= compressedSize;
@@ -231,7 +236,7 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
 
     if (zlibResult != Z_OK)
     {
-        fprintf(stderr, "Decode failed: Decompression error (zlib error %d)\n", zlibResult);
+        reporter.formatError("Decode failed: Decompression error (zlib error %d)", zlibResult);
         return std::nullopt;
     }
 
@@ -239,14 +244,14 @@ std::optional<LuteDecodeResult> LuteExePayload::decode(const std::string_view bi
     std::string_view decompressedBundle(reinterpret_cast<const char*>(uncompressedData.data()), actualUncompressedSize);
     if (!result.payload.parseFromDecompressedBundle(decompressedBundle))
     {
-        fprintf(stderr, "Decode failed: Failed to parse decompressed bundle\n");
+        reporter.reportError("Decode failed: Failed to parse decompressed bundle");
         return std::nullopt;
     }
 
     // Validate that the number of parsed files matches the metadata
     if (result.payload.filePathToBytecode.size() != numFiles)
     {
-        fprintf(stderr, "Decode failed: Expected %u files but parsed %zu\n", numFiles, result.payload.filePathToBytecode.size());
+        reporter.formatError("Decode failed: Expected %u files but parsed %zu", numFiles, result.payload.filePathToBytecode.size());
         return std::nullopt;
     }
 
@@ -267,7 +272,7 @@ bool LuteExePayload::parseFromDecompressedBundle(std::string_view decompressedBu
         // Read path length
         if (offset + sizeof(uint32_t) > decompressedBundle.size())
         {
-            fprintf(stderr, "Invalid bundle: incomplete path length field\n");
+            reporter.reportError("Invalid bundle: incomplete path length field");
             return false;
         }
 
@@ -278,7 +283,7 @@ bool LuteExePayload::parseFromDecompressedBundle(std::string_view decompressedBu
         // Read path string
         if (offset + pathLength > decompressedBundle.size())
         {
-            fprintf(stderr, "Invalid bundle: incomplete path string\n");
+            reporter.reportError("Invalid bundle: incomplete path string");
             return false;
         }
 
@@ -288,7 +293,7 @@ bool LuteExePayload::parseFromDecompressedBundle(std::string_view decompressedBu
         // Read bytecode size
         if (offset + sizeof(uint64_t) > decompressedBundle.size())
         {
-            fprintf(stderr, "Invalid bundle: incomplete bytecode size field\n");
+            reporter.reportError("Invalid bundle: incomplete bytecode size field");
             return false;
         }
 
@@ -299,7 +304,7 @@ bool LuteExePayload::parseFromDecompressedBundle(std::string_view decompressedBu
         // Read bytecode
         if (offset + bytecodeSize > decompressedBundle.size())
         {
-            fprintf(stderr, "Invalid bundle: incomplete bytecode data\n");
+            reporter.reportError("Invalid bundle: incomplete bytecode data");
             return false;
         }
 
@@ -313,8 +318,14 @@ bool LuteExePayload::parseFromDecompressedBundle(std::string_view decompressedBu
     return true;
 }
 
-LuteExecutable::LuteExecutable(const std::string& luteRuntimePath)
+LuteDecodeResult::LuteDecodeResult(LuteReporter& reporter)
+    : payload(reporter)
+{
+}
+
+LuteExecutable::LuteExecutable(const std::string& luteRuntimePath, LuteReporter& reporter)
     : executablePath(luteRuntimePath)
+    , reporter(reporter)
 {
 }
 
@@ -324,7 +335,7 @@ bool LuteExecutable::create(const std::string& outputPath, LuteExePayload& paylo
     std::ifstream sourceExe(executablePath, std::ios::binary | std::ios::ate);
     if (!sourceExe)
     {
-        fprintf(stderr, "Error: Failed to read executable '%s'\n", executablePath.c_str());
+        reporter.formatError("Error: Failed to read executable '%s'", executablePath.c_str());
         return false;
     }
 
@@ -342,7 +353,7 @@ bool LuteExecutable::create(const std::string& outputPath, LuteExePayload& paylo
 
     if (!encodeResult)
     {
-        fprintf(stderr, "Error: Failed to encode payload\n");
+        reporter.reportError("Error: Failed to encode payload");
         return false;
     }
 
@@ -350,7 +361,7 @@ bool LuteExecutable::create(const std::string& outputPath, LuteExePayload& paylo
     std::ofstream outputFile(outputPath, std::ios::binary);
     if (!outputFile)
     {
-        fprintf(stderr, "Error: Failed to create output file '%s'\n", outputPath.c_str());
+        reporter.formatError("Error: Failed to create output file '%s'", outputPath.c_str());
         return false;
     }
 
@@ -402,7 +413,7 @@ std::optional<LuteExePayload> LuteExecutable::extract()
         return std::nullopt;
 
     // Decode the payload
-    std::optional<LuteDecodeResult> decodedPayload = LuteExePayload::decode(std::string_view(fileData.data(), fileData.size()));
+    std::optional<LuteDecodeResult> decodedPayload = LuteExePayload::decode(std::string_view(fileData.data(), fileData.size()), reporter);
     if (!decodedPayload)
         return std::nullopt;
 

--- a/lute/cli/src/main.cpp
+++ b/lute/cli/src/main.cpp
@@ -1,8 +1,10 @@
 #include "lute/climain.h"
 #include "lute/uvstate.h"
+#include "lute/clireporter.h"
 
 int main(int argc, char** argv)
 {
     UvGlobalState uvState(argc, argv);
-    return cliMain(argc, argv);
+    CLIReporter reporter;
+    return cliMain(argc, argv, reporter);
 }

--- a/lute/cli/src/staticrequires.cpp
+++ b/lute/cli/src/staticrequires.cpp
@@ -31,6 +31,11 @@ public:
     }
 };
 
+StaticRequireTracer::StaticRequireTracer(LuteReporter& reporter)
+    : reporter(reporter)
+{
+}
+
 std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirectory, const std::string& entryPoint)
 {
     visited.clear();
@@ -58,7 +63,7 @@ std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirec
         std::optional<std::string> source = readFile(fullPath);
         if (!source)
         {
-            fprintf(stderr, "Warning: Could not read file '%s'\n", fullPath.c_str());
+            reporter.formatError("Warning: Could not read file '%s'\n", fullPath.c_str());
             continue;
         }
 
@@ -83,7 +88,7 @@ std::vector<std::string> StaticRequireTracer::trace(const std::string& rootDirec
                 bool isBuiltinLibrary = req.rfind("@std/", 0) == 0 || req.rfind("@lute/", 0) == 0;
                 if (!isBuiltinLibrary)
                 {
-                    fprintf(stderr, "Warning: Could not resolve require('%s') from '%s'\n", req.c_str(), filePath.c_str());
+                    reporter.formatError("Warning: Could not resolve require('%s') from '%s'\n", req.c_str(), filePath.c_str());
                 }
             }
         }

--- a/lute/cli/src/tc.cpp
+++ b/lute/cli/src/tc.cpp
@@ -122,59 +122,60 @@ struct LuteConfigResolver : Luau::ConfigResolver
     }
 };
 
-static void report(const char* name, const Luau::Location& loc, const char* type, const char* message)
+static void report(const char* name, const Luau::Location& loc, const char* type, const char* message, LuteReporter& reporter)
 {
     // fprintf(stderr, "%s(%d,%d): %s: %s\n", name, loc.begin.line + 1, loc.begin.column + 1, type, message);
     int columnEnd = (loc.begin.line == loc.end.line) ? loc.end.column : 100;
 
     // Use stdout to match luacheck behavior
-    fprintf(stdout, "%s:%d:%d-%d: (W0) %s: %s\n", name, loc.begin.line + 1, loc.begin.column + 1, columnEnd, type, message);
+    reporter.formatOutput("%s:%d:%d-%d: (W0) %s: %s\n", name, loc.begin.line + 1, loc.begin.column + 1, columnEnd, type, message);
 }
 
-static void reportError(const Luau::Frontend& frontend, const Luau::TypeError& error)
+static void reportError(const Luau::Frontend& frontend, const Luau::TypeError& error, LuteReporter& reporter)
 {
     std::string humanReadableName = frontend.fileResolver->getHumanReadableModuleName(error.moduleName);
 
     if (const Luau::SyntaxError* syntaxError = Luau::get_if<Luau::SyntaxError>(&error.data))
-        report(humanReadableName.c_str(), error.location, "SyntaxError", syntaxError->message.c_str());
+        report(humanReadableName.c_str(), error.location, "SyntaxError", syntaxError->message.c_str(), reporter);
     else
         report(
             humanReadableName.c_str(),
             error.location,
             "TypeError",
-            Luau::toString(error, Luau::TypeErrorToStringOptions{frontend.fileResolver}).c_str()
+            Luau::toString(error, Luau::TypeErrorToStringOptions{frontend.fileResolver}).c_str(),
+            reporter
         );
 }
 
-static void reportWarning(const char* name, const Luau::LintWarning& warning)
+static void reportWarning(const char* name, const Luau::LintWarning& warning, LuteReporter& reporter)
 {
-    report(name, warning.location, Luau::LintWarning::getName(warning.code), warning.text.c_str());
+    report(name, warning.location, Luau::LintWarning::getName(warning.code), warning.text.c_str(), reporter);
 }
 
-static bool reportModuleResult(Luau::Frontend& frontend, const Luau::ModuleName& name, bool annotate)
+static bool reportModuleResult(Luau::Frontend& frontend, const Luau::ModuleName& name, bool annotate, LuteReporter& reporter)
 {
     std::optional<Luau::CheckResult> cr = frontend.getCheckResult(name, false);
 
     if (!cr)
     {
-        fprintf(stderr, "Failed to find result for %s\n", name.c_str());
+        reporter.formatError("Failed to find result for %s\n", name.c_str());
         return false;
     }
 
     if (!frontend.getSourceModule(name))
     {
-        fprintf(stderr, "Error opening %s\n", name.c_str());
+        reporter.formatError("Error opening %s\n", name.c_str());
         return false;
     }
 
     for (auto& error : cr->errors)
-        reportError(frontend, error);
+        reportError(frontend, error, reporter);
 
     std::string humanReadableName = frontend.fileResolver->getHumanReadableModuleName(name);
     for (auto& error : cr->lintResult.errors)
-        reportWarning(humanReadableName.c_str(), error);
+        reportWarning(humanReadableName.c_str(), error, reporter);
     for (auto& warning : cr->lintResult.warnings)
-        reportWarning(humanReadableName.c_str(), warning);
+        reportWarning(humanReadableName.c_str(), warning, reporter);
 
     return cr->errors.empty() && cr->lintResult.errors.empty();
 }
@@ -220,13 +221,13 @@ std::vector<std::string> processSourceFiles(const std::vector<std::string>& sour
     return files;
 }
 
-int typecheck(const std::vector<std::string>& sourceFilesInput)
+int typecheck(const std::vector<std::string>& sourceFilesInput, LuteReporter& reporter)
 {
     std::vector<std::string> sourceFiles = processSourceFiles(sourceFilesInput);
 
     if (sourceFiles.empty())
     {
-        fprintf(stderr, "Error: lute check expects a file to type check.\n\n");
+        reporter.reportError("Error: lute check expects a file to type check.\n\n");
         return 1;
     }
 
@@ -268,7 +269,8 @@ int typecheck(const std::vector<std::string>& sourceFilesInput)
             humanReadableName.c_str(),
             location,
             "InternalCompilerError",
-            Luau::toString(error, Luau::TypeErrorToStringOptions{frontend.fileResolver}).c_str()
+            Luau::toString(error, Luau::TypeErrorToStringOptions{frontend.fileResolver}).c_str(),
+            reporter
         );
         return 1;
     }
@@ -276,14 +278,14 @@ int typecheck(const std::vector<std::string>& sourceFilesInput)
     int failed = 0;
 
     for (const Luau::ModuleName& name : checkedModules)
-        failed += !reportModuleResult(frontend, name, annotate);
+        failed += !reportModuleResult(frontend, name, annotate, reporter);
 
     if (!configResolver.configErrors.empty())
     {
         failed += int(configResolver.configErrors.size());
 
         for (const auto& pair : configResolver.configErrors)
-            fprintf(stderr, "%s: %s\n", pair.first.c_str(), pair.second.c_str());
+            reporter.formatError("%s: %s\n", pair.first.c_str(), pair.second.c_str());
     }
 
     return failed ? 1 : 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,11 +6,17 @@ target_sources(Lute.Test PRIVATE
     src/cliruntimefixture.h
     src/cliruntimefixture.cpp
 
+    src/lutefixture.h
+    src/lutefixture.cpp
+
     src/luteprojectroot.h
     src/luteprojectroot.cpp
 
     src/compile.test.cpp
     src/configresolver.test.cpp
+    src/testreporter.h
+    src/testreporter.cpp
+
     src/modulepath.test.cpp
     src/moduleresolver.test.cpp
     src/require.test.cpp

--- a/tests/src/cliruntimefixture.cpp
+++ b/tests/src/cliruntimefixture.cpp
@@ -5,12 +5,16 @@
 #include "lua.h"
 #include "lualib.h"
 
-static int capture(lua_State* L)
+#include "Luau/Compiler.h"
+
+#include "Luau/Compiler.h"
+
+static int report(lua_State* L)
 {
     const char* str = luaL_tolstring(L, 1, nullptr);
-    lua_pushstring(L, "capturedoutput");
-    lua_pushstring(L, str ? str : "");
-    lua_settable(L, LUA_REGISTRYINDEX);
+    lua_getfield(L, LUA_REGISTRYINDEX, "reporter");
+    TestReporter* reporter = static_cast<TestReporter*>(lua_touserdata(L, -1));
+    reporter->reportOutput(str);
     return 0;
 }
 
@@ -19,27 +23,18 @@ CliRuntimeFixture::CliRuntimeFixture()
 {
     L = setupCliState(
         *runtime,
-        [](lua_State* L)
+        [rep = reporter.get()](lua_State* L)
         {
-            lua_pushstring(L, "capturedoutput");
-            lua_pushstring(L, "");
-            lua_settable(L, LUA_REGISTRYINDEX);
-            lua_pushcfunction(L, capture, "capture");
-            lua_setglobal(L, "capture");
+            lua_pushlightuserdata(L, (void*)rep);
+            lua_setfield(L, LUA_REGISTRYINDEX, "reporter");
+            lua_pushcfunction(L, report, "");
+            lua_setglobal(L, "report");
         }
     );
-}
-
-std::string CliRuntimeFixture::getCapturedOutput()
-{
-    lua_getfield(L, LUA_REGISTRYINDEX, "capturedoutput");
-    const char* output = lua_tostring(L, -1);
-    lua_pop(L, 1);
-    return output ? output : "";
 }
 
 bool CliRuntimeFixture::runCode(const std::string& source)
 {
     std::string bytecode = Luau::compile(source, Luau::CompileOptions());
-    return runBytecode(*runtime, bytecode, "=stdin", L, 0, nullptr);
+    return runBytecode(*runtime, bytecode, "=stdin", L, 0, nullptr, getReporter());
 }

--- a/tests/src/cliruntimefixture.h
+++ b/tests/src/cliruntimefixture.h
@@ -2,19 +2,17 @@
 #include "lute/climain.h"
 #include "lute/runtime.h"
 
+#include "lutefixture.h"
+
 #include "lua.h"
 
 #include <memory>
 #include <string>
 
-#include "doctest.h"
-
-class CliRuntimeFixture
+class CliRuntimeFixture : public LuteFixture
 {
 public:
     CliRuntimeFixture();
-
-    std::string getCapturedOutput();
 
     bool runCode(const std::string& source);
 

--- a/tests/src/compile.test.cpp
+++ b/tests/src/compile.test.cpp
@@ -1,24 +1,25 @@
-#include "lute/compile.h"
-
 #include "lute/climain.h"
+#include "lute/compile.h"
 
 #include "Luau/FileUtils.h"
 
 #include <cstring>
 #include <fstream>
+#include <memory>
 #include <string>
 #include <vector>
 
 #include "doctest.h"
+#include "lutefixture.h"
 #include "luteprojectroot.h"
 
-TEST_CASE("lutepayload_single_file_roundtrip")
+TEST_CASE_FIXTURE(LuteFixture, "lutepayload_single_file_roundtrip")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
 
     // Create payload and add file
-    LuteExePayload originalPayload;
+    LuteExePayload originalPayload{getReporter()};
     originalPayload.add(testFilePath);
 
     // Encode
@@ -33,7 +34,7 @@ TEST_CASE("lutepayload_single_file_roundtrip")
     CHECK(encodeResult->compressedPayloadSizeBytes <= encodeResult->uncompressedPayloadSizeBytes);
 
     // Decode
-    auto decodeResult = LuteExePayload::decode(encodeResult->payload);
+    auto decodeResult = LuteExePayload::decode(encodeResult->payload, getReporter());
     REQUIRE(decodeResult.has_value());
 
     // Verify metrics match
@@ -56,7 +57,7 @@ TEST_CASE("lutepayload_single_file_roundtrip")
     CHECK(*it == *originalIt);
 }
 
-TEST_CASE("lutepayload_multiple_files_roundtrip")
+TEST_CASE_FIXTURE(LuteFixture, "lutepayload_multiple_files_roundtrip")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
 
@@ -67,7 +68,7 @@ TEST_CASE("lutepayload_multiple_files_roundtrip")
     };
 
     // Create payload with multiple files
-    LuteExePayload originalPayload;
+    LuteExePayload originalPayload{getReporter()};
     for (const auto& file : testFiles)
     {
         originalPayload.add(file);
@@ -80,7 +81,7 @@ TEST_CASE("lutepayload_multiple_files_roundtrip")
     REQUIRE(encodeResult.has_value());
     REQUIRE(!encodeResult->payload.empty());
 
-    auto decodeResult = LuteExePayload::decode(encodeResult->payload);
+    auto decodeResult = LuteExePayload::decode(encodeResult->payload, getReporter());
     REQUIRE(decodeResult.has_value());
 
     // Verify entry point
@@ -102,32 +103,32 @@ TEST_CASE("lutepayload_multiple_files_roundtrip")
     }
 }
 
-TEST_CASE("lutepayload_invalid_magic_flag")
+TEST_CASE_FIXTURE(LuteFixture, "lutepayload_invalid_magic_flag")
 {
     // Create a payload with invalid magic flag
     std::string invalidPayload = "INVALID_";
     invalidPayload.append(100, 'X'); // Add some data
 
-    auto decodeResult = LuteExePayload::decode(invalidPayload);
+    auto decodeResult = LuteExePayload::decode(invalidPayload, getReporter());
     CHECK(!decodeResult.has_value());
 }
 
-TEST_CASE("lutepayload_too_small_payload")
+TEST_CASE_FIXTURE(LuteFixture, "lutepayload_too_small_payload")
 {
     // Payload smaller than minimum size
     std::string tinyPayload = "TINY";
 
-    auto decodeResult = LuteExePayload::decode(tinyPayload);
+    auto decodeResult = LuteExePayload::decode(tinyPayload, getReporter());
     CHECK(!decodeResult.has_value());
 }
 
-TEST_CASE("lutepayload_corrupted_metadata")
+TEST_CASE_FIXTURE(LuteFixture, "lutepayload_corrupted_metadata")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
 
     // Create valid payload
-    LuteExePayload originalPayload;
+    LuteExePayload originalPayload{getReporter()};
     originalPayload.add(testFilePath);
     auto encodeResult = originalPayload.encode();
     REQUIRE(encodeResult.has_value());
@@ -142,7 +143,7 @@ TEST_CASE("lutepayload_corrupted_metadata")
     }
 
     // Attempt to decode corrupted payload
-    auto decodeResult = LuteExePayload::decode(corruptedPayload);
+    auto decodeResult = LuteExePayload::decode(corruptedPayload, getReporter());
     // Should either fail or produce different results
     if (decodeResult.has_value())
     {
@@ -151,7 +152,7 @@ TEST_CASE("lutepayload_corrupted_metadata")
     }
 }
 
-TEST_CASE("lutepayload_entry_point_is_first_added")
+TEST_CASE_FIXTURE(LuteFixture, "lutepayload_entry_point_is_first_added")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
@@ -159,7 +160,7 @@ TEST_CASE("lutepayload_entry_point_is_first_added")
     std::string firstFile = joinPaths(testDir, "main.luau");
     std::string secondFile = joinPaths(testDir, "utils.luau");
 
-    LuteExePayload payload;
+    LuteExePayload payload{getReporter()};
     payload.add(firstFile);
     payload.add(secondFile);
 
@@ -167,12 +168,12 @@ TEST_CASE("lutepayload_entry_point_is_first_added")
     CHECK(payload.entryPointPath == firstFile);
 }
 
-TEST_CASE("lutepayload_nonexistent_file")
+TEST_CASE_FIXTURE(LuteFixture, "lutepayload_nonexistent_file")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string nonExistentFile = joinPaths(luteProjectRoot, "tests/src/this_file_does_not_exist.luau");
 
-    LuteExePayload payload;
+    LuteExePayload payload{getReporter()};
     payload.add(nonExistentFile);
 
     // Encoding should fail because file doesn't exist
@@ -180,10 +181,10 @@ TEST_CASE("lutepayload_nonexistent_file")
     CHECK(!encodeResult.has_value());
 }
 
-TEST_CASE("lutepayload_empty_payload")
+TEST_CASE_FIXTURE(LuteFixture, "lutepayload_empty_payload")
 {
     // Create payload without adding any files
-    LuteExePayload emptyPayload;
+    LuteExePayload emptyPayload{getReporter()};
     CHECK(emptyPayload.entryPointPath.empty());
 
     // Encoding an empty payload should fail
@@ -191,12 +192,12 @@ TEST_CASE("lutepayload_empty_payload")
     CHECK(!encodeResult.has_value());
 }
 
-TEST_CASE("lutepayload_compression_effectiveness")
+TEST_CASE_FIXTURE(LuteFixture, "lutepayload_compression_effectiveness")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
 
-    LuteExePayload payload;
+    LuteExePayload payload{getReporter()};
     payload.add(testFilePath);
 
     auto encodeResult = payload.encode();
@@ -211,18 +212,18 @@ TEST_CASE("lutepayload_compression_effectiveness")
     CHECK(encodeResult->bytesWritten >= encodeResult->compressedPayloadSizeBytes);
 }
 
-TEST_CASE("lutepayload_bytecode_integrity")
+TEST_CASE_FIXTURE(LuteFixture, "lutepayload_bytecode_integrity")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
 
     // Create two separate payloads with the same file
-    LuteExePayload payload1;
+    LuteExePayload payload1{getReporter()};
     payload1.add(testFilePath);
     auto encode1 = payload1.encode();
     REQUIRE(encode1.has_value());
 
-    LuteExePayload payload2;
+    LuteExePayload payload2{getReporter()};
     payload2.add(testFilePath);
     auto encode2 = payload2.encode();
     REQUIRE(encode2.has_value());
@@ -238,13 +239,13 @@ TEST_CASE("lutepayload_bytecode_integrity")
     CHECK(encode1->payload == encode2->payload);
 }
 
-TEST_CASE("lutepayload_validates_numfiles_metadata")
+TEST_CASE_FIXTURE(LuteFixture, "lutepayload_validates_numfiles_metadata")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
 
     // Create and encode a valid payload
-    LuteExePayload payload;
+    LuteExePayload payload{getReporter()};
     payload.add(testFilePath);
     auto encodeResult = payload.encode();
     REQUIRE(encodeResult.has_value());
@@ -269,11 +270,11 @@ TEST_CASE("lutepayload_validates_numfiles_metadata")
     memcpy(corruptedPayload.data() + numFilesPos, &fakeNumFiles, sizeof(uint32_t));
 
     // Decoding should fail due to numFiles mismatch
-    auto decodeResult = LuteExePayload::decode(corruptedPayload);
+    auto decodeResult = LuteExePayload::decode(corruptedPayload, getReporter());
     CHECK(!decodeResult.has_value());
 }
 
-TEST_CASE("luteexecutable_single_file_roundtrip")
+TEST_CASE_FIXTURE(LuteFixture, "luteexecutable_single_file_roundtrip")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
@@ -290,12 +291,12 @@ TEST_CASE("luteexecutable_single_file_roundtrip")
     }
 
     // Create payload with a test file
-    LuteExePayload originalPayload;
+    LuteExePayload originalPayload{getReporter()};
     originalPayload.add(testFilePath);
 
     // Create LuteExecutable and write it out
     std::string outputExePath = joinPaths(luteProjectRoot, "tests/temp_output_exe");
-    LuteExecutable executable(dummyExePath);
+    LuteExecutable executable{dummyExePath, getReporter()};
 
     bool createSuccess = executable.create(outputExePath, originalPayload);
     REQUIRE(createSuccess);
@@ -306,7 +307,7 @@ TEST_CASE("luteexecutable_single_file_roundtrip")
     checkFile.close();
 
     // Extract the payload from the created executable
-    LuteExecutable readExecutable(outputExePath);
+    LuteExecutable readExecutable{outputExePath, getReporter()};
     auto extractedPayload = readExecutable.extract();
     REQUIRE(extractedPayload.has_value());
 
@@ -328,7 +329,7 @@ TEST_CASE("luteexecutable_single_file_roundtrip")
     std::remove(outputExePath.c_str());
 }
 
-TEST_CASE("luteexecutable_multiple_files_roundtrip")
+TEST_CASE_FIXTURE(LuteFixture, "luteexecutable_multiple_files_roundtrip")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
@@ -348,7 +349,7 @@ TEST_CASE("luteexecutable_multiple_files_roundtrip")
     }
 
     // Create payload with multiple files
-    LuteExePayload originalPayload;
+    LuteExePayload originalPayload{getReporter()};
     for (const auto& file : testFiles)
     {
         originalPayload.add(file);
@@ -359,13 +360,13 @@ TEST_CASE("luteexecutable_multiple_files_roundtrip")
 
     // Create the executable
     std::string outputExePath = joinPaths(luteProjectRoot, "tests/temp_output_exe_multi");
-    LuteExecutable executable(dummyExePath);
+    LuteExecutable executable{dummyExePath, getReporter()};
 
     bool createSuccess = executable.create(outputExePath, originalPayload);
     REQUIRE(createSuccess);
 
     // Extract the payload
-    LuteExecutable readExecutable(outputExePath);
+    LuteExecutable readExecutable{outputExePath, getReporter()};
     auto extractedPayload = readExecutable.extract();
     REQUIRE(extractedPayload.has_value());
 
@@ -392,7 +393,7 @@ TEST_CASE("luteexecutable_multiple_files_roundtrip")
     std::remove(outputExePath.c_str());
 }
 
-TEST_CASE("luteexecutable_extract_from_plain_executable")
+TEST_CASE_FIXTURE(LuteFixture, "luteexecutable_extract_from_plain_executable")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
 
@@ -407,7 +408,7 @@ TEST_CASE("luteexecutable_extract_from_plain_executable")
     }
 
     // Attempt to extract - should return nullopt since there's no payload
-    LuteExecutable executable(plainExePath);
+    LuteExecutable executable{plainExePath, getReporter()};
     auto extractedPayload = executable.extract();
     CHECK(!extractedPayload.has_value());
 
@@ -415,7 +416,7 @@ TEST_CASE("luteexecutable_extract_from_plain_executable")
     std::remove(plainExePath.c_str());
 }
 
-TEST_CASE("luteexecutable_extract_preserves_original_executable")
+TEST_CASE_FIXTURE(LuteFixture, "luteexecutable_extract_preserves_original_executable")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/main.luau");
@@ -431,11 +432,11 @@ TEST_CASE("luteexecutable_extract_preserves_original_executable")
     }
 
     // Create payload and executable
-    LuteExePayload payload;
+    LuteExePayload payload{getReporter()};
     payload.add(testFilePath);
 
     std::string outputExePath = joinPaths(luteProjectRoot, "tests/temp_output_exe_preserve");
-    LuteExecutable executable(dummyExePath);
+    LuteExecutable executable{dummyExePath, getReporter()};
     bool createSuccess = executable.create(outputExePath, payload);
     REQUIRE(createSuccess);
 
@@ -455,7 +456,7 @@ TEST_CASE("luteexecutable_extract_preserves_original_executable")
     std::remove(outputExePath.c_str());
 }
 
-TEST_CASE("compile_command_e2e")
+TEST_CASE_FIXTURE(LuteFixture, "compile_command_e2e")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
 
@@ -476,7 +477,7 @@ TEST_CASE("compile_command_e2e")
     std::vector<char*> argv = {executablePlaceholder, compileCommand, testFilePath.data(), outputFlag, outputExePath.data()};
 
     // Run the compile command
-    int compileResult = cliMain(argv.size(), argv.data());
+    int compileResult = cliMain(argv.size(), argv.data(), getReporter());
     REQUIRE(compileResult == 0);
 
     // Verify the output file was created
@@ -486,7 +487,7 @@ TEST_CASE("compile_command_e2e")
 
     // Now run the compiled executable to verify it works
     std::vector<char*> runArgv = {outputExePath.data()};
-    int runResult = cliMain(runArgv.size(), runArgv.data());
+    int runResult = cliMain(runArgv.size(), runArgv.data(), getReporter());
     CHECK(runResult == 0);
 
     // Clean up

--- a/tests/src/lutefixture.cpp
+++ b/tests/src/lutefixture.cpp
@@ -1,0 +1,11 @@
+#include "lutefixture.h"
+
+LuteFixture::LuteFixture()
+    : reporter(std::make_unique<TestReporter>())
+{
+}
+
+TestReporter& LuteFixture::getReporter()
+{
+    return *reporter;
+}

--- a/tests/src/lutefixture.h
+++ b/tests/src/lutefixture.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "testreporter.h"
+
+#include <memory>
+
+// Base fixture class for all Lute tests that need a reporter
+class LuteFixture
+{
+public:
+    LuteFixture();
+    virtual ~LuteFixture() = default;
+
+    TestReporter& getReporter();
+
+    std::unique_ptr<TestReporter> reporter;
+};

--- a/tests/src/require.test.cpp
+++ b/tests/src/require.test.cpp
@@ -6,7 +6,9 @@
 
 #include "cliruntimefixture.h"
 #include "doctest.h"
+#include "lutefixture.h"
 #include "luteprojectroot.h"
+
 
 TEST_CASE_FIXTURE(CliRuntimeFixture, "require_exists")
 {
@@ -14,9 +16,9 @@ TEST_CASE_FIXTURE(CliRuntimeFixture, "require_exists")
     CHECK(!lua_isnil(L, -1));
 }
 
-TEST_CASE("require_modules")
+TEST_CASE_FIXTURE(LuteFixture, "require_modules")
 {
-    auto doPassingSubcase = [](std::vector<char*> argv, std::string requirePath, std::vector<std::string> expectedResults)
+    auto doPassingSubcase = [&](std::vector<char*> argv, std::string requirePath, std::vector<std::string> expectedResults)
     {
         std::string pass = "pass";
         argv.push_back(pass.data());
@@ -25,10 +27,10 @@ TEST_CASE("require_modules")
         {
             argv.push_back(result.data());
         }
-        CHECK_EQ(cliMain(argv.size(), argv.data()), 0);
+        CHECK_EQ(cliMain(argv.size(), argv.data(), getReporter()), 0);
     };
 
-    auto doFailingSubcase = [](std::vector<char*> argv, std::string requirePath, std::vector<std::string> expectedResults)
+    auto doFailingSubcase = [&](std::vector<char*> argv, std::string requirePath, std::vector<std::string> expectedResults)
     {
         std::string fail = "fail";
         argv.push_back(fail.data());
@@ -37,7 +39,7 @@ TEST_CASE("require_modules")
         {
             argv.push_back(result.data());
         }
-        CHECK_EQ(cliMain(argv.size(), argv.data()), 0);
+        CHECK_EQ(cliMain(argv.size(), argv.data(), getReporter()), 0);
     };
 
     char executablePlaceholder[] = "lute";
@@ -161,7 +163,7 @@ TEST_CASE("require_modules")
     }
 }
 
-TEST_CASE("require_with_parent_ambiguity")
+TEST_CASE_FIXTURE(LuteFixture, "require_with_parent_ambiguity")
 {
     // This test case cannot be included in the general "require_modules" test
     // because ambiguity prevents the test's requirer.luau from navigating to
@@ -174,7 +176,7 @@ TEST_CASE("require_with_parent_ambiguity")
     {
         std::string requirer = joinPaths(luteProjectRoot, "tests/src/require/config_tests/with_config/src/parent_ambiguity/folder/requirer.luau");
         std::vector<char*> argv = {executablePlaceholder, requirer.data()};
-        CHECK_EQ(cliMain(argv.size(), argv.data()), 0);
+        CHECK_EQ(cliMain(argv.size(), argv.data(), getReporter()), 0);
     }
 
     // .config.luau
@@ -183,11 +185,11 @@ TEST_CASE("require_with_parent_ambiguity")
         std::string requirer =
             joinPaths(luteProjectRoot, "tests/src/require/config_tests/with_config_luau/src/parent_ambiguity/folder/requirer.luau");
         std::vector<char*> argv = {executablePlaceholder, requirer.data()};
-        CHECK_EQ(cliMain(argv.size(), argv.data()), 0);
+        CHECK_EQ(cliMain(argv.size(), argv.data(), getReporter()), 0);
     }
 }
 
-TEST_CASE("require_types")
+TEST_CASE_FIXTURE(LuteFixture, "require_types")
 {
     char executablePlaceholder[] = "lute";
     for (const std::string& luteProjectRoot : {getLuteProjectRootRelative(), getLuteProjectRootAbsolute()})
@@ -195,11 +197,11 @@ TEST_CASE("require_types")
         std::string requirer = joinPaths(luteProjectRoot, "tests/src/require/without_config/types/tester.luau");
         std::vector<char*> argv = {executablePlaceholder, requirer.data()};
 
-        CHECK_EQ(cliMain(argv.size(), argv.data()), 0);
+        CHECK_EQ(cliMain(argv.size(), argv.data(), getReporter()), 0);
     }
 }
 
-TEST_CASE("require_by_string_semantics_in_cli")
+TEST_CASE_FIXTURE(LuteFixture, "require_by_string_semantics_in_cli")
 {
     char executablePlaceholder[] = "lute";
 
@@ -216,7 +218,7 @@ TEST_CASE("require_by_string_semantics_in_cli")
         for (std::string& inputPath : inputPaths)
         {
             std::vector<char*> argv = {executablePlaceholder, inputPath.data()};
-            CHECK_EQ(cliMain(argv.size(), argv.data()), 0);
+            CHECK_EQ(cliMain(argv.size(), argv.data(), getReporter()), 0);
         }
     }
 
@@ -225,6 +227,6 @@ TEST_CASE("require_by_string_semantics_in_cli")
     {
         std::string inputPath = joinPaths(luteProjectRoot, "tests/src/require/without_config/nested/init");
         std::vector<char*> argv = {executablePlaceholder, inputPath.data()};
-        CHECK_NE(cliMain(argv.size(), argv.data()), 0);
+        CHECK_NE(cliMain(argv.size(), argv.data(), getReporter()), 0);
     }
 }

--- a/tests/src/staticrequires.test.cpp
+++ b/tests/src/staticrequires.test.cpp
@@ -7,14 +7,15 @@
 #include <vector>
 
 #include "doctest.h"
+#include "lutefixture.h"
 #include "luteprojectroot.h"
 
-TEST_CASE("staticrequiretracer_simple_dependencies")
+TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_simple_dependencies")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
 
-    StaticRequireTracer tracer;
+    StaticRequireTracer tracer{getReporter()};
     std::vector<std::string> deps = tracer.trace(testDir, "main.luau");
 
     // Should find: main.luau, utils.luau, lib/helper.luau, shared.luau
@@ -33,12 +34,12 @@ TEST_CASE("staticrequiretracer_simple_dependencies")
     }
 }
 
-TEST_CASE("staticrequiretracer_circular_dependencies")
+TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_circular_dependencies")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
 
-    StaticRequireTracer tracer;
+    StaticRequireTracer tracer{getReporter()};
     std::vector<std::string> deps = tracer.trace(testDir, "circular_a.luau");
 
     // Should find both circular_a and circular_b without infinite loop
@@ -55,12 +56,12 @@ TEST_CASE("staticrequiretracer_circular_dependencies")
     CHECK(hasB);
 }
 
-TEST_CASE("staticrequiretracer_no_dependencies")
+TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_no_dependencies")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
 
-    StaticRequireTracer tracer;
+    StaticRequireTracer tracer{getReporter()};
     std::vector<std::string> deps = tracer.trace(testDir, "utils.luau");
 
     // utils.luau has no requires, should only return itself
@@ -68,12 +69,12 @@ TEST_CASE("staticrequiretracer_no_dependencies")
     CHECK(deps[0] == "utils.luau");
 }
 
-TEST_CASE("staticrequiretracer_relative_paths")
+TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_relative_paths")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
 
-    StaticRequireTracer tracer;
+    StaticRequireTracer tracer{getReporter()};
     std::vector<std::string> deps = tracer.trace(testDir, "lib/helper.luau");
 
     // helper.luau requires ../shared, should resolve correctly
@@ -85,12 +86,12 @@ TEST_CASE("staticrequiretracer_relative_paths")
     CHECK(hasShared);
 }
 
-TEST_CASE("staticrequiretracer_require_graph")
+TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_require_graph")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
 
-    StaticRequireTracer tracer;
+    StaticRequireTracer tracer{getReporter()};
     std::vector<std::string> deps = tracer.trace(testDir, "main.luau");
 
     const auto& graph = tracer.getRequireGraph();

--- a/tests/src/stdsystem.test.cpp
+++ b/tests/src/stdsystem.test.cpp
@@ -1,3 +1,5 @@
+#include "Luau/StringUtils.h"
+
 #include <string>
 
 #include "cliruntimefixture.h"
@@ -20,24 +22,27 @@ TEST_CASE_FIXTURE(CliRuntimeFixture, "std_system_os_matches_host_os")
 {
     runCode(R"(
         local system = require("@std/system")
-        capture(system.os)
+        report(system.os)
     )");
-    CHECK(getCapturedOutput() == getHostOS());
+    CHECK(getReporter().getOutputs()[0] == getHostOS());
 }
 
 TEST_CASE_FIXTURE(CliRuntimeFixture, "check_std_system_env_bools")
 {
     std::string os = getHostOS();
 
-    auto checkBool = [&](const std::string& field, bool expected)
+    auto checkBool = [this](const std::string& field, bool expected)
     {
-        runCode(
-            "local system = require(\"@std/system\")\n"
-            "capture(system." +
-            field + ")\n"
+        std::string code = Luau::format(
+            R"(
+            local system = require("@std/system")
+            report(system.%s))",
+            field.c_str()
         );
-        std::string output = getCapturedOutput();
+        runCode(code);
+        std::string output = this->getReporter().getOutputs()[0];
         CHECK(output == (expected ? "true" : "false"));
+        this->getReporter().clear();
     };
 
     checkBool("win32", os == "Windows_NT");

--- a/tests/src/testreporter.cpp
+++ b/tests/src/testreporter.cpp
@@ -1,0 +1,27 @@
+#include "testreporter.h"
+
+void TestReporter::reportError(const std::string& message)
+{
+    errors.push_back(message);
+}
+
+void TestReporter::reportOutput(const std::string& message)
+{
+    outputs.push_back(message);
+}
+
+const std::vector<std::string>& TestReporter::getErrors() const
+{
+    return errors;
+}
+
+const std::vector<std::string>& TestReporter::getOutputs() const
+{
+    return outputs;
+}
+
+void TestReporter::clear()
+{
+    errors.clear();
+    outputs.clear();
+}

--- a/tests/src/testreporter.h
+++ b/tests/src/testreporter.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "lute/reporter.h"
+#include <string>
+#include <vector>
+
+// Test reporter that captures output in vectors for verification
+class TestReporter : public LuteReporter
+{
+public:
+    void reportError(const std::string& message) override;
+    void reportOutput(const std::string& message) override;
+
+    const std::vector<std::string>& getErrors() const;
+    const std::vector<std::string>& getOutputs() const;
+
+    void clear();
+
+private:
+    std::vector<std::string> errors;
+    std::vector<std::string> outputs;
+};


### PR DESCRIPTION
This PR adds a reporter to the Lute.CLI.Lib library. Right now, our tests just log directly to stderr / stdout and we don't have any control over this or ability to intercept and test these calls. I've introduced `LuteReporter` which has `TestReporter` and `CliReporter` as subclasses, which store reported strings / logs to stderr/stdout respectively. 

This lets us access the errors logged out in tests as well as suppresses random logging in our tests.

Fixes: https://github.com/luau-lang/lute/issues/511