### PR TITLE
docs: support doc comments in lute doc gen

### DIFF
--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -1,53 +1,145 @@
 local fs = require("@std/fs")
 local process = require("@std/process")
 local path = require("@std/path")
+local stringext = require("@std/stringext")
 
-local function extractPropertySignature(module: string, line: string): (string?, string?)
-	-- Match property declarations like: process.env = {} :: { [string]: string }
+-- extractPropertySignature:
+-- module: string
+-- line: string (current line)
+-- pendingDoc: {string} (accumulated doc lines so far)
+-- inBlock: boolean (are we currently inside a block comment?)
+-- blockEq: string? (the "=" sequence used for block comment delimiting, e.g. "=" for --[=[  ; nil when not inside)
+--
+-- returns: name?, signature?, doc?, newPendingDoc, newInBlock, newBlockEq
+local function extractPropertySignature(
+	module: string,
+	line: string,
+	pendingDoc: { string },
+	inBlock: boolean,
+	blockEq: string?
+): (string?, string?, string?, { string }, boolean, string?)
+	local name, signature, doc = nil, nil, nil
+
+	-- 1) If we're *not* in a block, detect block start that may include = signs:
+	if not inBlock then
+		local eq = string.match(line, "^%s*%-%-%[(=*)%[")
+		if eq ~= nil then
+			-- start of block comment, capture any text after the opening on the same line
+			inBlock = true
+			blockEq = eq -- remember the = count for closing pattern
+
+			-- capture part after the opening delimiter, if any
+			local after = string.match(line, "^%s*%-%-%[" .. eq .. "%[(.*)$")
+			if after then
+				after = stringext.trim(after)
+				if after ~= "" then
+					table.insert(pendingDoc, after)
+				end
+			end
+
+			-- nothing else to do this line
+			return nil, nil, nil, pendingDoc, inBlock, blockEq
+		end
+	end
+
+	-- 2) If we're inside a block, accumulate until we find the matching close
+	if inBlock then
+		local eq = blockEq or ""
+		-- find the closing pattern "]]", or "]=]" etc. that matches eq
+		local closingPattern = "%]" .. eq .. "%]"
+		local before = string.match(line, "^(.-)" .. closingPattern)
+		if before then
+			-- closing found on this line
+			before = stringext.trim(before)
+			if before ~= "" then
+				table.insert(pendingDoc, before)
+			end
+
+			-- there might be trailing comment markers like "]]" on the same line;
+			-- we've already captured inner content, so we just exit block mode.
+			inBlock = false
+			blockEq = nil
+		else
+			-- still inside block: append whole line (trimmed)
+			local trimmed = stringext.trim(line)
+			if trimmed ~= "" then
+				table.insert(pendingDoc, trimmed)
+			end
+		end
+
+		return nil, nil, nil, pendingDoc, inBlock, blockEq
+	end
+
+	-- 3) Single-line comment? (-- or ---)
+	local single = string.match(line, "^%s*%-%-%-?%s?(.*)$")
+	if single then
+		local txt = stringext.trim(single)
+		if txt ~= "" then
+			table.insert(pendingDoc, txt)
+		end
+		return nil, nil, nil, pendingDoc, inBlock, blockEq
+	end
+
+	-- 4) Try property declaration: module.name = ... :: type
 	local propName, propType = string.match(line, `^{module}%.([%w_]+)%s*=%s*.-::%s*(.+)$`)
 	if propName and propType then
-		return propName, propType
+		name = propName
+		signature = propType
+		doc = (#pendingDoc > 0) and table.concat(pendingDoc, "\n\n") or nil
+		pendingDoc = {}
+		return name, signature, doc, pendingDoc, inBlock, blockEq
 	end
 
-	-- Match function declarations like: function crypto.password.hash(password: string): buffer
-	local fullName, params, _return, returnType = string.match(line, `^function%s+{module}%.(.-)(%b())(:?)%s*(.*)$`)
+	-- 5) Try function declaration: function module.name(params): return
+	local fullName, params, _colon, returnType = string.match(line, `^function%s+{module}%.(.-)(%b())(:?)%s*(.*)$`)
 	if fullName then
 		fullName = string.match(fullName, "^(.*)%b<>$") or fullName
