### PR TITLE
perf: base64 decoder with buffer-based LUT and stricter validation

### DIFF
--- a/batteries/base64.luau
+++ b/batteries/base64.luau
@@ -112,7 +112,7 @@ local function decode(input_buffer: buffer): buffer
 			error("Invalid base64 input", 2)
 		end
 		read_offset += 4
-		-- u32 BE: [B1, B2, B3, 0] = b1<<26|b2<<20|b3<<14|b4<<8, trailing 0 will be ovewriten next iteration
+		-- u32 BE: [B1, B2, B3, 0] = b1<<26|b2<<20|b3<<14|b4<<8, trailing 0 will be overwritten next iteration
 		buffer.writeu32(output, write_offset, bit32.byteswap(b1 * 0x4000000 + b2 * 0x100000 + b3 * 0x4000 + b4 * 0x100))
 		write_offset += 3
 	end

--- a/batteries/base64.luau
+++ b/batteries/base64.luau
@@ -1,10 +1,12 @@
---!native
 --!optimize 2
 --!strict
 
+-- assume little-endian system
+assert(string.pack("=i2", 1) == "\1\0", "system must be little-endian")
+
 local BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-local BASE64_ENCODING_LUT = table.create(4096)
-local BASE64_DECODING_LUT = table.create(255, 0)
+local BASE64_ENCODING_LUT = table.create(4096) :: { number }
+local BASE64_DECODING_LUT = buffer.create(256)
 
 do
 	for i = 0, 4095 do
@@ -14,11 +16,14 @@ do
 			bit32.bor(string.byte(BASE64_ALPHABET, hi), bit32.lshift(string.byte(BASE64_ALPHABET, lo), 8))
 	end
 
+	-- prefill lookup table with invalid base64 value (0xFF)
+	buffer.fill(BASE64_DECODING_LUT, 0, 0xFF)
 	for i = 1, #BASE64_ALPHABET do
-		BASE64_DECODING_LUT[string.byte(BASE64_ALPHABET, i)] = i - 1
+		buffer.writeu8(BASE64_DECODING_LUT, string.byte(BASE64_ALPHABET, i), i - 1)
 	end
 end
 
+@native
 local function encode(input_buffer: buffer): buffer
 	assert(typeof(input_buffer) == "buffer", "Expected input to be a buffer")
 
@@ -71,6 +76,7 @@ local function encode(input_buffer: buffer): buffer
 	return output
 end
 
+@native
 local function decode(input_buffer: buffer): buffer
 	assert(typeof(input_buffer) == "buffer", "Expected input to be a buffer")
 
@@ -80,49 +86,56 @@ local function decode(input_buffer: buffer): buffer
 		return buffer.create(0)
 	end
 
-	local padding_size = 0
-	if input_length >= 2 and buffer.readu16(input_buffer, input_length - 2) == 0x3D3D then
-		padding_size = 2
-	elseif input_length >= 1 and buffer.readu8(input_buffer, input_length - 1) == 0x3D then
-		padding_size = 1
+	-- strip padding (rfc-4648 section 3.3: the excess pad characters MAY also be ignored)
+	while input_length > 0 and buffer.readu8(input_buffer, input_length - 1) == 0x3D do
+		input_length -= 1
+	end
+
+	-- rfc-4648 section 3.3 forbids padding that isn't preceded by at least one Base64 digit
+	if input_length == 0 then
+		error("Invalid base64 input", 2)
 	end
 
 	-- get correct output size
-	local output_length = ((input_length / 4) * 3) - padding_size
+	local output_length = (3 * input_length) // 4
 	local output = buffer.create(output_length)
-	local chunks = input_length // 4
 
