### PR TITLE
docs: Add basic standard library docs to lute.luau.org

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,7 +9,7 @@ export default defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: 'Guide', link: '/guide/installation' },
-      { text: 'Reference', link: '/reference/fs' }
+      { text: 'Reference', link: '/reference/definitions/crypto' }
     ],
 
     sidebar: [
@@ -22,16 +22,86 @@ export default defineConfig({
       {
         text: "Reference",
         items: [
-          { text: 'crypto', link: '/reference/crypto' },
-          { text: 'fs', link: '/reference/fs' },
-          { text: 'io', link: '/reference/io' },
-          { text: 'luau', link: '/reference/luau' },
-          { text: 'net', link: '/reference/net' },
-          { text: 'process', link: '/reference/process' },
-          { text: 'system', link: '/reference/system' },
-          { text: 'task', link: '/reference/task' },
-          { text: 'time', link: '/reference/time' },
-          { text: 'vm', link: '/reference/vm' },
+          // Definitions
+          { text: 'crypto', link: '/reference/definitions/crypto' },
+          { text: 'fs', link: '/reference/definitions/fs' },
+          { text: 'io', link: '/reference/definitions/io' },
+          { text: 'luau', link: '/reference/definitions/luau' },
+          { text: 'net', link: '/reference/definitions/net' },
+          { text: 'process', link: '/reference/definitions/process' },
+          { text: 'system', link: '/reference/definitions/system' },
+          { text: 'task', link: '/reference/definitions/task' },
+          { text: 'time', link: '/reference/definitions/time' },
+          { text: 'vm', link: '/reference/definitions/vm' },
+
+          // Standard Library subfolder
+          {
+            text: "Standard Library",
+            items: [
+              { text: 'assert', link: '/reference/std/assert' },
+              { text: 'fs', link: '/reference/std/fs' },
+              { text: 'io', link: '/reference/std/io' },
+              { text: 'json', link: '/reference/std/json' },
+              { text: 'luau', link: '/reference/std/luau' },
+              { text: 'process', link: '/reference/std/process' },
+              { text: 'stringext', link: '/reference/std/stringext' },
+              { text: 'tableext', link: '/reference/std/tableext' },
+              { text: 'task', link: '/reference/std/task' },
+              { text: 'test', link: '/reference/std/test' },
+              { text: 'vectorext', link: '/reference/std/vectorext' },
+
+              // Path lib subfolder
+              {
+                text: "Path",
+                items: [
+                  { text: 'path', link: '/reference/std/path/path' },
+                  { text: 'types', link: '/reference/std/path/types' },
+                  // Posix lib subfolder
+                  {
+                    text: "Posix",
+                    items: [
+                      { text: 'posix', link: '/reference/std/path/posix/posix' },
+                      { text: 'types', link: '/reference/std/path/posix/types' },
+                    ]
+                  },
+                  // Win32 lib subfolder
+                  {
+                    text: "Win32",
+                    items: [
+                      { text: 'win32', link: '/reference/std/path/win32/win32' },
+                      { text: 'types', link: '/reference/std/path/win32/types' },
+                    ]
+                  },
+                ]
+              },
+              // Syntax lib subfolder
+              {
+                text: "Syntax",
+                items: [
+                  { text: 'parser', link: '/reference/std/syntax/parser' },
+                  { text: 'printer', link: '/reference/std/syntax/printer' },
+                  { text: 'query', link: '/reference/std/syntax/query' },
+                  { text: 'visitor', link: '/reference/std/syntax/visitor' },
+                ]
+              },
+              // System lib subfolder
+              {
+                text: "System",
+                items: [
+                  { text: 'system', link: '/reference/std/system/system' },
+                  { text: 'platform', link: '/reference/std/system/platform' },
+                ]
+              },
+              // Time lib subfolder
+              {
+                text: "Time",
+                items: [
+                  { text: 'time', link: '/reference/std/time/time' },
+                  { text: 'duration', link: '/reference/std/time/duration' },
+                ]
+              }
+            ]
+          }
         ]
       }
     ],

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ hero:
       link: /guide/installation
     - theme: alt
       text: Reference
-      link: /reference/fs
+      link: /reference/definitions/crypto
 
 # TODO: add buzz words
 # features:

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -1,10 +1,11 @@
-local fs = require("@lute/fs")
-local process = require("@lute/process")
+local fs = require("@std/fs")
+local process = require("@std/process")
+local system = require("@std/system")
 
 local function projectRelative(...)
 	local cwd = process.cwd()
-	local pathSep = if string.find(string.lower(require("@lute/system").os), "windows") then "\\" else "/"
-	return table.concat({ cwd, "..", ... }, pathSep)
+	local sep = string.find(string.lower(system.os), "windows") and "\\" or "/"
+	return table.concat({ tostring(cwd), ... }, sep)
 end
 
 local function extractPropertySignature(module: string, line: string): (string?, string?)
@@ -26,6 +27,8 @@ local function extractPropertySignature(module: string, line: string): (string?,
 	return nil, nil
 end
 
+-- docs for definitions/*.luau --
+
 local function parseDefinitionFile(module: string, filePath: string): { { name: string, signature: string } }
 	local content = fs.readfiletostring(filePath)
 	local lines = string.split(content, "\n")
@@ -45,7 +48,10 @@ local function parseDefinitionFile(module: string, filePath: string): { { name: 
 	return definitions
 end
 
-local function generateMarkdown(moduleName: string, definitions: { { name: string, signature: string } }): string
+local function generateDefinitionsMarkdown(
+	moduleName: string,
+	definitions: { { name: string, signature: string } }
+): string
 	local lines = {
 		"# " .. moduleName,
 		"",
@@ -60,7 +66,7 @@ local function generateMarkdown(moduleName: string, definitions: { { name: strin
 	end)
 
 	for _, def in definitions do
-		table.insert(lines, "## " .. def.name)
+		table.insert(lines, "## " .. moduleName .. "." .. def.name)
 		table.insert(lines, "```luau")
 		table.insert(lines, def.signature)
 		table.insert(lines, "```")
@@ -70,28 +76,134 @@ local function generateMarkdown(moduleName: string, definitions: { { name: strin
 	return table.concat(lines, "\n")
 end
 
-local definitionsPath = projectRelative("definitions")
-local referencePath = projectRelative("docs", "reference")
+local function processDefinitionsDir(definitionsPath: string, referencePath: string)
+	pcall(fs.createdirectory, referencePath)
 
-pcall(fs.mkdir, referencePath)
+	local definitionFiles = fs.listdir(definitionsPath)
 
-local definitionFiles = fs.listdir(definitionsPath)
+	for _, file in definitionFiles do
+		if file.type == "file" and string.find(file.name, "%.luau$") then
+			local moduleName = string.gsub(file.name, "%.luau$", "")
+			local definitionFilePath = definitionsPath .. "/" .. file.name
+			local referenceFilePath = referencePath .. "/" .. moduleName .. ".md"
 
-for _, file in definitionFiles do
-	if file.type == "file" and string.find(file.name, "%.luau$") then
-		local moduleName = string.gsub(file.name, "%.luau$", "")
-		local definitionFilePath = definitionsPath .. "/" .. file.name
-		local referenceFilePath = referencePath .. "/" .. moduleName .. ".md"
+			print("Processing " .. moduleName .. "...")
 
-		print("Processing " .. moduleName .. "...")
+			local definitions = parseDefinitionFile(moduleName, definitionFilePath)
+			local markdown = generateDefinitionsMarkdown(moduleName, definitions)
 
-		local definitions = parseDefinitionFile(moduleName, definitionFilePath)
-		local markdown = generateMarkdown(moduleName, definitions)
+			fs.writestringtofile(referenceFilePath, markdown)
 
-		fs.writestringtofile(referenceFilePath, markdown)
-
-		print("Generated " .. referenceFilePath)
+			print("Generated " .. referenceFilePath)
+		end
 	end
 end
+
+-- docs for lute/std/libs/*.luau --
+
+local STDLIB_MODULE_ALIASES = {
+	assert = "assertions",
+	fs = "fslib",
+	io = "iolib",
+	process = "processlib",
+	task = "tasklib",
+	path = "pathlib",
+	system = "systemlib",
+}
+
+local function parseStdlibFile(module: string, filePath: string): { { name: string, signature: string } }
+	local content = fs.readfiletostring(filePath)
+	local lines = string.split(content, "\n")
+	local stdlibDefinitions = {}
+
+	for _, line in lines do
+		local mod = STDLIB_MODULE_ALIASES[module] or module
+
+		local name, signature = extractPropertySignature(mod, line)
+
+		if name and signature then
+			table.insert(stdlibDefinitions, {
+				name = name,
+				signature = signature,
+			})
+		end
+	end
+
+	return stdlibDefinitions
+end
+
+local function generateStdLibMarkdown(
+	moduleName: string,
+	definitions: { { name: string, signature: string } },
+	stdlibFilePath: string
+): string
+	local referencePath = projectRelative("lute/std/libs/")
+	local relativePath = string.sub(stdlibFilePath, #referencePath + 1)
+	relativePath = string.gsub(relativePath, "%.luau$", "")
+	local modulePath = string.gsub(relativePath, "/init$", "")
+
+	local lines = {
+		"# " .. moduleName,
+		"",
+		"```luau",
+		"local " .. moduleName .. ' = require("@std/' .. modulePath .. '")',
+		"```",
+		"",
+	}
+
+	table.sort(definitions, function(a, b)
+		return a.name < b.name
+	end)
+
+	for _, def in definitions do
+		table.insert(lines, "## " .. moduleName .. "." .. def.name)
+		table.insert(lines, "```luau")
+		table.insert(lines, def.signature)
+		table.insert(lines, "```")
+		table.insert(lines, "")
+	end
+
+	return table.concat(lines, "\n")
+end
+
+local function processStdlibDir(sourceDir: string, referenceDir: string)
+	pcall(fs.createdirectory, referenceDir)
+
+	local entries = fs.listdir(sourceDir)
+
+	for _, entry in entries do
+		local sourcePath = sourceDir .. "/" .. entry.name
+		local referencePath = referenceDir .. "/" .. entry.name
+
+		if entry.type == "dir" then
+			pcall(fs.createdirectory, referencePath)
+			processStdlibDir(sourcePath, referencePath)
+		elseif entry.type == "file" and string.find(entry.name, "%.luau$") then
+			local moduleName = string.gsub(entry.name, "%.luau$", "")
+			if moduleName == "init" then
+				moduleName = string.match(sourceDir, "([^/\\]+)$") or moduleName
+			end
+
+			local referenceFilePath = referenceDir .. "/" .. moduleName .. ".md"
+
+			print("Processing " .. moduleName .. "...")
+
+			local stdlibDefinitions = parseStdlibFile(moduleName, sourcePath)
+			local markdown = generateStdLibMarkdown(moduleName, stdlibDefinitions, sourcePath)
+
+			fs.writestringtofile(referenceFilePath, markdown)
+
+			print("Generated " .. referenceFilePath)
+		end
+	end
+end
+
+local definitionsPath = projectRelative("definitions")
+local referencePath = projectRelative("docs", "reference", "definitions")
+processDefinitionsDir(definitionsPath, referencePath)
+
+local stdlibPath = projectRelative("lute/std/libs")
+local stdlibReferencePath = projectRelative("docs", "reference", "std")
+processStdlibDir(stdlibPath, stdlibReferencePath)
 
 print("Reference documentation generation complete!")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -4,7 +4,7 @@ local system = require("@std/system")
 
 local function projectRelative(...)
 	local cwd = process.cwd()
-	local sep = string.find(string.lower(system.os), "windows") and "\\" or "/"
+	local sep = if string.find(string.lower(system.os), "windows") then "\\" else "/"
 	return table.concat({ tostring(cwd), ... }, sep)
 end
 
@@ -66,7 +66,7 @@ local function generateDefinitionsMarkdown(
 	end)
 
 	for _, def in definitions do
-		table.insert(lines, "## " .. moduleName .. "." .. def.name)
+		table.insert(lines, `## {moduleName}.{def.name}`)
 		table.insert(lines, "```luau")
 		table.insert(lines, def.signature)
 		table.insert(lines, "```")
@@ -156,7 +156,7 @@ local function generateStdLibMarkdown(
 	end)
 
 	for _, def in definitions do
-		table.insert(lines, "## " .. moduleName .. "." .. def.name)
+		table.insert(lines, `## {moduleName}.{def.name}`)
 		table.insert(lines, "```luau")
 		table.insert(lines, def.signature)
 		table.insert(lines, "```")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -1,12 +1,6 @@
 local fs = require("@std/fs")
 local process = require("@std/process")
-local system = require("@std/system")
-
-local function projectRelative(...)
-	local cwd = process.cwd()
-	local sep = if string.find(string.lower(system.os), "windows") then "\\" else "/"
-	return table.concat({ tostring(cwd), ... }, sep)
-end
+local path = require("@std/path")
 
 local function extractPropertySignature(module: string, line: string): (string?, string?)
 	-- Match property declarations like: process.env = {} :: { [string]: string }
@@ -29,13 +23,16 @@ end
 
 -- docs for definitions/*.luau --
 
-local function parseDefinitionFile(module: string, filePath: string): { { name: string, signature: string } }
+local function parseDefinitionFile(
+	module: path.pathlike,
+	filePath: path.pathlike
+): { { name: string, signature: string } }
 	local content = fs.readfiletostring(filePath)
 	local lines = string.split(content, "\n")
 	local definitions = {}
 
 	for _, line in lines do
-		local name, signature = extractPropertySignature(module, line)
+		local name, signature = extractPropertySignature(tostring(module), line)
 
 		if name and signature then
 			table.insert(definitions, {
@@ -53,10 +50,10 @@ local function generateDefinitionsMarkdown(
 	definitions: { { name: string, signature: string } }
 ): string
 	local lines = {
-		"# " .. moduleName,
+		`# {moduleName}`,
 		"",
 		"```luau",
-		"local " .. moduleName .. ' = require("@lute/' .. moduleName .. '")',
+		`local {moduleName} = require("@lute/{moduleName}")`,
 		"```",
 		"",
 	}
@@ -76,7 +73,7 @@ local function generateDefinitionsMarkdown(
 	return table.concat(lines, "\n")
 end
 
-local function processDefinitionsDir(definitionsPath: string, referencePath: string)
+local function processDefinitionsDir(definitionsPath: path.pathlike, referencePath: path.pathlike)
 	pcall(fs.createdirectory, referencePath)
 
 	local definitionFiles = fs.listdir(definitionsPath)
@@ -84,17 +81,17 @@ local function processDefinitionsDir(definitionsPath: string, referencePath: str
 	for _, file in definitionFiles do
 		if file.type == "file" and string.find(file.name, "%.luau$") then
 			local moduleName = string.gsub(file.name, "%.luau$", "")
-			local definitionFilePath = definitionsPath .. "/" .. file.name
-			local referenceFilePath = referencePath .. "/" .. moduleName .. ".md"
+			local definitionFilePath = path.join(definitionsPath, file.name)
+			local referenceFilePath = path.join(referencePath, moduleName .. ".md")
 
-			print("Processing " .. moduleName .. "...")
+			print(`Processing {moduleName}...`)
 
 			local definitions = parseDefinitionFile(moduleName, definitionFilePath)
 			local markdown = generateDefinitionsMarkdown(moduleName, definitions)
 
 			fs.writestringtofile(referenceFilePath, markdown)
 
-			print("Generated " .. referenceFilePath)
+			print(`Generated {tostring(referenceFilePath)}`)
 		end
 	end
 end
@@ -111,13 +108,13 @@ local STDLIB_MODULE_ALIASES = {
 	system = "systemlib",
 }
 
-local function parseStdlibFile(module: string, filePath: string): { { name: string, signature: string } }
+local function parseStdlibFile(module: path.pathlike, filePath: path.pathlike): { { name: string, signature: string } }
 	local content = fs.readfiletostring(filePath)
 	local lines = string.split(content, "\n")
 	local stdlibDefinitions = {}
 
 	for _, line in lines do
-		local mod = STDLIB_MODULE_ALIASES[module] or module
+		local mod = STDLIB_MODULE_ALIASES[tostring(module)] or tostring(module)
 
 		local name, signature = extractPropertySignature(mod, line)
 
@@ -135,18 +132,22 @@ end
 local function generateStdLibMarkdown(
 	moduleName: string,
 	definitions: { { name: string, signature: string } },
-	stdlibFilePath: string
+	stdlibFilePath: path.pathlike
 ): string
-	local referencePath = projectRelative("lute/std/libs/")
-	local relativePath = string.sub(stdlibFilePath, #referencePath + 1)
+	local referencePath = path.join(process.cwd(), "lute", "std", "libs")
+
+	local refPathStr = tostring(referencePath)
+	local stdlibFilePathStr = tostring(stdlibFilePath)
+
+	local relativePath = string.sub(stdlibFilePathStr, #refPathStr + 2) -- gets the path relative to std/libs for the require path
 	relativePath = string.gsub(relativePath, "%.luau$", "")
-	local modulePath = string.gsub(relativePath, "/init$", "")
+	local requirePath = string.gsub(relativePath, "/init$", "")
 
 	local lines = {
-		"# " .. moduleName,
+		`# {moduleName}`,
 		"",
 		"```luau",
-		"local " .. moduleName .. ' = require("@std/' .. modulePath .. '")',
+		`local {moduleName} = require("@lute/{requirePath}")`,
 		"```",
 		"",
 	}
@@ -166,14 +167,14 @@ local function generateStdLibMarkdown(
 	return table.concat(lines, "\n")
 end
 
-local function processStdlibDir(sourceDir: string, referenceDir: string)
+local function processStdlibDir(sourceDir: path.pathlike, referenceDir: path.pathlike)
 	pcall(fs.createdirectory, referenceDir)
 
 	local entries = fs.listdir(sourceDir)
 
 	for _, entry in entries do
-		local sourcePath = sourceDir .. "/" .. entry.name
-		local referencePath = referenceDir .. "/" .. entry.name
+		local sourcePath = path.join(sourceDir, entry.name)
+		local referencePath = path.join(referenceDir, entry.name)
 
 		if entry.type == "dir" then
 			pcall(fs.createdirectory, referencePath)
@@ -181,29 +182,29 @@ local function processStdlibDir(sourceDir: string, referenceDir: string)
 		elseif entry.type == "file" and string.find(entry.name, "%.luau$") then
 			local moduleName = string.gsub(entry.name, "%.luau$", "")
 			if moduleName == "init" then
-				moduleName = string.match(sourceDir, "([^/\\]+)$") or moduleName
+				moduleName = string.match(tostring(sourceDir), "([^/\\]+)$") or moduleName
 			end
 
-			local referenceFilePath = referenceDir .. "/" .. moduleName .. ".md"
+			local referenceFilePath = path.join(referenceDir, moduleName .. ".md")
 
-			print("Processing " .. moduleName .. "...")
+			print(`Processing {moduleName}...`)
 
 			local stdlibDefinitions = parseStdlibFile(moduleName, sourcePath)
 			local markdown = generateStdLibMarkdown(moduleName, stdlibDefinitions, sourcePath)
 
 			fs.writestringtofile(referenceFilePath, markdown)
 
-			print("Generated " .. referenceFilePath)
+			print(`Generated {tostring(referenceFilePath)}`)
 		end
 	end
 end
 
-local definitionsPath = projectRelative("definitions")
-local referencePath = projectRelative("docs", "reference", "definitions")
+local definitionsPath = path.join(process.cwd(), "definitions")
+local referencePath = path.join(process.cwd(), "docs", "reference", "definitions")
 processDefinitionsDir(definitionsPath, referencePath)
 
-local stdlibPath = projectRelative("lute/std/libs")
-local stdlibReferencePath = projectRelative("docs", "reference", "std")
+local stdlibPath = path.join(process.cwd(), "lute", "std", "libs")
+local stdlibReferencePath = path.join(process.cwd(), "docs", "reference", "std")
 processStdlibDir(stdlibPath, stdlibReferencePath)
 
 print("Reference documentation generation complete!")


### PR DESCRIPTION
Docs docs docs

Extending existing regex parsing for `definitions/` to our standard library modules too! 

Helps users have better visibility into using `@std/`

This is a super rough/basic extension and it's not great (and the vitepress site pages were manually added to the config) but I think it's a good temporary step for improving our docs, especially as we're reaching Release A soon.

These are some of the generated pages:
<img width="3680" height="2262" alt="image" src="https://github.com/user-attachments/assets/41119016-9941-40b0-84e0-64cc8a9df107" />
<img width="3680" height="2262" alt="image" src="https://github.com/user-attachments/assets/402ca5d6-e1ee-42d9-a5cf-f2ceac4f03d0" />
<img width="3680" height="2262" alt="image" src="https://github.com/user-attachments/assets/f3875ca8-34f3-427b-a3fe-2917850e47c9" />