-		returnType = if returnType == "" then "()" else returnType
-		local signature = `{params} -> {returnType}`
-		return fullName, signature
+		returnType = (returnType == "") and "()" or returnType
+		name = fullName
+		signature = `{params} -> {returnType}`
+		doc = (#pendingDoc > 0) and table.concat(pendingDoc, "\n\n") or nil
+		pendingDoc = {}
+		return name, signature, doc, pendingDoc, inBlock, blockEq
 	end
 
-	return nil, nil
+	-- 6) If we reach here and there's any non-whitespace, reset pendingDoc to clear old comments
+	if not string.match(line, "^%s*$") then
+		pendingDoc = {}
+	end
+
+	-- nothing found
+	return nil, nil, nil, pendingDoc, inBlock, blockEq
 end
 
 -- docs for definitions/*.luau --
 
-local function parseDefinitionFile(
-	module: path.pathlike,
-	filePath: path.pathlike
-): { { name: string, signature: string } }
+local function parseDefinitionFile(module: path.pathlike, filePath: path.pathlike)
 	local content = fs.readfiletostring(filePath)
 	local lines = string.split(content, "\n")
-	local definitions = {}
 
-	for _, line in lines do
-		local name, signature = extractPropertySignature(tostring(module), line)
+	local defs = {}
+	local pendingDoc = {}
+	local inBlock = false
 
-		if name and signature then
-			table.insert(definitions, {
+	for _, line in ipairs(lines) do
+		local name, sig, doc
+		name, sig, doc, pendingDoc, inBlock = extractPropertySignature(tostring(module), line, pendingDoc, inBlock)
+
+		if name and sig then
+			table.insert(defs, {
 				name = name,
-				signature = signature,
+				signature = sig,
+				doc = doc,
 			})
 		end
 	end
 
-	return definitions
+	return defs
 end
 
 local function generateDefinitionsMarkdown(
 	moduleName: string,
-	definitions: { { name: string, signature: string } }
+	definitions: { { name: string, signature: string, doc: string? } }
 ): string
 	local lines = {
 		`# {moduleName}`,
@@ -63,7 +155,12 @@ local function generateDefinitionsMarkdown(
 	end)
 
 	for _, def in definitions do
-		table.insert(lines, `## {moduleName}.{def.name}`)
+		table.insert(lines, `## {moduleName}.{def.name}\n`)
+
+		-- Insert the documentation if it exists
+		if def.doc then
+			table.insert(lines, `{def.doc}\n`)
+		end
 		table.insert(lines, "```luau")
 		table.insert(lines, def.signature)
 		table.insert(lines, "```")
@@ -108,30 +205,35 @@ local STDLIB_MODULE_ALIASES = {
 	system = "systemlib",
 }
 
-local function parseStdlibFile(module: path.pathlike, filePath: path.pathlike): { { name: string, signature: string } }
+local function parseStdlibFile(module: path.pathlike, filePath: path.pathlike)
 	local content = fs.readfiletostring(filePath)
 	local lines = string.split(content, "\n")
-	local stdlibDefinitions = {}
 
-	for _, line in lines do
-		local mod = STDLIB_MODULE_ALIASES[tostring(module)] or tostring(module)
+	local defs = {}
+	local pendingDoc = {}
+	local inBlock = false
 
-		local name, signature = extractPropertySignature(mod, line)
+	local mod = STDLIB_MODULE_ALIASES[tostring(module)] or tostring(module)
 
-		if name and signature then
-			table.insert(stdlibDefinitions, {
+	for _, line in ipairs(lines) do
+		local name, sig, doc
+		name, sig, doc, pendingDoc, inBlock = extractPropertySignature(mod, line, pendingDoc, inBlock)
+
+		if name and sig then
+			table.insert(defs, {
 				name = name,
-				signature = signature,
+				signature = sig,
+				doc = doc,
 			})
 		end
 	end
 
-	return stdlibDefinitions
+	return defs
 end
 
 local function generateStdLibMarkdown(
 	moduleName: string,
-	definitions: { { name: string, signature: string } },
+	definitions: { { name: string, signature: string, doc: string? } },
 	stdlibFilePath: path.pathlike
 ): string
 	local referencePath = path.join(process.cwd(), "..", "lute", "std", "libs")
@@ -157,7 +259,12 @@ local function generateStdLibMarkdown(
 	end)
 
 	for _, def in definitions do
-		table.insert(lines, `## {moduleName}.{def.name}`)
+		table.insert(lines, `## {moduleName}.{def.name}\n`)
+
+		-- Insert the documentation if it exists
+		if def.doc then
+			table.insert(lines, `{def.doc}\n`)
+		end
 		table.insert(lines, "```luau")
 		table.insert(lines, def.signature)
 		table.insert(lines, "```")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -11,10 +11,10 @@ local STDLIB_MODULE_ALIASES = {
 	task = "tasklib",
 	path = "pathlib",
 	system = "systemlib",
+	trivia = "retrieverLib",
 	visitor = "visitorlib",
 	query = "queryLib",
 	printer = "printerLib",
-	syntax = "syntaxlib",
 }
 
 local tripleDashCommentPattern = "^%s*%-%-%-%s?(.*)$"
@@ -27,26 +27,25 @@ local whitespacePattern = "^%s*$"
 -- pendingDoc (accumulated doc lines so far)
 -- inBlock (are we currently inside a block comment?)
 -- blockEq (the "=" sequence used for block comment delimiting, e.g. "=" for --[=[  ; nil when not inside)
---
--- returns: name?, signature?, doc?, newPendingDoc, newInBlock, newBlockEq
 local function extractPropertySignature(
 	module: string,
 	line: string,
 	pendingDoc: { string },
 	inBlock: boolean,
 	blockEq: string?
-): (string?, string?, string?, { string }, boolean, string?)
-	local name, signature, doc = nil, nil, nil
-
+): {
+	name: string?,
+	signature: string?,
+	doc: string?,
+	pendingDoc: { string },
+	inBlock: boolean,
+	blockEq: string?,
+}
 	-- 1) If we're *not* in a block, detect block start that may include = signs:
 	if not inBlock then
 		local eq = string.match(line, blockCommentStartPattern)
 		if eq ~= nil then
-			-- start of block comment, capture any text after the opening on the same line
-			inBlock = true
-			blockEq = eq -- remember the = count for closing pattern
-
-			-- capture part after the opening delimiter, if any
+			-- start of block comment, capture part after the opening delimiter, if any
 			local after = string.match(line, "^%s*%-%-%[" .. eq .. "%[(.*)$")
 			if after then
 				after = stringext.trim(after)
@@ -55,7 +54,14 @@ local function extractPropertySignature(
 				end
 			end
 
-			return nil, nil, nil, pendingDoc, inBlock, blockEq
+			return {
+				name = nil,
+				signature = nil,
+				doc = nil,
+				pendingDoc = pendingDoc,
+				inBlock = true,
+				blockEq = eq, -- remember the = count for closing pattern
+			}
 		end
 	end
 
@@ -84,7 +90,14 @@ local function extractPropertySignature(
 			end
 		end
 
-		return nil, nil, nil, pendingDoc, inBlock, blockEq
+		return {
+			name = nil,
+			signature = nil,
+			doc = nil,
+			pendingDoc = pendingDoc,
+			inBlock = inBlock,
+			blockEq = blockEq,
+		}
 	end
 
 	-- 3) Triple dash comment? (---)
@@ -94,29 +107,44 @@ local function extractPropertySignature(
 		if txt ~= "" then
 			table.insert(pendingDoc, txt)
 		end
-		return nil, nil, nil, pendingDoc, inBlock, blockEq
+		return {
+			name = nil,
+			signature = nil,
+			doc = nil,
+			pendingDoc = pendingDoc,
+			inBlock = inBlock,
+			blockEq = blockEq,
+		}
 	end
 
 	-- 4) Match property declarations like: process.env = {} :: { [string]: string }
 	local propName, propType = string.match(line, `^{module}%.([%w_]+)%s*=%s*.-::%s*(.+)$`)
 	if propName and propType then
-		name = propName
-		signature = propType
-		doc = (#pendingDoc > 0) and table.concat(pendingDoc, "\n\n") or nil
-		pendingDoc = {}
-		return name, signature, doc, pendingDoc, inBlock, blockEq
+		return {
+			name = propName,
+			signature = propType,
+			doc = (#pendingDoc > 0) and table.concat(pendingDoc, "\n\n") or nil,
+			pendingDoc = {},
+			inBlock = inBlock,
+			blockEq = blockEq,
+		}
 	end
 
 	-- 5) Match function declarations like: function crypto.password.hash(password: string): buffer
 	local fullName, params, _return, returnType = string.match(line, `^function%s+{module}%.(.-)(%b())(:?)%s*(.*)$`)
+	-- print(module)
 	if fullName then
 		fullName = string.match(fullName, "^(.*)%b<>$") or fullName
 		returnType = if returnType == "" then "()" else returnType
-		name = fullName
-		signature = `{params} -> {returnType}`
-		doc = (#pendingDoc > 0) and table.concat(pendingDoc, "\n\n") or nil
-		pendingDoc = {}
-		return name, signature, doc, pendingDoc, inBlock, blockEq
+
+		return {
+			name = fullName,
+			signature = `{params} -> {returnType}`,
+			doc = (#pendingDoc > 0) and table.concat(pendingDoc, "\n\n") or nil,
+			pendingDoc = {},
+			inBlock = inBlock,
+			blockEq = blockEq,
+		}
 	end
 
 	-- 6) If we reach here and there's any non-whitespace (i.e., code), reset pendingDoc to clear old comments
@@ -125,7 +153,14 @@ local function extractPropertySignature(
 	end
 
 	-- nothing found on this line
-	return nil, nil, nil, pendingDoc, inBlock, blockEq
+	return {
+		name = nil,
+		signature = nil,
+		doc = nil,
+		pendingDoc = pendingDoc,
+		inBlock = inBlock,
+		blockEq = blockEq,
+	}
 end
 
 local function generateMarkdown(
@@ -184,15 +219,18 @@ local function parseModule(
 	local blockEq = nil
 
 	for _, line in lines do
-		local name, signature, doc
-		name, signature, doc, pendingDoc, inBlock, blockEq =
-			extractPropertySignature(tostring(module), line, pendingDoc, inBlock, blockEq)
+		local res = extractPropertySignature(tostring(module), line, pendingDoc, inBlock, blockEq)
 
-		if name and signature then
+		-- update state carried across lines
+		pendingDoc = res.pendingDoc
+		inBlock = res.inBlock
+		blockEq = res.blockEq
+
+		if res.name and res.signature then
 			table.insert(moduleDefinitions, {
-				name = name,
-				signature = signature,
-				doc = doc,
+				name = res.name,
+				signature = res.signature,
+				doc = res.doc,
 			})
 		end
 	end
@@ -227,12 +265,11 @@ local function processDirectory(
 
 			print(`Processing {moduleName}...`)
 
-			local definitions = parseModule(moduleName, entryPath)
-
 			if requireLibraryAlias == "std" then
 				moduleName = STDLIB_MODULE_ALIASES[moduleName] or moduleName
 			end
 
+			local definitions = parseModule(moduleName, entryPath)
 			local markdown = generateMarkdown(moduleName, definitions, entryPath, libraryPath, requireLibraryAlias)
 
 			fs.writestringtofile(documentationFilePath, markdown)
@@ -252,8 +289,8 @@ processDirectory(stdlibPath, stdlibReferencePath, stdlibPath, "std")
 
 -- Mock module in test/ for testing purposes
 
-local testPath = path.join(process.cwd(), "test")
-local testReferencePath = path.join(process.cwd(), "test")
-processDirectory(testPath, testReferencePath, testPath, "test")
+-- local testPath = path.join(process.cwd(), "test")
+-- local testReferencePath = path.join(process.cwd(), "test")
+-- processDirectory(testPath, testReferencePath, testPath, "test")
 
 print("Reference documentation generation complete!")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -125,7 +125,6 @@ local function extractPropertySignature(
 
 	-- 5) Match function declarations like: function crypto.password.hash(password: string): buffer
 	local fullName, params, _return, returnType = string.match(line, `^function%s+{module}%.(.-)(%b())(:?)%s*(.*)$`)
-	-- print(module)
 	if fullName then
 		fullName = string.match(fullName, "^(.*)%b<>$") or fullName
 		returnType = if returnType == "" then "()" else returnType

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -19,7 +19,7 @@ local STDLIB_MODULE_ALIASES = {
 
 local tripleDashCommentPattern = "^%s*%-%-%-%s?(.*)$"
 local blockCommentStartPattern = "^%s*%-%-%[(=+)%["
-local blankLinePattern = "^%s*$"
+local whitespacePattern = "^%s*$"
 
 -- extractPropertySignature: (this function runs on one line at a time so we need to keep some states for block comments)
 -- module (module name)
@@ -120,7 +120,7 @@ local function extractPropertySignature(
 	end
 
 	-- 6) If we reach here and there's any non-whitespace (i.e., code), reset pendingDoc to clear old comments
-	if not string.match(line, blankLinePattern) then
+	if not string.match(line, whitespacePattern) then
 		pendingDoc = {}
 	end
 

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -80,7 +80,7 @@ local function extractPropertySignature(
 		return nil, nil, nil, pendingDoc, inBlock, blockEq
 	end
 
-	-- 4) Try property declaration: module.name = ... :: type
+	-- 4) Match property declarations like: process.env = {} :: { [string]: string }
 	local propName, propType = string.match(line, `^{module}%.([%w_]+)%s*=%s*.-::%s*(.+)$`)
 	if propName and propType then
 		name = propName
@@ -90,11 +90,11 @@ local function extractPropertySignature(
 		return name, signature, doc, pendingDoc, inBlock, blockEq
 	end
 
-	-- 5) Try function declaration: function module.name(params): return
+	-- 5) Match function declarations like: function crypto.password.hash(password: string): buffer
 	local fullName, params, _colon, returnType = string.match(line, `^function%s+{module}%.(.-)(%b())(:?)%s*(.*)$`)
 	if fullName then
 		fullName = string.match(fullName, "^(.*)%b<>$") or fullName
-		returnType = (returnType == "") and "()" or returnType
+		returnType = if returnType == "" then "()" else returnType
 		name = fullName
 		signature = `{params} -> {returnType}`
 		doc = (#pendingDoc > 0) and table.concat(pendingDoc, "\n\n") or nil
@@ -113,28 +113,32 @@ end
 
 -- docs for definitions/*.luau --
 
-local function parseDefinitionFile(module: path.pathlike, filePath: path.pathlike)
+local function parseDefinitionFile(
+	module: path.pathlike,
+	filePath: path.pathlike
+): { { name: string, signature: string, doc: string? } }
 	local content = fs.readfiletostring(filePath)
 	local lines = string.split(content, "\n")
 
-	local defs = {}
+	local definitions = {}
 	local pendingDoc = {}
 	local inBlock = false
 
-	for _, line in ipairs(lines) do
-		local name, sig, doc
-		name, sig, doc, pendingDoc, inBlock = extractPropertySignature(tostring(module), line, pendingDoc, inBlock)
+	for _, line in lines do
+		local name, signature, doc
+		name, signature, doc, pendingDoc, inBlock =
+			extractPropertySignature(tostring(module), line, pendingDoc, inBlock)
 
-		if name and sig then
-			table.insert(defs, {
+		if name and signature then
+			table.insert(definitions, {
 				name = name,
-				signature = sig,
+				signature = signature,
 				doc = doc,
 			})
 		end
 	end
 
-	return defs
+	return definitions
 end
 
 local function generateDefinitionsMarkdown(
@@ -205,30 +209,33 @@ local STDLIB_MODULE_ALIASES = {
 	system = "systemlib",
 }
 
-local function parseStdlibFile(module: path.pathlike, filePath: path.pathlike)
+local function parseStdlibFile(
+	module: path.pathlike,
+	filePath: path.pathlike
+): { { name: string, signature: string, doc: string? } }
 	local content = fs.readfiletostring(filePath)
 	local lines = string.split(content, "\n")
 
-	local defs = {}
+	local stdlibDefinitions = {}
 	local pendingDoc = {}
 	local inBlock = false
 
 	local mod = STDLIB_MODULE_ALIASES[tostring(module)] or tostring(module)
 
-	for _, line in ipairs(lines) do
-		local name, sig, doc
-		name, sig, doc, pendingDoc, inBlock = extractPropertySignature(mod, line, pendingDoc, inBlock)
+	for _, line in lines do
+		local name, signature, doc
+		name, signature, doc, pendingDoc, inBlock = extractPropertySignature(mod, line, pendingDoc, inBlock)
 
-		if name and sig then
-			table.insert(defs, {
+		if name and signature then
+			table.insert(stdlibDefinitions, {
 				name = name,
-				signature = sig,
+				signature = signature,
 				doc = doc,
 			})
 		end
 	end
 
-	return defs
+	return stdlibDefinitions
 end
 
 local function generateStdLibMarkdown(

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -11,6 +11,10 @@ local STDLIB_MODULE_ALIASES = {
 	task = "tasklib",
 	path = "pathlib",
 	system = "systemlib",
+	visitor = "visitorlib",
+	query = "queryLib",
+	printer = "printerLib",
+	syntax = "syntaxlib",
 }
 
 local singleLineCommentPattern = "^%s*%-%-%-?%s?(.*)$"

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -21,6 +21,15 @@ local tripleDashCommentPattern = "^%s*%-%-%-%s?(.*)$"
 local blockCommentStartPattern = "^%s*%-%-%[(=+)%["
 local whitespacePattern = "^%s*$"
 
+type PropertySignature = {
+	name: string?,
+	signature: string?,
+	doc: string?,
+	pendingDoc: { string },
+	inBlock: boolean,
+	blockEq: string?,
+}
+
 -- extractPropertySignature: (this function runs on one line at a time so we need to keep some states for block comments)
 -- module (module name)
 -- line (current line)
@@ -33,14 +42,7 @@ local function extractPropertySignature(
 	pendingDoc: { string },
 	inBlock: boolean,
 	blockEq: string?
-): {
-	name: string?,
-	signature: string?,
-	doc: string?,
-	pendingDoc: { string },
-	inBlock: boolean,
-	blockEq: string?,
-}
+): PropertySignature
 	-- 1) If we're *not* in a block, detect block start that may include = signs:
 	if not inBlock then
 		local eq = string.match(line, blockCommentStartPattern)
@@ -55,9 +57,6 @@ local function extractPropertySignature(
 			end
 
 			return {
-				name = nil,
-				signature = nil,
-				doc = nil,
 				pendingDoc = pendingDoc,
 				inBlock = true,
 				blockEq = eq, -- remember the = count for closing pattern
@@ -91,9 +90,6 @@ local function extractPropertySignature(
 		end
 
 		return {
-			name = nil,
-			signature = nil,
-			doc = nil,
 			pendingDoc = pendingDoc,
 			inBlock = inBlock,
 			blockEq = blockEq,
@@ -108,9 +104,6 @@ local function extractPropertySignature(
 			table.insert(pendingDoc, txt)
 		end
 		return {
-			name = nil,
-			signature = nil,
-			doc = nil,
 			pendingDoc = pendingDoc,
 			inBlock = inBlock,
 			blockEq = blockEq,
@@ -123,7 +116,7 @@ local function extractPropertySignature(
 		return {
 			name = propName,
 			signature = propType,
-			doc = (#pendingDoc > 0) and table.concat(pendingDoc, "\n\n") or nil,
+			doc = if #pendingDoc > 0 then table.concat(pendingDoc, "\n\n") else nil,
 			pendingDoc = {},
 			inBlock = inBlock,
 			blockEq = blockEq,
@@ -140,7 +133,7 @@ local function extractPropertySignature(
 		return {
 			name = fullName,
 			signature = `{params} -> {returnType}`,
-			doc = (#pendingDoc > 0) and table.concat(pendingDoc, "\n\n") or nil,
+			doc = if #pendingDoc > 0 then table.concat(pendingDoc, "\n\n") else nil,
 			pendingDoc = {},
 			inBlock = inBlock,
 			blockEq = blockEq,
@@ -154,9 +147,6 @@ local function extractPropertySignature(
 
 	-- nothing found on this line
 	return {
-		name = nil,
-		signature = nil,
-		doc = nil,
 		pendingDoc = pendingDoc,
 		inBlock = inBlock,
 		blockEq = blockEq,
@@ -219,18 +209,18 @@ local function parseModule(
 	local blockEq = nil
 
 	for _, line in lines do
-		local res = extractPropertySignature(tostring(module), line, pendingDoc, inBlock, blockEq)
+		local ps = extractPropertySignature(tostring(module), line, pendingDoc, inBlock, blockEq)
 
 		-- update state carried across lines
-		pendingDoc = res.pendingDoc
-		inBlock = res.inBlock
-		blockEq = res.blockEq
+		pendingDoc = ps.pendingDoc
+		inBlock = ps.inBlock
+		blockEq = ps.blockEq
 
-		if res.name and res.signature then
+		if ps.name and ps.signature then
 			table.insert(moduleDefinitions, {
-				name = res.name,
-				signature = res.signature,
-				doc = res.doc,
+				name = ps.name,
+				signature = ps.signature,
+				doc = ps.doc,
 			})
 		end
 	end

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -3,12 +3,12 @@ local process = require("@std/process")
 local path = require("@std/path")
 local stringext = require("@std/stringext")
 
--- extractPropertySignature:
--- module: string
--- line: string (current line)
--- pendingDoc: {string} (accumulated doc lines so far)
--- inBlock: boolean (are we currently inside a block comment?)
--- blockEq: string? (the "=" sequence used for block comment delimiting, e.g. "=" for --[=[  ; nil when not inside)
+-- extractPropertySignature: (this function runs on one line at a time so we need to keep some states for block comments)
+-- module (module name)
+-- line (current line)
+-- pendingDoc (accumulated doc lines so far)
+-- inBlock (are we currently inside a block comment?)
+-- blockEq (the "=" sequence used for block comment delimiting, e.g. "=" for --[=[  ; nil when not inside)
 --
 -- returns: name?, signature?, doc?, newPendingDoc, newInBlock, newBlockEq
 local function extractPropertySignature(
@@ -37,7 +37,6 @@ local function extractPropertySignature(
 				end
 			end
 
-			-- nothing else to do this line
 			return nil, nil, nil, pendingDoc, inBlock, blockEq
 		end
 	end
@@ -91,7 +90,7 @@ local function extractPropertySignature(
 	end
 
 	-- 5) Match function declarations like: function crypto.password.hash(password: string): buffer
-	local fullName, params, _colon, returnType = string.match(line, `^function%s+{module}%.(.-)(%b())(:?)%s*(.*)$`)
+	local fullName, params, _return, returnType = string.match(line, `^function%s+{module}%.(.-)(%b())(:?)%s*(.*)$`)
 	if fullName then
 		fullName = string.match(fullName, "^(.*)%b<>$") or fullName
 		returnType = if returnType == "" then "()" else returnType
@@ -107,7 +106,7 @@ local function extractPropertySignature(
 		pendingDoc = {}
 	end
 
-	-- nothing found
+	-- nothing found on this line
 	return nil, nil, nil, pendingDoc, inBlock, blockEq
 end
 

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -3,6 +3,20 @@ local process = require("@std/process")
 local path = require("@std/path")
 local stringext = require("@std/stringext")
 
+local STDLIB_MODULE_ALIASES = {
+	assert = "assertions",
+	fs = "fslib",
+	io = "iolib",
+	process = "processlib",
+	task = "tasklib",
+	path = "pathlib",
+	system = "systemlib",
+}
+
+local singleLineCommentPattern = "^%s*%-%-%-?%s?(.*)$"
+local blockCommentStartPattern = "^%s*%-%-%[(=*)%["
+local blankLinePattern = "^%s*$"
+
 -- extractPropertySignature: (this function runs on one line at a time so we need to keep some states for block comments)
 -- module (module name)
 -- line (current line)
@@ -22,7 +36,7 @@ local function extractPropertySignature(
 
 	-- 1) If we're *not* in a block, detect block start that may include = signs:
 	if not inBlock then
-		local eq = string.match(line, "^%s*%-%-%[(=*)%[")
+		local eq = string.match(line, blockCommentStartPattern)
 		if eq ~= nil then
 			-- start of block comment, capture any text after the opening on the same line
 			inBlock = true
@@ -70,7 +84,7 @@ local function extractPropertySignature(
 	end
 
 	-- 3) Single-line comment? (-- or ---)
-	local single = string.match(line, "^%s*%-%-%-?%s?(.*)$")
+	local single = string.match(line, singleLineCommentPattern)
 	if single then
 		local txt = stringext.trim(single)
 		if txt ~= "" then
@@ -101,8 +115,8 @@ local function extractPropertySignature(
 		return name, signature, doc, pendingDoc, inBlock, blockEq
 	end
 
-	-- 6) If we reach here and there's any non-whitespace, reset pendingDoc to clear old comments
-	if not string.match(line, "^%s*$") then
+	-- 6) If we reach here and there's any non-whitespace (i.e., code), reset pendingDoc to clear old comments
+	if not string.match(line, blankLinePattern) then
 		pendingDoc = {}
 	end
 
@@ -110,152 +124,25 @@ local function extractPropertySignature(
 	return nil, nil, nil, pendingDoc, inBlock, blockEq
 end
 
--- docs for definitions/*.luau --
-
-local function parseDefinitionFile(
-	module: path.pathlike,
-	filePath: path.pathlike
-): { { name: string, signature: string, doc: string? } }
-	local content = fs.readfiletostring(filePath)
-	local lines = string.split(content, "\n")
-
-	local definitions = {}
-	local pendingDoc = {}
-	local inBlock = false
-
-	for _, line in lines do
-		local name, signature, doc
-		name, signature, doc, pendingDoc, inBlock =
-			extractPropertySignature(tostring(module), line, pendingDoc, inBlock)
-
-		if name and signature then
-			table.insert(definitions, {
-				name = name,
-				signature = signature,
-				doc = doc,
-			})
-		end
-	end
-
-	return definitions
-end
-
-local function generateDefinitionsMarkdown(
-	moduleName: string,
-	definitions: { { name: string, signature: string, doc: string? } }
-): string
-	local lines = {
-		`# {moduleName}`,
-		"",
-		"```luau",
-		`local {moduleName} = require("@lute/{moduleName}")`,
-		"```",
-		"",
-	}
-
-	table.sort(definitions, function(a, b)
-		return a.name < b.name
-	end)
-
-	for _, def in definitions do
-		table.insert(lines, `## {moduleName}.{def.name}\n`)
-
-		-- Insert the documentation if it exists
-		if def.doc then
-			table.insert(lines, `{def.doc}\n`)
-		end
-		table.insert(lines, "```luau")
-		table.insert(lines, def.signature)
-		table.insert(lines, "```")
-		table.insert(lines, "")
-	end
-
-	return table.concat(lines, "\n")
-end
-
-local function processDefinitionsDir(definitionsPath: path.pathlike, referencePath: path.pathlike)
-	fs.createdirectory(referencePath, { makeparents = true })
-
-	local definitionFiles = fs.listdir(definitionsPath)
-
-	for _, file in definitionFiles do
-		if file.type == "file" and string.find(file.name, "%.luau$") then
-			local moduleName = string.gsub(file.name, "%.luau$", "")
-			local definitionFilePath = path.join(definitionsPath, file.name)
-			local referenceFilePath = path.join(referencePath, moduleName .. ".md")
-
-			print(`Processing {moduleName}...`)
-
-			local definitions = parseDefinitionFile(moduleName, definitionFilePath)
-			local markdown = generateDefinitionsMarkdown(moduleName, definitions)
-
-			fs.writestringtofile(referenceFilePath, markdown)
-
-			print(`Generated {tostring(referenceFilePath)}`)
-		end
-	end
-end
-
--- docs for lute/std/libs/*.luau --
-
-local STDLIB_MODULE_ALIASES = {
-	assert = "assertions",
-	fs = "fslib",
-	io = "iolib",
-	process = "processlib",
-	task = "tasklib",
-	path = "pathlib",
-	system = "systemlib",
-}
-
-local function parseStdlibFile(
-	module: path.pathlike,
-	filePath: path.pathlike
-): { { name: string, signature: string, doc: string? } }
-	local content = fs.readfiletostring(filePath)
-	local lines = string.split(content, "\n")
-
-	local stdlibDefinitions = {}
-	local pendingDoc = {}
-	local inBlock = false
-
-	local mod = STDLIB_MODULE_ALIASES[tostring(module)] or tostring(module)
-
-	for _, line in lines do
-		local name, signature, doc
-		name, signature, doc, pendingDoc, inBlock = extractPropertySignature(mod, line, pendingDoc, inBlock)
-
-		if name and signature then
-			table.insert(stdlibDefinitions, {
-				name = name,
-				signature = signature,
-				doc = doc,
-			})
-		end
-	end
-
-	return stdlibDefinitions
-end
-
-local function generateStdLibMarkdown(
+local function generateMarkdown(
 	moduleName: string,
 	definitions: { { name: string, signature: string, doc: string? } },
-	stdlibFilePath: path.pathlike
+	filePath: path.pathlike,
+	libraryPath: path.pathlike,
+	requireLibraryAlias: string
 ): string
-	local referencePath = path.join(process.cwd(), "..", "lute", "std", "libs")
+	local libPathStr = tostring(libraryPath)
+	local filePathStr = tostring(filePath)
 
-	local refPathStr = tostring(referencePath)
-	local stdlibFilePathStr = tostring(stdlibFilePath)
-
-	local relativePath = string.sub(stdlibFilePathStr, #refPathStr + 2) -- gets the path relative to std/libs for the require path
+	local relativePath = string.sub(filePathStr, #libPathStr + 2) -- gets the path relative to the require path (only relevant for subdirs like std/libs)
 	relativePath = string.gsub(relativePath, "%.luau$", "")
-	local requirePath = string.gsub(relativePath, "/init$", "")
+	local requirePath = string.gsub(relativePath, "/init$", "") -- remove trailing /init and use the module dir name
 
 	local lines = {
 		`# {moduleName}`,
 		"",
 		"```luau",
-		`local {moduleName} = require("@std/{requirePath}")`,
+		`local {moduleName} = require("@{requireLibraryAlias}/{requirePath}")`,
 		"```",
 		"",
 	}
@@ -280,44 +167,83 @@ local function generateStdLibMarkdown(
 	return table.concat(lines, "\n")
 end
 
-local function processStdlibDir(sourceDir: path.pathlike, referenceDir: path.pathlike)
-	fs.createdirectory(referenceDir, { makeparents = true })
+local function parseModule(
+	module: path.pathlike,
+	filePath: path.pathlike
+): { { name: string, signature: string, doc: string? } }
+	local content = fs.readfiletostring(filePath)
+	local lines = string.split(content, "\n")
 
-	local entries = fs.listdir(sourceDir)
+	local moduleDefinitions = {}
+	local pendingDoc = {}
+	local inBlock = false
+	local blockEq = nil
+
+	for _, line in lines do
+		local name, signature, doc
+		name, signature, doc, pendingDoc, inBlock, blockEq =
+			extractPropertySignature(tostring(module), line, pendingDoc, inBlock, blockEq)
+
+		if name and signature then
+			table.insert(moduleDefinitions, {
+				name = name,
+				signature = signature,
+				doc = doc,
+			})
+		end
+	end
+
+	return moduleDefinitions
+end
+
+local function processDirectory(
+	modulePath: path.pathlike,
+	documentationPath: path.pathlike,
+	libraryPath: path.pathlike,
+	requireLibraryAlias: string
+)
+	fs.createdirectory(documentationPath, { makeparents = true })
+
+	local entries = fs.listdir(modulePath)
 
 	for _, entry in entries do
-		local sourcePath = path.join(sourceDir, entry.name)
-		local referencePath = path.join(referenceDir, entry.name)
+		local entryPath = path.join(modulePath, entry.name)
+		local docPath = path.join(documentationPath, entry.name)
 
 		if entry.type == "dir" then
-			fs.createdirectory(referencePath, { makeparents = true })
-			processStdlibDir(sourcePath, referencePath)
+			fs.createdirectory(docPath, { makeparents = true })
+			processDirectory(entryPath, docPath, libraryPath, requireLibraryAlias)
 		elseif entry.type == "file" and string.find(entry.name, "%.luau$") then
 			local moduleName = string.gsub(entry.name, "%.luau$", "")
 			if moduleName == "init" then
-				moduleName = string.match(tostring(sourceDir), "([^/\\]+)$") or moduleName
+				moduleName = string.match(tostring(modulePath), "([^/\\]+)$") or moduleName
 			end
 
-			local referenceFilePath = path.join(referenceDir, moduleName .. ".md")
+			local documentationFilePath = path.join(documentationPath, moduleName .. ".md")
 
 			print(`Processing {moduleName}...`)
 
-			local stdlibDefinitions = parseStdlibFile(moduleName, sourcePath)
-			local markdown = generateStdLibMarkdown(moduleName, stdlibDefinitions, sourcePath)
+			local definitions = parseModule(moduleName, entryPath)
 
-			fs.writestringtofile(referenceFilePath, markdown)
+			if requireLibraryAlias == "std" then
+				moduleName = STDLIB_MODULE_ALIASES[moduleName] or moduleName
+			end
 
-			print(`Generated {tostring(referenceFilePath)}`)
+			local markdown = generateMarkdown(moduleName, definitions, entryPath, libraryPath, requireLibraryAlias)
+
+			fs.writestringtofile(documentationFilePath, markdown)
+
+			print(`Generated {tostring(documentationFilePath)}`)
 		end
 	end
 end
 
 local definitionsPath = path.join(process.cwd(), "..", "definitions")
 local referencePath = path.join(process.cwd(), "reference", "definitions")
-processDefinitionsDir(definitionsPath, referencePath)
+processDirectory(definitionsPath, referencePath, definitionsPath, "lute")
 
 local stdlibPath = path.join(process.cwd(), "..", "lute", "std", "libs")
 local stdlibReferencePath = path.join(process.cwd(), "reference", "std")
-processStdlibDir(stdlibPath, stdlibReferencePath)
+processDirectory(stdlibPath, stdlibReferencePath, stdlibPath, "std")
 
 print("Reference documentation generation complete!")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -17,8 +17,8 @@ local STDLIB_MODULE_ALIASES = {
 	syntax = "syntaxlib",
 }
 
-local singleLineCommentPattern = "^%s*%-%-%-?%s?(.*)$"
-local blockCommentStartPattern = "^%s*%-%-%[(=*)%["
+local tripleDashCommentPattern = "^%s*%-%-%-%s?(.*)$"
+local blockCommentStartPattern = "^%s*%-%-%[(=+)%["
 local blankLinePattern = "^%s*$"
 
 -- extractPropertySignature: (this function runs on one line at a time so we need to keep some states for block comments)
@@ -62,7 +62,7 @@ local function extractPropertySignature(
 	-- 2) If we're inside a block, accumulate until we find the matching close
 	if inBlock then
 		local eq = blockEq or ""
-		-- find the closing pattern "]]", or "]=]" etc. that matches eq
+		-- find the closing pattern "]=]" that matches the # of "=" used in opening
 		local closingPattern = "%]" .. eq .. "%]"
 		local before = string.match(line, "^(.-)" .. closingPattern)
 		if before then
@@ -87,10 +87,10 @@ local function extractPropertySignature(
 		return nil, nil, nil, pendingDoc, inBlock, blockEq
 	end
 
-	-- 3) Single-line comment? (-- or ---)
-	local single = string.match(line, singleLineCommentPattern)
-	if single then
-		local txt = stringext.trim(single)
+	-- 3) Triple dash comment? (---)
+	local triple = string.match(line, tripleDashCommentPattern)
+	if triple then
+		local txt = stringext.trim(triple)
 		if txt ~= "" then
 			table.insert(pendingDoc, txt)
 		end
@@ -252,8 +252,8 @@ processDirectory(stdlibPath, stdlibReferencePath, stdlibPath, "std")
 
 -- Mock module in test/ for testing purposes
 
--- local testPath = path.join(process.cwd(), "test")
--- local testReferencePath = path.join(process.cwd(), "test")
--- processDirectory(testPath, testReferencePath, testPath, "test")
+local testPath = path.join(process.cwd(), "test")
+local testReferencePath = path.join(process.cwd(), "test")
+processDirectory(testPath, testReferencePath, testPath, "test")
 
 print("Reference documentation generation complete!")

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -246,4 +246,10 @@ local stdlibPath = path.join(process.cwd(), "..", "lute", "std", "libs")
 local stdlibReferencePath = path.join(process.cwd(), "reference", "std")
 processDirectory(stdlibPath, stdlibReferencePath, stdlibPath, "std")
 
+-- Mock module in test/ for testing purposes
+
+-- local testPath = path.join(process.cwd(), "test")
+-- local testReferencePath = path.join(process.cwd(), "test")
+-- processDirectory(testPath, testReferencePath, testPath, "test")
+
 print("Reference documentation generation complete!")

--- a/docs/test/test_module.luau
+++ b/docs/test/test_module.luau
@@ -9,7 +9,7 @@ test_module.property["EXAMPLE_VAR"] = "value"
 
 --- Simple function with triple dashes comment that returns hello
 function test_module.triple_dash(name: string): string
-	return "Hello!"
+	return `Hello, {name}!`
 end
 
 --- Multiple triple-dash comments (---) above function declaration

--- a/docs/test/test_module.luau
+++ b/docs/test/test_module.luau
@@ -9,7 +9,7 @@ test_module.property["EXAMPLE_VAR"] = "value"
 
 --- Simple function with triple dashes comment that returns hello
 function test_module.triple_dash(name: string): string
-	return "Hello, " .. name .. "!"
+	return "Hello!"
 end
 
 --- Multiple triple-dash comments (---) above function declaration

--- a/docs/test/test_module.luau
+++ b/docs/test/test_module.luau
@@ -1,0 +1,48 @@
+-- This file creates a mock module called test_module with random mock functions and different types of comments to test the reference doc generator reference.luau
+-- See output documentation file generated in this folder `test_module.md`
+
+local test_module = {}
+
+-- Property declaration test: declare process.env as a map from string to string
+test_module.property = test_module.property or {} :: { [string]: string }
+test_module.property["EXAMPLE_VAR"] = "value"
+
+-- Simple add function with two dashes comment that returns the sum of two numbers
+function test_module.single_line(a: number, b: number): number
+	return a + b
+end
+
+--- Simple function with triple dashes comment that returns hello
+function test_module.triple_dash(name: string): string
+	return "Hello, " .. name .. "!"
+end
+
+-- Single line comment (--) directly above function declaration
+-- Should capture both of these single-line comments as a comment for the multiple_single_lines function
+function test_module.multiple_single_lines(x: number): number
+	return x * 2
+end
+
+--- Multiple triple-dash comments (---) above function declaration
+--- Should capture both of these lines
+function test_module.multiple_triple_dashes(y: number): number
+	return y + 1
+end
+
+--[[
+ Block comment above function declaration
+ It can span multiple lines and include more detail.
+]]
+function test_module.block(a: string, b: string): string
+	return a .. b
+end
+
+--[=[
+ Block comment with equals above function declaration
+ This tests nested bracket delimiters being recognized properly.
+]=]
+function test_module.block_with_equals(name: string): string
+	return "This is a nested bracket block comment: " .. name
+end
+
+return table.freeze(test_module)

--- a/docs/test/test_module.luau
+++ b/docs/test/test_module.luau
@@ -3,39 +3,31 @@
 
 local test_module = {}
 
--- Property declaration test: declare process.env as a map from string to string
+--- Property declaration test: declare process.env as a map from string to string
 test_module.property = test_module.property or {} :: { [string]: string }
 test_module.property["EXAMPLE_VAR"] = "value"
-
--- Simple add function with two dashes comment that returns the sum of two numbers
-function test_module.single_line(a: number, b: number): number
-	return a + b
-end
 
 --- Simple function with triple dashes comment that returns hello
 function test_module.triple_dash(name: string): string
 	return "Hello, " .. name .. "!"
 end
 
--- Single line comment (--) directly above function declaration
--- Should capture both of these single-line comments as a comment for the multiple_single_lines function
-function test_module.multiple_single_lines(x: number): number
-	return x * 2
-end
-
 --- Multiple triple-dash comments (---) above function declaration
 --- Should capture both of these lines
+
+--- Even if there are blank lines between them
 function test_module.multiple_triple_dashes(y: number): number
 	return y + 1
 end
 
+-- this comment should not be captured because it uses double dashes
+
 --[[
- Block comment above function declaration
- It can span multiple lines and include more detail.
+ This block comment is also not captured because there are no = signs.
 ]]
-function test_module.block(a: string, b: string): string
-	return a .. b
-end
+
+--- this should also not be captured because there is non function or property code
+local ignore = "value"
 
 --[=[
  Block comment with equals above function declaration

--- a/docs/test/test_module.md
+++ b/docs/test/test_module.md
@@ -1,0 +1,69 @@
+# test_module
+
+```luau
+local test_module = require("@test/test_module")
+```
+
+## test_module.block
+
+Block comment above function declaration
+
+It can span multiple lines and include more detail.
+
+```luau
+(a: string, b: string) -> string
+```
+
+## test_module.block_with_equals
+
+Block comment with equals above function declaration
+
+This tests nested bracket delimiters being recognized properly.
+
+```luau
+(name: string) -> string
+```
+
+## test_module.multiple_single_lines
+
+single line comment (--) directly above function declaration
+
+should capture both of these single-line comments as a comment for the multiple_single_line_comment function
+
+```luau
+(x: number) -> number
+```
+
+## test_module.multiple_triple_dashes
+
+multiple triple-dash comments (---) above function declaration
+
+should capture both of these lines
+
+```luau
+(y: number) -> number
+```
+
+## test_module.property
+
+property declaration test: declare process.env as a map from string to string
+
+```luau
+{ [string]: string }
+```
+
+## test_module.single_line
+
+simple add function with two dashes comment that returns the sum of two numbers
+
+```luau
+(a: number, b: number) -> number
+```
+
+## test_module.triple_dash
+
+simple hello function with triple dashes comment
+
+```luau
+(name: string) -> string
+```

--- a/docs/test/test_module.md
+++ b/docs/test/test_module.md
@@ -4,16 +4,6 @@
 local test_module = require("@test/test_module")
 ```
 
-## test_module.block
-
-Block comment above function declaration
-
-It can span multiple lines and include more detail.
-
-```luau
-(a: string, b: string) -> string
-```
-
 ## test_module.block_with_equals
 
 Block comment with equals above function declaration
@@ -24,21 +14,13 @@ This tests nested bracket delimiters being recognized properly.
 (name: string) -> string
 ```
 
-## test_module.multiple_single_lines
-
-single line comment (--) directly above function declaration
-
-should capture both of these single-line comments as a comment for the multiple_single_line_comment function
-
-```luau
-(x: number) -> number
-```
-
 ## test_module.multiple_triple_dashes
 
-multiple triple-dash comments (---) above function declaration
+Multiple triple-dash comments (---) above function declaration
 
-should capture both of these lines
+Should capture both of these lines
+
+Even if there are blank lines between them
 
 ```luau
 (y: number) -> number
@@ -46,23 +28,15 @@ should capture both of these lines
 
 ## test_module.property
 
-property declaration test: declare process.env as a map from string to string
+Property declaration test: declare process.env as a map from string to string
 
 ```luau
 { [string]: string }
 ```
 
-## test_module.single_line
-
-simple add function with two dashes comment that returns the sum of two numbers
-
-```luau
-(a: number, b: number) -> number
-```
-
 ## test_module.triple_dash
 
-simple hello function with triple dashes comment
+Simple function with triple dashes comment that returns hello
 
 ```luau
 (name: string) -> string


### PR DESCRIPTION
‼️ disclaimer - this code is pretty gross and is 100% just an intermediate step in the Luau doc gen plan while I'm still working on the implementation. This entire file should be deleted when we have implementations for parsing a module's return type and generating docs from that instead of this line-by-line pattern matching 😃👍 ‼️

Adding support for adding all sorts of doc comments to functions that are captured by the doc gen script for https://lute.luau.org/!

Only detects comments that are right above the function signature, but you can write 
- [single line comments](https://create.roblox.com/docs/luau/comments#single-line-comments) `---` or
- [block comments](https://create.roblox.com/docs/luau/comments#block-comments) with `--[=[ ]=]`
^this is because we don't have a standardized way of writing doc comments yet in Luau, so I'm just supporting these two for now

There is a mock module file and output documentation file in `docs/test/` that you can see what the doc gen script `reference.luau` generates! They're the `test_module.luau` and `test_module.md` files.

