### PR TITLE
std/tableext: implement `combine`, `foreach`, and `keys`

### DIFF
--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -44,7 +44,6 @@ function tableext.extend<T>(tbl: array<T>, ...: array<T>)
 	local extendees = tableext.filter(table.pack(...), function(v)
 		return typeof(v) == "table"
 	end)
-
 	tableext.foreach(extendees, function(_, other)
 		for _, entry in other do
 			table.insert(tbl, entry)

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -41,20 +41,20 @@ function tableext.fold<K, V, A>(table: { [K]: V }, f: (A, V) -> A, initial: A): 
 end
 
 function tableext.extend<T>(tbl: array<T>, ...: array<T>)
-	local extendees = table.pack(...)
-	extendees.n = nil :: never
-	for _, extendee in extendees do
-		for _, entry in extendee do
+	local extensions = table.pack(...)
+	extensions.n = nil :: any
+	for _, extension in extensions do
+		for _, entry in extension do
 			table.insert(tbl, entry)
 		end
 	end
 end
 
 function tableext.combine<K, V>(tbl: { [K]: V }, ...: { [K]: V }): { [K]: V }
-	local mergees = table.pack(...)
-	mergees.n = nil :: never
-	for _, mergee in mergees do
-		for key, val in mergee do
+	local tables = table.pack(...)
+	tables.n = nil :: any
+	for _, tocombine in tables do
+		for key, val in tocombine do
 			tbl[key] = val
 		end
 	end

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -42,7 +42,7 @@ end
 
 function tableext.extend<T>(tbl: array<T>, ...: array<T>)
 	local extendees = table.pack(...)
-	extendees.n = nil
+	extendees.n = nil :: never
 	for _, extendee in extendees do
 		for _, entry in extendee do
 			table.insert(tbl, entry)
@@ -50,9 +50,9 @@ function tableext.extend<T>(tbl: array<T>, ...: array<T>)
 	end
 end
 
-function tableext.merge<K, V>(tbl: { [K]: V }, ...: { [K]: V }): { [K]: V }
+function tableext.combine<K, V>(tbl: { [K]: V }, ...: { [K]: V }): { [K]: V }
 	local mergees = table.pack(...)
-	mergees.n = nil
+	mergees.n = nil :: never
 	for _, mergee in mergees do
 		for key, val in mergee do
 			tbl[key] = val

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -40,9 +40,33 @@ function tableext.fold<K, V, A>(table: { [K]: V }, f: (A, V) -> A, initial: A): 
 	return acc
 end
 
-function tableext.extend<T>(tbl: array<T>, other: array<T>)
-	for _, entry in other do
-		table.insert(tbl, entry)
+function tableext.extend<T>(tbl: array<T>, ...: array<T>)
+	local extendees = tableext.filter(table.pack(...), function(v)
+		return typeof(v) == "table"
+	end)
+
+	tableext.foreach(extendees, function(_, other)
+		for _, entry in other do
+			table.insert(tbl, entry)
+		end
+	end)
+end
+
+function tableext.merge<K, V>(tbl: { [K]: V }, ...: { [K]: V }): { [K]: V }
+	local mergees = tableext.filter(table.pack(...), function(v)
+		return typeof(v) == "table"
+	end)
+	tableext.foreach(mergees, function(_, toMerge)
+		for key, val in toMerge do
+			tbl[key] = val
+		end
+	end)
+	return tbl
+end
+
+function tableext.foreach<K, V>(tbl: { [K]: V }, callback: (K, V) -> ())
+	for k, v in tbl do
+		callback(k, v)
 	end
 end
 

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -67,4 +67,12 @@ function tableext.foreach<K, V>(tbl: { [K]: V }, callback: (K, V) -> ())
 	end
 end
 
+function tableext.keys<K, V>(tbl: { [K]: V }): { K }
+	local keys = {}
+	for k, _ in tbl do
+		table.insert(keys, k)
+	end
+	return keys
+end
+
 return table.freeze(tableext)

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -61,9 +61,9 @@ function tableext.combine<K, V>(tbl: { [K]: V }, ...: { [K]: V }): { [K]: V }
 	return tbl
 end
 
-function tableext.foreach<K, V>(tbl: { [K]: V }, callback: (K, V) -> ())
+function tableext.foreach<K, V>(tbl: { [K]: V }, f: (K, V) -> ())
 	for k, v in tbl do
-		callback(k, v)
+		f(k, v)
 	end
 end
 

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -41,25 +41,23 @@ function tableext.fold<K, V, A>(table: { [K]: V }, f: (A, V) -> A, initial: A): 
 end
 
 function tableext.extend<T>(tbl: array<T>, ...: array<T>)
-	local extendees = tableext.filter(table.pack(...), function(v)
-		return typeof(v) == "table"
-	end)
-	tableext.foreach(extendees, function(_, other)
-		for _, entry in other do
+	local extendees = table.pack(...)
+	extendees.n = nil
+	for _, extendee in extendees do
+		for _, entry in extendee do
 			table.insert(tbl, entry)
 		end
-	end)
+	end
 end
 
 function tableext.merge<K, V>(tbl: { [K]: V }, ...: { [K]: V }): { [K]: V }
-	local mergees = tableext.filter(table.pack(...), function(v)
-		return typeof(v) == "table"
-	end)
-	tableext.foreach(mergees, function(_, toMerge)
-		for key, val in toMerge do
+	local mergees = table.pack(...)
+	mergees.n = nil
+	for _, mergee in mergees do
+		for key, val in mergee do
 			tbl[key] = val
 		end
-	end)
+	end
 	return tbl
 end
 

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -30,10 +30,34 @@ test.suite("TableExt", function(suite)
 	suite:case("extend", function(assert)
 		local a: { number } = { 1, 2 }
 		local b: { number } = { 3, 4 }
-		tableext.extend(a, b)
-		assert.eq(#a, 4)
+		local c: { number } = { 5, 6 }
+		tableext.extend(a, b, c)
+		assert.eq(#a, 6)
 		assert.eq(a[3], 3)
 		assert.eq(a[4], 4)
+		assert.eq(a[5], 5)
+		assert.eq(a[6], 6)
+	end)
+
+	suite:case("merge", function(assert)
+		local a = { ["a"] = 1, ["b"] = 2 }
+		local b = { ["b"] = 3, ["c"] = 4 }
+		local c = { ["c"] = 1, ["d"] = 5 }
+		tableext.merge(a, b, c)
+		assert.eq(a["a"], 1)
+		assert.eq(a["b"], 3)
+		assert.eq(a["c"], 1)
+		assert.eq(a["d"], 5)
+	end)
+
+	suite:case("foreach", function(assert)
+		local a = { 1, 2, 3 }
+		local numCalls = 0
+		local function callback()
+			numCalls += 1
+		end
+		tableext.foreach(a, callback)
+		assert.eq(numCalls, #a)
 	end)
 end)
 

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -59,6 +59,14 @@ test.suite("TableExt", function(suite)
 		tableext.foreach(a, callback)
 		assert.eq(numCalls, #a)
 	end)
+
+	suite:case("keys", function(assert)
+		local a = { a = 1, b = 2, c = 3 }
+		local keys = tableext.keys(a)
+		for _, key in keys do
+			assert.neq(a[key], nil)
+		end
+	end)
 end)
 
 test.run()

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -39,11 +39,11 @@ test.suite("TableExt", function(suite)
 		assert.eq(a[6], 6)
 	end)
 
-	suite:case("merge", function(assert)
+	suite:case("combine", function(assert)
 		local a = { ["a"] = 1, ["b"] = 2 }
 		local b = { ["b"] = 3, ["c"] = 4 }
 		local c = { ["c"] = 1, ["d"] = 5 }
-		tableext.merge(a, b, c)
+		tableext.combine(a, b, c)
 		assert.eq(a["a"], 1)
 		assert.eq(a["b"], 3)
 		assert.eq(a["c"], 1)


### PR DESCRIPTION
This PR adds two methods to `tableext`:

- `combine`: merges keyed tables, with keys in last-passed tables taking precedence
- `foreach`: runs callback on each item in table
- `keys`: returns array-like of all the keys in the passed table

The PR also modifies the `extend` signature, to accept a variable number of extendee tables