### PR TITLE
stdlib: update stringext funcs to hasprefix and hassuffix

### DIFF
--- a/lute/cli/commands/test/finder.luau
+++ b/lute/cli/commands/test/finder.luau
@@ -5,7 +5,7 @@ local stringext = require("@std/stringext")
 local tableext = require("@std/tableext")
 
 local function istestfile(filename: string): boolean
-	return stringext.endswith(filename, ".test.luau") or stringext.endswith(filename, ".spec.luau")
+	return stringext.hassuffix(filename, ".test.luau") or stringext.hassuffix(filename, ".spec.luau")
 end
 
 local function findtestfilesrec(directory: path.path): { path.path }

--- a/lute/cli/commands/transform/lib/arguments.luau
+++ b/lute/cli/commands/transform/lib/arguments.luau
@@ -31,7 +31,7 @@ local function parse(arguments: { string }): Config
 	while i <= #arguments do
 		local argument = arguments[i]
 
-		if stringext.startswith(argument, "--") then
+		if stringext.hasprefix(argument, "--") then
 			local name = stringext.removeprefix(argument, "--")
 
 			if config.migrationPath == nil then

--- a/lute/cli/commands/transform/lib/files.luau
+++ b/lute/cli/commands/transform/lib/files.luau
@@ -21,7 +21,7 @@ local function traverseDirectoryRecursive(directory: path.path, ignoreResolver: 
 			tableext.extend(results, traverseDirectoryRecursive(fullPath, ignoreResolver))
 		else
 			-- TODO: allow customisation of the filter when traversing a directory. e.g., globs? file endings? ignore paths?
-			if stringext.endswith(entry.name, ".luau") or stringext.endswith(entry.name, ".lua") then
+			if stringext.hassuffix(entry.name, ".luau") or stringext.hassuffix(entry.name, ".lua") then
 				if ignoreResolver:isIgnoredFile(fullPath) then
 					print("Skipping", fullPath)
 					continue

--- a/lute/cli/commands/transform/lib/ignore.luau
+++ b/lute/cli/commands/transform/lib/ignore.luau
@@ -123,11 +123,11 @@ local function parseGitignoreContents(location: string, contents: string): Gitig
 	for _, line in lines do
 		line = stringext.trim(line)
 
-		if line == "" or stringext.startswith(line, "#") then
+		if line == "" or stringext.hasprefix(line, "#") then
 			continue
 		end
 
-		if stringext.startswith(line, "!") then
+		if stringext.hasprefix(line, "!") then
 			local globPattern = stringext.removeprefix(line, "!")
 			local glob = parseGlob(globPattern)
 			table.insert(ignoreData.whitelists, glob)

--- a/lute/std/libs/stringext.luau
+++ b/lute/std/libs/stringext.luau
@@ -5,7 +5,7 @@
 
 local stringext = {}
 
-function stringext.startswith(str: string, prefix: string): boolean
+function stringext.hasprefix(str: string, prefix: string): boolean
 	if #prefix > #str then
 		return false
 	end
@@ -14,19 +14,19 @@ function stringext.startswith(str: string, prefix: string): boolean
 end
 
 function stringext.removeprefix(str: string, prefix: string): string
-	if not stringext.startswith(str, prefix) then
+	if not stringext.hasprefix(str, prefix) then
 		return str
 	end
 
 	return str:sub(#prefix + 1)
 end
 
-function stringext.endswith(str: string, suffix: string): boolean
+function stringext.hassuffix(str: string, suffix: string): boolean
 	return str:sub(-#suffix) == suffix
 end
 
 function stringext.removesuffix(str: string, suffix: string): string
-	if not stringext.endswith(str, suffix) then
+	if not stringext.hassuffix(str, suffix) then
 		return str
 	end
 

--- a/tests/std/stringext.test.luau
+++ b/tests/std/stringext.test.luau
@@ -2,12 +2,12 @@ local stringext = require("@std/stringext")
 local test = require("@std/test")
 
 test.suite("StringExt", function(suite)
-	suite:case("startswith_and_endswith", function(assert)
-		assert.eq(stringext.startswith("hello", "he"), true)
-		assert.eq(stringext.startswith("hi", "hello"), false)
+	suite:case("hasprefix_and_hassuffix", function(assert)
+		assert.eq(stringext.hasprefix("hello", "he"), true)
+		assert.eq(stringext.hasprefix("hi", "hello"), false)
 
-		assert.eq(stringext.endswith("foobar", "bar"), true)
-		assert.eq(stringext.endswith("foo", "foobar"), false)
+		assert.eq(stringext.hassuffix("foobar", "bar"), true)
+		assert.eq(stringext.hassuffix("foo", "foobar"), false)
 	end)
 
 	suite:case("removeprefix_and_removesuffix", function(assert)


### PR DESCRIPTION
As part of the API audit/cleanup, we rename `startswith` to `hasprefix` and `endswith` to `hassuffix`