### PR TITLE
bugfix: initialize status variable

### DIFF
--- a/lute/require/src/requirevfs.cpp
+++ b/lute/require/src/requirevfs.cpp
@@ -102,7 +102,7 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
 
 NavigationStatus RequireVfs::toParent(lua_State* L)
 {
-    NavigationStatus status;
+    NavigationStatus status = NavigationStatus::NotFound;
 
     switch (vfsType)
     {


### PR DESCRIPTION
Fixes Release build failure due to uninitialized variable warning with -O3 optimization level. The status variable wasn't assigned when vfsType == VFSType::Lute before use.

https://github.com/luau-lang/lute/issues/575