### PR TITLE
crypto: add optional key argument for seal in definition files.

### DIFF
--- a/definitions/crypto.luau
+++ b/definitions/crypto.luau
@@ -26,7 +26,7 @@ function crypto.secretbox.keygen(): buffer
 	error("not implemented")
 end
 
-function crypto.secretbox.seal(message: string | buffer): secretbox
+function crypto.secretbox.seal(message: string | buffer, key: buffer?): secretbox
 	error("not implemented")
 end
 


### PR DESCRIPTION
In #571, we provided the ability for the secretbox api to use a separately generated key, but we forgot to update the definition file to appropriately describe that part of the interface.