-	for chunk_idx = 1, chunks do
-		local index = (chunk_idx - 1) * 4
-		local out_index = (chunk_idx - 1) * 3
-
-		local value1 = BASE64_DECODING_LUT[buffer.readu8(input_buffer, index)]
-		local value2 = BASE64_DECODING_LUT[buffer.readu8(input_buffer, index + 1)]
-		local value3 = BASE64_DECODING_LUT[buffer.readu8(input_buffer, index + 2)]
-		local value4 = BASE64_DECODING_LUT[buffer.readu8(input_buffer, index + 3)]
-
-		local chunk = bit32.bor(bit32.lshift(value1, 18), bit32.lshift(value2, 12), bit32.lshift(value3, 6), value4)
-
-		local character1 = bit32.rshift(chunk, 16)
-		local character2 = bit32.band(bit32.rshift(chunk, 8), 0b11111111)
-		local character3 = bit32.band(chunk, 0b11111111)
-
-		-- always write the first byte
-		if out_index < output_length then
-			buffer.writeu8(output, out_index, character1)
+	local read_offset = 0
+	local write_offset = 0
+	-- loop invariant: at least 4 bytes to write
+	while write_offset + 4 <= output_length do
+		local b4 = buffer.readu8(BASE64_DECODING_LUT, buffer.readu8(input_buffer, read_offset + 3))
+		local b3 = buffer.readu8(BASE64_DECODING_LUT, buffer.readu8(input_buffer, read_offset + 2))
+		local b2 = buffer.readu8(BASE64_DECODING_LUT, buffer.readu8(input_buffer, read_offset + 1))
+		local b1 = buffer.readu8(BASE64_DECODING_LUT, buffer.readu8(input_buffer, read_offset))
+		if bit32.bor(b1, b2, b3, b4) >= 64 then
+			error("Invalid base64 input", 2)
 		end
-
-		-- write second byte if have space (+padding)
-		if out_index + 1 < output_length then
-			buffer.writeu8(output, out_index + 1, character2)
-		end
-
-		-- Write third byte if we have space (+padding)
-		if out_index + 2 < output_length then
-			buffer.writeu8(output, out_index + 2, character3)
-		end
+		read_offset += 4
+		-- u32 BE: [B1, B2, B3, 0] = b1<<26|b2<<20|b3<<14|b4<<8, trailing 0 will be ovewriten next iteration
+		buffer.writeu32(output, write_offset, bit32.byteswap(b1 * 0x4000000 + b2 * 0x100000 + b3 * 0x4000 + b4 * 0x100))
+		write_offset += 3
 	end
 
+	local u24be, nbits = 0, 0
+	while read_offset < input_length do
+		local b = buffer.readu8(BASE64_DECODING_LUT, buffer.readu8(input_buffer, read_offset))
+		read_offset += 1
+		if b >= 64 then
+			error("Invalid base64 input", 2)
+		end
+		u24be = u24be * 0x40 + b
+		nbits += 6
+	end
+	while nbits >= 8 do
+		buffer.writeu8(output, write_offset, bit32.rshift(u24be, nbits - 8))
+		nbits -= 8
+		write_offset += 1
+	end
+	-- 2 or 4 leftover bits must be zero
+	if nbits == 6 or (nbits == 2 and bit32.btest(u24be, 0x03)) or (nbits == 4 and bit32.btest(u24be, 0x0F)) then
+		error("Invalid base64 input", 2)
+	end
 	return output
 end
 

--- a/batteries/base64.luau
+++ b/batteries/base64.luau
@@ -1,8 +1,6 @@
 --!optimize 2
 --!strict
 
--- assume little-endian system
-assert(string.pack("=i2", 1) == "\1\0", "system must be little-endian")
 
 local BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 local BASE64_ENCODING_LUT = table.create(4096) :: { number }

--- a/batteries/base64.luau
+++ b/batteries/base64.luau
@@ -1,7 +1,6 @@
 --!optimize 2
 --!strict
 
-
 local BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
 local BASE64_ENCODING_LUT = table.create(4096) :: { number }
 local BASE64_DECODING_LUT = buffer.create(256)

