### PR TITLE
infra: install a batteries-only version of the .luaurc file for CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Use CI .luaurc file
-        run: mv .luaurc.ci .luaurc
+        run: rm .luaurc && mv .luaurc.ci .luaurc
 
       - name: Run Luau Tests
         run: find tests -name "*.test.luau" | xargs -I {} ${{ steps.build_lute.outputs.exe_path }} run {}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,8 @@ jobs:
           options: ${{ matrix.options }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Remove .luaurc file
-        run: rm .luaurc
+      - name: Use CI .luaurc file
+        run: mv .luaurc.ci .luaurc
 
       - name: Run Luau Tests
         run: find tests -name "*.test.luau" | xargs -I {} ${{ steps.build_lute.outputs.exe_path }} run {}

--- a/.luaurc.ci
+++ b/.luaurc.ci
@@ -1,0 +1,6 @@
+{
+    "languageMode": "strict",
+    "aliases": {
+        "batteries": "./batteries",
+    }
+}


### PR DESCRIPTION
Fixes #561 by installing a batteries-only version of the .luaurc file in CI specifically. This allows us to author tests for batteries, without having to risk the failure mode where we don't notice the embedding of the standard library broke.