### PR TITLE
lute stdlib: Update createVisitor to take a default callback

### DIFF
--- a/lute/std/libs/syntax/printer.luau
+++ b/lute/std/libs/syntax/printer.luau
@@ -11,12 +11,12 @@ type PrintVisitor = visitor.Visitor & {
 	cursor: number,
 	replacements: types.replacements,
 	write: (self: PrintVisitor, str: string) -> (),
-	printTrivia: (self: PrintVisitor, trivia: luau.Trivia) -> (),
-	printTriviaList: (self: PrintVisitor, trivia: { luau.Trivia }) -> (),
-	printToken: (self: PrintVisitor, token: luau.Token) -> (),
-	printString: (self: PrintVisitor, expr: luau.AstExprConstantString | luau.AstTypeSingletonString) -> (),
-	printInterpolatedString: (self: PrintVisitor, expr: luau.AstExprInterpString) -> (),
-	printReplacement: (self: PrintVisitor, node: luau.AstNode, replacement: types.replacement) -> (),
+	printTrivia: (self: PrintVisitor, trivia: types.Trivia) -> (),
+	printTriviaList: (self: PrintVisitor, trivia: { types.Trivia }) -> (),
+	printToken: (self: PrintVisitor, token: types.Token) -> (),
+	printString: (self: PrintVisitor, expr: types.AstExprConstantString | types.AstTypeSingletonString) -> (),
+	printInterpolatedString: (self: PrintVisitor, expr: types.AstExprInterpString) -> (),
+	printReplacement: (self: PrintVisitor, node: types.AstNode, replacement: types.replacement) -> (),
 }
 local function exhaustiveMatch(value: never): never
 	error(`Unknown value in exhaustive match: {value}`)
