### PR TITLE
refactor: split process.run and process.shell into separate functions

### DIFF
--- a/definitions/process.luau
+++ b/definitions/process.luau
@@ -1,4 +1,4 @@
-export type StdioKind = "default" | "inherit" | "none" | ""
+export type StdioKind = "default" | "inherit" | "none"
 
 export type ProcessRunOptions = {
 	cwd: string?,

--- a/definitions/process.luau
+++ b/definitions/process.luau
@@ -7,8 +7,8 @@ export type ProcessRunOptions = {
 	env: { [string]: string }?,
 }
 
-export type ProcessShellOptions = {
-	shell: string?,
+export type ProcessSystemOptions = {
+	system: string?,
 	cwd: string?,
 	stdio: StdioKind?,
 
@@ -40,7 +40,7 @@ function process.run(args: { string }, options: ProcessRunOptions?): ProcessResu
 	error("not implemented")
 end
 
-function process.shell(command: string, options: ProcessShellOptions?): ProcessResult
+function process.system(command: string, options: ProcessSystemOptions?): ProcessResult
 	error("not implemented")
 end
 

--- a/definitions/process.luau
+++ b/definitions/process.luau
@@ -1,7 +1,14 @@
 export type StdioKind = "default" | "inherit" | "none" | ""
 
 export type ProcessRunOptions = {
-	shell: (string | boolean)?,
+	cwd: string?,
+	stdio: StdioKind?,
+
+	env: { [string]: string }?,
+}
+
+export type ProcessShellOptions = {
+	shell: string?,
 	cwd: string?,
 	stdio: StdioKind?,
 
@@ -29,7 +36,11 @@ function process.cwd(): string
 	error("not implemented")
 end
 
-function process.run(args: string | { string }, options: ProcessRunOptions?): ProcessResult
+function process.run(args: { string }, options: ProcessRunOptions?): ProcessResult
+	error("not implemented")
+end
+
+function process.shell(command: string, options: ProcessShellOptions?): ProcessResult
 	error("not implemented")
 end
 

--- a/examples/process.luau
+++ b/examples/process.luau
@@ -16,19 +16,19 @@ print(r1.stdout)
 print(r2.stdout)
 print(r3.stdout)
 
-local r4 = process.run("echo Hello, lute!", { shell = true })
+local r4 = process.shell("echo Hello, lute!")
 print(r4.stdout)
 
-local r5 = process.run({ "echo", "$HOME" }, { env = { HOME = "/home/lute" }, shell = true })
+local r5 = process.shell("echo $HOME", { env = { HOME = "/home/lute" } })
 print(r5.stdout)
 
 local r6 = process.run({ "pwd" }, { cwd = "/" })
 print(r6.stdout)
 
-local r7 = process.run("echo $0", { shell = true })
+local r7 = process.shell("echo $0")
 print(r7.stdout)
 
-local r8 = process.run("echo $0", { shell = "/bin/sh" })
+local r8 = process.shell("echo $0", { shell = "/bin/sh" })
 print(r8.stdout)
 
 process.exit(0)

--- a/examples/process.luau
+++ b/examples/process.luau
@@ -1,6 +1,8 @@
 local process = require("@std/process")
 local task = require("@std/task")
 
+process.system("echo hello", { cwd = {} })
+
 local result = process.run({ "echo", "Hello, lute!" })
 
 print(result.exitcode)

--- a/examples/process.luau
+++ b/examples/process.luau
@@ -16,19 +16,19 @@ print(r1.stdout)
 print(r2.stdout)
 print(r3.stdout)
 
-local r4 = process.shell("echo Hello, lute!")
+local r4 = process.system("echo Hello, lute!")
 print(r4.stdout)
 
-local r5 = process.shell("echo $HOME", { env = { HOME = "/home/lute" } })
+local r5 = process.system("echo $HOME", { env = { HOME = "/home/lute" } })
 print(r5.stdout)
 
 local r6 = process.run({ "pwd" }, { cwd = "/" })
 print(r6.stdout)
 
-local r7 = process.shell("echo $0")
+local r7 = process.system("echo $0")
 print(r7.stdout)
 
-local r8 = process.shell("echo $0", { shell = "/bin/sh" })
+local r8 = process.system("echo $0", { system = "/bin/sh" })
 print(r8.stdout)
 
 process.exit(0)

--- a/lute/process/include/lute/process.h
+++ b/lute/process/include/lute/process.h
@@ -15,6 +15,7 @@ namespace process
 {
 
 int run(lua_State* L);
+int shell(lua_State* L);
 
 int homedir(lua_State* L);
 int cwd(lua_State* L);
@@ -26,6 +27,7 @@ int execpath(lua_State* L);
 
 static const luaL_Reg lib[] = {
     {"run", run},
+    {"shell", shell},
     {"homedir", homedir},
     {"cwd", cwd},
     {"exit", exitFunc},

--- a/lute/process/include/lute/process.h
+++ b/lute/process/include/lute/process.h
@@ -15,7 +15,7 @@ namespace process
 {
 
 int run(lua_State* L);
-int shell(lua_State* L);
+int system(lua_State* L);
 
 int homedir(lua_State* L);
 int cwd(lua_State* L);
@@ -27,7 +27,7 @@ int execpath(lua_State* L);
 
 static const luaL_Reg lib[] = {
     {"run", run},
-    {"shell", shell},
+    {"system", system},
     {"homedir", homedir},
     {"cwd", cwd},
     {"exit", exitFunc},

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -350,28 +350,69 @@ ProcessOptions parseOptions(lua_State* L, int index)
         return opts;
 
     lua_getfield(L, index, "system");
-    if (lua_isstring(L, -1))
-        opts.customShell = lua_tostring(L, -1);
+    if (!lua_isnil(L, -1))
+    {
+        if (lua_isstring(L, -1))
+        {
+            opts.customShell = lua_tostring(L, -1);
+        }
+        else
+        {
+            luaL_error(L, "process.system option 'system' must be a string");
+        }
+    }
     lua_pop(L, 1);
 
     lua_getfield(L, index, "cwd");
     if (!lua_isnil(L, -1))
-        opts.cwd = lua_tostring(L, -1);
+    {
+        if (lua_isstring(L, -1))
+        {
+            opts.cwd = lua_tostring(L, -1);
+        }
+        else
+        {
+            luaL_error(L, "process option 'cwd' must be a string");
+        }
+    }
     lua_pop(L, 1);
 
     lua_getfield(L, index, "stdio");
-    if (lua_isstring(L, -1))
-        opts.stdioKind = lua_tostring(L, -1);
+    if (!lua_isnil(L, -1))
+    {
+        if (lua_isstring(L, -1))
+        {
+            opts.stdioKind = lua_tostring(L, -1);
+        }
+        else
+        {
+            luaL_error(L, "process option 'stdio' must be a string");
+        }
+    }
     lua_pop(L, 1);
 
     lua_getfield(L, index, "env");
-    if (lua_istable(L, -1))
+    if (!lua_isnil(L, -1))
     {
-        lua_pushnil(L);
-        while (lua_next(L, -2))
+        if (lua_istable(L, -1))
         {
-            opts.env[luaL_checkstring(L, -2)] = luaL_checkstring(L, -1);
-            lua_pop(L, 1);
+            lua_pushnil(L);
+            while (lua_next(L, -2))
+            {
+                if (!lua_isstring(L, -2) || !lua_isstring(L, -1))
+                {
+                    luaL_error(L, "process option 'env' must be a table of string keys and string values");
+                }
+                else
+                {
+                    opts.env[luaL_checkstring(L, -2)] = luaL_checkstring(L, -1);
+                }
+                lua_pop(L, 1);
+            }
+        }
+        else
+        {
+            luaL_error(L, "process option 'env' must be a table");
         }
     }
     lua_pop(L, 1);
@@ -381,25 +422,29 @@ ProcessOptions parseOptions(lua_State* L, int index)
 
 int run(lua_State* L)
 {
-    std::vector<std::string> args;
-    if (lua_istable(L, 1))
+    if (!lua_istable(L, 1))
     {
-        int len = lua_objlen(L, 1);
-        for (int i = 1; i <= len; i++)
-        {
-            lua_rawgeti(L, 1, i);
-            args.push_back(lua_tostring(L, -1));
-            lua_pop(L, 1);
-        }
-    }
-    else
-    {
-        args.push_back(lua_tostring(L, 1));
+        luaL_error(L, "process.run expects a table of arguments as the first parameter");
+        return 0;
     }
 
-    if (args.empty() || args[0].empty())
+    std::vector<std::string> args;
+    int len = lua_objlen(L, 1);
+    for (int i = 1; i <= len; i++)
     {
-        luaL_error(L, "process.run requires a non-empty command");
+        lua_rawgeti(L, 1, i);
+        args.push_back(lua_tostring(L, -1));
+        lua_pop(L, 1);
+    }
+
+    if (args.empty())
+    {
+        luaL_error(L, "process.run requires a non-empty table of arguments");
+        return 0;
+    }
+    if (args[0].empty())
+    {
+        luaL_error(L, "process.run requires a non-empty command as the first argument");
         return 0;
     }
 
@@ -412,7 +457,7 @@ int system(lua_State* L)
     std::string command = luaL_checkstring(L, 1);
     if (command.empty())
     {
-        luaL_error(L, "process.system requires a non-empty command");
+        luaL_error(L, "process.system requires a non-empty string as the command");
         return 0;
     }
 

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -250,9 +250,8 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
         int err = uv_os_environ(&currentEnvItems, &currentEnvCount);
         if (err != 0)
         {
-            luaL_error(L, "Failed to get current environment: %s", uv_strerror(err));
             uv_os_free_environ(currentEnvItems, currentEnvCount);
-            return 0;
+            luaL_error(L, "Failed to get current environment: %s", uv_strerror(err));
         }
         for (int i = 0; i < currentEnvCount; i++)
         {
@@ -311,7 +310,6 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
     else
     {
         luaL_error(L, "Invalid stdio kind: %s", opts.stdioKind.c_str());
-        return 0;
     }
     options.stdio = stdio;
 
@@ -333,7 +331,6 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
         handle->closeHandles();
 
         luaL_error(L, "Failed to spawn process: %s", uv_strerror(spawnResult));
-        return 0;
     }
 
     uv_read_start((uv_stream_t*)&handle->stdoutPipe, allocBuffer, onPipeRead);
@@ -352,42 +349,21 @@ ProcessOptions parseOptions(lua_State* L, int index)
     lua_getfield(L, index, "system");
     if (!lua_isnil(L, -1))
     {
-        if (lua_isstring(L, -1))
-        {
-            opts.customShell = lua_tostring(L, -1);
-        }
-        else
-        {
-            luaL_error(L, "process.system option 'system' must be a string");
-        }
+        opts.customShell = luaL_checkstring(L, -1);
     }
     lua_pop(L, 1);
 
     lua_getfield(L, index, "cwd");
     if (!lua_isnil(L, -1))
     {
-        if (lua_isstring(L, -1))
-        {
-            opts.cwd = lua_tostring(L, -1);
-        }
-        else
-        {
-            luaL_error(L, "process option 'cwd' must be a string");
-        }
+        opts.cwd = luaL_checkstring(L,-1);
     }
     lua_pop(L, 1);
 
     lua_getfield(L, index, "stdio");
     if (!lua_isnil(L, -1))
     {
-        if (lua_isstring(L, -1))
-        {
-            opts.stdioKind = lua_tostring(L, -1);
-        }
-        else
-        {
-            luaL_error(L, "process option 'stdio' must be a string");
-        }
+        opts.stdioKind = luaL_checkstring(L, -1);
     }
     lua_pop(L, 1);
 
@@ -399,14 +375,7 @@ ProcessOptions parseOptions(lua_State* L, int index)
             lua_pushnil(L);
             while (lua_next(L, -2))
             {
-                if (!lua_isstring(L, -2) || !lua_isstring(L, -1))
-                {
-                    luaL_error(L, "process option 'env' must be a table of string keys and string values");
-                }
-                else
-                {
-                    opts.env[luaL_checkstring(L, -2)] = luaL_checkstring(L, -1);
-                }
+                opts.env[luaL_checkstring(L, -2)] = luaL_checkstring(L, -1);
                 lua_pop(L, 1);
             }
         }
@@ -425,7 +394,6 @@ int run(lua_State* L)
     if (!lua_istable(L, 1))
     {
         luaL_error(L, "process.run expects a table of arguments as the first parameter");
-        return 0;
     }
 
     std::vector<std::string> args;
@@ -440,12 +408,10 @@ int run(lua_State* L)
     if (args.empty())
     {
         luaL_error(L, "process.run requires a non-empty table of arguments");
-        return 0;
     }
     if (args[0].empty())
     {
         luaL_error(L, "process.run requires a non-empty command as the first argument");
-        return 0;
     }
 
     ProcessOptions opts = parseOptions(L, 2);
@@ -458,7 +424,6 @@ int system(lua_State* L)
     if (command.empty())
     {
         luaL_error(L, "process.system requires a non-empty string as the command");
-        return 0;
     }
 
     ProcessOptions opts = parseOptions(L, 2);

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -408,7 +408,7 @@ int run(lua_State* L)
     for (int i = 1; i <= len; i++)
     {
         lua_rawgeti(L, 1, i);
-        args.push_back(lua_tostring(L, -1));
+        args.push_back(luaL_checkstring(L, -1));
         lua_pop(L, 1);
     }
 

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -213,117 +213,9 @@ const std::string kStdioKindNone = "none";
 // TODO: add forwarding
 // const std::string kStdioKindForward = "forward";
 
-int run(lua_State* L)
+// helper function for run() and shell()
+int executionHelper(lua_State* L, std::vector<std::string> args, std::string cwd, std::string stdioKind, std::map<std::string, std::string> env)
 {
-    std::vector<std::string> args;
-    if (lua_istable(L, 1))
-    {
-        int len = lua_objlen(L, 1);
-        for (int i = 1; i <= len; i++)
-        {
-            lua_rawgeti(L, 1, i);
-            args.push_back(lua_tostring(L, -1));
-            lua_pop(L, 1);
-        }
-    }
-    else
-    {
-        args.push_back(lua_tostring(L, 1));
-    }
-
-    if (args.empty() || args[0].empty())
-    {
-        luaL_error(L, "process.create requires a non-empty command");
-        return 0;
-    }
-
-    bool useShell = false;
-    std::string customShell;
-    std::string cwd;
-    std::string stdioKind;
-    std::map<std::string, std::string> env;
-
-    if (lua_istable(L, 2))
-    {
-        lua_getfield(L, 2, "shell");
-        if (lua_isboolean(L, -1))
-        {
-            useShell = lua_toboolean(L, -1);
-        }
-        else if (lua_isstring(L, -1))
-        {
-            customShell = lua_tostring(L, -1);
-            useShell = true;
-        }
-
-        lua_pop(L, 1);
-
-        lua_getfield(L, 2, "cwd");
-        if (!lua_isnil(L, -1))
-            cwd = lua_tostring(L, -1);
-
-        lua_pop(L, 1);
-
-        lua_getfield(L, 2, "stdio");
-        if (lua_isstring(L, -1))
-        {
-            stdioKind = lua_tostring(L, -1);
-            // TODO: support stdin and separate stdout/stderr kinds
-        }
-        lua_pop(L, 1);
-
-        lua_getfield(L, 2, "env");
-        if (lua_istable(L, -1))
-        {
-            lua_pushnil(L);
-            while (lua_next(L, -2))
-            {
-                env[luaL_checkstring(L, -2)] = luaL_checkstring(L, -1);
-                lua_pop(L, 1);
-            }
-        }
-        lua_pop(L, 1);
-    }
-
-    if (useShell)
-    {
-        std::string commandStr = args[0];
-
-        for (size_t i = 1; i < args.size(); ++i)
-        {
-            commandStr += " ";
-            commandStr += args[i];
-        }
-
-#ifdef _WIN32
-        const char* shellVar = "COMSPEC";
-        const char* shellFallback = "cmd.exe";
-        const char* shellArg = "/c";
-#else
-        const char* shellVar = "SHELL";
-        const char* shellFallback = "/bin/sh";
-        const char* shellArg = "-c";
-#endif
-
-        std::string resolvedShell;
-        if (customShell.empty())
-        {
-            char shellBuffer[1024];
-            size_t shellSize = sizeof(shellBuffer);
-            int result = uv_os_getenv(shellVar, shellBuffer, &shellSize);
-            resolvedShell = result == 0 ? shellBuffer : shellFallback;
-        }
-        else
-        {
-            resolvedShell = customShell;
-        }
-
-        args.clear();
-        args.emplace_back(resolvedShell);
-        args.emplace_back(shellArg);
-        args.emplace_back(commandStr);
-    }
-
     auto handle = std::make_shared<ProcessHandle>();
     handle->loop = uv_default_loop();
     handle->self = handle;
@@ -440,6 +332,171 @@ int run(lua_State* L)
     uv_read_start((uv_stream_t*)&handle->stderrPipe, allocBuffer, onPipeRead);
 
     return lua_yield(L, 0);
+}
+
+int run(lua_State* L)
+{
+    std::vector<std::string> args;
+    if (lua_istable(L, 1))
+    {
+        int len = lua_objlen(L, 1);
+        for (int i = 1; i <= len; i++)
+        {
+            lua_rawgeti(L, 1, i);
+            args.push_back(lua_tostring(L, -1));
+            lua_pop(L, 1);
+        }
+    }
+    else
+    {
+        args.push_back(lua_tostring(L, 1));
+    }
+
+    if (args.empty() || args[0].empty())
+    {
+        luaL_error(L, "process.create requires a non-empty command");
+        return 0;
+    }
+
+    std::string cwd;
+    std::string stdioKind;
+    std::map<std::string, std::string> env;
+
+    if (lua_istable(L, 2))
+    {
+        lua_getfield(L, 2, "cwd");
+        if (!lua_isnil(L, -1))
+            cwd = lua_tostring(L, -1);
+
+        lua_pop(L, 1);
+
+        lua_getfield(L, 2, "stdio");
+        if (lua_isstring(L, -1))
+        {
+            stdioKind = lua_tostring(L, -1);
+            // TODO: support stdin and separate stdout/stderr kinds
+        }
+        lua_pop(L, 1);
+
+        lua_getfield(L, 2, "env");
+        if (lua_istable(L, -1))
+        {
+            lua_pushnil(L);
+            while (lua_next(L, -2))
+            {
+                env[luaL_checkstring(L, -2)] = luaL_checkstring(L, -1);
+                lua_pop(L, 1);
+            }
+        }
+        lua_pop(L, 1);
+    }
+
+    return executionHelper(L, args, cwd, stdioKind, env);
+}
+
+int shell(lua_State* L)
+{
+    std::vector<std::string> args;
+    if (lua_istable(L, 1))
+    {
+        int len = lua_objlen(L, 1);
+        for (int i = 1; i <= len; i++)
+        {
+            lua_rawgeti(L, 1, i);
+            args.push_back(lua_tostring(L, -1));
+            lua_pop(L, 1);
+        }
+    }
+    else
+    {
+        args.push_back(lua_tostring(L, 1));
+    }
+
+    if (args.empty() || args[0].empty())
+    {
+        luaL_error(L, "process.create requires a non-empty command");
+        return 0;
+    }
+
+    std::string customShell;
+    std::string cwd;
+    std::string stdioKind;
+    std::map<std::string, std::string> env;
+
+    if (lua_istable(L, 2))
+    {
+        lua_getfield(L, 2, "shell");
+        if (lua_isstring(L, -1))
+        {
+            customShell = lua_tostring(L, -1);
+        }
+
+        lua_pop(L, 1);
+
+        lua_getfield(L, 2, "cwd");
+        if (!lua_isnil(L, -1))
+            cwd = lua_tostring(L, -1);
+
+        lua_pop(L, 1);
+
+        lua_getfield(L, 2, "stdio");
+        if (lua_isstring(L, -1))
+        {
+            stdioKind = lua_tostring(L, -1);
+            // TODO: support stdin and separate stdout/stderr kinds
+        }
+        lua_pop(L, 1);
+
+        lua_getfield(L, 2, "env");
+        if (lua_istable(L, -1))
+        {
+            lua_pushnil(L);
+            while (lua_next(L, -2))
+            {
+                env[luaL_checkstring(L, -2)] = luaL_checkstring(L, -1);
+                lua_pop(L, 1);
+            }
+        }
+        lua_pop(L, 1);
+    }
+
+    std::string commandStr = args[0];
+
+    for (size_t i = 1; i < args.size(); ++i)
+    {
+        commandStr += " ";
+        commandStr += args[i];
+    }
+
+#ifdef _WIN32
+        const char* shellVar = "COMSPEC";
+        const char* shellFallback = "cmd.exe";
+        const char* shellArg = "/c";
+#else
+        const char* shellVar = "SHELL";
+        const char* shellFallback = "/bin/sh";
+        const char* shellArg = "-c";
+#endif
+
+    std::string resolvedShell;
+    if (customShell.empty())
+    {
+        char shellBuffer[1024];
+        size_t shellSize = sizeof(shellBuffer);
+        int result = uv_os_getenv(shellVar, shellBuffer, &shellSize);
+        resolvedShell = result == 0 ? shellBuffer : shellFallback;
+    }
+    else
+    {
+        resolvedShell = customShell;
+    }
+
+    args.clear();
+    args.emplace_back(resolvedShell);
+    args.emplace_back(shellArg);
+    args.emplace_back(commandStr);
+
+    return executionHelper(L, args, cwd, stdioKind, env);
 }
 
 int homedir(lua_State* L)

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -342,26 +342,6 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
     return lua_yield(L, 0);
 }
 
-std::vector<std::string> parseArgs(lua_State* L, int index)
-{
-    std::vector<std::string> args;
-    if (lua_istable(L, index))
-    {
-        int len = lua_objlen(L, index);
-        for (int i = 1; i <= len; i++)
-        {
-            lua_rawgeti(L, index, i);
-            args.push_back(lua_tostring(L, -1));
-            lua_pop(L, 1);
-        }
-    }
-    else
-    {
-        args.push_back(lua_tostring(L, index));
-    }
-    return args;
-}
-
 ProcessOptions parseOptions(lua_State* L, int index)
 {
     ProcessOptions opts;
@@ -399,15 +379,27 @@ ProcessOptions parseOptions(lua_State* L, int index)
     return opts;
 }
 
-
-
 int run(lua_State* L)
 {
-    std::vector<std::string> args = parseArgs(L, 1);
+    std::vector<std::string> args;
+    if (lua_istable(L, 1))
+    {
+        int len = lua_objlen(L, 1);
+        for (int i = 1; i <= len; i++)
+        {
+            lua_rawgeti(L, 1, i);
+            args.push_back(lua_tostring(L, -1));
+            lua_pop(L, 1);
+        }
+    }
+    else
+    {
+        args.push_back(lua_tostring(L, 1));
+    }
 
     if (args.empty() || args[0].empty())
     {
-        luaL_error(L, "process.create requires a non-empty command");
+        luaL_error(L, "process.run requires a non-empty command");
         return 0;
     }
 
@@ -417,23 +409,14 @@ int run(lua_State* L)
 
 int system(lua_State* L)
 {
-    std::vector<std::string> args = parseArgs(L, 1);
-
-    if (args.empty() || args[0].empty())
+    std::string command = luaL_checkstring(L, 1);
+    if (command.empty())
     {
-        luaL_error(L, "process.create requires a non-empty command");
+        luaL_error(L, "process.system requires a non-empty command");
         return 0;
     }
 
     ProcessOptions opts = parseOptions(L, 2);
-
-    std::string commandStr = args[0];
-
-    for (size_t i = 1; i < args.size(); ++i)
-    {
-        commandStr += " ";
-        commandStr += args[i];
-    }
 
 #ifdef _WIN32
         const char* shellVar = "COMSPEC";
@@ -458,10 +441,11 @@ int system(lua_State* L)
         resolvedShell = opts.customShell;
     }
 
+    std::vector<std::string> args;
     args.clear();
     args.emplace_back(resolvedShell);
     args.emplace_back(shellArg);
-    args.emplace_back(commandStr);
+    args.emplace_back(command);
 
     return executionHelper(L, args, opts);
 }

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -152,6 +152,14 @@ struct ProcessHandle
     }
 };
 
+struct ProcessOptions
+{
+    std::string cwd;
+    std::string stdioKind;
+    std::map<std::string, std::string> env;
+    std::string customShell;  // only used by system()
+};
+
 static void onProcessExit(uv_process_t* process, int64_t exitStatus, int termSignal)
 {
     ProcessHandle* handle = static_cast<ProcessHandle*>(process->data);
@@ -214,7 +222,7 @@ const std::string kStdioKindNone = "none";
 // const std::string kStdioKindForward = "forward";
 
 // helper function for run() and system()
-int executionHelper(lua_State* L, std::vector<std::string> args, std::string cwd, std::string stdioKind, std::map<std::string, std::string> env)
+int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions opts)
 {
     auto handle = std::make_shared<ProcessHandle>();
     handle->loop = uv_default_loop();
@@ -234,7 +242,7 @@ int executionHelper(lua_State* L, std::vector<std::string> args, std::string cwd
 
     std::vector<std::string> envStrings;
     std::vector<char*> envPtr;
-    if (!env.empty())
+    if (!opts.env.empty())
     {
         // Copy current environment into the new environment
         uv_env_item_t* currentEnvItems;
@@ -248,17 +256,17 @@ int executionHelper(lua_State* L, std::vector<std::string> args, std::string cwd
         }
         for (int i = 0; i < currentEnvCount; i++)
         {
-            if (currentEnvItems[i].name && currentEnvItems[i].value && env.find(currentEnvItems[i].name) == env.end())
+            if (currentEnvItems[i].name && currentEnvItems[i].value && opts.env.find(currentEnvItems[i].name) == opts.env.end())
             {
-                env[currentEnvItems[i].name] = currentEnvItems[i].value;
+                opts.env[currentEnvItems[i].name] = currentEnvItems[i].value;
             }
         }
         uv_os_free_environ(currentEnvItems, currentEnvCount);
 
         // Turn the new environment into a char** array
-        envStrings.reserve(env.size());
-        envPtr.reserve(env.size() + 1);
-        for (const auto& pair : env)
+        envStrings.reserve(opts.env.size());
+        envPtr.reserve(opts.env.size() + 1);
+        for (const auto& pair : opts.env)
         {
             envStrings.push_back(pair.first + "=" + pair.second);
         }
@@ -270,9 +278,9 @@ int executionHelper(lua_State* L, std::vector<std::string> args, std::string cwd
         options.env = envPtr.data();
     }
 
-    if (!cwd.empty())
+    if (!opts.cwd.empty())
     {
-        options.cwd = cwd.c_str();
+        options.cwd = opts.cwd.c_str();
     }
 
     uv_pipe_init(handle->loop, &handle->stdoutPipe, 0);
@@ -281,19 +289,19 @@ int executionHelper(lua_State* L, std::vector<std::string> args, std::string cwd
     options.stdio_count = 3;
     uv_stdio_container_t stdio[3];
     stdio[0].flags = UV_IGNORE;
-    if (stdioKind == kStdioKindNone)
+    if (opts.stdioKind == kStdioKindNone)
     {
         stdio[1].flags = UV_IGNORE;
         stdio[2].flags = UV_IGNORE;
     }
-    else if (stdioKind == kStdioKindInherit)
+    else if (opts.stdioKind == kStdioKindInherit)
     {
         stdio[1].flags = UV_INHERIT_FD;
         stdio[1].data.fd = fileno(stdout);
         stdio[2].flags = UV_INHERIT_FD;
         stdio[2].data.fd = fileno(stderr);
     }
-    else if (stdioKind == kStdioKindDefault || stdioKind.empty())
+    else if (opts.stdioKind == kStdioKindDefault || opts.stdioKind.empty())
     {
         stdio[1].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
         stdio[1].data.stream = (uv_stream_t*)&handle->stdoutPipe;
@@ -302,7 +310,7 @@ int executionHelper(lua_State* L, std::vector<std::string> args, std::string cwd
     }
     else
     {
-        luaL_error(L, "Invalid stdio kind: %s", stdioKind.c_str());
+        luaL_error(L, "Invalid stdio kind: %s", opts.stdioKind.c_str());
         return 0;
     }
     options.stdio = stdio;
@@ -334,23 +342,68 @@ int executionHelper(lua_State* L, std::vector<std::string> args, std::string cwd
     return lua_yield(L, 0);
 }
 
-int run(lua_State* L)
+std::vector<std::string> parseArgs(lua_State* L, int index)
 {
     std::vector<std::string> args;
-    if (lua_istable(L, 1))
+    if (lua_istable(L, index))
     {
-        int len = lua_objlen(L, 1);
+        int len = lua_objlen(L, index);
         for (int i = 1; i <= len; i++)
         {
-            lua_rawgeti(L, 1, i);
+            lua_rawgeti(L, index, i);
             args.push_back(lua_tostring(L, -1));
             lua_pop(L, 1);
         }
     }
     else
     {
-        args.push_back(lua_tostring(L, 1));
+        args.push_back(lua_tostring(L, index));
     }
+    return args;
+}
+
+ProcessOptions parseOptions(lua_State* L, int index)
+{
+    ProcessOptions opts;
+
+    if (!lua_istable(L, index))
+        return opts;
+
+    lua_getfield(L, index, "system");
+    if (lua_isstring(L, -1))
+        opts.customShell = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
+    lua_getfield(L, index, "cwd");
+    if (!lua_isnil(L, -1))
+        opts.cwd = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
+    lua_getfield(L, index, "stdio");
+    if (lua_isstring(L, -1))
+        opts.stdioKind = lua_tostring(L, -1);
+    lua_pop(L, 1);
+
+    lua_getfield(L, index, "env");
+    if (lua_istable(L, -1))
+    {
+        lua_pushnil(L);
+        while (lua_next(L, -2))
+        {
+            opts.env[luaL_checkstring(L, -2)] = luaL_checkstring(L, -1);
+            lua_pop(L, 1);
+        }
+    }
+    lua_pop(L, 1);
+
+    return opts;
+}
+
+
+
+int run(lua_State* L)
+{
+    std::vector<std::string> args = parseArgs(L, 1);
 
     if (args.empty() || args[0].empty())
     {
@@ -358,59 +411,13 @@ int run(lua_State* L)
         return 0;
     }
 
-    std::string cwd;
-    std::string stdioKind;
-    std::map<std::string, std::string> env;
-
-    if (lua_istable(L, 2))
-    {
-        lua_getfield(L, 2, "cwd");
-        if (!lua_isnil(L, -1))
-            cwd = lua_tostring(L, -1);
-
-        lua_pop(L, 1);
-
-        lua_getfield(L, 2, "stdio");
-        if (lua_isstring(L, -1))
-        {
-            stdioKind = lua_tostring(L, -1);
-            // TODO: support stdin and separate stdout/stderr kinds
-        }
-        lua_pop(L, 1);
-
-        lua_getfield(L, 2, "env");
-        if (lua_istable(L, -1))
-        {
-            lua_pushnil(L);
-            while (lua_next(L, -2))
-            {
-                env[luaL_checkstring(L, -2)] = luaL_checkstring(L, -1);
-                lua_pop(L, 1);
-            }
-        }
-        lua_pop(L, 1);
-    }
-
-    return executionHelper(L, args, cwd, stdioKind, env);
+    ProcessOptions opts = parseOptions(L, 2);
+    return executionHelper(L, args, opts);
 }
 
 int system(lua_State* L)
 {
-    std::vector<std::string> args;
-    if (lua_istable(L, 1))
-    {
-        int len = lua_objlen(L, 1);
-        for (int i = 1; i <= len; i++)
-        {
-            lua_rawgeti(L, 1, i);
-            args.push_back(lua_tostring(L, -1));
-            lua_pop(L, 1);
-        }
-    }
-    else
-    {
-        args.push_back(lua_tostring(L, 1));
-    }
+    std::vector<std::string> args = parseArgs(L, 1);
 
     if (args.empty() || args[0].empty())
     {
@@ -418,47 +425,7 @@ int system(lua_State* L)
         return 0;
     }
 
-    std::string customShell;
-    std::string cwd;
-    std::string stdioKind;
-    std::map<std::string, std::string> env;
-
-    if (lua_istable(L, 2))
-    {
-        lua_getfield(L, 2, "system");
-        if (lua_isstring(L, -1))
-        {
-            customShell = lua_tostring(L, -1);
-        }
-
-        lua_pop(L, 1);
-
-        lua_getfield(L, 2, "cwd");
-        if (!lua_isnil(L, -1))
-            cwd = lua_tostring(L, -1);
-
-        lua_pop(L, 1);
-
-        lua_getfield(L, 2, "stdio");
-        if (lua_isstring(L, -1))
-        {
-            stdioKind = lua_tostring(L, -1);
-            // TODO: support stdin and separate stdout/stderr kinds
-        }
-        lua_pop(L, 1);
-
-        lua_getfield(L, 2, "env");
-        if (lua_istable(L, -1))
-        {
-            lua_pushnil(L);
-            while (lua_next(L, -2))
-            {
-                env[luaL_checkstring(L, -2)] = luaL_checkstring(L, -1);
-                lua_pop(L, 1);
-            }
-        }
-        lua_pop(L, 1);
-    }
+    ProcessOptions opts = parseOptions(L, 2);
 
     std::string commandStr = args[0];
 
@@ -479,7 +446,7 @@ int system(lua_State* L)
 #endif
 
     std::string resolvedShell;
-    if (customShell.empty())
+    if (opts.customShell.empty())
     {
         char shellBuffer[1024];
         size_t shellSize = sizeof(shellBuffer);
@@ -488,7 +455,7 @@ int system(lua_State* L)
     }
     else
     {
-        resolvedShell = customShell;
+        resolvedShell = opts.customShell;
     }
 
     args.clear();
@@ -496,7 +463,7 @@ int system(lua_State* L)
     args.emplace_back(shellArg);
     args.emplace_back(commandStr);
 
-    return executionHelper(L, args, cwd, stdioKind, env);
+    return executionHelper(L, args, opts);
 }
 
 int homedir(lua_State* L)

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -213,7 +213,7 @@ const std::string kStdioKindNone = "none";
 // TODO: add forwarding
 // const std::string kStdioKindForward = "forward";
 
-// helper function for run() and shell()
+// helper function for run() and system()
 int executionHelper(lua_State* L, std::vector<std::string> args, std::string cwd, std::string stdioKind, std::map<std::string, std::string> env)
 {
     auto handle = std::make_shared<ProcessHandle>();
@@ -394,7 +394,7 @@ int run(lua_State* L)
     return executionHelper(L, args, cwd, stdioKind, env);
 }
 
-int shell(lua_State* L)
+int system(lua_State* L)
 {
     std::vector<std::string> args;
     if (lua_istable(L, 1))
@@ -425,7 +425,7 @@ int shell(lua_State* L)
 
     if (lua_istable(L, 2))
     {
-        lua_getfield(L, 2, "shell");
+        lua_getfield(L, 2, "system");
         if (lua_isstring(L, -1))
         {
             customShell = lua_tostring(L, -1);

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -343,8 +343,15 @@ ProcessOptions parseOptions(lua_State* L, int index)
 {
     ProcessOptions opts;
 
+    if (lua_isnoneornil(L, index))
+    {
+        return opts; // use defaults
+    }
+
     if (!lua_istable(L, index))
-        return opts;
+    {
+        luaL_error(L, "process options must be a table");
+    }
 
     lua_getfield(L, index, "system");
     if (!lua_isnil(L, -1))
@@ -451,13 +458,7 @@ int system(lua_State* L)
         resolvedShell = opts.customShell;
     }
 
-    std::vector<std::string> args;
-    args.clear();
-    args.emplace_back(resolvedShell);
-    args.emplace_back(shellArg);
-    args.emplace_back(command);
-
-    return executionHelper(L, args, opts);
+    return executionHelper(L, { resolvedShell, shellArg, command }, opts);
 }
 
 int homedir(lua_State* L)

--- a/lute/std/libs/process.luau
+++ b/lute/std/libs/process.luau
@@ -10,6 +10,7 @@ local processlib = {}
 
 export type stdiokind = process.StdioKind
 export type processrunoptions = process.ProcessRunOptions
+export type processshelloptions = process.ProcessShellOptions
 export type processresult = process.ProcessResult
 export type path = pathlib.path
 export type pathlike = pathlib.pathlike
@@ -22,8 +23,12 @@ function processlib.cwd(): path
 	return pathlib.parse(process.cwd())
 end
 
-function processlib.run(args: string | { string }, options: processrunoptions?): processresult
+function processlib.run(args: { string }, options: processrunoptions?): processresult
 	return process.run(args, options)
+end
+
+function processlib.shell(command: string, options: processshelloptions?): processresult
+	return process.shell(command, options)
 end
 
 function processlib.exit(exitcode: number): never

--- a/lute/std/libs/process.luau
+++ b/lute/std/libs/process.luau
@@ -10,7 +10,7 @@ local processlib = {}
 
 export type stdiokind = process.StdioKind
 export type processrunoptions = process.ProcessRunOptions
-export type processshelloptions = process.ProcessShellOptions
+export type processsystemoptions = process.ProcessSystemOptions
 export type processresult = process.ProcessResult
 export type path = pathlib.path
 export type pathlike = pathlib.pathlike
@@ -27,8 +27,8 @@ function processlib.run(args: { string }, options: processrunoptions?): processr
 	return process.run(args, options)
 end
 
-function processlib.shell(command: string, options: processshelloptions?): processresult
-	return process.shell(command, options)
+function processlib.system(command: string, options: processsystemoptions?): processresult
+	return process.system(command, options)
 end
 
 function processlib.exit(exitcode: number): never

--- a/lute/std/libs/test/assert.luau
+++ b/lute/std/libs/test/assert.luau
@@ -115,7 +115,7 @@ function assertions.erroreq(func: () -> (), expectedErrorMessage: string)
 	local actualErrorMessage = tostring(err)
 	-- pcall appends filename and line number of the error, so we check suffix only
 	if not stringext.hassuffix(actualErrorMessage, expectedErrorMessage) then
-		error({ msg = `Expected error message "{expectedErrorMessage}", but got "{actualErrorMessage}"` })
+		error({ msg = `Expected suffix of error message "{expectedErrorMessage}", but got "{actualErrorMessage}"` })
 	end
 end
 

--- a/lute/std/libs/test/assert.luau
+++ b/lute/std/libs/test/assert.luau
@@ -1,6 +1,7 @@
 --!strict
 -- @std/test/assert
 -- Standard assertion library for Luau
+local stringext = require("@std/stringext")
 
 local assertions = {}
 
@@ -102,6 +103,19 @@ function assertions.buffereq(lhs: buffer, rhs: buffer)
 		if left ~= right then
 			error(string.format("lhs[%d] = %02x, but rhs[%d] = %02x", offset, left, offset, right))
 		end
+	end
+end
+
+function assertions.erroreq(func: () -> (), expectedErrorMessage: string)
+	local success, err = pcall(func)
+	if success then
+		error({ msg = `Function did not error as expected.` })
+	end
+
+	local actualErrorMessage = tostring(err)
+	-- pcall appends filename and line number of the error, so we check suffix only
+	if not stringext.hassuffix(actualErrorMessage, expectedErrorMessage) then
+		error({ msg = `Expected error message "{expectedErrorMessage}", but got "{actualErrorMessage}"` })
 	end
 end
 

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -60,7 +60,7 @@ test.suite("ProcessSuite", function(suite)
 	end)
 
 	suite:case("run_nonzero_exitcode", function(assert)
-		local r = process.system("sh -c 'exit 41'")
+		local r = process.run({ "sh", "-c", "exit 41" })
 		assert.tableeq(r, {
 			exitcode = 41,
 			stdout = "",

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -1,18 +1,7 @@
 local pathlib = require("@std/path")
 local process = require("@std/process")
 local system = require("@std/system")
-local stringext = require("@std/stringext")
 local test = require("@std/test")
-
-local function compareStrings(result: string, expected: string)
-	for i = 1, math.max(#result, #expected) do
-		local rChar = result:sub(i, i):byte()
-		local eChar = expected:sub(i, i):byte()
-		if rChar ~= eChar then
-			print(`Difference at index {i}: result='{rChar}', expected='{eChar}'`)
-		end
-	end
-end
 
 test.suite("ProcessSuite", function(suite)
 	suite:case("homedir_and_cwd_and_execpath", function(assert)
@@ -81,86 +70,47 @@ test.suite("ProcessSuite", function(suite)
 	end)
 
 	suite:case("process_run_options_error_cases", function(assert)
-		local ok, err = pcall(function()
-			process.run()
-		end)
-		assert.neq(ok, true)
-		local expectedError = "process.run expects a table of arguments as the first parameter"
-		-- pcall inserts the filename and line number before the actual error message in `err`, so we check suffix only
-		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
-
-		ok, err = pcall(function()
+		assert.erroreq(function()
 			process.run({})
-		end)
-		assert.neq(ok, true)
-		expectedError = "process.run requires a non-empty table of arguments"
-		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+		end, "process.run requires a non-empty table of arguments")
 
-		ok, err = pcall(function()
+		assert.erroreq(function()
 			process.run({ "echo", "hello" }, { cwd = {} })
-		end)
-		assert.neq(ok, true)
-		expectedError = "process option 'cwd' must be a string"
-		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+		end, "process option 'cwd' must be a string")
 
-		ok, err = pcall(function()
+		assert.erroreq(function()
 			process.run({ "echo", "hello" }, { stdio = {} })
-		end)
-		assert.neq(ok, true)
-		expectedError = "process option 'stdio' must be a string"
-		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+		end, "process option 'stdio' must be a string")
 
-		ok, err = pcall(function()
+		assert.erroreq(function()
 			process.run({ "echo", "hello" }, { env = "not-a-table" })
-		end)
-		assert.neq(ok, true)
-		expectedError = "process option 'env' must be a table"
-		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+		end, "process option 'env' must be a table")
 	end)
 
 	suite:case("process_system_options_error_cases", function(assert)
-		local ok, err = pcall(function()
+		assert.erroreq(function()
 			process.system()
-		end)
-		assert.neq(ok, true)
-		local expectedError = "invalid argument #1 to 'system' (string expected, got nil)"
-		-- pcall inserts the filename and line number before the actual error message in `err`, so we check suffix only
-		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+		end, "invalid argument #1 to 'system' (string expected, got nil)")
 
-		ok, err = pcall(function()
+		assert.erroreq(function()
 			process.system({})
-		end)
-		assert.neq(ok, true)
-		expectedError = "invalid argument #1 to 'system' (string expected, got table)"
-		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+		end, "invalid argument #1 to 'system' (string expected, got table)")
 
-		ok, err = pcall(function()
+		assert.erroreq(function()
 			process.system("echo hello", { system = {} })
-		end)
-		assert.neq(ok, true)
-		expectedError = "process.system option 'system' must be a string"
-		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+		end, "process.system option 'system' must be a string")
 
-		ok, err = pcall(function()
+		assert.erroreq(function()
 			process.system("echo hello", { cwd = {} })
-		end)
-		assert.neq(ok, true)
-		expectedError = "process option 'cwd' must be a string"
-		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+		end, "process option 'cwd' must be a string")
 
-		ok, err = pcall(function()
+		assert.erroreq(function()
 			process.system("echo hello", { stdio = {} })
-		end)
-		assert.neq(ok, true)
-		expectedError = "process option 'stdio' must be a string"
-		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+		end, "process option 'stdio' must be a string")
 
-		ok, err = pcall(function()
+		assert.erroreq(function()
 			process.system("echo hello", { env = "not-a-table" })
-		end)
-		assert.neq(ok, true)
-		expectedError = "process option 'env' must be a table"
-		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+		end, "process option 'env' must be a table")
 	end)
 end)
 

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -76,11 +76,11 @@ test.suite("ProcessSuite", function(suite)
 
 		assert.erroreq(function()
 			process.run({ "echo", "hello" }, { cwd = {} })
-		end, "process option 'cwd' must be a string")
+		end, "invalid argument #-1 to 'run' (string expected, got table)")
 
 		assert.erroreq(function()
 			process.run({ "echo", "hello" }, { stdio = {} })
-		end, "process option 'stdio' must be a string")
+		end, "invalid argument #-1 to 'run' (string expected, got table)")
 
 		assert.erroreq(function()
 			process.run({ "echo", "hello" }, { env = "not-a-table" })
@@ -98,15 +98,14 @@ test.suite("ProcessSuite", function(suite)
 
 		assert.erroreq(function()
 			process.system("echo hello", { system = {} })
-		end, "process.system option 'system' must be a string")
+		end, "invalid argument #-1 to 'system' (string expected, got table)")
 
 		assert.erroreq(function()
 			process.system("echo hello", { cwd = {} })
-		end, "process option 'cwd' must be a string")
-
+		end, "invalid argument #-1 to 'system' (string expected, got table)")
 		assert.erroreq(function()
 			process.system("echo hello", { stdio = {} })
-		end, "process option 'stdio' must be a string")
+		end, "invalid argument #-1 to 'system' (string expected, got table)")
 
 		assert.erroreq(function()
 			process.system("echo hello", { env = "not-a-table" })

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -93,6 +93,10 @@ test.suite("ProcessSuite", function(suite)
 		assert.erroreq(function()
 			process.run({ "echo", "hello" }, "not-a-table")
 		end, "process options must be a table")
+
+		assert.erroreq(function()
+			process.run({ huh = 42 })
+		end, "process.run requires a non-empty table of arguments")
 	end)
 
 	suite:case("process_run_arraylike_table", function(assert)

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -1,7 +1,18 @@
 local pathlib = require("@std/path")
 local process = require("@std/process")
 local system = require("@std/system")
+local stringext = require("@std/stringext")
 local test = require("@std/test")
+
+local function compareStrings(result: string, expected: string)
+	for i = 1, math.max(#result, #expected) do
+		local rChar = result:sub(i, i):byte()
+		local eChar = expected:sub(i, i):byte()
+		if rChar ~= eChar then
+			print(`Difference at index {i}: result='{rChar}', expected='{eChar}'`)
+		end
+	end
+end
 
 test.suite("ProcessSuite", function(suite)
 	suite:case("homedir_and_cwd_and_execpath", function(assert)
@@ -67,6 +78,89 @@ test.suite("ProcessSuite", function(suite)
 			stderr = "",
 			ok = false,
 		})
+	end)
+
+	suite:case("process_run_options_error_cases", function(assert)
+		local ok, err = pcall(function()
+			process.run()
+		end)
+		assert.neq(ok, true)
+		local expectedError = "process.run expects a table of arguments as the first parameter"
+		-- pcall inserts the filename and line number before the actual error message in `err`, so we check suffix only
+		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+
+		ok, err = pcall(function()
+			process.run({})
+		end)
+		assert.neq(ok, true)
+		expectedError = "process.run requires a non-empty table of arguments"
+		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+
+		ok, err = pcall(function()
+			process.run({ "echo", "hello" }, { cwd = {} })
+		end)
+		assert.neq(ok, true)
+		expectedError = "process option 'cwd' must be a string"
+		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+
+		ok, err = pcall(function()
+			process.run({ "echo", "hello" }, { stdio = {} })
+		end)
+		assert.neq(ok, true)
+		expectedError = "process option 'stdio' must be a string"
+		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+
+		ok, err = pcall(function()
+			process.run({ "echo", "hello" }, { env = "not-a-table" })
+		end)
+		assert.neq(ok, true)
+		expectedError = "process option 'env' must be a table"
+		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+	end)
+
+	suite:case("process_system_options_error_cases", function(assert)
+		local ok, err = pcall(function()
+			process.system()
+		end)
+		assert.neq(ok, true)
+		local expectedError = "invalid argument #1 to 'system' (string expected, got nil)"
+		-- pcall inserts the filename and line number before the actual error message in `err`, so we check suffix only
+		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+
+		ok, err = pcall(function()
+			process.system({})
+		end)
+		assert.neq(ok, true)
+		expectedError = "invalid argument #1 to 'system' (string expected, got table)"
+		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+
+		ok, err = pcall(function()
+			process.system("echo hello", { system = {} })
+		end)
+		assert.neq(ok, true)
+		expectedError = "process.system option 'system' must be a string"
+		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+
+		ok, err = pcall(function()
+			process.system("echo hello", { cwd = {} })
+		end)
+		assert.neq(ok, true)
+		expectedError = "process option 'cwd' must be a string"
+		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+
+		ok, err = pcall(function()
+			process.system("echo hello", { stdio = {} })
+		end)
+		assert.neq(ok, true)
+		expectedError = "process option 'stdio' must be a string"
+		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
+
+		ok, err = pcall(function()
+			process.system("echo hello", { env = "not-a-table" })
+		end)
+		assert.neq(ok, true)
+		expectedError = "process option 'env' must be a table"
+		assert.eq(stringext.hassuffix(tostring(err), expectedError), true)
 	end)
 end)
 

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -20,12 +20,12 @@ test.suite("ProcessSuite", function(suite)
 		assert.eq(r.stdout, "hello-from-lute\n")
 	end)
 
-	suite:case("run_echo_array_via_shell", function(assert)
-		local r = process.shell("echo hello-from-lute")
+	suite:case("run_echo_array_via_system", function(assert)
+		local r = process.system("echo hello-from-lute")
 		assert.eq(r.stdout, "hello-from-lute\n")
 	end)
 
-	suite:case("run_shell_and_cwd", function(check)
+	suite:case("run_system_and_cwd", function(check)
 		local rootdir: string = "/"
 		local root: pathlib.path? = nil
 		if system.win32 then
@@ -50,7 +50,7 @@ test.suite("ProcessSuite", function(suite)
 			})
 		end
 
-		local r2 = process.shell("echo hello!")
+		local r2 = process.system("echo hello!")
 		check.tableeq(r2, {
 			exitcode = 0,
 			stdout = "hello!\n",
@@ -60,7 +60,7 @@ test.suite("ProcessSuite", function(suite)
 	end)
 
 	suite:case("run_nonzero_exitcode", function(assert)
-		local r = process.shell("sh -c 'exit 41'")
+		local r = process.system("sh -c 'exit 41'")
 		assert.tableeq(r, {
 			exitcode = 41,
 			stdout = "",

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -15,8 +15,13 @@ test.suite("ProcessSuite", function(suite)
 		assert.neq(pathlib.format(ex), "")
 	end)
 
-	suite:case("run_echo_array", function(assert)
+	suite:case("run_echo_array_via_run", function(assert)
 		local r = process.run({ "echo", "hello-from-lute" })
+		assert.eq(r.stdout, "hello-from-lute\n")
+	end)
+
+	suite:case("run_echo_array_via_shell", function(assert)
+		local r = process.shell("echo hello-from-lute")
 		assert.eq(r.stdout, "hello-from-lute\n")
 	end)
 
@@ -45,7 +50,7 @@ test.suite("ProcessSuite", function(suite)
 			})
 		end
 
-		local r2 = process.run({ "echo hello!" }, { shell = true })
+		local r2 = process.shell("echo hello!")
 		check.tableeq(r2, {
 			exitcode = 0,
 			stdout = "hello!\n",
@@ -55,7 +60,7 @@ test.suite("ProcessSuite", function(suite)
 	end)
 
 	suite:case("run_nonzero_exitcode", function(assert)
-		local r = process.run({ "sh", "-c", "exit 41" })
+		local r = process.shell("sh -c 'exit 41'")
 		assert.tableeq(r, {
 			exitcode = 41,
 			stdout = "",

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -85,6 +85,14 @@ test.suite("ProcessSuite", function(suite)
 		assert.erroreq(function()
 			process.run({ "echo", "hello" }, { env = "not-a-table" })
 		end, "process option 'env' must be a table")
+
+		assert.erroreq(function()
+			process.run({ "echo", "hello" }, "invalid_option")
+		end, "process options must be a table")
+
+		assert.erroreq(function()
+			process.run({ "echo", "hello" }, "not-a-table")
+		end, "process options must be a table")
 	end)
 
 	suite:case("process_system_options_error_cases", function(assert)
@@ -110,6 +118,10 @@ test.suite("ProcessSuite", function(suite)
 		assert.erroreq(function()
 			process.system("echo hello", { env = "not-a-table" })
 		end, "process option 'env' must be a table")
+
+		assert.erroreq(function()
+			process.system("echo hello", "invalid_option")
+		end, "process options must be a table")
 	end)
 end)
 

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -95,6 +95,12 @@ test.suite("ProcessSuite", function(suite)
 		end, "process options must be a table")
 	end)
 
+	suite:case("process_run_arraylike_table", function(assert)
+		-- We expect this to still work and ignore the non-string keys
+		local r = process.run({ "echo", "hello", foo = "bar" })
+		assert.eq(r.stdout, "hello\n")
+	end)
+
 	suite:case("process_system_options_error_cases", function(assert)
 		assert.erroreq(function()
 			process.system()


### PR DESCRIPTION
As part of the API audit/cleanup, we separate `run` and `shell` execution in `@std/process` to be separate functions for more intuitive APIs 😊

Also add `assert.erroreq` function to compare a function's error message with the expected error msg