### PR TITLE
fix: fs.open should handle optional mode

### DIFF
--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -324,21 +324,25 @@ std::optional<FileHandle> openHelper(lua_State* L, const char* path, const char*
 int open(lua_State* L)
 {
     int nArgs = lua_gettop(L);
-    const char* path = luaL_checkstring(L, 1);
-    int openFlags = 0x0000;
-    // When the number of arguments is less 2
     if (nArgs < 1)
     {
         luaL_errorL(L, "Error: no file supplied\n");
         return 0;
     }
+    const char* path = luaL_checkstring(L, 1);
 
-    if (nArgs < 2)
+    int openFlags = 0x0000;
+    const char* mode = "r";
+    // Default to read mode if no mode is supplied (i.e., mode is nil in Luau)
+    if (nArgs < 2 || lua_isnil(L, 2))
     {
         openFlags = O_RDONLY;
     }
+    else
+    {
+        mode = luaL_checkstring(L, 2);
+    }
 
-    const char* mode = luaL_checkstring(L, 2);
     if (std::optional<FileHandle> result = openHelper(L, path, mode, &openFlags))
     {
         createFileHandle(L, *result);

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -164,6 +164,8 @@ test.suite("FsSuite", function(suite)
 		local contents = fs.read(h2)
 		assert.eq(contents, "created file")
 		fs.close(h2)
+
+		fs.remove(file)
 	end)
 end)
 

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -152,6 +152,19 @@ test.suite("FsSuite", function(suite)
 		assert.neq(success, true)
 		assert.neq(err, nil)
 	end)
+
+	suite:case("fs_open_optional_mode", function(assert)
+		local file = path.join(tmpdir, "optional_mode.txt")
+
+		local h1 = fs.open(file, "w+")
+		fs.write(h1, "created file")
+		fs.close(h1)
+
+		local h2 = fs.open(file) -- with no mode specified, should default to "r"
+		local contents = fs.read(h2)
+		assert.eq(contents, "created file")
+		fs.close(h2)
+	end)
 end)
 
 test.run()


### PR DESCRIPTION
per our [docs](https://lute.luau.org/reference/definitions/fs.html#fs-open), the `mode` argument in `fs.open` is an optional argument, but `fs.open(path)` was erroring with `invalid argument #2 to 'open' (string expected, got nil)` when mode is not specified. We fix `fs.cpp` by defaulting the mode to read only if it's not specified through the `mode: HandleMode` in either `@lute/fs` or `@std/fs`.