@@ -82,7 +82,7 @@ local function printInterpolatedString(self: PrintVisitor, expr: types.AstExprIn
 	end
 end
 
-local function printReplacement(self: PrintVisitor, node: luau.AstNode, replacement: types.replacement)
+local function printReplacement(self: PrintVisitor, node: types.AstNode, replacement: types.replacement)
 	if typeof(replacement) == "string" then
 		self:write(replacement)
 	elseif replacement.kind ~= nil then -- LUAUFIX: type solver upset comparing string singleton union to nil
@@ -130,9 +130,11 @@ local function printVisitor(replacements: types.replacements?)
 		return false
 	end
 
+	printer = visitor.create(maybeReplace) :: PrintVisitor
+
 	printer.result = result
 	printer.cursor = cursor
-	printer.replacements = if replacements ~= nil then replacements else {}
+	printer.replacements = if replacements ~= nil then replacements else {} :: types.replacements
 	printer.write = write
 	printer.printTrivia = printTrivia
 	printer.printTriviaList = printTriviaList
@@ -140,80 +142,27 @@ local function printVisitor(replacements: types.replacements?)
 	printer.printString = printString
 	printer.printInterpolatedString = printInterpolatedString
 	printer.printReplacement = printReplacement
-
-	printer.visitBlock = maybeReplace
-	printer.visitBlockEnd = maybeReplace
-	printer.visitIf = maybeReplace
-	printer.visitWhile = maybeReplace
-	printer.visitRepeat = maybeReplace
-	printer.visitReturn = maybeReplace
-	printer.visitLocalDeclaration = maybeReplace
-	printer.visitLocalDeclarationEnd = maybeReplace
-	printer.visitFor = maybeReplace
-	printer.visitForIn = maybeReplace
-	printer.visitAssign = maybeReplace
-	printer.visitCompoundAssign = maybeReplace
-	printer.visitFunction = maybeReplace
-	printer.visitLocalFunction = maybeReplace
-	printer.visitTypeAlias = maybeReplace
-	printer.visitStatTypeFunction = maybeReplace
-
-	printer.visitExpression = maybeReplace
-	printer.visitExpressionEnd = maybeReplace
-	printer.visitLocalReference = maybeReplace
-	printer.visitGlobal = maybeReplace
-	printer.visitCall = maybeReplace
-	printer.visitUnary = maybeReplace
-	printer.visitBinary = maybeReplace
-	printer.visitAnonymousFunction = maybeReplace
-	printer.visitTableItem = maybeReplace
-	printer.visitTable = maybeReplace
-	printer.visitIndexName = maybeReplace
-	printer.visitIndexExpr = maybeReplace
-	printer.visitGroup = maybeReplace
-	printer.visitInterpolatedString = function(node: luau.AstExprInterpString)
+	printer.visitInterpolatedString = function(node: types.AstExprInterpString)
 		printer:printInterpolatedString(node)
 		return false
 	end
-	printer.visitTypeAssertion = maybeReplace
-	printer.visitIfExpression = maybeReplace
-
-	printer.visitTypeReference = maybeReplace
-	printer.visitTypeBoolean = maybeReplace
 	printer.visitTypeString = function(node: types.AstTypeSingletonString)
 		printer:printString(node)
 		return false
 	end
-	printer.visitTypeTypeof = maybeReplace
-	printer.visitTypeGroup = maybeReplace
-	printer.visitTypeUnion = maybeReplace
-	printer.visitTypeIntersection = maybeReplace
-	printer.visitTypeArray = maybeReplace
-	printer.visitTypeTable = maybeReplace
-	printer.visitTypeFunction = maybeReplace
-
-	printer.visitTypePackExplicit = maybeReplace
-	printer.visitTypePackGeneric = maybeReplace
-	printer.visitTypePackVariadic = maybeReplace
-
 	printer.visitToken = function(node: types.Token)
 		printer:printToken(node)
 		return false
 	end
-	printer.visitNil = maybeReplace
 	printer.visitString = function(node: types.AstExprConstantString)
 		printer:printString(node)
 		return false
 	end
-	printer.visitBoolean = maybeReplace
-	printer.visitNumber = maybeReplace
-	printer.visitLocal = maybeReplace
-	printer.visitVarargs = maybeReplace
 
 	return printer
 end
 
-function printerLib.printnode(node: luau.AstNode, replacements: types.replacements?): string
+function printerLib.printnode(node: types.AstNode, replacements: types.replacements?): string
 	local printer = printVisitor(replacements)
 	visitor.visit(node, printer)
 	return buffer.readstring(printer.result, 0, printer.cursor)

--- a/lute/std/libs/syntax/query.luau
+++ b/lute/std/libs/syntax/query.luau
@@ -2,7 +2,6 @@
 -- @std/syntax/query
 -- Provides utility functions for querying Luau AST nodes
 
-local luau = require("@std/luau")
 local printer = require("./printer")
 local types = require("./types")
 local visitor = require("./visitor")
@@ -76,68 +75,16 @@ function queryLib.selectFromRoot<T>(ast: node, fn: (node) -> T?): query<T>
 		return true
 	end
 
-	local selectVisitor: visitor.Visitor = {
-		visitBlock = visit,
-		visitBlockEnd = function(n) end,
-		visitIf = visit,
-		visitWhile = visit,
-		visitRepeat = visit,
-		visitReturn = visit,
-		visitLocalDeclaration = visit,
-		visitLocalDeclarationEnd = function(n) end,
-		visitFor = visit,
-		visitForIn = visit,
-		visitAssign = visit,
-		visitCompoundAssign = visit,
-		visitFunction = visit,
-		visitLocalFunction = visit,
-		visitTypeAlias = visit,
-		visitStatTypeFunction = visit,
-
-		visitExpression = function(n)
-			return true
-		end,
-		visitExpressionEnd = function(n) end,
-		visitLocalReference = visit,
-		visitGlobal = visit,
-		visitCall = visit,
-		visitUnary = visit,
-		visitBinary = visit,
-		visitAnonymousFunction = visit,
-		visitTableItem = visit,
-		visitTable = visit,
-		visitIndexName = visit,
-		visitIndexExpr = visit,
-		visitGroup = visit,
-		visitInterpolatedString = visit,
-		visitTypeAssertion = visit,
-		visitIfExpression = visit,
-
-		visitTypeReference = visit,
-		visitTypeBoolean = visit,
-		visitTypeString = visit,
-		visitTypeTypeof = visit,
-		visitTypeGroup = visit,
-		visitTypeUnion = visit,
-		visitTypeIntersection = visit,
-		visitTypeArray = visit,
-		visitTypeTable = visit,
-		visitTypeFunction = visit,
-
-		visitTypePackExplicit = visit,
-		visitTypePackGeneric = visit,
-		visitTypePackVariadic = visit,
-
-		visitToken = function(n)
-			return true
-		end,
-		visitNil = visit,
-		visitString = visit,
-		visitBoolean = visit,
-		visitNumber = visit,
-		visitLocal = visit,
-		visitVarargs = visit,
-	}
+	local selectVisitor = visitor.create(visit)
+	selectVisitor.visitBlockEnd = function(n) end
+	selectVisitor.visitLocalDeclarationEnd = function(n) end
+	selectVisitor.visitExpression = function(n)
+		return true
+	end
+	selectVisitor.visitExpressionEnd = function(n) end
+	selectVisitor.visitToken = function(n)
+		return true
+	end
 
 	visitor.visit(ast, selectVisitor)
 

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -877,8 +877,69 @@ function visitTypePack(type: types.AstTypePack, visitor: Visitor)
 	end
 end
 
-local function create()
-	return table.clone(defaultVisitor)
+local function create(visit: ((types.AstNode) -> boolean)?): Visitor
+	if visit then
+		return {
+			visitBlock = visit,
+			visitBlockEnd = visit :: any,
+			visitIf = visit,
+			visitWhile = visit,
+			visitRepeat = visit,
+			visitReturn = visit,
+			visitLocalDeclaration = visit,
+			visitLocalDeclarationEnd = visit,
+			visitFor = visit,
+			visitForIn = visit,
+			visitAssign = visit,
+			visitCompoundAssign = visit,
+			visitFunction = visit,
+			visitLocalFunction = visit,
+			visitTypeAlias = visit,
+			visitStatTypeFunction = visit,
+
+			visitExpression = visit,
+			visitExpressionEnd = visit,
+			visitLocalReference = visit,
+			visitGlobal = visit,
+			visitCall = visit,
+			visitUnary = visit,
+			visitBinary = visit,
+			visitAnonymousFunction = visit,
+			visitTableItem = visit,
+			visitTable = visit,
+			visitIndexName = visit,
+			visitIndexExpr = visit,
+			visitGroup = visit,
+			visitInterpolatedString = visit,
+			visitTypeAssertion = visit,
+			visitIfExpression = visit,
+
+			visitTypeReference = visit,
+			visitTypeBoolean = visit,
+			visitTypeString = visit,
+			visitTypeTypeof = visit,
+			visitTypeGroup = visit,
+			visitTypeUnion = visit,
+			visitTypeIntersection = visit,
+			visitTypeArray = visit,
+			visitTypeTable = visit,
+			visitTypeFunction = visit,
+
+			visitTypePackExplicit = visit,
+			visitTypePackGeneric = visit,
+			visitTypePackVariadic = visit,
+
+			visitToken = visit,
+			visitNil = visit,
+			visitString = visit,
+			visitBoolean = visit,
+			visitNumber = visit,
+			visitLocal = visit,
+			visitVarargs = visit,
+		}
+	else
+		return table.clone(defaultVisitor)
+	end
 end
 
 local function visit(node: types.AstNode, visitor: Visitor)

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -571,7 +571,7 @@ local function visitIfExpression(node: types.AstExprIfElse, visitor: Visitor)
 end
 
 local function visitTypeOrPack(node: types.AstType | types.AstTypePack, visitor: Visitor)
-	if node.tag == "explicit" or node.tag == "generic" or node.tag == "variadic" then
+	if node.kind == "typepack" then
 		visitTypePack(node, visitor)
 	else
 		visitType(node, visitor)
@@ -881,7 +881,7 @@ local function create()
 	return table.clone(defaultVisitor)
 end
 
-local function visit(node: luau.AstNode, visitor: Visitor)
+local function visit(node: types.AstNode, visitor: Visitor)
 	if node.kind == "stat" then
 		visitStatement(node, visitor)
 	elseif node.kind == "expr" then

--- a/tests/std/syntax/query.test.luau
+++ b/tests/std/syntax/query.test.luau
@@ -1,4 +1,3 @@
-local luau = require("@std/luau")
 local syntax = require("@std/syntax")
 local query = require("@std/syntax/query")
 local test = require("@std/test")


### PR DESCRIPTION
Creating visitors today can be a bit of a pain if you want to override most of the default visitor's fields. I added an optional visit callback to make life a bit easier. Also found some incorrect type annotations and unused requires along the way.