### PR TITLE
lute parse: fix serialization of union type separators

### DIFF
--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -1,5 +1,8 @@
 #include "lute/luau.h"
 
+#include "lute/configresolver.h"
+#include "lute/moduleresolver.h"
+
 #include "Luau/Ast.h"
 #include "Luau/BuiltinDefinitions.h"
 #include "Luau/Compiler.h"
@@ -13,9 +16,6 @@
 
 #include "lua.h"
 #include "lualib.h"
-
-#include "lute/configresolver.h"
-#include "lute/moduleresolver.h"
 
 #include <cstddef>
 #include <cstring>
@@ -1962,7 +1962,14 @@ struct AstSerialize : public Luau::AstVisitor
                 lua_setfield(L, -2, "tag");
                 lua_setfield(L, -2, "node");
 
-                lua_pushnil(L);
+                // Since this option is an optional type, the separator is always present unless it's the last type
+                if (i < node->types.size - 1 && separatorPositions < cstNode->separatorPositions.size)
+                {
+                    serializeToken(cstNode->separatorPositions.data[separatorPositions], "|");
+                    separatorPositions++;
+                }
+                else
+                    lua_pushnil(L);
                 lua_setfield(L, -2, "separator");
             }
             else
@@ -1970,13 +1977,16 @@ struct AstSerialize : public Luau::AstVisitor
                 node->types.data[i]->visit(this);
                 lua_setfield(L, -2, "node");
 
+                // If the next type is optional, we don't have a separator token
                 if (i < node->types.size - 1 && !node->types.data[i + 1]->is<Luau::AstTypeOptional>() &&
                     separatorPositions < cstNode->separatorPositions.size)
+                {
                     serializeToken(cstNode->separatorPositions.data[separatorPositions], "|");
+                    separatorPositions++;
+                }
                 else
                     lua_pushnil(L);
                 lua_setfield(L, -2, "separator");
-                separatorPositions++;
             }
 
             lua_rawseti(L, -2, i + 1);

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -969,7 +969,6 @@ test.suite("parse types", function(suite)
 		assert.eq(pair1.node.tag, "reference")
 		assert.eq(pair1.separator, nil)
 
-		-- Wack that optional types are two whole Ast nodes, but it's how it is on the C++ side too
 		local pair2 = unionType.types[2]
 		assert.eq(pair2.node.tag, "optional")
 		assert.neq(pair2.separator, nil)

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -956,6 +956,30 @@ test.suite("parse types", function(suite)
 		assert.eq((unionType.types[2].node :: luau.AstTypeOptional).text, "?")
 	end)
 
+	suite:case("testTypeUnionWithOptionalPart", function(assert)
+		local block = parser.parse("type T = number? | string")
+		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias
+		assert.eq(typeAlias.type.tag, "union")
+
+		local unionType = typeAlias.type :: luau.AstTypeUnion
+		assert.eq(unionType.leading, nil)
+		assert.eq(#unionType.types, 3)
+
+		local pair1 = unionType.types[1]
+		assert.eq(pair1.node.tag, "reference")
+		assert.eq(pair1.separator, nil)
+
+		-- Wack that optional types are two whole Ast nodes, but it's how it is on the C++ side too
+		local pair2 = unionType.types[2]
+		assert.eq(pair2.node.tag, "optional")
+		assert.neq(pair2.separator, nil)
+		assert.eq((pair2.separator :: luau.Token<"|">).text, "|")
+
+		local pair3 = unionType.types[3]
+		assert.eq(pair3.node.tag, "reference")
+		assert.eq(pair3.separator, nil)
+	end)
+
 	suite:case("testTypeIntersection", function(assert)
 		local block = parser.parse("type T = A & B & C")
 		local typeAlias = block.statements[1] :: luau.AstStatTypeAlias


### PR DESCRIPTION
This PR fixes a bug where the `|` separator was not being correctly serialized when it followed an optional option of a union. For example, the `|` in the union type `number? | string` was not being correctly serialized, and was instead being consumed as the preceding trivia of the `string` option. We now _always_ try to consume the separator if serializing an optional option which isn't the last option of the union.

Added a test checking this functionality.

Addresses #551.