### PR TITLE
Fix infinite recursion in ignore

### DIFF
--- a/lute/cli/commands/transform/lib/ignore.luau
+++ b/lute/cli/commands/transform/lib/ignore.luau
@@ -143,7 +143,8 @@ end
 local function parseGitignore(filepath: path.path): GitignoreData
 	local contents = fs.readfiletostring(path.format(filepath))
 	local parentDirectory = if path.basename(filepath) then path.dirname(filepath) else nil
-	return parseGitignoreContents(assert(parentDirectory), contents)
+	assert(parentDirectory)
+	return parseGitignoreContents(parentDirectory, contents)
 end
 
 local function matchesGlob(glob: Glob, filepath: string, isDirectory: boolean): boolean

--- a/lute/cli/commands/transform/lib/ignore.luau
+++ b/lute/cli/commands/transform/lib/ignore.luau
@@ -142,7 +142,7 @@ end
 
 local function parseGitignore(filepath: path.path): GitignoreData
 	local contents = fs.readfiletostring(path.format(filepath))
-	local parentDirectory = if path.basename(filepath) then path.dirname(filepath) else nil
+	local parentDirectory = if #filepath.parts > 0 then path.dirname(filepath) else nil
 	assert(parentDirectory)
 	return parseGitignoreContents(parentDirectory, contents)
 end
@@ -198,7 +198,7 @@ end
 
 --- Checks whether the given file matches an ignore
 function IgnoreResolver.isIgnoredFile(self: IgnoreResolver, filepath: path.path)
-	local directory = if path.basename(filepath) then path.dirname(filepath) else nil
+	local directory = if #filepath.parts > 0 then path.dirname(filepath) else nil
 	assert(directory ~= nil, "filepath has no directory!")
 
 	local ignoreData = self:_readIgnoreRecursive(directory)
@@ -207,11 +207,12 @@ end
 
 function IgnoreResolver.isIgnoredDirectory(self: IgnoreResolver, directorypath: path.path)
 	-- Hardcode: skip the .git directory
-	if path.basename(directorypath) == ".git" then
+	local basename = path.basename(directorypath)
+	if basename == ".git" then
 		return true
 	end
 
-	local parentDirectory = if path.basename(directorypath) then path.dirname(directorypath) else nil
+	local parentDirectory = if basename then path.dirname(directorypath) else nil
 	if parentDirectory then
 		local ignoreData = self:_readIgnoreRecursive(parentDirectory)
 		return isIgnored(ignoreData, path.format(directorypath), true)

--- a/lute/cli/commands/transform/lib/ignore.luau
+++ b/lute/cli/commands/transform/lib/ignore.luau
@@ -224,7 +224,7 @@ function IgnoreResolver._readIgnoreRecursive(self: IgnoreResolver, directory: st
 		return self._ignoreCache[directory]
 	end
 
-	local parentPath = if path.basename(directory) then path.dirname(directory) else nil -- don't continue recurring if we're at the root
+	local parentPath = if path.basename(directory) then path.dirname(directory) else nil
 	local baseIgnores = if parentPath then self:_readIgnoreRecursive(parentPath) else nil
 	local gitignorePath = path.join(directory, ".gitignore")
 

--- a/lute/cli/commands/transform/lib/ignore.luau
+++ b/lute/cli/commands/transform/lib/ignore.luau
@@ -142,7 +142,8 @@ end
 
 local function parseGitignore(filepath: path.path): GitignoreData
 	local contents = fs.readfiletostring(path.format(filepath))
-	return parseGitignoreContents(assert(path.dirname(filepath)), contents)
+	local parentDirectory = if path.basename(filepath) then path.dirname(filepath) else nil
+	return parseGitignoreContents(assert(parentDirectory), contents)
 end
 
 local function matchesGlob(glob: Glob, filepath: string, isDirectory: boolean): boolean
@@ -196,7 +197,7 @@ end
 
 --- Checks whether the given file matches an ignore
 function IgnoreResolver.isIgnoredFile(self: IgnoreResolver, filepath: path.path)
-	local directory = path.dirname(filepath)
+	local directory = if path.basename(filepath) then path.dirname(filepath) else nil
 	assert(directory ~= nil, "filepath has no directory!")
 
 	local ignoreData = self:_readIgnoreRecursive(directory)
@@ -209,7 +210,7 @@ function IgnoreResolver.isIgnoredDirectory(self: IgnoreResolver, directorypath: 
 		return true
 	end
 
-	local parentDirectory = path.dirname(directorypath)
+	local parentDirectory = if path.basename(directorypath) then path.dirname(directorypath) else nil
 	if parentDirectory then
 		local ignoreData = self:_readIgnoreRecursive(parentDirectory)
 		return isIgnored(ignoreData, path.format(directorypath), true)
@@ -223,7 +224,7 @@ function IgnoreResolver._readIgnoreRecursive(self: IgnoreResolver, directory: st
 		return self._ignoreCache[directory]
 	end
 
-	local parentPath = path.dirname(directory)
+	local parentPath = if path.basename(directory) then path.dirname(directory) else nil -- don't continue recurring if we're at the root
 	local baseIgnores = if parentPath then self:_readIgnoreRecursive(parentPath) else nil
 	local gitignorePath = path.join(directory, ".gitignore")
 


### PR DESCRIPTION
`ignore` was recently ported over from a different repo, that used an adhoc `path` implementation. This repo's `path.dirname` returned a string or nil, but lute's `path.dirname` always returns a string. 

On various occasions in ``ignore`` ([ one example here](https://github.com/luau-lang/lute/blob/primary/lute/cli/commands/transform/lib/ignore.luau#L226-L227)), we gate continued processing behind checks that `path.dirname(arbitrary)` exists. These are all invalid checks now and in some of these cases, we recur leading to death by stack overflow.

This PR fixes aforementioned checks, using `path.basename` (returns string | nil if at root) to determine if the current path is the root.

I found this bug when encountering a stack overflow error while trying to use `lute transform`:
```
_readIgnoreRecursive
... (+19979 frames)
@cli/transform/lib/ignore.luau:227 function _readIgnoreRecursive
@cli/transform/lib/ignore.luau:227 function _readIgnoreRecursive
@cli/transform/lib/ignore.luau:227 function _readIgnoreRecursive
@cli/transform/lib/ignore.luau:227 function _readIgnoreRecursive
@cli/transform/lib/ignore.luau:227 function _readIgnoreRecursive
@cli/transform/lib/ignore.luau:214 function isIgnoredDirectory
@cli/transform/lib/files.luau:16 function traverseDirectoryRecursive
@cli/transform/lib/files.luau:52 function getSourceFiles
@cli/transform/init.luau:139 function main
@cli/transform/init.luau:153
```

I rebuilt lute with these changes and `transform` worked as expected.