### PR TITLE
bugfix: remaining failing windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: ["primary"]
   pull_request:
     branches: ["primary"]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -43,7 +44,8 @@ jobs:
         run: rm .luaurc && mv .luaurc.ci .luaurc
 
       - name: Run Luau Tests
-        run: find tests -name "*.test.luau" | xargs -I {} ${{ steps.build_lute.outputs.exe_path }} run {}
+        shell: bash
+        run: find tests -name "*.test.luau" | xargs -I {} $(echo '${{ steps.build_lute.outputs.exe_path }}' | tr '\\' '/') run {}
 
   run-lute-cxx-unittests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
     branches: ["primary"]
   pull_request:
     branches: ["primary"]
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -43,9 +42,15 @@ jobs:
       - name: Use CI .luaurc file
         run: rm .luaurc && mv .luaurc.ci .luaurc
 
-      - name: Run Luau Tests
+      - name: Run Luau Tests (POSIX)
+        if: runner.os != 'Windows'
         shell: bash
-        run: find tests -name "*.test.luau" | xargs -I {} $(echo '${{ steps.build_lute.outputs.exe_path }}' | tr '\\' '/') run {}
+        run: find tests -name "*.test.luau" | xargs -I {} "${{ steps.build_lute.outputs.exe_path }}" run {}
+
+      - name: Run Luau Tests (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: for /r tests %%f in (*.test.luau) do "${{ steps.build_lute.outputs.exe_path }}" run "%%f"
 
   run-lute-cxx-unittests:
     runs-on: ${{ matrix.os }}

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -26,6 +26,15 @@
 namespace process
 {
 
+void convertCRLFtoLF(std::string& str)
+{
+      size_t pos = 0;
+      while ((pos = str.find("\r\n", pos)) != std::string::npos) {
+          str.erase(pos, 1);  // Remove the '\r'
+          pos++;  // Move past the '\n'
+      }
+}
+    
 struct ProcessHandle
 {
     uv_process_t process;
@@ -96,7 +105,8 @@ struct ProcessHandle
             std::string finalStdout = stdoutData;
             std::string finalStderr = stderrData;
             std::string finalSignalStr = finalTermSignal ? std::to_string(finalTermSignal) : "";
-
+            convertCRLFtoLF(finalStdout);
+            convertCRLFtoLF(finalStderr);
             resumeToken->complete(
                 [=](lua_State* L)
                 {

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -28,11 +28,14 @@ namespace process
 
 void convertCRLFtoLF(std::string& str)
 {
-      size_t pos = 0;
-      while ((pos = str.find("\r\n", pos)) != std::string::npos) {
-          str.erase(pos, 1);  // Remove the '\r'
-          pos++;  // Move past the '\n'
-      }
+    size_t writePos = 0;
+    for (size_t readPos = 0; readPos < str.size(); ++readPos)
+    {
+        if (str[readPos] == '\r' && readPos + 1 < str.size() && str[readPos + 1] == '\n')
+            continue;  // Skip the '\r' in CRLF
+        str[writePos++] = str[readPos];
+    }
+    str.resize(writePos);
 }
     
 struct ProcessHandle

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -75,7 +75,7 @@ test.run()
 			result.stdout:find(`Failed with: Runtime error in nil_field_suite.access_field_of_nil in:`, 1, true),
 			nil
 		)
-		assert.neq(result.stdout:find(`{tostring(testFilePath)}:6`, 1, true), nil)
+		assert.neq(result.stdout:find(`{path.format(testFilePath)}:6`, 1, true), nil)
 
 		fs.remove(testFilePath)
 	end)
@@ -107,7 +107,7 @@ test.run()
 		assert.eq(result.stdout:find("xpcall", 1, true), nil)
 		-- Check that the error points to filepath + correct line number
 		assert.neq(result.stdout:find(`Failed with: Runtime error in access_field_of_nil in:`, 1, true), nil)
-		assert.neq(result.stdout:find(`{tostring(testFilePath)}:5`, 1, true), nil)
+		assert.neq(result.stdout:find(`{path.format(testFilePath)}:5`, 1, true), nil)
 
 		fs.remove(testFilePath)
 	end)

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -1,7 +1,7 @@
 local pathlib = require("@std/path")
 local process = require("@std/process")
 local test = require("@std/test")
-
+local system = require("@std/system")
 test.suite("ProcessSuite", function(suite)
 	suite:case("homedir_and_cwd_and_execpath", function(assert)
 		local hd = process.homedir()
@@ -20,7 +20,12 @@ test.suite("ProcessSuite", function(suite)
 	end)
 
 	suite:case("run_shell_and_cwd", function(assert)
-		local r = process.run({ "pwd" }, { cwd = "/" })
+		local rootdir: string = "/"
+		if system.win32 then
+			local root = pathlib.win32.drive(process.cwd())
+			rootdir = pathlib.format(root)
+		end
+		local r = process.run({ "pwd" }, { cwd = rootdir, shell = if system.win32 then "cmd" else "bash" })
 		assert.tableeq(r, {
 			exitcode = 0,
 			stdout = "/\n",

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -25,7 +25,7 @@ test.suite("ProcessSuite", function(suite)
 			local root = pathlib.win32.drive(process.cwd())
 			rootdir = pathlib.format(root)
 		end
-		local r = process.run({ "pwd" }, { cwd = rootdir, shell = if system.win32 then "cmd" else "bash" })
+		local r = process.run({ "pwd" }, { cwd = rootdir })
 		assert.tableeq(r, {
 			exitcode = 0,
 			stdout = "/\n",


### PR DESCRIPTION
This PR fixes the remaining windows tests that fail due to platform specific new line conventions. Inside of process.cpp, we now convert CRLF line endings to LF endings automatically.

Finally, some of tasks display diverging behaviour on git bash vs command prompt. I've update the job to run tests on `cmd` in windows and `bash` on posix systems.