### PR TITLE
std/syntax: `visitor.visit` should support table items (`luau.AstExprTableItem`)

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -135,7 +135,7 @@ export type AstExprAnonymousFunction = {
 }
 
 -- helper types for items contained in an AstExprTable, not actually AstExprs themselves
-export type AstExprTableItemList = { kind: "list", value: AstExpr, separator: Token<"," | ";">? }
+export type AstExprTableItemList = { kind: "list", value: AstExpr, separator: Token<"," | ";">?, istableitem: true }
 
 export type AstExprTableItemRecord = {
 	kind: "record",
@@ -143,6 +143,7 @@ export type AstExprTableItemRecord = {
 	equals: Token<"=">,
 	value: AstExpr,
 	separator: Token<"," | ";">?,
+	istableitem: true,
 }
 
 export type AstExprTableItemGeneral = {
@@ -153,11 +154,10 @@ export type AstExprTableItemGeneral = {
 	equals: Token<"=">,
 	value: AstExpr,
 	separator: Token<"," | ";">?,
+	istableitem: true,
 }
 
-export type AstExprTableItem =
-	{ istableitem: true }
-	& (AstExprTableItemList | AstExprTableItemRecord | AstExprTableItemGeneral)
+export type AstExprTableItem = AstExprTableItemList | AstExprTableItemRecord | AstExprTableItemGeneral
 
 export type AstExprTable = {
 	kind: "expr",

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -155,7 +155,9 @@ export type AstExprTableItemGeneral = {
 	separator: Token<"," | ";">?,
 }
 
-export type AstExprTableItem = AstExprTableItemList | AstExprTableItemRecord | AstExprTableItemGeneral
+export type AstExprTableItem =
+	{ istableitem: true }
+	& (AstExprTableItemList | AstExprTableItemRecord | AstExprTableItemGeneral)
 
 export type AstExprTable = {
 	kind: "expr",

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -371,18 +371,24 @@ struct AstSerialize : public Luau::AstVisitor
 
         if (item.kind == Luau::AstExprTable::Item::List)
         {
-            lua_createtable(L, 0, 3);
+            lua_createtable(L, 0, 4);
             lua_pushstring(L, "list");
             lua_setfield(L, -2, "kind");
+
+            lua_pushboolean(L, 1);
+            lua_setfield(L, -2, "istableitem")
 
             visit(item.value);
             lua_setfield(L, -2, "value");
         }
         else if (item.kind == Luau::AstExprTable::Item::Record)
         {
-            lua_createtable(L, 0, 5);
+            lua_createtable(L, 0, 6);
             lua_pushstring(L, "record");
             lua_setfield(L, -2, "kind");
+
+            lua_pushboolean(L, 1);
+            lua_setfield(L, -2, "istableitem")
 
             const auto& value = item.key->as<Luau::AstExprConstantString>()->value;
             serializeToken(item.key->location.begin, std::string(value.data, value.size).data());
@@ -397,9 +403,12 @@ struct AstSerialize : public Luau::AstVisitor
         }
         else if (item.kind == Luau::AstExprTable::Item::General)
         {
-            lua_createtable(L, 0, 7);
+            lua_createtable(L, 0, 8);
             lua_pushstring(L, "general");
             lua_setfield(L, -2, "kind");
+
+            lua_pushboolean(L, 1);
+            lua_setfield(L, -2, "istableitem")
 
             LUAU_ASSERT(cstNode->indexerOpenPosition);
             serializeToken(*cstNode->indexerOpenPosition, "[");

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -376,7 +376,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "kind");
 
             lua_pushboolean(L, 1);
-            lua_setfield(L, -2, "istableitem")
+            lua_setfield(L, -2, "istableitem");
 
             visit(item.value);
             lua_setfield(L, -2, "value");
@@ -388,7 +388,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "kind");
 
             lua_pushboolean(L, 1);
-            lua_setfield(L, -2, "istableitem")
+            lua_setfield(L, -2, "istableitem");
 
             const auto& value = item.key->as<Luau::AstExprConstantString>()->value;
             serializeToken(item.key->location.begin, std::string(value.data, value.size).data());
@@ -408,7 +408,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "kind");
 
             lua_pushboolean(L, 1);
-            lua_setfield(L, -2, "istableitem")
+            lua_setfield(L, -2, "istableitem");
 
             LUAU_ASSERT(cstNode->indexerOpenPosition);
             serializeToken(*cstNode->indexerOpenPosition, "[");

--- a/lute/std/libs/syntax/utils/init.luau
+++ b/lute/std/libs/syntax/utils/init.luau
@@ -58,6 +58,10 @@ function utils.isExprTable(n: types.AstNode): types.AstExprTable?
 	return if n.kind == "expr" and n.tag == "table" then n else nil
 end
 
+function utils.isExprTableItem(n: types.AstNode): types.AstExprTableItem?
+	return if n.kind == "list" or n.kind == "record" or n.kind == "general" then n else nil
+end
+
 function utils.isExprUnary(n: types.AstNode): types.AstExprUnary?
 	return if n.kind == "expr" and n.tag == "unary" then n else nil
 end

--- a/lute/std/libs/syntax/utils/init.luau
+++ b/lute/std/libs/syntax/utils/init.luau
@@ -59,7 +59,7 @@ function utils.isExprTable(n: types.AstNode): types.AstExprTable?
 end
 
 function utils.isExprTableItem(n: types.AstNode): types.AstExprTableItem?
-	return if n.kind == "list" or n.kind == "record" or n.kind == "general" then n else nil
+	return if n.istableitem then n else nil
 end
 
 function utils.isExprUnary(n: types.AstNode): types.AstExprUnary?

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -1001,6 +1001,8 @@ local function visit(node: types.AstNode, visitor: Visitor)
 		visitAttribute(node, visitor)
 	elseif node.istoken then
 		visitToken(node, visitor)
+	elseif node.kind == "list" or node.kind == "record" or node.kind == "general" then
+		visitTableItem(node, visitor)
 	else
 		exhaustiveMatch(node.kind)
 	end

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -1001,7 +1001,7 @@ local function visit(node: types.AstNode, visitor: Visitor)
 		visitAttribute(node, visitor)
 	elseif node.istoken then
 		visitToken(node, visitor)
-	elseif node.kind == "list" or node.kind == "record" or node.kind == "general" then
+	elseif node.istableitem then
 		visitTableItem(node, visitor)
 	else
 		exhaustiveMatch(node.kind)

--- a/tests/std/syntax/printer.test.luau
+++ b/tests/std/syntax/printer.test.luau
@@ -113,6 +113,22 @@ test.suite("syntax_printer", function(suite)
 		end, assert)
 	end)
 
+	suite:case("expr_table_item_replacement", function(assert)
+		local source = "local tbl = { a = 1, }"
+		local expected = "local tbl = { b = 2, }"
+
+		checkReplacement(source, expected, function(ast)
+			return query
+				.findallfromroot(ast, syntaxUtils.isExprTable)
+				:map(function(node)
+					return node.entries[1]
+				end)
+				:replace(function(entry)
+					return "b = 2,"
+				end)
+		end, assert)
+	end)
+
 	suite:case("exprgroup_trivia", function(assert)
 		local source = [[local x =
 (1 + 2) -- after]]


### PR DESCRIPTION
`visitor.visit` will currently fallback to `exhaustiveMatch` and error if passed an `AstExprTableItem` node.
This causes `printnode` to fail if passed a `replacements` map containing any `AstExprTableItem` node, preventing table entries from being replaced.

You can minimally repro this with:

```luau
local printer = require("@std/syntax/printer")
local parser = require("@std/syntax/parser")
local query = require("@std/syntax/query")
local utils = require("@std/syntax/utils")

local demo = [[

local tbl = {
    a = 1,
}

]]

local ast = parser.parseblock(demo)

local replacements = {}

local tbl = query.selectFromRoot(ast, utils.isExprTable):forEach(function(n)
    for i, entry in n.entries do
        replacements[entry] = `a{i} = "hello",`
    end
end)

print(printer.printnode(ast, replacements))
```

This PR ensures `visitor.visit` supports table entries and that we can replace them in codemods