### PR TITLE
bugfix: lute setup should destroy the typedefs folder

### DIFF
--- a/lute/cli/commands/setup/init.luau
+++ b/lute/cli/commands/setup/init.luau
@@ -18,6 +18,9 @@ local args = { ... }
 
 -- TODO we're assuming the files are completely unmodified, but we really shouldn't do that.
 print(`Writing definitions at {BASE_PATH_PRETTY}`)
+if fs.exists(BASE_PATH) then
+	fs.removedirectory(BASE_PATH, { recursive = true })
+end
 fs.createdirectory(BASE_PATH, { makeparents = true })
 
 for key, value in definitions :: { [string]: string } do

--- a/lute/std/libs/fs.luau
+++ b/lute/std/libs/fs.luau
@@ -22,6 +22,10 @@ export type createdirectoryoptions = {
 	makeparents: boolean?,
 }
 
+export type removedirectoryoptions = {
+	recursive: boolean?,
+}
+
 function fslib.open(path: pathlike, mode: handlemode?): filehandle
 	return fs.open(pathlib.format(path), mode)
 end
@@ -114,6 +118,26 @@ function fslib.createdirectory(path: pathlike, options: createdirectoryoptions?)
 		end
 	else
 		fs.mkdir(pathlib.format(path))
+	end
+end
+
+function fslib.removedirectory(path: pathlike, options: removedirectoryoptions?): ()
+	if options and options.recursive then
+		-- Recursively delete all contents first
+		if fslib.exists(path) and fslib.type(path) == "dir" then
+			local entries = fslib.listdir(path)
+			for _, entry in entries do
+				local entryPath = pathlib.join(path, entry.name)
+				if entry.type == "dir" then
+					fslib.removedirectory(entryPath, { recursive = true })
+				else
+					fslib.remove(entryPath)
+				end
+			end
+			fs.rmdir(pathlib.format(path))
+		end
+	else
+		fs.rmdir(pathlib.format(path))
 	end
 end
 

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -167,6 +167,64 @@ test.suite("FsSuite", function(suite)
 
 		fs.remove(file)
 	end)
+
+	suite:case("removedirectory_non_recursive", function(assert)
+		local dir = path.join(tmpdir, "empty_dir")
+		fs.createdirectory(dir, { makeparents = true })
+		assert.eq(fs.exists(dir), true)
+
+		fs.removedirectory(dir)
+		assert.eq(fs.exists(dir), false)
+	end)
+
+	suite:case("removedirectory_recursive", function(assert)
+		local dir = path.join(tmpdir, "recursive_test")
+		local subdir1 = path.join(dir, "subdir1")
+		local subdir2 = path.join(dir, "subdir2")
+		local nestedDir = path.join(subdir1, "nested")
+
+		fs.createdirectory(nestedDir, { makeparents = true })
+		fs.createdirectory(subdir2, { makeparents = true })
+
+		local file1 = path.join(dir, "file1.txt")
+		local file2 = path.join(subdir1, "file2.txt")
+		local file3 = path.join(nestedDir, "file3.txt")
+
+		fs.writestringtofile(file1, "content1")
+		fs.writestringtofile(file2, "content2")
+		fs.writestringtofile(file3, "content3")
+
+		assert.eq(fs.exists(dir), true)
+		assert.eq(fs.exists(file1), true)
+		assert.eq(fs.exists(file2), true)
+		assert.eq(fs.exists(file3), true)
+
+		fs.removedirectory(dir, { recursive = true })
+
+		assert.eq(fs.exists(dir), false)
+		assert.eq(fs.exists(file1), false)
+		assert.eq(fs.exists(file2), false)
+		assert.eq(fs.exists(file3), false)
+	end)
+
+	suite:case("removedirectory_recursive_false_with_contents", function(assert)
+		local dir = path.join(tmpdir, "non_empty_dir")
+		fs.createdirectory(dir, { makeparents = true })
+
+		local file = path.join(dir, "file.txt")
+		fs.writestringtofile(file, "content")
+
+		local success, err = pcall(function()
+			fs.removedirectory(dir, { recursive = false })
+		end)
+
+		assert.neq(success, true)
+		assert.neq(err, nil)
+
+		-- Cleanup
+		fs.remove(file)
+		fs.rmdir(dir)
+	end)
 end)
 
 test.run()


### PR DESCRIPTION
Lute setup had a bug whereby it would write new typedefs into the typedefs folder, but sometimes these could conflict with stale typedefs, causing ambiguous requires. For example, moving "posix.luau" into `posix/init.luau` but keeping `posix.luau` around will lead to an ambiguous require.

To do this, lute setup will call a new standard library method - `fs.removedirectory` with the `{ recursive = true}` option. 