### PR TITLE
stdlib: luacase some ast node fields

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -270,9 +270,9 @@ export type AstStatWhile = {
 export type AstStatRepeat = {
 	kind: "stat",
 	tag: "repeat",
-	repeatKeyword: Token<"repeat">,
+	repeatkeyword: Token<"repeat">,
 	body: AstStatBlock,
-	untilKeyword: Token<"until">,
+	untilkeyword: Token<"until">,
 	condition: AstExpr,
 }
 
@@ -367,7 +367,7 @@ export type AstStatTypeAlias = {
 	kind: "stat",
 	tag: "typealias",
 	export: Token<"export">?,
-	typeToken: Token<"type">,
+	typetoken: Token<"type">,
 	name: Token,
 	opengenerics: Token<"<">?,
 	generics: Punctuated<AstGenericType>?,

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -1259,14 +1259,14 @@ struct AstSerialize : public Luau::AstVisitor
         serializeNodePreamble(node, "repeat", "stat");
 
         serializeToken(node->location.begin, "repeat");
-        lua_setfield(L, -2, "repeatKeyword");
+        lua_setfield(L, -2, "repeatkeyword");
 
         node->body->visit(this);
         lua_setfield(L, -2, "body");
 
         auto cstNode = lookupCstNode<Luau::CstStatRepeat>(node);
         serializeToken(cstNode->untilPosition, "until");
-        lua_setfield(L, -2, "untilKeyword");
+        lua_setfield(L, -2, "untilkeyword");
 
         node->condition->visit(this);
         lua_setfield(L, -2, "condition");
@@ -1532,7 +1532,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "export");
 
         serializeToken(cstNode->typeKeywordPosition, "type");
-        lua_setfield(L, -2, "typeToken");
+        lua_setfield(L, -2, "typetoken");
 
         serializeToken(node->nameLocation.begin, node->name.value);
         lua_setfield(L, -2, "name");

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -213,9 +213,9 @@ end
 
 local function visitRepeat(node: types.AstStatRepeat, visitor: Visitor)
 	if visitor.visitRepeat(node) then
-		visitToken(node.repeatKeyword, visitor)
+		visitToken(node.repeatkeyword, visitor)
 		visitBlock(node.body, visitor)
-		visitToken(node.untilKeyword, visitor)
+		visitToken(node.untilkeyword, visitor)
 		visitExpression(node.condition, visitor)
 	end
 end
@@ -326,7 +326,7 @@ local function visitTypeAlias(node: types.AstStatTypeAlias, visitor: Visitor)
 		if node.export then
 			visitToken(node.export, visitor)
 		end
-		visitToken(node.typeToken, visitor)
+		visitToken(node.typetoken, visitor)
 		visitToken(node.name, visitor)
 		if node.opengenerics then
 			visitToken(node.opengenerics, visitor)

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -618,10 +618,10 @@ test.suite("parse", function(suite)
 
 		local repeatStat = block.statements[1] :: syntax.AstStatRepeat
 		assert.eq(repeatStat.tag, "repeat")
-		assert.eq(repeatStat.repeatKeyword.text, "repeat")
+		assert.eq(repeatStat.repeatkeyword.text, "repeat")
 		checkIsBlock(repeatStat.body, assert)
 		assert.eq(#repeatStat.body.statements, 2)
-		assert.eq(repeatStat.untilKeyword.text, "until")
+		assert.eq(repeatStat.untilkeyword.text, "until")
 		assert.eq(repeatStat.condition.tag, "binary")
 	end)
 
@@ -790,7 +790,7 @@ test.suite("parse", function(suite)
 		local typeAlias = block.statements[1] :: syntax.AstStatTypeAlias
 		assert.eq(typeAlias.tag, "typealias")
 		assert.eq(typeAlias.export, nil)
-		assert.eq(typeAlias.typeToken.text, "type")
+		assert.eq(typeAlias.typetoken.text, "type")
 		assert.eq(typeAlias.name.text, "Vector3")
 		assert.eq(typeAlias.opengenerics, nil)
 		assert.eq(typeAlias.generics, nil)


### PR DESCRIPTION
A while back, I went through and luacased the AST node fields. It looks like I missed a few on that pass, so fixing them here.