### PR TITLE
actually report failing windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           set _errorFlag=0
           for /r tests %%f in (*.test.luau) do (
             "${{ steps.build_lute.outputs.exe_path }}" run "%%f"
-            if ERRORLEVEL 1 set _errorFlag=1
+            echo error level: %errorlevel%
           )
           if !_errorFlag! equ 1 exit /b 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,10 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          set _errorFlag=0
           for /r tests %%f in (*.test.luau) do (
             "${{ steps.build_lute.outputs.exe_path }}" run "%%f"
             echo error level: %errorlevel%
           )
-          if !_errorFlag! equ 1 exit /b 1
 
   run-lute-cxx-unittests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
         include:
           - os: windows-latest
             options: --c-compiler cl.exe --cxx-compiler cl.exe
-          - os: ubuntu-latest
-            options: --c-compiler gcc --cxx-compiler g++ --enable-asan
-          - os: ubuntu-latest
-            options: --c-compiler clang --cxx-compiler clang++ --enable-asan
-          - os: macos-latest
-            options: --enable-asan
+          # - os: ubuntu-latest
+          #   options: --c-compiler gcc --cxx-compiler g++ --enable-asan
+          # - os: ubuntu-latest
+          #   options: --c-compiler clang --cxx-compiler clang++ --enable-asan
+          # - os: macos-latest
+          #   options: --enable-asan
       fail-fast: false
 
     steps:
@@ -50,7 +50,9 @@ jobs:
       - name: Run Luau Tests (Windows)
         if: runner.os == 'Windows'
         shell: cmd
-        run: for /r tests %%f in (*.test.luau) do "${{ steps.build_lute.outputs.exe_path }}" run "%%f"
+        run: |
+          for /r tests %%f in (*.test.luau) do "${{ steps.build_lute.outputs.exe_path }}" run "%%f"
+          echo Error level: %ERRORLEVEL%
 
   run-lute-cxx-unittests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,12 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          for /r tests %%f in (*.test.luau) do "${{ steps.build_lute.outputs.exe_path }}" run "%%f"
-          echo Error level: %ERRORLEVEL%
+          set _errorFlag=0
+          for /r tests %%f in (*.test.luau) do (
+            "${{ steps.build_lute.outputs.exe_path }}" run "%%f"
+            if ERRORLEVEL 1 set _errorFlag=1
+          )
+          if !_errorFlag! equ 1 exit /b 1
 
   run-lute-cxx-unittests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,10 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          for /r tests %%f in (*.test.luau) do (
-            "${{ steps.build_lute.outputs.exe_path }}" run "%%f" && (echo Test %%f passed) || (echo Test %%f failed)
-          )
+          set _errorFlag=0
+          for /r tests %%f in (*.test.luau) do "${{ steps.build_lute.outputs.exe_path }}" run "%%f" || (set _errorFlag=1)
+          if %_errorFlag% neq 0 exit /b 1
+        
 
   run-lute-cxx-unittests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,7 @@ jobs:
         shell: cmd
         run: |
           for /r tests %%f in (*.test.luau) do (
-            "${{ steps.build_lute.outputs.exe_path }}" run "%%f"
-            echo error level: %errorlevel%
+            "${{ steps.build_lute.outputs.exe_path }}" run "%%f" && (echo Test %%f passed) || (echo Test %%f failed)
           )
 
   run-lute-cxx-unittests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
         include:
           - os: windows-latest
             options: --c-compiler cl.exe --cxx-compiler cl.exe
-          # - os: ubuntu-latest
-          #   options: --c-compiler gcc --cxx-compiler g++ --enable-asan
-          # - os: ubuntu-latest
-          #   options: --c-compiler clang --cxx-compiler clang++ --enable-asan
-          # - os: macos-latest
-          #   options: --enable-asan
+          - os: ubuntu-latest
+            options: --c-compiler gcc --cxx-compiler g++ --enable-asan
+          - os: ubuntu-latest
+            options: --c-compiler clang --cxx-compiler clang++ --enable-asan
+          - os: macos-latest
+            options: --enable-asan
       fail-fast: false
 
     steps:

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -12,6 +12,7 @@
 
 #include <climits> // IWYU pragma: keep
 #include <functional>
