### PR TITLE
Remove infinite loop test for .config.luau

### DIFF
--- a/tests/src/require.test.cpp
+++ b/tests/src/require.test.cpp
@@ -142,13 +142,6 @@ TEST_CASE("require_modules")
             );
         }
 
-        SUBCASE("config_luau_timeout")
-        {
-            doFailingSubcase(
-                argv, {"./config_tests/config_luau_timeout/requirer"}, {R"(error requiring module "@dep": configuration execution timed out)"}
-            );
-        }
-
         SUBCASE("lute_modules")
         {
             doPassingSubcase(argv, {"./lute/lute"}, {"successfully required @lute modules"});

--- a/tests/src/require/config_tests/config_luau_timeout/.config.luau
+++ b/tests/src/require/config_tests/config_luau_timeout/.config.luau
@@ -1,2 +1,0 @@
--- Infinite loop
-while true do end

--- a/tests/src/require/config_tests/config_luau_timeout/requirer.luau
+++ b/tests/src/require/config_tests/config_luau_timeout/requirer.luau
@@ -1,1 +1,0 @@
-return require("@dep")


### PR DESCRIPTION
We already have a test for this in the Luau repository, and it's just causing issues for luau-lsp here. If there ever is a bug with this functionality, it needs to be fixed in the Luau repository anyway, so I think it's okay to remove from here.

I was considering replacing it with a test that created the files in memory, but it seems like too much hassle for not much benefit.

Resolves https://github.com/JohnnyMorganz/luau-lsp/issues/1246 on our end.