### PR TITLE
bugfix: Use after free in fs.cpp's watch method

### DIFF
--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -561,6 +561,8 @@ struct WatchHandle
                 luaL_errorL(L, "Error stopping fs event: %s", uv_strerror(err));
             }
 
+            uv_close((uv_handle_t*) &handle, nullptr);
+
             isClosed = true;
 
             getRuntime(L)->releasePendingToken();
@@ -584,12 +586,6 @@ static int closeWatchHandle(lua_State* L)
     {
         luaL_errorL(L, "Invalid fs event handle");
         return 0;
-    }
-
-    int err = uv_fs_event_stop(&handle->handle);
-    if (err)
-    {
-        luaL_errorL(L, "Error stopping fs event: %s", uv_strerror(err));
     }
 
     handle->close();


### PR DESCRIPTION
This use after free manifested intermittently when running lots and lots of tests at a time in this PR: https://github.com/luau-lang/lute/pull/557.

The cause of this uaf happens because we do not close the `fs_event_t` handle. When the `WatchHandle` wrapper gets closed, it invoked `uv_event_stop` but not `uv_close`, so the memory associated with the handle gets freed, but `libuv` doesn't know that this handle is closed. This causes uv's internal data structures to get messed up and we may accidentally touch this freed memory causing the Use-After-Free.

`WatchHandle::close` already invokes `uv_event_stop`, so we can remove this from the implementation of `closeHandle`.