### PR TITLE
Add optional `msg` param to asserts

### DIFF
--- a/lute/std/libs/test/assert.luau
+++ b/lute/std/libs/test/assert.luau
@@ -4,22 +4,22 @@
 
 local assertions = {}
 
-function assertions.eq<T>(lhs: T, rhs: T)
+function assertions.eq<T>(lhs: T, rhs: T, msg: string?)
 	if lhs ~= rhs then
-		error({ msg = `{lhs} ~= {rhs}` })
+		error({ msg = msg or `{lhs} ~= {rhs}` })
 	end
 end
 
-function assertions.neq<T>(lhs: T, rhs: T)
+function assertions.neq<T>(lhs: T, rhs: T, msg: string?)
 	if lhs == rhs then
-		error({ msg = `{lhs} == {rhs}` })
+		error({ msg = msg or `{lhs} == {rhs}` })
 	end
 end
 
-function assertions.errors(callback: () -> ())
+function assertions.errors(callback: () -> (), msg: string?)
 	local success = pcall(callback)
 	if success then
-		error({ msg = `{callback} did not throw error.` })
+		error({ msg = msg or `{callback} did not throw error.` })
 	end
 end
 


### PR DESCRIPTION
Supporting a custom ``msg`` in the ``assert`` functions that the ``test`` framework leans on would add nice flexibility for users.

I ended up hacking this into a separate project, so I figure it just makes sense to add