### PR TITLE
Implements flag arguments to specify test case and test suite to run for `lute test`

### DIFF
--- a/lute/cli/commands/test/filter.luau
+++ b/lute/cli/commands/test/filter.luau
@@ -17,8 +17,35 @@ local function filtertests(
 		return env
 	end
 
+	-- Filter by both suite and case name
+	if suiteName and caseName then
+		local caseEntry = env.caseindex[caseName]
+		if caseEntry and caseEntry.suites[suiteName] then
+			local suite = env.suiteindex[suiteName]
+			local filteredSuite = {
+				name = suite.name,
+				cases = caseEntry.suites[suiteName],
+				_beforeeach = suite._beforeeach,
+				_beforeall = suite._beforeall,
+				_aftereach = suite._aftereach,
+				_afterall = suite._afterall,
+			}
+			table.insert(filtered.suites, filteredSuite)
+		end
+		return filtered
+	end
+
+	-- Filter by suite name only
+	if suiteName then
+		local suite = env.suiteindex[suiteName]
+		if suite then
+			table.insert(filtered.suites, suite)
+		end
+		return filtered
+	end
+
 	-- Filter by case name only
-	if caseName and not suiteName then
+	if caseName then
 		local caseEntry = env.caseindex[caseName]
 		if caseEntry then
 			-- Add all anonymous tests with this case name
@@ -37,33 +64,6 @@ local function filtertests(
 				}
 				table.insert(filtered.suites, filteredSuite)
 			end
-		end
-		return filtered
-	end
-
-	-- Filter by suite name only
-	if suiteName and not caseName then
-		local suite = env.suiteindex[suiteName]
-		if suite then
-			table.insert(filtered.suites, suite)
-		end
-		return filtered
-	end
-
-	-- Filter by both suite and case name
-	if suiteName and caseName then
-		local caseEntry = env.caseindex[caseName]
-		if caseEntry and caseEntry.suites[suiteName] then
-			local suite = env.suiteindex[suiteName]
-			local filteredSuite = {
-				name = suite.name,
-				cases = caseEntry.suites[suiteName],
-				_beforeeach = suite._beforeeach,
-				_beforeall = suite._beforeall,
-				_aftereach = suite._aftereach,
-				_afterall = suite._afterall,
-			}
-			table.insert(filtered.suites, filteredSuite)
 		end
 		return filtered
 	end

--- a/lute/cli/commands/test/filter.luau
+++ b/lute/cli/commands/test/filter.luau
@@ -1,0 +1,74 @@
+local testtypes = require("@std/test/types")
+
+local function filtertests(
+	env: testtypes.testenvironment,
+	suiteName: string?,
+	caseName: string?
+): testtypes.testenvironment
+	local filtered: testtypes.testenvironment = {
+		anonymous = {},
+		suites = {},
+		suiteindex = {},
+		caseindex = {},
+	}
+
+	-- No filters: return all tests
+	if not suiteName and not caseName then
+		return env
+	end
+
+	-- Filter by case name only
+	if caseName and not suiteName then
+		local caseEntry = env.caseindex[caseName]
+		if caseEntry then
+			-- Add all anonymous tests with this case name
+			filtered.anonymous = caseEntry.anonymous
+
+			-- Add all suites that have tests with this case name
+			for sName, cases in caseEntry.suites do
+				local suite = env.suiteindex[sName]
+				local filteredSuite = {
+					name = suite.name,
+					cases = cases,
+					_beforeeach = suite._beforeeach,
+					_beforeall = suite._beforeall,
+					_aftereach = suite._aftereach,
+					_afterall = suite._afterall,
+				}
+				table.insert(filtered.suites, filteredSuite)
+			end
+		end
+		return filtered
+	end
+
+	-- Filter by suite name only
+	if suiteName and not caseName then
+		local suite = env.suiteindex[suiteName]
+		if suite then
+			table.insert(filtered.suites, suite)
+		end
+		return filtered
+	end
+
+	-- Filter by both suite and case name
+	if suiteName and caseName then
+		local caseEntry = env.caseindex[caseName]
+		if caseEntry and caseEntry.suites[suiteName] then
+			local suite = env.suiteindex[suiteName]
+			local filteredSuite = {
+				name = suite.name,
+				cases = caseEntry.suites[suiteName],
+				_beforeeach = suite._beforeeach,
+				_beforeall = suite._beforeall,
+				_aftereach = suite._aftereach,
+				_afterall = suite._afterall,
+			}
+			table.insert(filtered.suites, filteredSuite)
+		end
+		return filtered
+	end
+
+	return filtered
+end
+
+return table.freeze({ filtertests = filtertests })

--- a/lute/cli/commands/test/filter.luau
+++ b/lute/cli/commands/test/filter.luau
@@ -22,41 +22,10 @@ local function filtertests(
 		local caseEntry = env.caseindex[caseName]
 		if caseEntry and caseEntry.suites[suiteName] then
 			local suite = env.suiteindex[suiteName]
-			local filteredSuite = {
-				name = suite.name,
-				cases = caseEntry.suites[suiteName],
-				_beforeeach = suite._beforeeach,
-				_beforeall = suite._beforeall,
-				_aftereach = suite._aftereach,
-				_afterall = suite._afterall,
-			}
-			table.insert(filtered.suites, filteredSuite)
-		end
-		return filtered
-	end
-
-	-- Filter by suite name only
-	if suiteName then
-		local suite = env.suiteindex[suiteName]
-		if suite then
-			table.insert(filtered.suites, suite)
-		end
-		return filtered
-	end
-
-	-- Filter by case name only
-	if caseName then
-		local caseEntry = env.caseindex[caseName]
-		if caseEntry then
-			-- Add all anonymous tests with this case name
-			filtered.anonymous = caseEntry.anonymous
-
-			-- Add all suites that have tests with this case name
-			for sName, cases in caseEntry.suites do
-				local suite = env.suiteindex[sName]
+			if suite then
 				local filteredSuite = {
 					name = suite.name,
-					cases = cases,
+					cases = caseEntry.suites[suiteName],
 					_beforeeach = suite._beforeeach,
 					_beforeall = suite._beforeall,
 					_aftereach = suite._aftereach,
@@ -65,7 +34,35 @@ local function filtertests(
 				table.insert(filtered.suites, filteredSuite)
 			end
 		end
-		return filtered
+
+	-- Filter by suite name only
+	elseif suiteName then
+		local suite = env.suiteindex[suiteName]
+		if suite then
+			table.insert(filtered.suites, suite)
+		end
+	elseif caseName then
+		local caseEntry = env.caseindex[caseName]
+		if caseEntry then
+			-- Add all anonymous tests with this case name
+			filtered.anonymous = caseEntry.anonymous
+
+			-- Add all suites that have tests with this case name
+			for sName, cases in caseEntry.suites do
+				local suite = env.suiteindex[sName]
+				if suite then
+					local filteredSuite = {
+						name = suite.name,
+						cases = cases,
+						_beforeeach = suite._beforeeach,
+						_beforeall = suite._beforeall,
+						_aftereach = suite._aftereach,
+						_afterall = suite._afterall,
+					}
+					table.insert(filtered.suites, filteredSuite)
+				end
+			end
+		end
 	end
 
 	return filtered

--- a/lute/cli/commands/test/finder.luau
+++ b/lute/cli/commands/test/finder.luau
@@ -8,37 +8,22 @@ local function istestfile(filename: string): boolean
 	return stringext.hassuffix(filename, ".test.luau") or stringext.hassuffix(filename, ".spec.luau")
 end
 
-local function findtestfilesrec(directory: path.path): { path.path }
-	local results = {}
-
-	for _, entry in fs.listdirectory(directory) do
-		local fullPath = path.join(directory, entry.name)
-
-		if entry.type == "dir" then
-			tableext.extend(results, findtestfilesrec(fullPath))
-		elseif istestfile(entry.name) then
-			table.insert(results, path.normalize(fullPath))
+local function findtestfiles(paths: { string }): { path.path }
+	local files = {}
+	local function findfiles(p: path.pathlike)
+		local it = fs.walk(path.normalize(p), { recursive = true })
+		local file = it()
+		while file do
+			if fs.type(file) ~= "dir" and istestfile(path.format(file)) then
+				table.insert(files, path.normalize(file))
+			end
+			file = it()
 		end
 	end
 
-	return results
-end
-
-local function findtestfiles(paths: { string }): { path.path }
-	local files = {}
 	local cwd = ps.cwd()
-	for _, filepath in paths do
-		local pathObj = path.parse(filepath)
-
-		if not path.isabsolute(pathObj) then
-			pathObj = path.join(cwd, pathObj)
-		end
-
-		if fs.type(pathObj) == "dir" then
-			tableext.extend(files, findtestfilesrec(pathObj))
-		elseif istestfile(filepath) then
-			table.insert(files, path.normalize(pathObj))
-		end
+	for _, p in paths do
+		findfiles(path.join(cwd, p))
 	end
 
 	return files

--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -1,4 +1,5 @@
 local finder = require("@self/finder")
+local filter = require("@self/filter")
 local luau = require("@std/luau")
 local path = require("@std/path")
 local ps = require("@std/process")
@@ -16,14 +17,10 @@ Run tests discovered in .test.luau and .spec.luau files.
 OPTIONS:
   -h, --help              Show this help message
   --list                  List all discovered test cases without running them
-  --filter=PATTERN        Run only tests matching PATTERN
-                          Examples:
-                            --filter=SuiteName           (run all tests in suite)
-                            --filter=SuiteName.testname  (run specific test)
-                            --filter=testname            (run anonymous test)
-  --reporter=REPORTER     Choose test reporter (default: rich)
+  -s, --suite=SUITE       Run only tests in the specified suite
+  -c, --case=CASE         Run only test cases matching the specified name
+  --reporter=REPORTER     Choose test reporter (default: simple)
                           Options:
-                            rich    - Color output with visual diffs
                             simple  - Plain text output
                             <path>  - Custom reporter from file path
 
@@ -33,8 +30,9 @@ PATHS:
 EXAMPLES:
   lute test                                    Run all tests in ./tests
   lute test --list                             List all test cases
-  lute test --filter=MyTestSuite               Run all tests in MyTestSuite
-  lute test --reporter=simple src/             Run tests with simple reporter
+  lute test -s MyTestSuite                     Run all tests in MyTestSuite
+  lute test --suite MyTestSuite --case mytest  Run specific test in suite
+  lute test --case "some case"                 Run all test cases named "some case"
 ]])
 end
 
@@ -91,6 +89,7 @@ end
 
 local function runtests(env: testtypes.testenvironment, runner: testtypes.testrunner, reporter: testtypes.testreporter)
 	local result = runner(env)
+
 	reporter(result)
 	if result.failed ~= 0 then
 		ps.exit(1)
@@ -102,17 +101,43 @@ local function main(...: string)
 	local args = { ... }
 	local testPaths = {}
 	local isListMode = false
+	local suiteName: string? = nil
+	local caseName: string? = nil
 
-	for _, arg in args do
+	local i = 1
+	while i <= #args do
+		local arg = args[i]
+
 		if arg == "-h" or arg == "--help" then
 			printHelp()
 			return
 		elseif arg == "--list" then
 			isListMode = true
+			i += 1
+		elseif arg == "-s" or arg == "--suite" then
+			i += 1
+			if i <= #args then
+				suiteName = args[i]
+				i += 1
+			else
+				print(`Error: {arg} requires a value`)
+				ps.exit(1)
+			end
+		elseif arg == "-c" or arg == "--case" then
+			i += 1
+			if i <= #args then
+				caseName = args[i]
+				i += 1
+			else
+				print(`Error: {arg} requires a value`)
+				ps.exit(1)
+			end
 		else
 			table.insert(testPaths, arg)
+			i += 1
 		end
 	end
+
 	local searchpath = if #testPaths > 0 then testPaths else { "./tests" }
 	loadtests(finder.findtestfiles(searchpath))
 
@@ -120,7 +145,8 @@ local function main(...: string)
 		listtests()
 	else
 		local env = test._registered()
-		runtests(env, runner.run, reporter.simple)
+		local filteredEnv = filter.filtertests(env, suiteName, caseName)
+		runtests(filteredEnv, runner.run, reporter.simple)
 	end
 end
 

--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -19,10 +19,6 @@ OPTIONS:
   --list                  List all discovered test cases without running them
   -s, --suite=SUITE       Run only tests in the specified suite
   -c, --case=CASE         Run only test cases matching the specified name
-  --reporter=REPORTER     Choose test reporter (default: simple)
-                          Options:
-                            simple  - Plain text output
-                            <path>  - Custom reporter from file path
 
 PATHS:
   Directories or files to search for tests (default: ./tests)

--- a/lute/std/libs/test/init.luau
+++ b/lute/std/libs/test/init.luau
@@ -49,19 +49,21 @@ function TestSuite:afterall(hook: () -> ())
 	self._afterall = hook
 end
 
-local env: TestEnvironment = { anonymous = {}, suites = {}, reporter = reporter.simple }
+local env: TestEnvironment = { anonymous = {}, suites = {}, suiteindex = {}, caseindex = {} }
 
 -- Test library export surface
 local test = {}
-
-function test.setreporter(reporter: TestReporter)
-	test.reporter = reporter
-end
 
 -- register an anonymous test case
 function test.case(name: string, case: Test)
 	local testcase = { name = name, case = case }
 	table.insert(env.anonymous, testcase)
+
+	-- Update caseindex
+	if not env.caseindex[name] then
+		env.caseindex[name] = { anonymous = {}, suites = {} }
+	end
+	table.insert(env.caseindex[name].anonymous, testcase)
 end
 
 -- register a test suite
@@ -69,11 +71,30 @@ function test.suite(name: string, registerFn: (TestSuite) -> ())
 	local suite = TestSuite.new(name)
 	registerFn(suite)
 	table.insert(env.suites, suite)
+
+	-- Update suiteindex
+	env.suiteindex[name] = suite
+
+	-- Update caseindex for all cases in this suite
+	for _, testcase in suite.cases do
+		if not env.caseindex[testcase.name] then
+			env.caseindex[testcase.name] = { anonymous = {}, suites = {} }
+		end
+		if not env.caseindex[testcase.name].suites[name] then
+			env.caseindex[testcase.name].suites[name] = {}
+		end
+		table.insert(env.caseindex[testcase.name].suites[name], testcase)
+	end
 end
 
 -- get all registered tests without running them (internal)
 function test._registered()
-	return table.freeze({ anonymous = env.anonymous, suites = env.suites })
+	return table.freeze({
+		anonymous = env.anonymous,
+		suites = env.suites,
+		suiteindex = env.suiteindex,
+		caseindex = env.caseindex,
+	})
 end
 
 -- run all the tests

--- a/lute/std/libs/test/init.luau
+++ b/lute/std/libs/test/init.luau
@@ -61,9 +61,10 @@ function test.case(name: string, case: Test)
 
 	-- Update caseindex
 	if not env.caseindex[name] then
-		env.caseindex[name] = { anonymous = {}, suites = {} }
+		env.caseindex[name] = { anonymous = { testcase }, suites = {} }
+	else
+		table.insert(env.caseindex[name].anonymous, testcase)
 	end
-	table.insert(env.caseindex[name].anonymous, testcase)
 end
 
 -- register a test suite

--- a/lute/std/libs/test/types.luau
+++ b/lute/std/libs/test/types.luau
@@ -41,10 +41,16 @@ export type testrunresult = {
 export type testreporter = (testrunresult) -> ()
 
 -- Testing Environment
+export type caseindexentry = {
+	anonymous: { testcase },
+	suites: { [string]: { testcase } },
+}
+
 export type testenvironment = {
 	anonymous: { testcase },
 	suites: { testsuite },
-	reporter: testreporter,
+	suiteindex: { [string]: testsuite },
+	caseindex: { [string]: caseindexentry },
 }
 
 export type testrunner = (testenvironment) -> testrunresult

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -32,13 +32,43 @@ test.suite("LuteTestCommand", function(suite)
 		assert.eq(result.exitcode, 0)
 	end)
 
-	suite:case("lute test discovers test files in custom directory", function(assert)
+	suite:case("lute_test_discovery_custom_directory", function(assert)
 		-- Run lute test with custom directory path
 		local result = process.run({ lutePath, "test", "--list", "tests/cli/discovery" })
 
 		-- Check that it discovers test files (.test.luau and .spec.luau)
 		assert.eq(result.exitcode, 0)
 		assert.eq(expected, result.stdout)
+	end)
+
+	suite:case("filter_by_suite_name", function(assert)
+		-- Run lute test with --suite flag
+		local result = process.run({ lutePath, "test", "-s", "SmokeSuite", "tests/cli/discovery" })
+
+		-- Check that it runs only tests in SmokeSuite
+		assert.eq(result.exitcode, 0)
+		assert.neq(result.stdout:find("Total:  2", 1, true), nil)
+		assert.neq(result.stdout:find("Passed: 2", 1, true), nil)
+	end)
+
+	suite:case("lute test filters by case name", function(assert)
+		-- Run lute test with --case flag
+		local result = process.run({ lutePath, "test", "--case", "make_pass", "tests/cli/discovery" })
+
+		-- Check that it runs only tests named make_pass
+		assert.eq(result.exitcode, 0)
+		assert.neq(result.stdout:find("Total:  1", 1, true), nil)
+		assert.neq(result.stdout:find("Passed: 1", 1, true), nil)
+	end)
+
+	suite:case("lute test filters by suite and case name", function(assert)
+		-- Run lute test with both --suite and --case flags
+		local result = process.run({ lutePath, "test", "-s", "SmokeSuite", "-c", "make_fail", "tests/cli/discovery" })
+
+		-- Check that it runs only make_fail in SmokeSuite
+		assert.eq(result.exitcode, 0)
+		assert.neq(result.stdout:find("Total:  1", 1, true), nil)
+		assert.neq(result.stdout:find("Passed: 1", 1, true), nil)
 	end)
 end)
 


### PR DESCRIPTION
This PR adds support for lute test to run specific tests:

```
lute test --suite SomeSuite
lute test -s SomeSuite -- runs SomeSuite
lute test --case some_case 
lute test -c some_case -- runs some_case

lute test -s Suite -c case -- runs Suite.case
lute test -s "ABC" -c "some test with spaces" -- runs `ABC.some test with spaces`
```
