### PR TITLE
Fetch out-of-date dependencies and force configure in Luthier for `build` and `run` subcommands

### DIFF
--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -757,7 +757,7 @@ elseif subcommand == "configure" or subcommand == "tune" then
 elseif subcommand == "build" or subcommand == "craft" then
 	generateFilesIfNeeded()
 
-	if not projectPathExists() then
+	if not projectPathExists() or not areTuneFilesUpToDate() then
 		check(configure())
 	end
 
@@ -765,7 +765,7 @@ elseif subcommand == "build" or subcommand == "craft" then
 elseif subcommand == "run" or subcommand == "play" then
 	generateFilesIfNeeded()
 
-	if not projectPathExists() then
+	if not projectPathExists() or not areTuneFilesUpToDate() then
 		check(configure())
 	end
 


### PR DESCRIPTION
We previously only did this for the `configure` subcommand, which forces a configure. Now, if a fetch is needed, we force a configure in both the `build` and `run` subcommands, which also fetches dependencies.