### PR TITLE
crypto: include the ability to separately generate a key before sealing

### DIFF
--- a/definitions/crypto.luau
+++ b/definitions/crypto.luau
@@ -22,6 +22,10 @@ export type secretbox = {
 	read key: buffer,
 }
 
+function crypto.secretbox.keygen(): buffer
+	error("not implemented")
+end
+
 function crypto.secretbox.seal(message: string | buffer): secretbox
 	error("not implemented")
 end

--- a/lute/crypto/include/lute/crypto.h
+++ b/lute/crypto/include/lute/crypto.h
@@ -24,11 +24,14 @@ static const char kCiphertextField[] = "ciphertext";
 static const char kKeyField[] = "key";
 static const char kNonceField[] = "nonce";
 
+static const char kKeygenName[] = "keygen";
+int lua_secretbox_keygen(lua_State* L);
+
 static const char kSealName[] = "seal";
-int lua_seal(lua_State* L);
+int lua_secretbox_seal(lua_State* L);
 
 static const char kOpenName[] = "open";
-int lua_open(lua_State* L);
+int lua_secretbox_open(lua_State* L);
 
 static const char kPasswordHashName[] = "hash";
 int lua_pwhash(lua_State* L);

--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -98,12 +98,26 @@ int lua_digest(lua_State* L)
     return 1;
 }
 
