### PR TITLE
bugfix: lute check supports ~ in luaurc paths

### DIFF
--- a/lute/require/CMakeLists.txt
+++ b/lute/require/CMakeLists.txt
@@ -22,5 +22,5 @@ target_sources(Lute.Require PRIVATE
 
 target_compile_features(Lute.Require PUBLIC cxx_std_17)
 target_include_directories(Lute.Require PUBLIC include)
-target_link_libraries(Lute.Require PUBLIC Luau.Require PRIVATE Luau.CLI.lib Luau.Compiler Luau.CodeGen Lute.Std Lute.CLI.Commands)
+target_link_libraries(Lute.Require PUBLIC Luau.Require PRIVATE Luau.CLI.lib Luau.Compiler Luau.CodeGen Lute.Std Lute.CLI.Commands Lute.Runtime)
 target_compile_options(Lute.Require PRIVATE ${LUTE_OPTIONS})

--- a/lute/require/src/filevfs.cpp
+++ b/lute/require/src/filevfs.cpp
@@ -1,11 +1,14 @@
 #include "lute/filevfs.h"
 
 #include "lute/modulepath.h"
+#include "lute/uvutils.h"
 
 #include "Luau/Common.h"
 #include "Luau/Config.h"
 #include "Luau/FileUtils.h"
 #include "Luau/LuauConfig.h"
+
+#include "uv.h"
 
 #include <array>
 #include <string>
@@ -26,7 +29,25 @@ NavigationStatus FileVfs::resetToStdIn()
 
 NavigationStatus FileVfs::resetToPath(const std::string& path)
 {
-    std::string normalizedPath = normalizePath(path);
+    std::string pathToProcess = path;
+
+    // Handle tilde expansion for home directory
+    if (!path.empty() && path[0] == '~')
+    {
+        auto result = uvutils::getStringFromUv(uv_os_homedir);
+        if (result.get_if<uvutils::UvError>() != nullptr)
+            return NavigationStatus::NotFound;
+
+        std::string* homeDir = result.get_if<std::string>();
+
+        // Replace ~ with home directory
+        if (path.size() == 1)
+            pathToProcess = *homeDir;
+        else if (path[1] == '/' || path[1] == '\\')
+            pathToProcess = *homeDir + path.substr(1);
+    }
+
+    std::string normalizedPath = normalizePath(pathToProcess);
 
     if (isAbsolutePath(normalizedPath))
     {

--- a/tests/src/require.test.cpp
+++ b/tests/src/require.test.cpp
@@ -1,8 +1,14 @@
 #include "lute/climain.h"
+#include "lute/uvutils.h"
 
 #include "Luau/FileUtils.h"
 
 #include "lua.h"
+
+#include "uv.h"
+
+#include <filesystem>
+#include <fstream>
 
 #include "cliruntimefixture.h"
 #include "doctest.h"
@@ -222,4 +228,37 @@ TEST_CASE_FIXTURE(LuteFixture, "require_by_string_semantics_in_cli")
         std::vector<char*> argv = {executablePlaceholder, inputPath.data()};
         CHECK_NE(cliMain(argv.size(), argv.data(), getReporter()), 0);
     }
+}
+
+TEST_CASE_FIXTURE(LuteFixture, "require_check_tilde_path")
+{
+    char executablePlaceholder[] = "lute";
+    char subCommand[] = "check";
+    // Get home directory
+    auto result = uvutils::getStringFromUv(uv_os_homedir);
+    REQUIRE(result.get_if<std::string>() != nullptr);
+    std::string homeDir = *result.get_if<std::string>();
+
+    // Create test directory and test file
+    std::filesystem::path testDir = std::filesystem::path(homeDir) / "lute_test_special";
+    std::filesystem::path testFile = testDir / "foo.luau";
+    std::filesystem::create_directories(testDir);
+
+    // Write test module file
+    std::ofstream file(testFile);
+    REQUIRE(file.is_open());
+    file << "return { foo = \"bar\" }\n";
+    file.close();
+
+    // Run the test
+    for (const std::string& luteProjectRoot : {getLuteProjectRootRelative(), getLuteProjectRootAbsolute()})
+    {
+        std::string mainPath = joinPaths(luteProjectRoot, "tests/src/require/config_tests/tilde_config/main.luau");
+        std::vector<char*> argv = {executablePlaceholder, subCommand, mainPath.data()};
+        CHECK_EQ(cliMain(argv.size(), argv.data(), getReporter()), 0);
+    }
+
+    // Clean up
+    std::filesystem::remove(testFile);
+    std::filesystem::remove(testDir);
 }

--- a/tests/src/require/config_tests/tilde_config/.luaurc
+++ b/tests/src/require/config_tests/tilde_config/.luaurc
@@ -1,0 +1,5 @@
+{
+    "aliases": {
+        "tilde": "~/lute_test_special"
+    }
+}

--- a/tests/src/require/config_tests/tilde_config/main.luau
+++ b/tests/src/require/config_tests/tilde_config/main.luau
@@ -1,0 +1,1 @@
+local x = require("@tilde/foo")


### PR DESCRIPTION
Users have been having issues with the `.luaurc` generated by the `lute setup` command. This sets certain aliases up in a path with `~` in them but the require rfc didn't support navigating to aliases with `~` in them.

This PR fixes this by allowing the FileVFS to navigate to aliases that represent paths with `~` in them.

Annoyingly, I had to use the filesystem header to handle the test, because it sets up a directory under `~` called `lute_test_special` and writes a file there - if yall have suggestions for how to fix this, please let me know.