### PR TITLE
crypto: implement a secretbox interface for authenticated encryption

### DIFF
--- a/definitions/crypto.luau
+++ b/definitions/crypto.luau
@@ -1,6 +1,6 @@
 local crypto = {}
 
-export type hash<T> = { write __hash: T }
+export type hash<T> = { __hash: T }
 
 crypto.hash = table.freeze({
 	md5 = {} :: hash<"md5">,

--- a/definitions/crypto.luau
+++ b/definitions/crypto.luau
@@ -17,9 +17,9 @@ end
 crypto.secretbox = {}
 
 export type secretbox = {
-    read ciphertext: buffer,
-    read nonce: buffer,
-    read key: buffer,
+	read ciphertext: buffer,
+	read nonce: buffer,
+	read key: buffer,
 }
 
 function crypto.secretbox.seal(message: string | buffer): secretbox

--- a/definitions/crypto.luau
+++ b/definitions/crypto.luau
@@ -1,19 +1,36 @@
 local crypto = {}
 
-export type Hash<T> = { __hash: T }
+export type hash<T> = { write __hash: T }
 
-crypto.hash = {
-	md5 = {} :: Hash<"md5">,
-	sha1 = {} :: Hash<"sha1">,
-	sha256 = {} :: Hash<"sha256">,
-	sha512 = {} :: Hash<"sha512">,
-	blake2b256 = {} :: Hash<"blake2b256">,
-}
-crypto.password = {}
+crypto.hash = table.freeze({
+	md5 = {} :: hash<"md5">,
+	sha1 = {} :: hash<"sha1">,
+	sha256 = {} :: hash<"sha256">,
+	sha512 = {} :: hash<"sha512">,
+	blake2b256 = {} :: hash<"blake2b256">,
+})
 
-function crypto.digest(hash: Hash<any>, message: string | buffer): buffer
+function crypto.digest(hash: hash<any>, message: string | buffer): buffer
 	error("not implemented")
 end
+
+crypto.secretbox = {}
+
+export type secretbox = {
+    read ciphertext: buffer,
+    read nonce: buffer,
+    read key: buffer,
+}
+
+function crypto.secretbox.seal(message: string | buffer): secretbox
+	error("not implemented")
+end
+
+function crypto.secretbox.open(box: secretbox): buffer
+	error("not implemented")
+end
+
+crypto.password = {}
 
 function crypto.password.hash(password: string): buffer
 	error("not implemented")

--- a/examples/secretbox.luau
+++ b/examples/secretbox.luau
@@ -1,0 +1,20 @@
+local crypto = require("@lute/crypto")
+
+local message = "Hello, world!"
+local box = crypto.secretbox.seal(message)
+
+function hexify(digest)
+	local hex = {}
+	for i = 1, buffer.len(digest) do
+		hex[i] = string.format("%02x", buffer.readu8(digest, i - 1))
+	end
+	return table.concat(hex)
+end
+
+print(hexify(box.ciphertext))
+
+local opened = crypto.secretbox.open(box)
+local output = buffer.readstring(opened, 0, buffer.len(opened))
+
+print(output)
+assert(output == message)

--- a/lute/crypto/include/lute/crypto.h
+++ b/lute/crypto/include/lute/crypto.h
@@ -14,10 +14,21 @@ namespace crypto
 {
 
 static const char kHashProperty[] = "hash";
+static const char kSecretboxProperty[] = "secretbox";
 static const char kPasswordProperty[] = "password";
 
 static const char kDigestName[] = "digest";
 int lua_digest(lua_State* L);
+
+static const char kCiphertextField[] = "ciphertext";
+static const char kKeyField[] = "key";
+static const char kNonceField[] = "nonce";
+
+static const char kSealName[] = "seal";
+int lua_seal(lua_State* L);
+
+static const char kOpenName[] = "open";
+int lua_open(lua_State* L);
 
 static const char kPasswordHashName[] = "hash";
 int lua_pwhash(lua_State* L);
@@ -29,6 +40,7 @@ static const luaL_Reg lib[] = {{kDigestName, lua_digest}, {nullptr, nullptr}};
 
 static const std::string properties[] = {
     kHashProperty,
+    kSecretboxProperty,
     kPasswordProperty,
 };
 

--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -144,14 +144,21 @@ int lua_secretbox_open(lua_State* L)
     lua_getfield(L, 1, "nonce");
     lua_getfield(L, 1, "key");
 
-    BinaryData ciphertext = extractData(L, 2);
-    size_t nonceLength = crypto_secretbox_keybytes();
-    uint8_t* nonce = static_cast<uint8_t*>(luaL_checkbuffer(L, 3, &nonceLength));
-    size_t keyLength = crypto_secretbox_keybytes();
-    uint8_t* key = static_cast<uint8_t*>(luaL_checkbuffer(L, 4, &keyLength));
+    size_t ciphertextLength = 0;
+    uint8_t* ciphertext = static_cast<uint8_t*>(luaL_checkbuffer(L, 2, &ciphertextLength));
 
-    uint8_t* buffer = static_cast<uint8_t*>(lua_newbuffer(L, ciphertext.length - crypto_secretbox_macbytes()));
-    if (crypto_secretbox_open_easy(buffer, static_cast<const uint8_t*>(ciphertext.data), ciphertext.length, nonce, key) != 0)
+    size_t nonceLength = 0;
+    uint8_t* nonce = static_cast<uint8_t*>(luaL_checkbuffer(L, 3, &nonceLength));
+    if (nonceLength != crypto_secretbox_noncebytes())
+        luaL_error(L, "%s: nonce buffer should be %d bytes", kOpenName, int(crypto_secretbox_noncebytes()));
+
+    size_t keyLength = 0;
+    uint8_t* key = static_cast<uint8_t*>(luaL_checkbuffer(L, 4, &keyLength));
+    if (keyLength != crypto_secretbox_keybytes())
+        luaL_error(L, "%s: keys buffer should be %d bytes", kOpenName, int(crypto_secretbox_keybytes()));
+
+    uint8_t* buffer = static_cast<uint8_t*>(lua_newbuffer(L, ciphertextLength - crypto_secretbox_macbytes()));
+    if (crypto_secretbox_open_easy(buffer, ciphertext, ciphertextLength, nonce, key) != 0)
         luaL_error(L, "%s: failed to verify the message", kOpenName);
 
     return 1;

--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -1,10 +1,13 @@
 #include "lute/crypto.h"
+#include "lute/userdatas.h"
 
 #include "lua.h"
 #include "lualib.h"
 
 #include "openssl/digest.h"
 #include "sodium/crypto_pwhash.h"
+#include "sodium/crypto_secretbox.h"
+#include "sodium/randombytes.h"
 
 #include <string>
 #include <vector>
@@ -17,8 +20,6 @@ struct HashFunction
     std::string name;
     const env_md_st* md;
 };
-
-static const int kHashFunctionTag = 81;
 
 static const HashFunction hashFunctions[] = {
     {"md5", EVP_md5()},
@@ -34,7 +35,7 @@ int makeHashFunctionMap(lua_State* L)
 
     for (auto& [name, md] : hashFunctions)
     {
-        lua_pushlightuserdatatagged(L, (void*)md, kHashFunctionTag);
+        lua_pushlightuserdatatagged(L, (void*) md, kHashFunctionTag);
         lua_setfield(L, -2, name.c_str());
     }
 
@@ -80,6 +81,7 @@ BinaryData extractData(lua_State* L, int idx)
     luaL_error(L, "failed to extract binary data from stack: %d", idx);
 }
 
+// digest(hash: hash<any>, message: string | buffer): buffer
 int lua_digest(lua_State* L)
 {
     int argumentCount = lua_gettop(L);
@@ -89,9 +91,85 @@ int lua_digest(lua_State* L)
     const env_md_st* hashFunction = getHashFunction(L, 1);
     BinaryData message = extractData(L, 2);
 
-    void* buffer = lua_newbuffer(L, EVP_MD_size(hashFunction));
-    if (EVP_Digest(message.data, message.length, (uint8_t*)buffer, nullptr, hashFunction, nullptr) == 0)
+    uint8_t* buffer = static_cast<uint8_t*>(lua_newbuffer(L, EVP_MD_size(hashFunction)));
+    if (EVP_Digest(message.data, message.length, buffer, nullptr, hashFunction, nullptr) == 0)
         luaL_error(L, "%s: failed to compute hash", kDigestName);
+
+    return 1;
+}
+
+// seal(message: string | buffer): { ciphertext: buffer, key: buffer, nonce: buffer }
+int lua_secretbox_seal(lua_State* L)
+{
+    int argumentCount = lua_gettop(L);
+    if (argumentCount != 1)
+        luaL_error(L, "%s: expected 1 argument, but got %d", kSealName, argumentCount);
+
+    BinaryData message = extractData(L, 1);
+
+    lua_createtable(L, 0, 3);
+
+    // ciphertext
+    uint8_t* buffer = static_cast<uint8_t*>(lua_newbuffer(L, crypto_secretbox_macbytes() + message.length));
+    lua_setfield(L, -2, kCiphertextField);
+
+    // key
+    uint8_t* key = static_cast<uint8_t*>(lua_newbuffer(L, crypto_secretbox_keybytes()));
+    crypto_secretbox_keygen(key);
+    lua_setfield(L, -2, kKeyField);
+
+    // nonce
+    uint8_t* nonce = static_cast<uint8_t*>(lua_newbuffer(L, crypto_secretbox_noncebytes()));
+    randombytes_buf(nonce, crypto_secretbox_noncebytes());
+    lua_setfield(L, -2, kNonceField);
+
+    // compute the ciphertext based on the message, nonce, and key
+    crypto_secretbox_easy(buffer, static_cast<const uint8_t*>(message.data), message.length, nonce, key);
+
+    // freeze the result
+    lua_setreadonly(L, -1, true);
+
+    return 1;
+}
+
+// open(secretbox: { ciphertext: buffer, key: buffer, nonce: buffer }): buffer
+int lua_secretbox_open(lua_State* L)
+{
+    int argumentCount = lua_gettop(L);
+    if (argumentCount != 1)
+        luaL_error(L, "%s: expected 1 argument, but got %d", kOpenName, argumentCount);
+
+    // read all three of the required fields out of the table
+    lua_getfield(L, 1, "ciphertext");
+    lua_getfield(L, 1, "nonce");
+    lua_getfield(L, 1, "key");
+
+    BinaryData ciphertext = extractData(L, 2);
+    size_t nonceLength = crypto_secretbox_keybytes();
+    uint8_t* nonce = static_cast<uint8_t*>(luaL_checkbuffer(L, 3, &nonceLength));
+    size_t keyLength = crypto_secretbox_keybytes();
+    uint8_t* key = static_cast<uint8_t*>(luaL_checkbuffer(L, 4, &keyLength));
+
+    uint8_t* buffer = static_cast<uint8_t*>(lua_newbuffer(L, ciphertext.length - crypto_secretbox_macbytes()));
+    if (crypto_secretbox_open_easy(buffer, static_cast<const uint8_t*>(ciphertext.data), ciphertext.length, nonce, key) != 0)
+        luaL_error(L, "%s: failed to verify the message", kOpenName);
+
+    return 1;
+}
+
+int makeSecretboxLibrary(lua_State* L)
+{
+    lua_createtable(L, 0, 2);
+
+    // seal
+    lua_pushcfunction(L, lua_secretbox_seal, kSealName);
+    lua_setfield(L, -2, kSealName);
+
+    // open
+    lua_pushcfunction(L, lua_secretbox_open, kOpenName);
+    lua_setfield(L, -2, kOpenName);
+
+    lua_setreadonly(L, -1, true);
 
     return 1;
 }
@@ -145,6 +223,8 @@ int makePasswordHashLibrary(lua_State* L)
     lua_pushcfunction(L, lua_pwhash_verify, kVerifyPasswordHashName);
     lua_setfield(L, -2, kVerifyPasswordHashName);
 
+    lua_setreadonly(L, -1, true);
+
     return 1;
 }
 
@@ -174,10 +254,13 @@ int luteopen_crypto(lua_State* L)
     crypto::makeHashFunctionMap(L);
     lua_setfield(L, -2, crypto::kHashProperty);
 
+    crypto::makeSecretboxLibrary(L);
+    lua_setfield(L, -2, crypto::kSecretboxProperty);
+
     crypto::makePasswordHashLibrary(L);
     lua_setfield(L, -2, crypto::kPasswordProperty);
 
-    lua_setreadonly(L, -1, 1);
+    lua_setreadonly(L, -1, true);
 
     return 1;
 }