+#include <iostream>
 #include <map>
 #include <memory>
 #include <optional>
@@ -32,12 +33,12 @@ void convertCRLFtoLF(std::string& str)
     for (size_t readPos = 0; readPos < str.size(); ++readPos)
     {
         if (str[readPos] == '\r' && readPos + 1 < str.size() && str[readPos + 1] == '\n')
-            continue;  // Skip the '\r' in CRLF
+            continue; // Skip the '\r' in CRLF
         str[writePos++] = str[readPos];
     }
     str.resize(writePos);
 }
-    
+
 struct ProcessHandle
 {
     uv_process_t process;
@@ -457,7 +458,7 @@ int exitFunc(lua_State* L)
 {
     int exitCode = luaL_optinteger(L, 1, 0);
 
-
+    std::cout << "Exiting with code: " << exitCode << std::endl;
     // Exit with the provided code
     std::exit(exitCode);
 

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -12,7 +12,6 @@
 
 #include <climits> // IWYU pragma: keep
 #include <functional>
-#include <iostream>
 #include <map>
 #include <memory>
 #include <optional>
@@ -458,7 +457,6 @@ int exitFunc(lua_State* L)
 {
     int exitCode = luaL_optinteger(L, 1, 0);
 
-    std::cout << "Exiting with code: " << exitCode << std::endl;
     // Exit with the provided code
     std::exit(exitCode);
 

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -3,7 +3,7 @@ local path = require("@std/path")
 local process = require("@std/process")
 local system = require("@std/system")
 local test = require("@std/test")
-local fs = require("@std/fs")
+
 local lutePath = path.format(process.execpath())
 local tmpDir = system.tmpdir()
 
@@ -75,9 +75,14 @@ test.run()
 			result.stdout:find(`Failed with: Runtime error in nil_field_suite.access_field_of_nil in:`, 1, true),
 			nil
 		)
-		print("EXPECTED PATH: ", path.format(testFilePath))
-		print("TEST OUTPUT: ", result.stdout)
-		assert.neq(result.stdout:find(`{path.format(testFilePath)}:6`, 1, true), nil)
+		assert.neq(
+			result.stdout:find( -- filename comes from debug.info, which uses forward slashes even on Windows
+				`{if system.win32 then path.format(testFilePath):gsub("\\", "/") else path.format(testFilePath)}:6`,
+				1,
+				true
+			),
+			nil
+		)
 
 		fs.remove(testFilePath)
 	end)
@@ -109,9 +114,14 @@ test.run()
 		assert.eq(result.stdout:find("xpcall", 1, true), nil)
 		-- Check that the error points to filepath + correct line number
 		assert.neq(result.stdout:find(`Failed with: Runtime error in access_field_of_nil in:`, 1, true), nil)
-		print("EXPECTED PATH: ", path.format(testFilePath))
-		print("TEST OUTPUT: ", result.stdout)
-		assert.neq(result.stdout:find(`{path.format(testFilePath)}:5`, 1, true), nil)
+		assert.neq(
+			result.stdout:find( -- filename comes from debug.info, which uses forward slashes even on Windows
+				`{if system.win32 then path.format(testFilePath):gsub("\\", "/") else path.format(testFilePath)}:5`,
+				1,
+				true
+			),
+			nil
+		)
 
 		fs.remove(testFilePath)
 	end)

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -75,6 +75,7 @@ test.run()
 			result.stdout:find(`Failed with: Runtime error in nil_field_suite.access_field_of_nil in:`, 1, true),
 			nil
 		)
+		print("TEST OUTPUT: ", result.stdout)
 		assert.neq(result.stdout:find(`{path.format(testFilePath)}:6`, 1, true), nil)
 
 		fs.remove(testFilePath)
@@ -107,6 +108,7 @@ test.run()
 		assert.eq(result.stdout:find("xpcall", 1, true), nil)
 		-- Check that the error points to filepath + correct line number
 		assert.neq(result.stdout:find(`Failed with: Runtime error in access_field_of_nil in:`, 1, true), nil)
