### PR TITLE
site: link folder and page names together for api docs & fix nav

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -21,6 +21,8 @@ export default withSidebar(
     // ============ [ SIDEBAR OPTIONS ] ============
     useFolderLinkFromSameNameSubFile: true,
     useFolderLinkFromIndexFile: false,
+    useTitleFromFileHeading: true,
+    useTitleFromFrontmatter: true,
     hyphenToSpace: true,
     underscoreToSpace: true,
     sortMenusByName: true,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -19,15 +19,10 @@ export default withSidebar(
   }),
   {
     // ============ [ SIDEBAR OPTIONS ] ============
-    // ============ [ GROUPING ] ============
-    // collapsed: true,         // Collapse subgroups by default
-    // ============ [ GETTING MENU TITLE ] ============
-    useTitleFromFileHeading: true,
-    useTitleFromFrontmatter: true,
-    // ============ [ STYLING MENU TITLE ] ============
+    useFolderLinkFromSameNameSubFile: true,
+    useFolderLinkFromIndexFile: false,
     hyphenToSpace: true,
     underscoreToSpace: true,
-    // ============ [ SORTING ] ============
     sortMenusByName: true,
   }
 )

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,7 +20,6 @@ export default withSidebar(
   {
     // ============ [ SIDEBAR OPTIONS ] ============
     useFolderLinkFromSameNameSubFile: true,
-    useFolderLinkFromIndexFile: false,
     useTitleFromFileHeading: true,
     useTitleFromFrontmatter: true,
     hyphenToSpace: true,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,7 +9,7 @@ export default withSidebar(
     themeConfig: {
       nav: [
         { text: 'Guide', link: '/guide/installation' },
-        { text: 'Reference', link: '/reference/' },
+        { text: 'Reference', link: '/reference/definitions/crypto' },
       ],
       search: { provider: 'local' },
       socialLinks: [


### PR DESCRIPTION
<img width="1432" height="934" alt="image" src="https://github.com/user-attachments/assets/b40ea281-ce8c-462d-a1b2-0cd605e37c76" />


Note: to test locally like github actions does, `cd docs`, `npm run build; npm run dev` in the `docs/` directory