### PR TITLE
Fix missed `Package::RequireVfs` renames from #339

### DIFF
--- a/lute/require/include/lute/userlandvfs.h
+++ b/lute/require/include/lute/userlandvfs.h
@@ -56,7 +56,7 @@ private:
 class UserlandVfs
 {
 public:
-    static UserlandVfs create(std::vector<Identifier> directDependencies, std::vector<std::pair<Identifier, Info>> libraries);
+    static UserlandVfs create(std::vector<Identifier> directDependencies, std::vector<std::pair<Identifier, Info>> allDependencies);
 
     NavigationStatus resetToPath(const std::string& path);
     NavigationStatus jumpToDependencySubtree(const std::string& identifierStringified);
@@ -73,7 +73,7 @@ public:
     std::string getCurrentPath() const;
 
 private:
-    UserlandVfs(std::map<Identifier, Info> libraries, std::string generatedRootLuaurc);
+    UserlandVfs(std::map<Identifier, Info> allDependencies, std::string generatedRootLuaurc);
     NavigationStatus jumpToDependencySubtreeImpl(Identifier identifier);
 
     enum class VFSType
@@ -86,7 +86,7 @@ private:
 
     FileVfs fileVfs;
     std::optional<Subtree> currentSubtree = std::nullopt;
-    std::map<Identifier, Info> libraries;
+    std::map<Identifier, Info> allDependencies;
 
     bool atDiskFakeRoot = false;
     std::string generatedRootLuaurc;

--- a/lute/require/src/userlandvfs.cpp
+++ b/lute/require/src/userlandvfs.cpp
@@ -127,26 +127,26 @@ std::string Subtree::getCurrentPath() const
     return result.realPath;
 }
 
-UserlandVfs UserlandVfs::create(std::vector<Identifier> directDependencies, std::vector<std::pair<Identifier, Info>> libraries)
+UserlandVfs UserlandVfs::create(std::vector<Identifier> directDependencies, std::vector<std::pair<Identifier, Info>> allDependencies)
 {
-    std::map<Identifier, Info> librariesMap;
-    for (auto& [identifier, info] : libraries)
+    std::map<Identifier, Info> allDependenciesMap;
+    for (auto& [identifier, info] : allDependencies)
     {
-        librariesMap[std::move(identifier)] = std::move(info);
+        allDependenciesMap[std::move(identifier)] = std::move(info);
     }
 
-    return UserlandVfs{std::move(librariesMap), generateRootLuaurc(directDependencies)};
+    return UserlandVfs{std::move(allDependenciesMap), generateRootLuaurc(directDependencies)};
 }
 
-UserlandVfs::UserlandVfs(std::map<Identifier, Info> libraries, std::string generatedRootLuaurc)
-    : libraries(std::move(libraries))
+UserlandVfs::UserlandVfs(std::map<Identifier, Info> allDependencies, std::string generatedRootLuaurc)
+    : allDependencies(std::move(allDependencies))
     , generatedRootLuaurc(std::move(generatedRootLuaurc))
 {
 }
 
 NavigationStatus UserlandVfs::resetToPath(const std::string& path)
 {
-    for (const auto& [identifier, info] : libraries)
+    for (const auto& [identifier, info] : allDependencies)
     {
         if (path.find(info.rootDirectory) == 0)
         {
@@ -179,10 +179,10 @@ NavigationStatus UserlandVfs::jumpToDependencySubtree(const std::string& identif
 
 NavigationStatus UserlandVfs::jumpToDependencySubtreeImpl(Identifier identifier)
 {
-    if (libraries.find(identifier) == libraries.end())
+    if (allDependencies.find(identifier) == allDependencies.end())
         return NavigationStatus::NotFound;
 
-    std::optional<Subtree> st = Subtree::create(libraries.at(identifier));
+    std::optional<Subtree> st = Subtree::create(allDependencies.at(identifier));
     if (!st)
         return NavigationStatus::NotFound;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,9 +18,9 @@ target_sources(Lute.Test PRIVATE
     # Test files
     src/compile.test.cpp
     src/configresolver.test.cpp
-    src/libraryrequire.test.cpp
     src/modulepath.test.cpp
     src/moduleresolver.test.cpp
+    src/packagerequire.test.cpp
     src/require.test.cpp
     src/staticrequires.test.cpp
     src/stdsystem.test.cpp)

--- a/tests/src/packagerequire.test.cpp
+++ b/tests/src/packagerequire.test.cpp
@@ -33,26 +33,26 @@ TEST_CASE_FIXTURE(LuteFixture, "package_aware_require")
                 {"dep", "2.0.0"},
             };
 
-            std::string librariesRoot = luteProjectRoot + '/' + "tests/src/packages";
-            std::vector<std::pair<Package::Identifier, Package::Info>> libraries;
-            libraries.push_back(
+            std::string packagesRoot = luteProjectRoot + '/' + "tests/src/packages";
+            std::vector<std::pair<Package::Identifier, Package::Info>> allDependencies;
+            allDependencies.push_back(
                 {{"dep", "1.0.0"},
                  {
-                     librariesRoot + '/' + "internaldep",
-                     librariesRoot + '/' + "internaldep/init.luau",
+                     packagesRoot + '/' + "internaldep",
+                     packagesRoot + '/' + "internaldep/init.luau",
                      {},
                  }}
             );
-            libraries.push_back(
+            allDependencies.push_back(
                 {{"dep", "2.0.0"},
                  {
-                     librariesRoot + '/' + "dep",
-                     librariesRoot + '/' + "dep/module.luau",
+                     packagesRoot + '/' + "dep",
+                     packagesRoot + '/' + "dep/module.luau",
                      {{"dep", "1.0.0"}},
                  }}
             );
 
-            Package::UserlandVfs libraryVfs = Package::UserlandVfs::create(std::move(directDependencies), std::move(libraries));
+            Package::UserlandVfs userlandVfs = Package::UserlandVfs::create(std::move(directDependencies), std::move(allDependencies));
 
             void* ctx = lua_newuserdatadtor(
                 L,
@@ -66,7 +66,7 @@ TEST_CASE_FIXTURE(LuteFixture, "package_aware_require")
             if (!ctx)
                 luaL_errorL(L, "unable to allocate RequireCtx");
 
-            ctx = new (ctx) RequireCtx{std::make_unique<Package::RequireVfs>(std::move(libraryVfs))};
+            ctx = new (ctx) RequireCtx{std::make_unique<Package::RequireVfs>(std::move(userlandVfs))};
 
             // Store RequireCtx in the registry to keep it alive for the lifetime of
             // this lua_State. Memory address is used as a key to avoid collisions.


### PR DESCRIPTION
Missed a few places in #339 when removing "library"/"libraries" from this part of our code.