### PR TITLE
stdlib: Fix Lute test assertions

### DIFF
--- a/lute/std/libs/test/reporter.luau
+++ b/lute/std/libs/test/reporter.luau
@@ -15,7 +15,7 @@ local function printFailedTest(failed: FailedTest)
 	print(`❌ {failed.test}`)
 	if failed.assertion ~= nil then
 		print(`   {failed.filename}:{failed.linenumber}`)
-		print(`   	{failed.assertion}: {failed.message}`)
+		print(`   	{failed.assertion}: {failed.error}`)
 	else
 		print(`   Failed with: Runtime error in {failed.test} in:`)
 		print(`   	{failed.filename}:{failed.linenumber}`)

--- a/lute/std/libs/test/runner.luau
+++ b/lute/std/libs/test/runner.luau
@@ -3,7 +3,7 @@
 -- Standard test runner library for Luau
 
 local types = require("./types")
-local assert = require("./assert")
+local asserts = require("./assert")
 
 type Test = types.Test
 type TestCase = types.TestCase
@@ -110,7 +110,7 @@ function runner.run(env: TestEnvironment): TestRunResult
 			failed += 1
 		end
 
-		local success = xpcall(tc.case, handlefailure, assert)
+		local success = xpcall(tc.case, handlefailure, asserts)
 		if success then
 			passed += 1
 		end
@@ -156,7 +156,7 @@ function runner.run(env: TestEnvironment): TestRunResult
 				end
 			end
 
-			local success = xpcall(tc.case, handlefailure, assert)
+			local success = xpcall(tc.case, handlefailure, asserts)
 			-- Run aftereach hook if it exists (runs even if test failed)
 			if suite._aftereach then
 				local afterSuccess = xpcall(suite._aftereach, afterachErrorHandler(testFullName))

--- a/lute/std/libs/test/types.luau
+++ b/lute/std/libs/test/types.luau
@@ -26,7 +26,7 @@ export type testsuite = {
 export type failedtest = {
 	test: string, -- name of the test case that failed
 	assertion: string?, -- if an assertion failed, name of the assertion that failed (e.g., "assert.eq")
-	message: string?, -- the error message to report with a failed assertion
+	error: string?, -- the error message to report with a failed assertion
 	filename: string, -- source file where the failure occurred
 	linenumber: number, -- line number of the failure
 }

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -111,6 +111,110 @@ test.run()
 
 		fs.remove(testFilePath)
 	end)
+
+	suite:case("assert.eq_error_message_in_case", function(assert)
+		local testFilePath = path.join(tmpDir, "assert_eq_fails.test.luau")
+		local handle = fs.open(testFilePath, "w+")
+		fs.write(
+			handle,
+			[[
+local test = require("@std/test")
+
+test.case("eq_error", function(assert)
+	assert.eq(1, 2)
+end)
+
+test.run()
+			]]
+		)
+		fs.close(handle)
+
+		-- Run lute on the created test file
+		local result = process.run({ lutePath, tostring(testFilePath) })
+
+		-- Check that the output specifies the inequal values
+		assert.eq(result.exitcode, 1)
+		assert.neq(result.stdout:find("eq: 1 ~= 2", 1, true), nil)
+	end)
+
+	suite:case("assert.eq_error_message_in_suite", function(assert)
+		local testFilePath = path.join(tmpDir, "assert_eq_fails.test.luau")
+		local handle = fs.open(testFilePath, "w+")
+		fs.write(
+			handle,
+			[[
+local test = require("@std/test")
+
+test.suite("eq_failure_suite", function(suite)
+	suite:case("eq_error", function(assert)
+		assert.eq(1, 2)
+	end)
+end)
+
+test.run()
+			]]
+		)
+		fs.close(handle)
+
+		-- Run lute on the created test file
+		local result = process.run({ lutePath, tostring(testFilePath) })
+
+		-- Check that the output specifies the inequal values
+		assert.eq(result.exitcode, 1)
+		assert.neq(result.stdout:find("eq: 1 ~= 2", 1, true), nil)
+	end)
+
+	suite:case("assert.neq_error_message_in_case", function(assert)
+		local testFilePath = path.join(tmpDir, "assert_neq_fails.test.luau")
+		local handle = fs.open(testFilePath, "w+")
+		fs.write(
+			handle,
+			[[
+local test = require("@std/test")
+
+test.case("neq_error", function(assert)
+	assert.neq(1, 1)
+end)
+
+test.run()
+			]]
+		)
+		fs.close(handle)
+
+		-- Run lute on the created test file
+		local result = process.run({ lutePath, tostring(testFilePath) })
+
+		-- Check that the output specifies the inequal values
+		assert.eq(result.exitcode, 1)
+		assert.neq(result.stdout:find("neq: 1 == 1", 1, true), nil)
+	end)
+
+	suite:case("assert.neq_error_message_in_suite", function(assert)
+		local testFilePath = path.join(tmpDir, "assert_neq_fails.test.luau")
+		local handle = fs.open(testFilePath, "w+")
+		fs.write(
+			handle,
+			[[
+local test = require("@std/test")
+
+test.suite("neq_failure_suite", function(suite)
+	suite:case("neq_error", function(assert)
+		assert.neq(1, 1)
+	end)
+end)
+
+test.run()
+			]]
+		)
+		fs.close(handle)
+
+		-- Run lute on the created test file
+		local result = process.run({ lutePath, tostring(testFilePath) })
+
+		-- Check that the output specifies the inequal values
+		assert.eq(result.exitcode, 1)
+		assert.neq(result.stdout:find("neq: 1 == 1", 1, true), nil)
+	end)
 end)
 
 test.run()


### PR DESCRIPTION
`lute test` wasn't correctly reporting the values from failed `assert.eq` and `assert.neq` values due to a recent refactoring. @~Vighnesh-V authored the fix, and I've completed the PR with some tests in his absence.