### PR TITLE
docs: add build-docs-site to CI and fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,24 @@ jobs:
       - name: Run StyLua
         run: stylua --check .
 
+  build-docs-site:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        working-directory: lute/docs
+        run: npm ci
+
+      - name: Build docs site
+        working-directory: lute/docs
+        run: npm run gen && npx vitepress build
+
   aggregator:
     name: Gated Commits
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,21 +96,33 @@ jobs:
 
   build-docs-site:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
+
+      - name: Install tools
+        uses: Roblox/setup-foreman@v3
         with:
-          node-version: 20
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allow-external-github-orgs: true
 
       - name: Install dependencies
-        working-directory: lute/docs
-        run: npm ci
+        run: npm install
+        working-directory: docs
 
       - name: Build docs site
-        working-directory: lute/docs
-        run: npm run gen && npx vitepress build
+        run: npm run build
+        working-directory: docs
+
+      - name: Upload docs artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist/
 
   aggregator:
     name: Gated Commits

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -200,11 +200,11 @@ local function processStdlibDir(sourceDir: path.pathlike, referenceDir: path.pat
 end
 
 local definitionsPath = path.join(process.cwd(), "..", "definitions")
-local referencePath = path.join(process.cwd(), "docs", "reference", "definitions")
+local referencePath = path.join(process.cwd(), "reference", "definitions")
 processDefinitionsDir(definitionsPath, referencePath)
 
 local stdlibPath = path.join(process.cwd(), "..", "lute", "std", "libs")
-local stdlibReferencePath = path.join(process.cwd(), "docs", "reference", "std")
+local stdlibReferencePath = path.join(process.cwd(), "reference", "std")
 processStdlibDir(stdlibPath, stdlibReferencePath)
 
 print("Reference documentation generation complete!")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -134,10 +134,13 @@ local function generateStdLibMarkdown(
 	definitions: { { name: string, signature: string } },
 	stdlibFilePath: path.pathlike
 ): string
-	local referencePath = path.join(process.cwd(), "lute", "std", "libs")
+	local referencePath = path.join(process.cwd(), "..", "lute", "std", "libs")
 
 	local refPathStr = tostring(referencePath)
 	local stdlibFilePathStr = tostring(stdlibFilePath)
+
+	print(`Ref path: {refPathStr}`)
+	print(`Stdlib file path: {stdlibFilePathStr}`)
 
 	local relativePath = string.sub(stdlibFilePathStr, #refPathStr + 2) -- gets the path relative to std/libs for the require path
 	relativePath = string.gsub(relativePath, "%.luau$", "")
@@ -147,7 +150,7 @@ local function generateStdLibMarkdown(
 		`# {moduleName}`,
 		"",
 		"```luau",
-		`local {moduleName} = require("@lute/{requirePath}")`,
+		`local {moduleName} = require("@std/{requirePath}")`,
 		"```",
 		"",
 	}
@@ -199,12 +202,12 @@ local function processStdlibDir(sourceDir: path.pathlike, referenceDir: path.pat
 	end
 end
 
-local definitionsPath = path.join(process.cwd(), "definitions")
-local referencePath = path.join(process.cwd(), "docs", "reference", "definitions")
+local definitionsPath = path.join(process.cwd(), "..", "definitions")
+local referencePath = path.join(process.cwd(), "reference", "definitions")
 processDefinitionsDir(definitionsPath, referencePath)
 
-local stdlibPath = path.join(process.cwd(), "lute", "std", "libs")
-local stdlibReferencePath = path.join(process.cwd(), "docs", "reference", "std")
+local stdlibPath = path.join(process.cwd(), "..", "lute", "std", "libs")
+local stdlibReferencePath = path.join(process.cwd(), "reference", "std")
 processStdlibDir(stdlibPath, stdlibReferencePath)
 
 print("Reference documentation generation complete!")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -200,11 +200,11 @@ local function processStdlibDir(sourceDir: path.pathlike, referenceDir: path.pat
 end
 
 local definitionsPath = path.join(process.cwd(), "..", "definitions")
-local referencePath = path.join(process.cwd(), "reference", "definitions")
+local referencePath = path.join(process.cwd(), "docs", "reference", "definitions")
 processDefinitionsDir(definitionsPath, referencePath)
 
 local stdlibPath = path.join(process.cwd(), "..", "lute", "std", "libs")
-local stdlibReferencePath = path.join(process.cwd(), "reference", "std")
+local stdlibReferencePath = path.join(process.cwd(), "docs", "reference", "std")
 processStdlibDir(stdlibPath, stdlibReferencePath)
 
 print("Reference documentation generation complete!")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -74,7 +74,7 @@ local function generateDefinitionsMarkdown(
 end
 
 local function processDefinitionsDir(definitionsPath: path.pathlike, referencePath: path.pathlike)
-	pcall(fs.createdirectory, referencePath)
+	fs.createdirectory(referencePath, { makeparents = true })
 
 	local definitionFiles = fs.listdir(definitionsPath)
 
@@ -168,7 +168,7 @@ local function generateStdLibMarkdown(
 end
 
 local function processStdlibDir(sourceDir: path.pathlike, referenceDir: path.pathlike)
-	pcall(fs.createdirectory, referenceDir)
+	fs.createdirectory(referenceDir, { makeparents = true })
 
 	local entries = fs.listdir(sourceDir)
 
@@ -177,7 +177,7 @@ local function processStdlibDir(sourceDir: path.pathlike, referenceDir: path.pat
 		local referencePath = path.join(referenceDir, entry.name)
 
 		if entry.type == "dir" then
-			pcall(fs.createdirectory, referencePath)
+			fs.createdirectory(referencePath, { makeparents = true })
 			processStdlibDir(sourcePath, referencePath)
 		elseif entry.type == "file" and string.find(entry.name, "%.luau$") then
 			local moduleName = string.gsub(entry.name, "%.luau$", "")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -139,9 +139,6 @@ local function generateStdLibMarkdown(
 	local refPathStr = tostring(referencePath)
 	local stdlibFilePathStr = tostring(stdlibFilePath)
 
-	print(`Ref path: {refPathStr}`)
-	print(`Stdlib file path: {stdlibFilePathStr}`)
-
 	local relativePath = string.sub(stdlibFilePathStr, #refPathStr + 2) -- gets the path relative to std/libs for the require path
 	relativePath = string.gsub(relativePath, "%.luau$", "")
 	local requirePath = string.gsub(relativePath, "/init$", "")


### PR DESCRIPTION
Adding build-docs-site to CI and fix for getting the build working! (had to use the `makeparents = true` option for `fs.createdirectory()`