+		print("TEST OUTPUT: ", result.stdout)
 		assert.neq(result.stdout:find(`{path.format(testFilePath)}:5`, 1, true), nil)
 
 		fs.remove(testFilePath)

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -75,6 +75,7 @@ test.run()
 			result.stdout:find(`Failed with: Runtime error in nil_field_suite.access_field_of_nil in:`, 1, true),
 			nil
 		)
+		print("EXPECTED PATH: ", path.format(testFilePath))
 		print("TEST OUTPUT: ", result.stdout)
 		assert.neq(result.stdout:find(`{path.format(testFilePath)}:6`, 1, true), nil)
 
@@ -108,6 +109,7 @@ test.run()
 		assert.eq(result.stdout:find("xpcall", 1, true), nil)
 		-- Check that the error points to filepath + correct line number
 		assert.neq(result.stdout:find(`Failed with: Runtime error in access_field_of_nil in:`, 1, true), nil)
+		print("EXPECTED PATH: ", path.format(testFilePath))
 		print("TEST OUTPUT: ", result.stdout)
 		assert.neq(result.stdout:find(`{path.format(testFilePath)}:5`, 1, true), nil)
 

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -28,7 +28,7 @@ test.suite("ProcessSuite", function(suite)
 		local r = process.run({ "pwd" }, { cwd = rootdir })
 		assert.tableeq(r, {
 			exitcode = 0,
-			stdout = "/\n",
+			stdout = if system.win32 then "/d\n" else "/\n",
 			stderr = "",
 			ok = true,
 		})

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -28,7 +28,7 @@ test.suite("ProcessSuite", function(suite)
 		local r = process.run({ "pwd" }, { cwd = rootdir })
 		assert.tableeq(r, {
 			exitcode = 0,
-			stdout = if system.win32 then "/d\n" else "/\n",
+			stdout = rootdir .. "\n",
 			stderr = "",
 			ok = true,
 		})

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -1,7 +1,8 @@
 local pathlib = require("@std/path")
 local process = require("@std/process")
-local test = require("@std/test")
 local system = require("@std/system")
+local test = require("@std/test")
+
 test.suite("ProcessSuite", function(suite)
 	suite:case("homedir_and_cwd_and_execpath", function(assert)
 		local hd = process.homedir()
@@ -19,22 +20,33 @@ test.suite("ProcessSuite", function(suite)
 		assert.eq(r.stdout, "hello-from-lute\n")
 	end)
 
-	suite:case("run_shell_and_cwd", function(assert)
+	suite:case("run_shell_and_cwd", function(check)
 		local rootdir: string = "/"
+		local root: pathlib.path? = nil
 		if system.win32 then
-			local root = pathlib.win32.drive(process.cwd())
+			root = pathlib.win32.drive(process.cwd())
 			rootdir = pathlib.format(root)
 		end
 		local r = process.run({ "pwd" }, { cwd = rootdir })
-		assert.tableeq(r, {
-			exitcode = 0,
-			stdout = rootdir .. "\n",
-			stderr = "",
-			ok = true,
-		})
+		if system.win32 then
+			assert(root ~= nil and root.driveLetter ~= nil)
+			check.tableeq(r, {
+				exitcode = 0,
+				stdout = `/{root.driveLetter:lower()}\n`,
+				stderr = "",
+				ok = true,
+			})
+		else
+			check.tableeq(r, {
+				exitcode = 0,
+				stdout = "/\n",
+				stderr = "",
+				ok = true,
+			})
+		end
 
 		local r2 = process.run({ "echo hello!" }, { shell = true })
-		assert.tableeq(r2, {
+		check.tableeq(r2, {
 			exitcode = 0,
 			stdout = "hello!\n",
 			stderr = "",


### PR DESCRIPTION
A while back, we ensured that Windows tests actually run in CI, but due to how Command Prompt for loops work, test failures didn't actually cause the status check to fail. This PR fixes that and also fixes the tests that were failing unreported.