### PR TITLE
stdlib: query:findall and query:flatmap

### DIFF
--- a/examples/query.luau
+++ b/examples/query.luau
@@ -1,11 +1,11 @@
-local luau = require("@std/luau")
+local syntax = require("@std/syntax")
 local query = require("@std/syntax/query")
 local utils = require("@std/syntax/utils")
 
-local ast = luau.parseexpr("require(OldComponent)")
+local ast = syntax.parseexpr("require(OldComponent)")
 
 local p = query
-	.select(ast, utils.isExprCall)
+	.findallfromroot(ast, utils.isExprCall)
 	:filter(function(call)
 		local calledFunc = call.func
 		return calledFunc.tag == "global" and calledFunc.name.text == "require"
@@ -16,8 +16,8 @@ local p = query
 	end)
 
 -- Can we improve the type solver here so we don't need to add this annotation?
-local argIndexNames = query.map(p, function(call: luau.AstExprCall)
-	return call.arguments[1].node :: luau.AstExprIndexName
+local argIndexNames = query.map(p, function(call: syntax.AstExprCall)
+	return call.arguments[1].node :: syntax.AstExprIndexName
 end)
 
 local replacements = argIndexNames:replace(function(node)

--- a/examples/query_transformer.luau
+++ b/examples/query_transformer.luau
@@ -4,7 +4,7 @@ local syntax_utils = require("@std/syntax/utils")
 
 local function transform(ctx)
 	return query
-		.selectFromRoot(ctx.parseresult.root, syntax_utils.isExprBinary)
+		.findallfromroot(ctx.parseresult.root, syntax_utils.isExprBinary)
 		:filter(function(bin)
 			return bin.operator.text == "~="
 				and bin.lhsoperand.tag == "local"

--- a/lute/std/libs/syntax/printer.luau
+++ b/lute/std/libs/syntax/printer.luau
@@ -3,7 +3,6 @@
 
 local triviaUtils = require("./utils/trivia")
 local types = require("./types")
-local utils = require("./utils")
 local visitor = require("./visitor")
 
 local printerLib = {}
@@ -39,6 +38,11 @@ local function printTriviaList(self: PrintVisitor, trivia: { types.Trivia })
 end
 
 local function printToken(self: PrintVisitor, token: types.Token)
+	if self.replacements[token] ~= nil then
+		self:printReplacement(token, self.replacements[token])
+		return
+	end
+
 	self:printTriviaList(token.leadingtrivia)
 	self:write(token.text)
 	self:printTriviaList(token.trailingtrivia)
@@ -69,6 +73,11 @@ local function printString(self: PrintVisitor, expr: types.AstExprConstantString
 end
 
 local function printInterpolatedString(self: PrintVisitor, expr: types.AstExprInterpString)
+	if self.replacements[expr] ~= nil then
+		self:printReplacement(expr, self.replacements[expr])
+		return
+	end
+
 	for i = 1, #expr.strings do
 		self:printTriviaList(expr.strings[i].leadingtrivia)
 		if i == 1 then

--- a/lute/std/libs/syntax/query.luau
+++ b/lute/std/libs/syntax/query.luau
@@ -2,6 +2,7 @@
 -- @std/syntax/query
 -- Provides utility functions for querying Luau AST nodes
 
+local tableext = require("@std/tableext")
 local types = require("./types")
 local visitor = require("./visitor")
 local utils = require("./utils")
@@ -13,8 +14,10 @@ export type query<T = node> = {
 	filter: (self: query<T>, pred: (T) -> boolean) -> query<T>,
 	replace: (self: query<T>, repl: (T) -> types.replacement?) -> types.replacements,
 	map: <U>(self: query<T>, fn: (T) -> U?) -> query<U>, -- recursion violation reported
-	forEach: (self: query<T>, callback: (T) -> ()) -> (),
-} -- TODO: Add a select: (self: query<T>, fn: (node) -> U?) -> query<U> method and a flatMap: <U>(self: query<T>, fn: (T) -> { U }) -> query<U> method
+	forEach: (self: query<T>, callback: (T) -> ()) -> query<T>,
+	select: <U>(self: query<T>, fn: (node) -> U?) -> query<U>,
+	flatMap: <U>(self: query<T>, fn: (T) -> { U }) -> query<U>,
+}
 
 local queryLib = {}
 
@@ -60,9 +63,7 @@ function queryLib.forEach<T>(self: query<T>, callback: (T) -> ()): query<T>
 	return self
 end
 
-function queryLib.selectFromRoot<T>(ast: types.ParseResult | node, fn: (node) -> T?): query<T>
-	local nodes: { T } = {}
-
+local function newSelectVisitor<T>(nodes: { T }, fn: (node) -> T?): visitor.Visitor
 	local function visit(n: node) -- LUAUFIX: type checker doesn't like assigning visit in the visitor fields with n: node
 		local selected = fn(n)
 		if selected ~= nil then
@@ -86,6 +87,40 @@ function queryLib.selectFromRoot<T>(ast: types.ParseResult | node, fn: (node) ->
 		return true
 	end
 
+	return selectVisitor
+end
+
+function queryLib.select<T, U>(self: query<T>, fn: (node) -> U?): query<U>
+	local selectedNodes: { U } = {}
+
+	local selectVisitor = newSelectVisitor(selectedNodes, fn)
+
+	for _, node in self.nodes do
+		visitor.visit(node, selectVisitor)
+	end
+
+	self.nodes = selectedNodes
+
+	return self
+end
+
+function queryLib.flatMap<T, U>(self: query<T>, fn: (T) -> { U }): query<U>
+	local newNodes: { U } = {}
+	for _, node in self.nodes do
+		local mapped = fn(node)
+		if #mapped > 0 then
+			tableext.extend(newNodes, mapped)
+		end
+	end
+	self.nodes = newNodes
+	return self
+end
+
+function queryLib.selectFromRoot<T>(ast: types.ParseResult | node, fn: (node) -> T?): query<T>
+	local nodes: { T } = {}
+
+	local selectVisitor = newSelectVisitor(nodes, fn)
+
 	local root: node = if ast.root ~= nil then ast.root else ast
 	visitor.visit(root, selectVisitor)
 
@@ -95,6 +130,8 @@ function queryLib.selectFromRoot<T>(ast: types.ParseResult | node, fn: (node) ->
 		replace = queryLib.replace,
 		map = queryLib.map,
 		forEach = queryLib.forEach,
+		select = queryLib.select,
+		flatMap = queryLib.flatMap,
 	} -- LUAUFIX: queryLib.map has generics quantified at a different level than expected
 end
 

--- a/lute/std/libs/syntax/query.luau
+++ b/lute/std/libs/syntax/query.luau
@@ -14,9 +14,9 @@ export type query<T = node> = {
 	filter: (self: query<T>, pred: (T) -> boolean) -> query<T>,
 	replace: (self: query<T>, repl: (T) -> types.replacement?) -> types.replacements,
 	map: <U>(self: query<T>, fn: (T) -> U?) -> query<U>, -- recursion violation reported
-	forEach: (self: query<T>, callback: (T) -> ()) -> query<T>,
-	select: <U>(self: query<T>, fn: (node) -> U?) -> query<U>,
-	flatMap: <U>(self: query<T>, fn: (T) -> { U }) -> query<U>,
+	foreach: (self: query<T>, callback: (T) -> ()) -> query<T>,
+	findall: <U>(self: query<T>, fn: (node) -> U?) -> query<U>,
+	flatmap: <U>(self: query<T>, fn: (T) -> { U }) -> query<U>,
 }
 
 local queryLib = {}
@@ -56,7 +56,7 @@ function queryLib.map<T, U>(self: query<T>, fn: (T) -> U?): query<U>
 	return self
 end
 
-function queryLib.forEach<T>(self: query<T>, callback: (T) -> ()): query<T>
+function queryLib.foreach<T>(self: query<T>, callback: (T) -> ()): query<T>
 	for _, node in self.nodes do
 		callback(node)
 	end
@@ -90,7 +90,7 @@ local function newSelectVisitor<T>(nodes: { T }, fn: (node) -> T?): visitor.Visi
 	return selectVisitor
 end
 
-function queryLib.select<T, U>(self: query<T>, fn: (node) -> U?): query<U>
+function queryLib.findall<T, U>(self: query<T>, fn: (node) -> U?): query<U>
 	local selectedNodes: { U } = {}
 
 	local selectVisitor = newSelectVisitor(selectedNodes, fn)
@@ -104,7 +104,7 @@ function queryLib.select<T, U>(self: query<T>, fn: (node) -> U?): query<U>
 	return self
 end
 
-function queryLib.flatMap<T, U>(self: query<T>, fn: (T) -> { U }): query<U>
+function queryLib.flatmap<T, U>(self: query<T>, fn: (T) -> { U }): query<U>
 	local newNodes: { U } = {}
 	for _, node in self.nodes do
 		local mapped = fn(node)
@@ -116,7 +116,7 @@ function queryLib.flatMap<T, U>(self: query<T>, fn: (T) -> { U }): query<U>
 	return self
 end
 
-function queryLib.selectFromRoot<T>(ast: types.ParseResult | node, fn: (node) -> T?): query<T>
+function queryLib.findallfromroot<T>(ast: types.ParseResult | node, fn: (node) -> T?): query<T>
 	local nodes: { T } = {}
 
 	local selectVisitor = newSelectVisitor(nodes, fn)
@@ -129,9 +129,9 @@ function queryLib.selectFromRoot<T>(ast: types.ParseResult | node, fn: (node) ->
 		filter = queryLib.filter,
 		replace = queryLib.replace,
 		map = queryLib.map,
-		forEach = queryLib.forEach,
-		select = queryLib.select,
-		flatMap = queryLib.flatMap,
+		foreach = queryLib.foreach,
+		findall = queryLib.findall,
+		flatmap = queryLib.flatmap,
 	} -- LUAUFIX: queryLib.map has generics quantified at a different level than expected
 end
 

--- a/lute/std/libs/syntax/utils/trivia.luau
+++ b/lute/std/libs/syntax/utils/trivia.luau
@@ -4,7 +4,7 @@ local types = require("../types")
 local retrieverLib = {}
 
 function retrieverLib.leftmosttrivia(n: types.AstNode): { types.Trivia }
-	local q: query.query<types.Token> = query.selectFromRoot(n, function(n)
+	local q: query.query<types.Token> = query.findallfromroot(n, function(n)
 		return if n.istoken ~= nil and n.istoken then n else nil
 	end)
 
@@ -27,7 +27,7 @@ function retrieverLib.leftmosttrivia(n: types.AstNode): { types.Trivia }
 end
 
 function retrieverLib.rightmosttrivia(n: types.AstNode): { types.Trivia }
-	local q: query.query<types.Token> = query.selectFromRoot(n, function(n)
+	local q: query.query<types.Token> = query.findallfromroot(n, function(n)
 		return if n.istoken ~= nil and n.istoken then n else nil
 	end)
 

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -999,6 +999,8 @@ local function visit(node: types.AstNode, visitor: Visitor)
 		visitLocal(node, visitor)
 	elseif node.kind == "attribute" then
 		visitAttribute(node, visitor)
+	elseif node.istoken then
+		visitToken(node, visitor)
 	else
 		exhaustiveMatch(node.kind)
 	end

--- a/tests/std/syntax/printer.test.luau
+++ b/tests/std/syntax/printer.test.luau
@@ -39,7 +39,7 @@ test.suite("syntax_printer", function(suite)
 		local expected = "            local name = 1 + 2\n"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprConstantString):replace(function(s)
+			return query.findallfromroot(ast, syntaxUtils.isExprConstantString):replace(function(s)
 				return if s.text == "World" then "1 + 2" else nil
 			end)
 		end, assert)
@@ -53,7 +53,7 @@ test.suite("syntax_printer", function(suite)
 		local expected = "            local name = 1 + 2\n"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprConstantString):replace(function(s)
+			return query.findallfromroot(ast, syntaxUtils.isExprConstantString):replace(function(s)
 				return if s.text == "World" then syntax.parseexpr("1 + 2") else nil
 			end)
 		end, assert)
@@ -67,7 +67,7 @@ test.suite("syntax_printer", function(suite)
 		local expected = "            local name = 1 + 2\n"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatLocal):replace(function(s)
+			return query.findallfromroot(ast, syntaxUtils.isStatLocal):replace(function(s)
 				return syntax.parseblock("local name = 1 + 2")
 			end)
 		end, assert)
@@ -82,7 +82,7 @@ test.suite("syntax_printer", function(suite)
 
 		checkReplacement(source, expected, function(ast)
 			return query
-				.selectFromRoot(ast, syntaxUtils.isStatLocal)
+				.findallfromroot(ast, syntaxUtils.isStatLocal)
 				:map(function(assign)
 					return assign.variables[1].node.annotation
 				end)
@@ -101,7 +101,7 @@ test.suite("syntax_printer", function(suite)
 
 		checkReplacement(source, expected, function(ast)
 			return query
-				.selectFromRoot(ast, syntaxUtils.isStatTypeAlias)
+				.findallfromroot(ast, syntaxUtils.isStatTypeAlias)
 				:map(function(ta)
 					if ta.type.tag == "function" then
 						return ta.type.returntypes
@@ -119,7 +119,7 @@ test.suite("syntax_printer", function(suite)
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprGroup):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprGroup):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -131,7 +131,7 @@ nil -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprConstantNil):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprConstantNil):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -143,7 +143,7 @@ true -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprConstantBool):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprConstantBool):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -155,7 +155,7 @@ true -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprConstantNumber):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprConstantNumber):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -168,7 +168,7 @@ y -- after]]
 		local expected = "local y = 3\n\t\tlocal x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprLocal):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprLocal):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -180,7 +180,7 @@ y -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprGlobal):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprGlobal):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -192,7 +192,7 @@ y -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprVarargs):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprVarargs):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -204,7 +204,7 @@ print() -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprCall):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprCall):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -216,7 +216,7 @@ hello.world -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprIndexName):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprIndexName):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -228,7 +228,7 @@ hello['world'] -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprIndexExpr):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprIndexExpr):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -240,7 +240,7 @@ function() return end -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprAnonymousFunction):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprAnonymousFunction):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -252,7 +252,7 @@ function() return end -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprTable):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprTable):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -264,7 +264,7 @@ function() return end -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprUnary):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprUnary):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -276,7 +276,7 @@ function() return end -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprBinary):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprBinary):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -288,7 +288,7 @@ function() return end -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprInterpString):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprInterpString):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -300,7 +300,7 @@ y :: number -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprTypeAssertion):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprTypeAssertion):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -312,7 +312,7 @@ if true then 'hello' else 'world' -- after]]
 		local expected = "local x =\nreplaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExprIfElse):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExprIfElse):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -324,7 +324,7 @@ if true then 'hello' else 'world', z :: string -- after]]
 		local expected = "local x, y =\nreplaced, replaced -- after"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isExpr):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isExpr):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -337,7 +337,7 @@ local y = 1
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatBlock):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatBlock):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -354,7 +354,7 @@ end
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatIf):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatIf):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -369,7 +369,7 @@ end
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatWhile):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatWhile):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -384,7 +384,7 @@ until true
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatRepeat):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatRepeat):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -399,7 +399,7 @@ end
 		local expected = "-- hello\nwhile true do\n\treplaced\nend\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatBreak):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatBreak):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -414,7 +414,7 @@ end
 		local expected = "-- hello\nwhile true do\n\treplaced\nend\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatContinue):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatContinue):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -427,7 +427,7 @@ function foo() return 1, 2 end
 		local expected = "-- hello\nfunction foo() replaced end\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatReturn):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatReturn):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -440,7 +440,7 @@ foobar()
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatExpr):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatExpr):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -453,7 +453,7 @@ local x = 1
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatLocal):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatLocal):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -468,7 +468,7 @@ end
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatFor):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatFor):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -483,7 +483,7 @@ end
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatForIn):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatForIn):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -497,7 +497,7 @@ y = 1
 		local expected = "-- hello\nlocal y = 2\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatAssign):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatAssign):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -511,7 +511,7 @@ y -= 1
 		local expected = "-- hello\nlocal y = 2\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatCompoundAssign):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatCompoundAssign):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -526,7 +526,7 @@ end
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatFunction):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatFunction):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -541,7 +541,7 @@ end
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatLocalFunction):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatLocalFunction):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -554,7 +554,7 @@ type foo = number
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatTypeAlias):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatTypeAlias):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -567,7 +567,7 @@ type function foo() return number end
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStatTypeFunction):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStatTypeFunction):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -581,7 +581,7 @@ local y = 2
 		local expected = "-- hello\nreplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isStat):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isStat):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -594,7 +594,7 @@ type foo = number
 		local expected = "-- hello\ntype foo = replaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypeReference):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypeReference):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -607,7 +607,7 @@ type foo = true
 		local expected = "-- hello\ntype foo = replaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypeSingletonBool):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypeSingletonBool):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -620,7 +620,7 @@ local x : "hello"
 		local expected = "-- hello\nlocal x : replaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypeSingletonString):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypeSingletonString):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -633,7 +633,7 @@ type foo = typeof(123)
 		local expected = "-- hello\ntype foo = replaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypeTypeof):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypeTypeof):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -646,7 +646,7 @@ type foo = (number)
 		local expected = "-- hello\ntype foo = replaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypeGroup):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypeGroup):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -659,7 +659,7 @@ type foo = true?
 		local expected = "-- hello\ntype foo = truereplaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypeOptional):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypeOptional):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -672,7 +672,7 @@ type foo = true? | false
 		local expected = "-- hello\ntype foo = replaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypeUnion):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypeUnion):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -685,7 +685,7 @@ type foo = true & false
 		local expected = "-- hello\ntype foo = replaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypeIntersection):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypeIntersection):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -698,7 +698,7 @@ type foo = { number }
 		local expected = "-- hello\ntype foo = replaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypeArray):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypeArray):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -711,7 +711,7 @@ type foo = {}
 		local expected = "-- hello\ntype foo = replaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypeTable):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypeTable):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -724,7 +724,7 @@ type foo = (number) -> ()
 		local expected = "-- hello\ntype foo = replaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypeFunction):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypeFunction):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -737,7 +737,7 @@ type foo = (number) -> ()
 		local expected = "-- hello\ntype foo = replaced\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isType):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isType):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -750,7 +750,7 @@ type foo = (number) -> (number, ...string)
 		local expected = "-- hello\ntype foo = (number) -> (replaced)\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypePackExplicit):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypePackExplicit):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -763,7 +763,7 @@ type foo = <G...>(number) -> (number, G...)
 		local expected = "-- hello\ntype foo = <G...>(number) -> (number, replaced)\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypePackGeneric):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypePackGeneric):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -776,7 +776,7 @@ type foo = (number) -> (...number)
 		local expected = "-- hello\ntype foo = (number) -> (replaced)\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypePackVariadic):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypePackVariadic):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -789,7 +789,7 @@ type foo = (number) -> (number, ...string)
 		local expected = "-- hello\ntype foo = (number) -> (replaced)\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isTypePack):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isTypePack):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -802,7 +802,7 @@ local x, y = 1, 2
 		local expected = "-- hello\nlocal replaced, replaced = 1, 2\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isLocal):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isLocal):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -816,7 +816,7 @@ function foo() return end
 		local expected = "-- hello\nreplaced\nfunction foo() return end\n-- world"
 
 		checkReplacement(source, expected, function(ast)
-			return query.selectFromRoot(ast, syntaxUtils.isAttribute):replace(function()
+			return query.findallfromroot(ast, syntaxUtils.isAttribute):replace(function()
 				return "replaced"
 			end)
 		end, assert)
@@ -833,7 +833,7 @@ function foo() return end
 
 		checkReplacement(source, expected, function(ast)
 			return query
-				.selectFromRoot(ast, syntaxUtils.isExprGlobal)
+				.findallfromroot(ast, syntaxUtils.isExprGlobal)
 				:filter(function(g)
 					return g.name.text == "baz"
 				end)
@@ -864,8 +864,8 @@ function foo() return end
 
 		checkReplacement(source, expected, function(ast)
 			return query
-				.selectFromRoot(ast, syntaxUtils.isExprTable)
-				:flatMap(function(t)
+				.findallfromroot(ast, syntaxUtils.isExprTable)
+				:flatmap(function(t)
 					local l = {}
 					for _, entry in t.entries do
 						table.insert(l, entry.key)

--- a/tests/std/syntax/printer.test.luau
+++ b/tests/std/syntax/printer.test.luau
@@ -842,6 +842,41 @@ function foo() return end
 				end)
 		end, assert)
 	end)
+
+	suite:case("comments_in_table", function(assert)
+		local source = [[local x = {
+  foo = -- what about this
+  1, 
+  bar = 2, 
+  -- and this
+  
+  baz = 3 -- and this??
+}]]
+
+		local expected = [[local x = {
+  replaced = -- what about this
+  1, 
+  replaced = 2, 
+  -- and this
+  
+  replaced = 3 -- and this??
+}]]
+
+		checkReplacement(source, expected, function(ast)
+			return query
+				.selectFromRoot(ast, syntaxUtils.isExprTable)
+				:flatMap(function(t)
+					local l = {}
+					for _, entry in t.entries do
+						table.insert(l, entry.key)
+					end
+					return l
+				end)
+				:replace(function()
+					return "replaced"
+				end)
+		end, assert)
+	end)
 end)
 
 test.run()

--- a/tests/std/syntax/query.test.luau
+++ b/tests/std/syntax/query.test.luau
@@ -5,7 +5,7 @@ local utils = require("@std/syntax/utils")
 
 test.suite("AST Query", function(suite)
 	suite:case("filter", function(assert)
-		local testQuery = query.selectFromRoot(syntax.parse("local _ = {0, 1, 2, 3, 4}"), utils.isExprConstantNumber) -- LUAUFIX: Complains that AstStatBlock doesn't have location? field
+		local testQuery = query.findallfromroot(syntax.parse("local _ = {0, 1, 2, 3, 4}"), utils.isExprConstantNumber) -- LUAUFIX: Complains that AstStatBlock doesn't have location? field
 
 		local filteredQuery = testQuery:filter(function(n)
 			return n.value > 2
@@ -18,7 +18,7 @@ test.suite("AST Query", function(suite)
 	end)
 
 	suite:case("replace", function(assert)
-		local testQuery = query.selectFromRoot(syntax.parse("local _ = {0, 1, 2, 3, 4}"), utils.isExprConstantNumber) -- LUAUFIX: Complains that AstStatBlock doesn't have location? field
+		local testQuery = query.findallfromroot(syntax.parse("local _ = {0, 1, 2, 3, 4}"), utils.isExprConstantNumber) -- LUAUFIX: Complains that AstStatBlock doesn't have location? field
 
 		local replacements = testQuery:replace(function(n): string?
 			if n.value > 0 then
@@ -45,7 +45,7 @@ test.suite("AST Query", function(suite)
 	end)
 
 	suite:case("map", function(assert)
-		local testQuery = query.selectFromRoot(syntax.parse("local _ = {0, 1, 2, 3, 4}"), utils.isExprConstantNumber) -- LUAUFIX: Complains that AstStatBlock doesn't have location? field
+		local testQuery = query.findallfromroot(syntax.parse("local _ = {0, 1, 2, 3, 4}"), utils.isExprConstantNumber) -- LUAUFIX: Complains that AstStatBlock doesn't have location? field
 
 		local mappedQuery = query.map(testQuery, function(n: syntax.AstExprConstantNumber): number?
 			if n.value % 2 == 0 then
@@ -60,20 +60,20 @@ test.suite("AST Query", function(suite)
 		assert.eq(mappedQuery.nodes[3], 40)
 	end)
 
-	suite:case("forEach", function(assert)
-		local testQuery = query.selectFromRoot(syntax.parse("local _ = {0, 1, 2}"), utils.isExprConstantNumber) -- LUAUFIX: Complains that AstStatBlock doesn't have location? field
+	suite:case("foreach", function(assert)
+		local testQuery = query.findallfromroot(syntax.parse("local _ = {0, 1, 2}"), utils.isExprConstantNumber) -- LUAUFIX: Complains that AstStatBlock doesn't have location? field
 
 		local sum = 0
-		testQuery:forEach(function(n: syntax.AstExprConstantNumber)
+		testQuery:foreach(function(n: syntax.AstExprConstantNumber)
 			sum = sum + n.value
 		end)
 
 		assert.eq(sum, 3) -- 0 + 1 + 2 = 3
 	end)
 
-	suite:case("select_nums", function(assert)
+	suite:case("findall_nums", function(assert)
 		local ast = syntax.parse("print(1 + 2)")
-		local queryResult: query.query<syntax.AstExprConstantNumber> = query.selectFromRoot(
+		local queryResult: query.query<syntax.AstExprConstantNumber> = query.findallfromroot(
 			ast, -- LUAUFIX: Complains that AstStatBlock doesn't have location? field
 			function(n: syntax.AstNode): syntax.AstExprConstantNumber?
 				if n.kind == "expr" and n.tag == "number" then
@@ -94,10 +94,10 @@ test.suite("AST Query", function(suite)
 		assert.eq((num :: syntax.AstExprConstantNumber).value, 2)
 	end)
 
-	suite:case("select_utils", function(assert)
+	suite:case("findall_utils", function(assert)
 		local ast = syntax.parse("print(1 + 2)")
 		local queryResult: query.query<syntax.AstExprConstantNumber> =
-			query.selectFromRoot(ast, utils.isExprConstantNumber) -- LUAUFIX: Complains that AstStatBlock doesn't have location? field
+			query.findallfromroot(ast, utils.isExprConstantNumber) -- LUAUFIX: Complains that AstStatBlock doesn't have location? field
 
 		assert.eq(#queryResult.nodes, 2)
 		local num: syntax.AstExpr = queryResult.nodes[1]
@@ -110,44 +110,44 @@ test.suite("AST Query", function(suite)
 		assert.eq((num :: syntax.AstExprConstantNumber).value, 2)
 	end)
 
-	suite:case("select_tokens", function(assert)
+	suite:case("findall_tokens", function(assert)
 		local ast = syntax.parse("local x = 1 or nil")
 		-- verify that query doesn't doubly count tokens
-		local queryResult = query.selectFromRoot(ast, utils.isToken)
+		local queryResult = query.findallfromroot(ast, utils.isToken)
 		assert.eq(#queryResult.nodes, 6)
-		queryResult:forEach(function(node)
+		queryResult:foreach(function(node)
 			assert.eq(node.istoken, true)
 		end)
-		local constNums = query.selectFromRoot(ast, utils.isExprConstantNumber)
+		local constNums = query.findallfromroot(ast, utils.isExprConstantNumber)
 		assert.eq(#constNums.nodes, 1)
-		local constNils = query.selectFromRoot(ast, utils.isExprConstantNil)
+		local constNils = query.findallfromroot(ast, utils.isExprConstantNil)
 		assert.eq(#constNils.nodes, 1)
-		local baseTokens = query.selectFromRoot(ast, utils.isBaseToken)
+		local baseTokens = query.findallfromroot(ast, utils.isBaseToken)
 		assert.eq(#baseTokens.nodes, 4)
 	end)
 
-	suite:case("select", function(assert)
+	suite:case("findall", function(assert)
 		-- Test selecting from a query of binary expressions to find their operands
 		local ast = syntax.parse("local x = 1 + 2")
-		local nums = query.selectFromRoot(ast, utils.isExprBinary):select(utils.isExprConstantNumber)
+		local nums = query.findallfromroot(ast, utils.isExprBinary):findall(utils.isExprConstantNumber)
 
 		assert.eq(#nums.nodes, 2)
 		assert.eq(nums.nodes[1].value, 1)
 		assert.eq(nums.nodes[2].value, 2)
 	end)
 
-	suite:case("select_nested", function(assert)
+	suite:case("findall", function(assert)
 		-- Test selecting through nested structures
 		local ast = syntax.parse("local x = {a = 1 + 2, b = 3 + 4}")
-		local tables = query.selectFromRoot(ast, utils.isExprTable)
+		local tables = query.findallfromroot(ast, utils.isExprTable)
 
 		-- Select all binary expressions within the table
-		local binaryExprs = tables:select(utils.isExprBinary)
+		local binaryExprs = tables:findall(utils.isExprBinary)
 
 		assert.eq(#binaryExprs.nodes, 2)
 
 		-- Now select all numbers from those binary expressions
-		local numbers = binaryExprs:select(utils.isExprConstantNumber)
+		local numbers = binaryExprs:findall(utils.isExprConstantNumber)
 
 		assert.eq(#numbers.nodes, 4)
 		assert.eq(numbers.nodes[1].value, 1)
@@ -156,10 +156,10 @@ test.suite("AST Query", function(suite)
 		assert.eq(numbers.nodes[4].value, 4)
 	end)
 
-	suite:case("flatMap", function(assert)
-		-- Test flatMap to collect multiple items from each node
+	suite:case("flatmap", function(assert)
+		-- Test flatmap to collect multiple items from each node
 		local ast = syntax.parse("local x = 1 + 2; local y = 3 + 4")
-		local locals = query.selectFromRoot(ast, utils.isStatLocal):flatMap(function(l)
+		local locals = query.findallfromroot(ast, utils.isStatLocal):flatmap(function(l)
 			local values = {}
 			for _, v in l.values do
 				table.insert(values, v.node)
@@ -174,10 +174,10 @@ test.suite("AST Query", function(suite)
 		assert.eq(locals.nodes[2].tag, "binary")
 	end)
 
-	suite:case("flatMap_empty", function(assert)
-		-- Test flatMap with some nodes returning empty arrays
+	suite:case("flatmap_empty", function(assert)
+		-- Test flatmap with some nodes returning empty arrays
 		local ast = syntax.parse("local x; local y = 1; local z")
-		local locals = query.selectFromRoot(ast, utils.isStatLocal):flatMap(function(l)
+		local locals = query.findallfromroot(ast, utils.isStatLocal):flatmap(function(l)
 			local values = {}
 			for _, v in l.values do
 				table.insert(values, v.node)
@@ -191,10 +191,10 @@ test.suite("AST Query", function(suite)
 		assert.eq((locals.nodes[1] :: syntax.AstExprConstantNumber).value, 1)
 	end)
 
-	suite:case("flatMap_multiple", function(assert)
-		-- Test flatMap with nodes that return multiple items
+	suite:case("flatmap_multiple", function(assert)
+		-- Test flatmap with nodes that return multiple items
 		local ast = syntax.parse("local a, b = 1, 2; local c, d = 3, 4, 5")
-		local locals = query.selectFromRoot(ast, utils.isStatLocal):flatMap(function(l: syntax.AstStatLocal)
+		local locals = query.findallfromroot(ast, utils.isStatLocal):flatmap(function(l: syntax.AstStatLocal)
 			local vars = {}
 			for _, v in l.variables do
 				table.insert(vars, v.node)

--- a/tests/std/syntax/query.test.luau
+++ b/tests/std/syntax/query.test.luau
@@ -125,6 +125,89 @@ test.suite("AST Query", function(suite)
 		local baseTokens = query.selectFromRoot(ast, utils.isBaseToken)
 		assert.eq(#baseTokens.nodes, 4)
 	end)
+
+	suite:case("select", function(assert)
+		-- Test selecting from a query of binary expressions to find their operands
+		local ast = syntax.parse("local x = 1 + 2")
+		local nums = query.selectFromRoot(ast, utils.isExprBinary):select(utils.isExprConstantNumber)
+
+		assert.eq(#nums.nodes, 2)
+		assert.eq(nums.nodes[1].value, 1)
+		assert.eq(nums.nodes[2].value, 2)
+	end)
+
+	suite:case("select_nested", function(assert)
+		-- Test selecting through nested structures
+		local ast = syntax.parse("local x = {a = 1 + 2, b = 3 + 4}")
+		local tables = query.selectFromRoot(ast, utils.isExprTable)
+
+		-- Select all binary expressions within the table
+		local binaryExprs = tables:select(utils.isExprBinary)
+
+		assert.eq(#binaryExprs.nodes, 2)
+
+		-- Now select all numbers from those binary expressions
+		local numbers = binaryExprs:select(utils.isExprConstantNumber)
+
+		assert.eq(#numbers.nodes, 4)
+		assert.eq(numbers.nodes[1].value, 1)
+		assert.eq(numbers.nodes[2].value, 2)
+		assert.eq(numbers.nodes[3].value, 3)
+		assert.eq(numbers.nodes[4].value, 4)
+	end)
+
+	suite:case("flatMap", function(assert)
+		-- Test flatMap to collect multiple items from each node
+		local ast = syntax.parse("local x = 1 + 2; local y = 3 + 4")
+		local locals = query.selectFromRoot(ast, utils.isStatLocal):flatMap(function(l)
+			local values = {}
+			for _, v in l.values do
+				table.insert(values, v.node)
+			end
+			return values
+		end)
+
+		assert.eq(#locals.nodes, 2) -- Two binary expressions
+		assert.eq(locals.nodes[1].kind, "expr")
+		assert.eq(locals.nodes[1].tag, "binary")
+		assert.eq(locals.nodes[2].kind, "expr")
+		assert.eq(locals.nodes[2].tag, "binary")
+	end)
+
+	suite:case("flatMap_empty", function(assert)
+		-- Test flatMap with some nodes returning empty arrays
+		local ast = syntax.parse("local x; local y = 1; local z")
+		local locals = query.selectFromRoot(ast, utils.isStatLocal):flatMap(function(l)
+			local values = {}
+			for _, v in l.values do
+				table.insert(values, v.node)
+			end
+			return values
+		end)
+
+		assert.eq(#locals.nodes, 1) -- Only 'local y = 1' has a value
+		assert.eq(locals.nodes[1].kind, "expr")
+		assert.eq(locals.nodes[1].tag, "number")
+		assert.eq((locals.nodes[1] :: syntax.AstExprConstantNumber).value, 1)
+	end)
+
+	suite:case("flatMap_multiple", function(assert)
+		-- Test flatMap with nodes that return multiple items
+		local ast = syntax.parse("local a, b = 1, 2; local c, d = 3, 4, 5")
+		local locals = query.selectFromRoot(ast, utils.isStatLocal):flatMap(function(l: syntax.AstStatLocal)
+			local vars = {}
+			for _, v in l.variables do
+				table.insert(vars, v.node)
+			end
+			return vars
+		end)
+
+		assert.eq(#locals.nodes, 4) -- a, b, c, d
+		assert.eq(locals.nodes[1].name.text, "a")
+		assert.eq(locals.nodes[2].name.text, "b")
+		assert.eq(locals.nodes[3].name.text, "c")
+		assert.eq(locals.nodes[4].name.text, "d")
+	end)
 end)
 
 test.run()


### PR DESCRIPTION
Follow up work to AST querying:
- Select provides the same functionality as `selectFromRoot`, but rooted on each node contained in the query.
- flatMap allows programmers to return array-like tables in their lambdas, which are then flattened and collected to form the next collection of nodes.

flatMap also allowed me to write an additional unit test which revealed a bug with how token replacements were being handled.