### PR TITLE
fix: exclude `docs/test/` from doc gen and fix file naming

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,6 +16,7 @@ export default withSidebar(
         { icon: 'github', link: 'https://github.com/luau-lang/lute' },
       ],
     },
+    srcExclude: ['/test/**' ],
   }),
   {
     // ============ [ SIDEBAR OPTIONS ] ============

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -254,10 +254,9 @@ local function processDirectory(
 
 			print(`Processing {moduleName}...`)
 
-			local moduleAlias = moduleName
-			if requireLibraryAlias == "std" then
-				moduleAlias = STDLIB_MODULE_ALIASES[moduleName] or moduleName
-			end
+			local moduleAlias = if requireLibraryAlias == "std"
+				then STDLIB_MODULE_ALIASES[moduleName] or moduleName
+				else moduleName
 
 			local definitions = parseModule(moduleAlias, entryPath)
 			local markdown = generateMarkdown(moduleName, definitions, entryPath, libraryPath, requireLibraryAlias)

--- a/docs/scripts/reference.luau
+++ b/docs/scripts/reference.luau
@@ -254,11 +254,12 @@ local function processDirectory(
 
 			print(`Processing {moduleName}...`)
 
+			local moduleAlias = moduleName
 			if requireLibraryAlias == "std" then
-				moduleName = STDLIB_MODULE_ALIASES[moduleName] or moduleName
+				moduleAlias = STDLIB_MODULE_ALIASES[moduleName] or moduleName
 			end
 
-			local definitions = parseModule(moduleName, entryPath)
+			local definitions = parseModule(moduleAlias, entryPath)
 			local markdown = generateMarkdown(moduleName, definitions, entryPath, libraryPath, requireLibraryAlias)
 
 			fs.writestringtofile(documentationFilePath, markdown)


### PR DESCRIPTION
`test/` folder was being published to the site and the filenames were the internal table variable names (i.e. `printerlib`) instead of the intended module names (i.e. `printer`)