### PR TITLE
lute transform: pass parsed ASTs to codemods

### DIFF
--- a/examples/transformer.luau
+++ b/examples/transformer.luau
@@ -1,11 +1,8 @@
-local parser = require("@std/syntax/parser")
 local printer = require("@std/syntax/printer")
 local visitor = require("@std/syntax/visitor")
 local luau = require("@lute/luau")
 
-function transformation(ctx)
-	local parsedResult = parser.parsefile(ctx.source)
-
+local function transformation(ctx)
 	local v = visitor.create()
 
 	v.visitBinary = function(node: luau.AstExprBinary)
@@ -80,9 +77,9 @@ function transformation(ctx)
 		return false
 	end
 
-	visitor.visitblock(parsedResult.root, v)
+	visitor.visitblock(ctx.parseresult.root, v)
 
-	return printer.printfile(parsedResult)
+	return printer.printfile(ctx.parseresult)
 end
 
 return transformation

--- a/lute/cli/commands/transform/init.luau
+++ b/lute/cli/commands/transform/init.luau
@@ -98,9 +98,12 @@ local function applyMigration(
 
 		local source = fs.readfiletostring(pathStr)
 
+		local parseresult = luau.parse(source)
+
 		local ctx = {
 			path = pathStr,
 			source = source,
+			parseresult = parseresult,
 			options = options,
 		}
 

--- a/lute/cli/commands/transform/lib/types.luau
+++ b/lute/cli/commands/transform/lib/types.luau
@@ -1,6 +1,9 @@
+local luau = require("@std/luau")
+
 export type Context<Options = { [any]: any }> = {
 	path: string,
 	source: string,
+	parseresult: luau.ParseResult,
 	options: Options,
 }
 


### PR DESCRIPTION
The existing API of `lute transform` requires that codemod authors call the parser themselves on the source code. Almost all codemod writers are going to operate on the AST anyway, so parse it for them and pass it in the context passed to the transforms. I updated `examples/transformer.luau`, which is used in the existing test for `lute transform`.