### PR TITLE
fix: update paths in lute site doc gen

### DIFF
--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -200,11 +200,11 @@ local function processStdlibDir(sourceDir: path.pathlike, referenceDir: path.pat
 end
 
 local definitionsPath = path.join(process.cwd(), "..", "definitions")
-local referencePath = path.join(process.cwd(), "docs", "reference", "definitions")
+local referencePath = path.join(process.cwd(), "reference", "definitions")
 processDefinitionsDir(definitionsPath, referencePath)
 
 local stdlibPath = path.join(process.cwd(), "..", "lute", "std", "libs")
-local stdlibReferencePath = path.join(process.cwd(), "docs", "reference", "std")
+local stdlibReferencePath = path.join(process.cwd(), "reference", "std")
 processStdlibDir(stdlibPath, stdlibReferencePath)
 
 print("Reference documentation generation complete!")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -134,10 +134,13 @@ local function generateStdLibMarkdown(
 	definitions: { { name: string, signature: string } },
 	stdlibFilePath: path.pathlike
 ): string
-	local referencePath = path.join(process.cwd(), "lute", "std", "libs")
+	local referencePath = path.join(process.cwd(), "..", "lute", "std", "libs")
 
 	local refPathStr = tostring(referencePath)
 	local stdlibFilePathStr = tostring(stdlibFilePath)
+
+	print(`Ref path: {refPathStr}`)
+	print(`Stdlib file path: {stdlibFilePathStr}`)
 
 	local relativePath = string.sub(stdlibFilePathStr, #refPathStr + 2) -- gets the path relative to std/libs for the require path
 	relativePath = string.gsub(relativePath, "%.luau$", "")
@@ -147,7 +150,7 @@ local function generateStdLibMarkdown(
 		`# {moduleName}`,
 		"",
 		"```luau",
-		`local {moduleName} = require("@lute/{requirePath}")`,
+		`local {moduleName} = require("@std/{requirePath}")`,
 		"```",
 		"",
 	}
@@ -199,12 +202,12 @@ local function processStdlibDir(sourceDir: path.pathlike, referenceDir: path.pat
 	end
 end
 
-local definitionsPath = path.join(process.cwd(), "definitions")
-local referencePath = path.join(process.cwd(), "docs", "reference", "definitions")
+local definitionsPath = path.join(process.cwd(), "..", "definitions")
+local referencePath = path.join(process.cwd(), "reference", "definitions")
 processDefinitionsDir(definitionsPath, referencePath)
 
-local stdlibPath = path.join(process.cwd(), "lute", "std", "libs")
-local stdlibReferencePath = path.join(process.cwd(), "docs", "reference", "std")
+local stdlibPath = path.join(process.cwd(), "..", "lute", "std", "libs")
+local stdlibReferencePath = path.join(process.cwd(), "reference", "std")
 processStdlibDir(stdlibPath, stdlibReferencePath)
 
 print("Reference documentation generation complete!")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -200,11 +200,11 @@ local function processStdlibDir(sourceDir: path.pathlike, referenceDir: path.pat
 end
 
 local definitionsPath = path.join(process.cwd(), "..", "definitions")
-local referencePath = path.join(process.cwd(), "reference", "definitions")
+local referencePath = path.join(process.cwd(), "docs", "reference", "definitions")
 processDefinitionsDir(definitionsPath, referencePath)
 
 local stdlibPath = path.join(process.cwd(), "..", "lute", "std", "libs")
-local stdlibReferencePath = path.join(process.cwd(), "reference", "std")
+local stdlibReferencePath = path.join(process.cwd(), "docs", "reference", "std")
 processStdlibDir(stdlibPath, stdlibReferencePath)
 
 print("Reference documentation generation complete!")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -139,9 +139,6 @@ local function generateStdLibMarkdown(
 	local refPathStr = tostring(referencePath)
 	local stdlibFilePathStr = tostring(stdlibFilePath)
 
-	print(`Ref path: {refPathStr}`)
-	print(`Stdlib file path: {stdlibFilePathStr}`)
-
 	local relativePath = string.sub(stdlibFilePathStr, #refPathStr + 2) -- gets the path relative to std/libs for the require path
 	relativePath = string.gsub(relativePath, "%.luau$", "")
 	local requirePath = string.gsub(relativePath, "/init$", "")


### PR DESCRIPTION
Didn't realize vitepress runs in `docs/` subfolder so adding a `..` (and a typo fix) to fix the github deployment for docs site

fixes [build docs site failure](https://github.com/luau-lang/lute/actions/runs/19150222075/job/54738321290)