### PR TITLE
fix: correctly exclude test folder for docgen + require build-docs-site success in CI to merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,12 +134,12 @@ jobs:
   aggregator:
     name: Gated Commits
     runs-on: ubuntu-latest
-    needs: [run-lutecli-luau-tests, run-lute-cxx-unittests, check-format]
+    needs: [run-lutecli-luau-tests, run-lute-cxx-unittests, check-format, build-docs-site]
     if: ${{ always() }}
     steps:
       - name: Aggregator
         run: |
-          if [ "${{ needs.run-lutecli-luau-tests.result }}" == "success" ] && [ "${{ needs.run-lute-cxx-unittests.result }}" == "success" ] && [ "${{ needs.check-format.result }}" == "success" ]; then
+          if [ "${{ needs.run-lutecli-luau-tests.result }}" == "success" ] && [ "${{ needs.run-lute-cxx-unittests.result }}" == "success" ] && [ "${{ needs.check-format.result }}" == "success" ] && [ "${{ needs.build-docs-site.result }}" == "success" ]; then
             echo "All jobs succeeded"
           else
             echo "One or more jobs failed"

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,7 +16,6 @@ export default withSidebar(
         { icon: 'github', link: 'https://github.com/luau-lang/lute' },
       ],
     },
-    srcExclude: ['/test/**' ],
   }),
   {
     // ============ [ SIDEBAR OPTIONS ] ============
@@ -26,5 +25,6 @@ export default withSidebar(
     hyphenToSpace: true,
     underscoreToSpace: true,
     sortMenusByName: true,
+    excludeByGlobPattern: ['**/test/**'],
   }
 )


### PR DESCRIPTION
Apparently vitepress sidebar extension shadows the vitepress exclude directories somehow, so fixing that and making sure `build-docs-site` CI test needs to succeed before github can merge

I tested it correctly this time and `test/test_module.md` does not get generated on the sidebar

<img width="454" height="1410" alt="image" src="https://github.com/user-attachments/assets/7b867efc-e65d-4453-8c09-07933bf41d1f" />