--- a/lute/runtime/include/lute/userdatas.h
+++ b/lute/runtime/include/lute/userdatas.h
@@ -4,3 +4,4 @@
 constexpr int kDurationTag = 127;
 constexpr int kInstantTag = 126;
 constexpr int kWatchHandleTag = 125;
+constexpr int kHashFunctionTag = 124;

--- a/lute/std/libs/test/assert.luau
+++ b/lute/std/libs/test/assert.luau
@@ -81,6 +81,31 @@ function assertions.tableeq(lhs: { [unknown]: unknown }, rhs: { [unknown]: unkno
 	end
 end
 
+function assertions.buffereq(lhs: buffer, rhs: buffer)
+    if typeof(lhs) ~= "buffer" then
+		error(`lhs is of type {typeof(lhs)}, not buffer`)
+	end
+
+	if typeof(rhs) ~= "buffer" then
+        error(`rhs is of type {typeof(rhs)}, not buffer`)
+    end
+
+    if buffer.len(lhs) ~= buffer.len(rhs) then
+        error("buffers are of unequal length")
+    end
+
+    local len = buffer.len(lhs)
+    for offset = 0, len - 1 do
+        local left = buffer.readu8(lhs, offset)
+        local right = buffer.readu8(rhs, offset)
+
+        if left ~= right then
+            error(string.format("lhs[%d] = %02x, but rhs[%d] = %02x", offset, left, offset, right))
+        end
+    end
+
+end
+
 export type asserts = typeof(assertions)
 
 return table.freeze(assertions)

--- a/lute/std/libs/test/assert.luau
+++ b/lute/std/libs/test/assert.luau
@@ -82,28 +82,27 @@ function assertions.tableeq(lhs: { [unknown]: unknown }, rhs: { [unknown]: unkno
 end
 
 function assertions.buffereq(lhs: buffer, rhs: buffer)
-    if typeof(lhs) ~= "buffer" then
+	if typeof(lhs) ~= "buffer" then
 		error(`lhs is of type {typeof(lhs)}, not buffer`)
 	end
 
 	if typeof(rhs) ~= "buffer" then
-        error(`rhs is of type {typeof(rhs)}, not buffer`)
-    end
+		error(`rhs is of type {typeof(rhs)}, not buffer`)
+	end
 
-    if buffer.len(lhs) ~= buffer.len(rhs) then
-        error("buffers are of unequal length")
-    end
+	if buffer.len(lhs) ~= buffer.len(rhs) then
+		error("buffers are of unequal length")
+	end
 
-    local len = buffer.len(lhs)
-    for offset = 0, len - 1 do
-        local left = buffer.readu8(lhs, offset)
-        local right = buffer.readu8(rhs, offset)
+	local len = buffer.len(lhs)
+	for offset = 0, len - 1 do
+		local left = buffer.readu8(lhs, offset)
+		local right = buffer.readu8(rhs, offset)
 
-        if left ~= right then
-            error(string.format("lhs[%d] = %02x, but rhs[%d] = %02x", offset, left, offset, right))
-        end
-    end
-
+		if left ~= right then
+			error(string.format("lhs[%d] = %02x, but rhs[%d] = %02x", offset, left, offset, right))
+		end
+	end
 end
 
 export type asserts = typeof(assertions)

--- a/tests/runtime/crypto.test.luau
+++ b/tests/runtime/crypto.test.luau
@@ -45,9 +45,9 @@ test.suite("CryptoRuntimeTests", function(suite)
 
 		local box = crypto.secretbox.seal(buf)
 		local other = {
-    		ciphertext = buffer.readstring(box.ciphertext, 0, #message),
-            nonce = box.nonce,
-            key = box.key,
+			ciphertext = buffer.readstring(box.ciphertext, 0, #message),
+			nonce = box.nonce,
+			key = box.key,
 		}
 
 		assert.errors(function()
@@ -63,9 +63,9 @@ test.suite("CryptoRuntimeTests", function(suite)
 
 		local box = crypto.secretbox.seal(buf)
 		local other = {
-    		ciphertext = box.ciphertext,
-            nonce = box.nonce,
-            key = buffer.create(5),
+			ciphertext = box.ciphertext,
+			nonce = box.nonce,
+			key = buffer.create(5),
 		}
 
 		assert.errors(function()

--- a/tests/runtime/crypto.test.luau
+++ b/tests/runtime/crypto.test.luau
@@ -1,0 +1,78 @@
+local test = require("@std/test")
+
+local crypto = require("@lute/crypto")
+
+test.suite("CryptoRuntimeTests", function(suite)
+    suite:case("secretbox_is_a_roundtrip_strings", function(assert)
+        local message = "Remember, remember the Fifth of November."
+        local box = crypto.secretbox.seal(message)
+
+        local opened = crypto.secretbox.open(box)
+        local output = buffer.readstring(opened, 0, buffer.len(opened))
+
+        assert.eq(output, message)
+	end)
+
+    suite:case("secretbox_is_a_roundtrip_buffers", function(assert)
+        local message = "Gunpowder, treason, and plot."
+        local buf = buffer.create(#message)
+        buffer.writestring(buf, 0, message)
+
+        local box = crypto.secretbox.seal(buf)
+        local opened = crypto.secretbox.open(box)
+
+        assert.buffereq(opened, buf)
+	end)
+
+
+    suite:case("secretbox_errors_on_tampering", function(assert)
+        local message = "Gunpowder, treason, and plot."
+        local buf = buffer.create(#message)
+        buffer.writestring(buf, 0, message)
+
+        local box = crypto.secretbox.seal(buf)
+        buffer.writeu32(box.ciphertext, 2, 10_11_2025)
+
+        assert.errors(function()
+            crypto.secretbox.open(box)
+        end)
+	end)
+
+    suite:case("secretbox_on_ill_typed_inputs", function(assert)
+        local message = "I see no reason why gunpowder treason should ever be forgot."
+
+        assert.errors(function()
+            crypto.secretbox.seal({message} :: any)
+        end)
+
+        assert.errors(function()
+            crypto.secretbox.seal({message, message, message} :: any)
+        end)
+
+        assert.errors(function()
+            crypto.secretbox.seal({ ciphertext = message, key = message, nonce = message} :: any)
+        end)
+
+        assert.errors(function()
+            crypto.secretbox.open(message :: any)
+        end)
+
+        assert.errors(function()
+            crypto.secretbox.open({ ciphertext = message, key = buffer.create(), nonce = "woof" } :: any)
+        end)
+
+        assert.errors(function()
+            crypto.secretbox.open({ ciphertext = message, key = "woof", nonce = buffer.create() } :: any)
+        end)
+
+        assert.errors(function()
+            crypto.secretbox.open({ ciphertext = message } :: any)
+        end)
+
+        assert.errors(function()
+            crypto.secretbox.open(nil :: any)
+        end)
+	end)
+end)
+
+test.run()

--- a/tests/runtime/crypto.test.luau
+++ b/tests/runtime/crypto.test.luau
@@ -3,75 +3,74 @@ local test = require("@std/test")
 local crypto = require("@lute/crypto")
 
 test.suite("CryptoRuntimeTests", function(suite)
-    suite:case("secretbox_is_a_roundtrip_strings", function(assert)
-        local message = "Remember, remember the Fifth of November."
-        local box = crypto.secretbox.seal(message)
+	suite:case("secretbox_is_a_roundtrip_strings", function(assert)
+		local message = "Remember, remember the Fifth of November."
+		local box = crypto.secretbox.seal(message)
 
-        local opened = crypto.secretbox.open(box)
-        local output = buffer.readstring(opened, 0, buffer.len(opened))
+		local opened = crypto.secretbox.open(box)
+		local output = buffer.readstring(opened, 0, buffer.len(opened))
 
-        assert.eq(output, message)
+		assert.eq(output, message)
 	end)
 
-    suite:case("secretbox_is_a_roundtrip_buffers", function(assert)
-        local message = "Gunpowder, treason, and plot."
-        local buf = buffer.create(#message)
-        buffer.writestring(buf, 0, message)
+	suite:case("secretbox_is_a_roundtrip_buffers", function(assert)
+		local message = "Gunpowder, treason, and plot."
+		local buf = buffer.create(#message)
+		buffer.writestring(buf, 0, message)
 
-        local box = crypto.secretbox.seal(buf)
-        local opened = crypto.secretbox.open(box)
+		local box = crypto.secretbox.seal(buf)
+		local opened = crypto.secretbox.open(box)
 
-        assert.buffereq(opened, buf)
+		assert.buffereq(opened, buf)
 	end)
 
+	suite:case("secretbox_errors_on_tampering", function(assert)
+		local message = "Gunpowder, treason, and plot."
+		local buf = buffer.create(#message)
+		buffer.writestring(buf, 0, message)
 
-    suite:case("secretbox_errors_on_tampering", function(assert)
-        local message = "Gunpowder, treason, and plot."
-        local buf = buffer.create(#message)
-        buffer.writestring(buf, 0, message)
+		local box = crypto.secretbox.seal(buf)
+		buffer.writeu32(box.ciphertext, 2, 10_11_2025)
 
-        local box = crypto.secretbox.seal(buf)
-        buffer.writeu32(box.ciphertext, 2, 10_11_2025)
-
-        assert.errors(function()
-            crypto.secretbox.open(box)
-        end)
+		assert.errors(function()
+			crypto.secretbox.open(box)
+		end)
 	end)
 
-    suite:case("secretbox_on_ill_typed_inputs", function(assert)
-        local message = "I see no reason why gunpowder treason should ever be forgot."
+	suite:case("secretbox_on_ill_typed_inputs", function(assert)
+		local message = "I see no reason why gunpowder treason should ever be forgot."
 
-        assert.errors(function()
-            crypto.secretbox.seal({message} :: any)
-        end)
+		assert.errors(function()
+			crypto.secretbox.seal({ message } :: any)
+		end)
 
-        assert.errors(function()
-            crypto.secretbox.seal({message, message, message} :: any)
-        end)
+		assert.errors(function()
+			crypto.secretbox.seal({ message, message, message } :: any)
+		end)
 
-        assert.errors(function()
-            crypto.secretbox.seal({ ciphertext = message, key = message, nonce = message} :: any)
-        end)
+		assert.errors(function()
+			crypto.secretbox.seal({ ciphertext = message, key = message, nonce = message } :: any)
+		end)
 
-        assert.errors(function()
-            crypto.secretbox.open(message :: any)
-        end)
+		assert.errors(function()
+			crypto.secretbox.open(message :: any)
+		end)
 
-        assert.errors(function()
-            crypto.secretbox.open({ ciphertext = message, key = buffer.create(), nonce = "woof" } :: any)
-        end)
+		assert.errors(function()
+			crypto.secretbox.open({ ciphertext = message, key = buffer.create(), nonce = "woof" } :: any)
+		end)
 
-        assert.errors(function()
-            crypto.secretbox.open({ ciphertext = message, key = "woof", nonce = buffer.create() } :: any)
-        end)
+		assert.errors(function()
+			crypto.secretbox.open({ ciphertext = message, key = "woof", nonce = buffer.create() } :: any)
+		end)
 
-        assert.errors(function()
-            crypto.secretbox.open({ ciphertext = message } :: any)
-        end)
+		assert.errors(function()
+			crypto.secretbox.open({ ciphertext = message } :: any)
+		end)
 
-        assert.errors(function()
-            crypto.secretbox.open(nil :: any)
-        end)
+		assert.errors(function()
+			crypto.secretbox.open(nil :: any)
+		end)
 	end)
 end)
 

--- a/tests/runtime/crypto.test.luau
+++ b/tests/runtime/crypto.test.luau
@@ -37,6 +37,42 @@ test.suite("CryptoRuntimeTests", function(suite)
 		end)
 	end)
 
+	suite:case("secretbox_no_open_string", function(assert)
+		local message = "I see no reason why gunpowder treason should ever be forgot."
+
+		local buf = buffer.create(#message)
+		buffer.writestring(buf, 0, message)
+
+		local box = crypto.secretbox.seal(buf)
+		local other = {
+    		ciphertext = buffer.readstring(box.ciphertext, 0, #message),
+            nonce = box.nonce,
+            key = box.key,
+		}
+
+		assert.errors(function()
+			crypto.secretbox.open(other)
+		end)
+	end)
+
+	suite:case("secretbox_missized_key", function(assert)
+		local message = "I see no reason why gunpowder treason should ever be forgot."
+
+		local buf = buffer.create(#message)
+		buffer.writestring(buf, 0, message)
+
+		local box = crypto.secretbox.seal(buf)
+		local other = {
+    		ciphertext = box.ciphertext,
+            nonce = box.nonce,
+            key = buffer.create(5),
+		}
+
+		assert.errors(function()
+			crypto.secretbox.open(other)
+		end)
+	end)
+
 	suite:case("secretbox_on_ill_typed_inputs", function(assert)
 		local message = "I see no reason why gunpowder treason should ever be forgot."
 


### PR DESCRIPTION
The last remaining bit of work to close out #161 was the desire to have some kind of API for authenticated encryption (AE) or authenticated encrypted with additional data (AEAD). I worked a bit on trying to provide the full AEAD interface from boringssl, but it felt clunky and bad to use in Luau. I don't want to commit to the runtime providing a standard interface that is literally reproducing openssl's headers, that's something that can be done later with FFI. Instead, I want the crypto library to feel more in the spirit of libsodium, providing opinionated default ways of solving common cryptography tasks. The secretbox interface is a well-understood metaphor for AE(AD), and one that works quite nicely. To mitigate the likelihood of nonce or key reuse, the interface provided right now seals a message providing the key and nonce as output. We can extend the API in the future with optional arguments for nonce and key as needed.