-// seal(message: string | buffer): { ciphertext: buffer, key: buffer, nonce: buffer }
+
+// keygen(): buffer
+int lua_secretbox_keygen(lua_State* L)
+{
+    int argumentCount = lua_gettop(L);
+    if (argumentCount != 0)
+        luaL_error(L, "%s: expected no arguments, but got %d", kKeygenName, argumentCount);
+
+    uint8_t* key = static_cast<uint8_t*>(lua_newbuffer(L, crypto_secretbox_keybytes()));
+    crypto_secretbox_keygen(key);
+    
+    return 1;
+}
+
+// seal(message: string | buffer, key: buffer?): { ciphertext: buffer, key: buffer, nonce: buffer }
 int lua_secretbox_seal(lua_State* L)
 {
     int argumentCount = lua_gettop(L);
-    if (argumentCount != 1)
-        luaL_error(L, "%s: expected 1 argument, but got %d", kSealName, argumentCount);
+    if (argumentCount != 1 && argumentCount != 2)
+        luaL_error(L, "%s: expected 1 or 2 arguments, but got %d", kSealName, argumentCount);
 
     BinaryData message = extractData(L, 1);
 
@@ -113,11 +127,25 @@ int lua_secretbox_seal(lua_State* L)
     uint8_t* buffer = static_cast<uint8_t*>(lua_newbuffer(L, crypto_secretbox_macbytes() + message.length));
     lua_setfield(L, -2, kCiphertextField);
 
-    // key
-    uint8_t* key = static_cast<uint8_t*>(lua_newbuffer(L, crypto_secretbox_keybytes()));
-    crypto_secretbox_keygen(key);
-    lua_setfield(L, -2, kKeyField);
+    uint8_t* key;
+    // user-provided a key
+    if (argumentCount == 2)
+    {
+        size_t keyLength = 0;
+        key = static_cast<uint8_t*>(luaL_checkbuffer(L, 2, &keyLength));
+        if (keyLength != crypto_secretbox_keybytes())
+            luaL_error(L, "%s: keys buffer should be %d bytes", kOpenName, int(crypto_secretbox_keybytes()));
 
+        lua_pushvalue(L, 2);
+        lua_setfield(L, -2, kKeyField);
+    }
+    else
+    {
+        key = static_cast<uint8_t*>(lua_newbuffer(L, crypto_secretbox_keybytes()));
+        crypto_secretbox_keygen(key);
+        lua_setfield(L, -2, kKeyField);
+    }
+    
     // nonce
     uint8_t* nonce = static_cast<uint8_t*>(lua_newbuffer(L, crypto_secretbox_noncebytes()));
     randombytes_buf(nonce, crypto_secretbox_noncebytes());
@@ -166,7 +194,11 @@ int lua_secretbox_open(lua_State* L)
 
 int makeSecretboxLibrary(lua_State* L)
 {
-    lua_createtable(L, 0, 2);
+    lua_createtable(L, 0, 3);
+
+    // keygen
+    lua_pushcfunction(L, lua_secretbox_keygen, kKeygenName);
+    lua_setfield(L, -2, kKeygenName);
 
     // seal
     lua_pushcfunction(L, lua_secretbox_seal, kSealName);

--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -133,7 +133,7 @@ int lua_secretbox_seal(lua_State* L)
         size_t keyLength = 0;
         key = static_cast<uint8_t*>(luaL_checkbuffer(L, 2, &keyLength));
         if (keyLength != crypto_secretbox_keybytes())
-            luaL_error(L, "%s: keys buffer should be %d bytes", kOpenName, int(crypto_secretbox_keybytes()));
+            luaL_error(L, "%s: key buffer should be %d bytes", kOpenName, int(crypto_secretbox_keybytes()));
 
         lua_pushvalue(L, 2);
         lua_setfield(L, -2, kKeyField);
@@ -182,7 +182,7 @@ int lua_secretbox_open(lua_State* L)
     size_t keyLength = 0;
     uint8_t* key = static_cast<uint8_t*>(luaL_checkbuffer(L, 4, &keyLength));
     if (keyLength != crypto_secretbox_keybytes())
-        luaL_error(L, "%s: keys buffer should be %d bytes", kOpenName, int(crypto_secretbox_keybytes()));
+        luaL_error(L, "%s: key buffer should be %d bytes", kOpenName, int(crypto_secretbox_keybytes()));
 
     uint8_t* buffer = static_cast<uint8_t*>(lua_newbuffer(L, ciphertextLength - crypto_secretbox_macbytes()));
     if (crypto_secretbox_open_easy(buffer, ciphertext, ciphertextLength, nonce, key) != 0)

--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -127,7 +127,7 @@ int lua_secretbox_seal(lua_State* L)
     lua_setfield(L, -2, kCiphertextField);
 
     uint8_t* key;
-    // user-provided a key
+    // user provided a key
     if (argumentCount == 2)
     {
         size_t keyLength = 0;

--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -98,7 +98,6 @@ int lua_digest(lua_State* L)
     return 1;
 }
 
-
 // keygen(): buffer
 int lua_secretbox_keygen(lua_State* L)
 {

--- a/tests/runtime/crypto.test.luau
+++ b/tests/runtime/crypto.test.luau
@@ -25,9 +25,9 @@ test.suite("CryptoRuntimeTests", function(suite)
 	end)
 
 	suite:case("secretbox_separate_keygen", function(assert)
-	    local key = crypto.secretbox.keygen()
+		local key = crypto.secretbox.keygen()
 
-    	local message = "Remember, remember the Fifth of November."
+		local message = "Remember, remember the Fifth of November."
 		local box = crypto.secretbox.seal(message, key)
 
 		local opened = crypto.secretbox.open(box)

--- a/tests/runtime/crypto.test.luau
+++ b/tests/runtime/crypto.test.luau
@@ -24,6 +24,18 @@ test.suite("CryptoRuntimeTests", function(suite)
 		assert.buffereq(opened, buf)
 	end)
 
+	suite:case("secretbox_separate_keygen", function(assert)
+	    local key = crypto.secretbox.keygen()
+
+    	local message = "Remember, remember the Fifth of November."
+		local box = crypto.secretbox.seal(message, key)
+
+		local opened = crypto.secretbox.open(box)
+		local output = buffer.readstring(opened, 0, buffer.len(opened))
+
+		assert.eq(output, message)
+	end)
+
 	suite:case("secretbox_errors_on_tampering", function(assert)
 		local message = "Gunpowder, treason, and plot."
 		local buf = buffer.create(#message)


### PR DESCRIPTION
The initial `secretbox` API provided opinionatedly generates keys and nonces on your behalf in `seal`. I believe this makes sense for one-off situations, but there's also definitely situations where people would reasonably want to reuse the key across a series of messages being sent with authenticated encryption. We should clearly make that possible.