### PR TITLE
stdlib: update tableext by removing unnecessary funcs and types

### DIFF
--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -5,9 +5,6 @@
 
 local tableext = {}
 
-export type array<T> = { T }
-export type dictionary<T> = { [string]: T }
-
 function tableext.map<K, A, B>(table: { [K]: A }, f: (A) -> B): { [K]: B }
 	local new = {}
 
@@ -30,17 +27,7 @@ function tableext.filter<K, V>(table: { [K]: V }, predicate: (V) -> boolean): { 
 	return new
 end
 
-function tableext.fold<K, V, A>(table: { [K]: V }, f: (A, V) -> A, initial: A): A
-	local acc = initial
-
-	for _, v in table do
-		acc = f(acc, v)
-	end
-
-	return acc
-end
-
-function tableext.extend<T>(tbl: array<T>, ...: array<T>)
+function tableext.extend<T>(tbl: { T }, ...: { T })
 	local extensions = table.pack(...)
 	extensions.n = nil :: any
 	for _, extension in extensions do
@@ -59,12 +46,6 @@ function tableext.combine<K, V>(tbl: { [K]: V }, ...: { [K]: V }): { [K]: V }
 		end
 	end
 	return tbl
-end
-
-function tableext.foreach<K, V>(tbl: { [K]: V }, f: (K, V) -> ())
-	for k, v in tbl do
-		f(k, v)
-	end
 end
 
 function tableext.keys<K, V>(tbl: { [K]: V }): { K }

--- a/tests/src/resolver/mainmodule.luau
+++ b/tests/src/resolver/mainmodule.luau
@@ -7,7 +7,7 @@ local testFilter: { [string]: number } = {
 }
 
 local a = {}
-type tb = tableext.dictionary<number>
+type tb = { [string]: number }
 
 function a._a(a: number)
 	return function(s: string): types.test

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -19,14 +19,6 @@ test.suite("TableExt", function(suite)
 		assert.eq(filtered.c, 3)
 	end)
 
-	suite:case("fold", function(assert)
-		local arr: { number } = { 1, 2, 3, 4 }
-		local sum = tableext.fold(arr, function(acc: number, v: number)
-			return acc + v
-		end, 0)
-		assert.eq(sum, 10)
-	end)
-
 	suite:case("extend", function(assert)
 		local a: { number } = { 1, 2 }
 		local b: { number } = { 3, 4 }
@@ -48,16 +40,6 @@ test.suite("TableExt", function(suite)
 		assert.eq(a["b"], 3)
 		assert.eq(a["c"], 1)
 		assert.eq(a["d"], 5)
-	end)
-
-	suite:case("foreach", function(assert)
-		local a = { 1, 2, 3 }
-		local numCalls = 0
-		local function callback()
-			numCalls += 1
-		end
-		tableext.foreach(a, callback)
-		assert.eq(numCalls, #a)
 	end)
 
 	suite:case("keys", function(assert)


### PR DESCRIPTION
As part of the API audit/cleanup, we remove `fold`, `foreach`, `array` and `dictionary` from `tableext` and any use cases