### PR TITLE
bugfix: windows path api needs to be able to get the drive letter for a path

### DIFF
--- a/lute/std/libs/path/win32/init.luau
+++ b/lute/std/libs/path/win32/init.luau
@@ -59,7 +59,7 @@ function win32.extname(path: pathlike): string
 	return filename:sub(dotIndex)
 end
 
-function win32.getdrive(path: pathlike): path
+function win32.drive(path: pathlike): path
 	if typeof(path) == "string" then
 		path = win32.parse(path)
 	end

--- a/lute/std/libs/path/win32/init.luau
+++ b/lute/std/libs/path/win32/init.luau
@@ -59,6 +59,24 @@ function win32.extname(path: pathlike): string
 	return filename:sub(dotIndex)
 end
 
+function win32.getdrive(path: pathlike): path
+	if typeof(path) == "string" then
+		path = win32.parse(path)
+	end
+
+	path = path :: path
+
+	if path.driveLetter == nil then
+		error("Path does not have a drive letter: " .. win32.format(path))
+	end
+
+	return setmetatable({
+		parts = {},
+		kind = "absolute",
+		driveLetter = path.driveLetter,
+	}, path_mt)
+end
+
 function win32.format(path: pathlike): string
 	if typeof(path) == "string" then
 		return path

--- a/tests/std/path/path.win32.test.luau
+++ b/tests/std/path/path.win32.test.luau
@@ -1,5 +1,6 @@
 local system = require("@std/system")
 local test = require("@std/test")
+local process = require("@std/process")
 
 local path = require("@std/path")
 local win32 = require("@std/path/win32")
@@ -298,6 +299,47 @@ test.suite("PathWin32ExtnameSuite", function(suite)
 	suite:case("extname_filename_is_dotdot", function(assert)
 		local result = path.win32.extname("C:\\Users\\username\\..")
 		assert.eq(result, "")
+	end)
+end)
+
+test.suite("PathWin32GetDriveSuite", function(suite)
+	suite:case("getdrive_absolute_path_string", function(assert)
+		local result = path.win32.getdrive("C:\\Users\\username\\Documents\\file.txt")
+		assert.eq(result.kind, "absolute")
+		assert.eq(result.driveLetter, "C")
+		assert.eq(#result.parts, 0)
+	end)
+
+	suite:case("getdrive_relative_path_with_drive", function(assert)
+		local result = path.win32.getdrive("D:Documents\\file.txt")
+		assert.eq(result.kind, "absolute")
+		assert.eq(result.driveLetter, "D")
+		assert.eq(#result.parts, 0)
+	end)
+
+	suite:case("getdrive_path_object", function(assert)
+		local pathobj: win32.path = {
+			parts = { "Users", "username", "Documents" },
+			kind = "absolute",
+			driveLetter = "E",
+		}
+		local result = path.win32.getdrive(pathobj)
+		assert.eq(result.kind, "absolute")
+		assert.eq(result.driveLetter, "E")
+		assert.eq(#result.parts, 0)
+	end)
+
+	suite:case("getdrive_root_path", function(assert)
+		local result = path.win32.getdrive("F:\\")
+		assert.eq(result.kind, "absolute")
+		assert.eq(result.driveLetter, "F")
+		assert.eq(#result.parts, 0)
+	end)
+
+	suite:case("getdrive_error_on_empty_path", function(assert)
+		assert.errors(function()
+			return path.win32.getdrive("")
+		end)
 	end)
 end)
 
@@ -655,10 +697,16 @@ test.suite("PathWin32ResolveSuite", function(suite)
 	end)
 
 	suite:case("resolve_drive_relative_path", function(assert)
-		local result = path.win32.resolve("C:Documents\\file.txt")
+		-- Get the drive letter from the current working directory
+		local cwd = process.cwd()
+		local cwdPath = path.win32.parse(cwd)
+		local driveLetter = if system.win32 then cwdPath.driveLetter else "C"
+
+		local testPath = driveLetter .. ":Documents\\file.txt"
+		local result = path.win32.resolve(testPath)
 		-- Absolute unix paths will be parsed as relative Windows paths because they don't have drive letters
 		assert.eq(result.kind, if system.win32 then "absolute" else "relative")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.driveLetter, driveLetter)
 		-- The exact parts depend on cwd, but should be absolute
 		local endIndex = #result.parts
 		assert.eq(result.parts[endIndex - 1], "Documents")

--- a/tests/std/path/path.win32.test.luau
+++ b/tests/std/path/path.win32.test.luau
@@ -304,14 +304,14 @@ end)
 
 test.suite("PathWin32GetDriveSuite", function(suite)
 	suite:case("getdrive_absolute_path_string", function(assert)
-		local result = path.win32.getdrive("C:\\Users\\username\\Documents\\file.txt")
+		local result = path.win32.drive("C:\\Users\\username\\Documents\\file.txt")
 		assert.eq(result.kind, "absolute")
 		assert.eq(result.driveLetter, "C")
 		assert.eq(#result.parts, 0)
 	end)
 
 	suite:case("getdrive_relative_path_with_drive", function(assert)
-		local result = path.win32.getdrive("D:Documents\\file.txt")
+		local result = path.win32.drive("D:Documents\\file.txt")
 		assert.eq(result.kind, "absolute")
 		assert.eq(result.driveLetter, "D")
 		assert.eq(#result.parts, 0)
@@ -323,14 +323,14 @@ test.suite("PathWin32GetDriveSuite", function(suite)
 			kind = "absolute",
 			driveLetter = "E",
 		}
-		local result = path.win32.getdrive(pathobj)
+		local result = path.win32.drive(pathobj)
 		assert.eq(result.kind, "absolute")
 		assert.eq(result.driveLetter, "E")
 		assert.eq(#result.parts, 0)
 	end)
 
 	suite:case("getdrive_root_path", function(assert)
-		local result = path.win32.getdrive("F:\\")
+		local result = path.win32.drive("F:\\")
 		assert.eq(result.kind, "absolute")
 		assert.eq(result.driveLetter, "F")
 		assert.eq(#result.parts, 0)
@@ -338,7 +338,7 @@ test.suite("PathWin32GetDriveSuite", function(suite)
 
 	suite:case("getdrive_error_on_empty_path", function(assert)
 		assert.errors(function()
-			return path.win32.getdrive("")
+			return path.win32.drive("")
 		end)
 	end)
 end)
@@ -700,7 +700,7 @@ test.suite("PathWin32ResolveSuite", function(suite)
 		-- Get the drive letter from the current working directory
 		local cwd = process.cwd()
 		local cwdPath = path.win32.parse(cwd)
-		local driveLetter = if system.win32 then cwdPath.driveLetter else "C"
+		local driveLetter = if system.win32 then path.win32.drive(cwdPath).driveLetter else "C"
 
 		local testPath = driveLetter .. ":Documents\\file.txt"
 		local result = path.win32.resolve(testPath)


### PR DESCRIPTION
There are a number of tests failing on windows runners because the github runners execute tests under the D:\ drive. However, many of our tests assume execution under the C drive. This PR adds a function called `getdrive(path)` to the win32 path api, as well as fixes some of those tests to be drive aware.