--- a/tests/batteries/base64.test.luau
+++ b/tests/batteries/base64.test.luau
@@ -35,7 +35,7 @@ local invalidInputs = {
 local invalidLastBytes = {
 	"====", -- all padding
 	"A==A", -- char after padding
-	"A",    -- invalid length
+	"A", -- invalid length
 	"AB==", -- impossible sequence
 	"AAB=", -- impossible sequence
 }

--- a/tests/batteries/base64.test.luau
+++ b/tests/batteries/base64.test.luau
@@ -1,0 +1,76 @@
+local test = require("@std/test")
+local base64 = require("@batteries/base64")
+
+local function enc(s: string): string
+	return buffer.tostring(base64.encode(buffer.fromstring(s)))
+end
+local function dec(s: string): string
+	return buffer.tostring(base64.decode(buffer.fromstring(s)))
+end
+
+-- RFC 4648 test vectors
+local testVectors = {
+	{ "", "" },
+	{ "f", "Zg==" },
+	{ "fo", "Zm8=" },
+	{ "foo", "Zm9v" },
+	{ "foob", "Zm9vYg==" },
+	{ "fooba", "Zm9vYmE=" },
+	{ "foobar", "Zm9vYmFy" },
+	{ "foobarb", "Zm9vYmFyYg==" },
+	{ "foobarba", "Zm9vYmFyYmE=" },
+	{ "foobarbaz", "Zm9vYmFyYmF6" },
+}
+
+local invalidInputs = {
+	"SGVsbG8\0",
+	"SGVsbG8\255",
+	"Hell@oWorld!",
+	"Test1#23",
+	"DataMon$ey",
+	"SGVsbG8-V29ybGQ_",
+	"SGVs=bG8=",
+}
+
+local invalidLastBytes = {
+	"====", -- all padding
+	"A==A", -- char after padding
+	"A",    -- invalid length
+	"AB==", -- impossible sequence
+	"AAB=", -- impossible sequence
+}
+
+test.suite("Base64", function(suite)
+	for _, vector in ipairs(testVectors) do
+		local input = vector[1]
+		local expected_encoded = vector[2]
+
+		suite:case("Encode: '" .. input .. "'", function(assert)
+			local encoded = enc(input)
+			assert.eq(expected_encoded, encoded)
+		end)
+
+		suite:case("Decode: '" .. expected_encoded .. "'", function(assert)
+			local decoded = dec(expected_encoded)
+			assert.eq(input, decoded)
+		end)
+	end
+
+	for _, invalid in invalidInputs do
+		suite:case("Invalid Decode: '" .. invalid .. "'", function(assert)
+			assert.errors(function()
+				dec(invalid)
+			end)
+		end)
+	end
+
+	for _, invalid in invalidLastBytes do
+		suite:case("Invalid Decode (last bytes): '" .. invalid .. "'", function(assert)
+			assert.errors(function()
+				dec(invalid)
+			end)
+		end)
+	end
+end)
+
+test.run()


### PR DESCRIPTION
## Summary
- Replace table-based decoding LUT with buffer for faster lookups
- Switch from file-scope `--!native` to function-level `@native` attributes
- Implement RFC 4648-compliant padding handling (strip instead of count)
- Add input validation to reject invalid base64 characters
- Validate non-zero padding bits per RFC 4648 section 3.5
- Optimize decode loop using u32 writes

## Test coverage
- RFC 4648 test vectors (encode/decode)
- Invalid character detection
- Invalid padding/length cases

## Performance
```text
> luau --codegen -O2
-- Output size 1 KB
   old base64.decode     10.61 us/iter
-> new base64.decode      7.31 us/iter
-- Output size 1024 KB
   old base64.decode     10.51 ms/iter
-> new base64.decode      6.80 ms/iter

> luau -O2
-- Output size 1 KB
   old base64.decode     45.48 us/iter
-> new base64.decode     36.32 us/iter
-- Output size 1024 KB
   old base64.decode     47.37 ms/iter
-> new base64.decode     34.48 ms/iter
```

