### PR TITLE
lute lint: support multiple lint rules

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -1,12 +1,16 @@
 local luau = {}
 
 -- this is a userdata, not a table, but it has this interface
-export type span = {
+type spandata = {
 	beginline: number,
 	begincolumn: number,
 	endline: number,
 	endcolumn: number,
 }
+type spanMT = {
+	__lt: (a: spandata, b: spandata) -> boolean,
+}
+export type span = setmetatable<spandata, spanMT>
 
 luau.span = {}
 

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -106,9 +106,12 @@ local function main(...: string)
 	for _, rule in lintRules do
 		tableext.extend(violations, rule.lint(ast, inputFilePath))
 	end
-	table.sort(violations, function(a, b)
-		return syntax.span.cmp(a.location, b.location)
-	end)
+	table.sort(
+		violations,
+		function(a: types.LintViolation, b: types.LintViolation) -- LUAUFIX: bidirecitonal inference should mean that annotations on a and b aren't needed
+		return a.location < b.location
+		end
+	)
 
 	print(`Printing {#violations} violations\n`)
 	printer.printLints(violations, fileContent)

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -16,7 +16,7 @@ Lint the specified Luau file using the specified lint rule(s).
 
 OPTIONS:
   -h, --help              Show this help message
-  -r, --rules [RULE]      Path to a single lint rule or a folder containing lint rules. If a folder is provided, all .luau files will be assumed to be lint rules.
+  -r, --rules [RULE]      Path to a single lint rule or a folder containing lint rules. If a folder is provided, any subfolders containing init.luau files will be treated as modules exporting lint rules, while all other .luau files will be treated as individual lint rules.
 
 PATH:
   Path to the Luau file to be linted.
@@ -43,24 +43,31 @@ end
 local function loadLintRules(path: string): { types.LintRule }
 	assert(fs.exists(path), `Lint rule at path '{path}' does not exist`)
 
-	if fs.metadata(path).type == "dir" then
-		local rules = {}
+	local rules = {}
 
-		local walker = fs.walk(path, { recursive = true })
-		local curr = walker()
+	local queue: { string } = { path }
+	while #queue > 0 do
+		local currentPath = table.remove(queue, 1)
+		assert(currentPath, "We should never pop from an empty queue")
 
-		while curr ~= nil do
-			if pathLib.extname(curr) == ".luau" then
-				table.insert(rules, loadLintRule(pathLib.format(curr)))
+		if fs.metadata(currentPath).type == "dir" then
+			local currentPathObj = pathLib.parse(currentPath)
+			local initPath = pathLib.format(pathLib.join(currentPathObj, "init.luau"))
+			if fs.exists(initPath) then
+				table.insert(rules, loadLintRule(initPath))
+			else
+				local entries = fs.listdirectory(currentPath)
+				local childPaths = tableext.map(entries, function(entry)
+					return pathLib.format(pathLib.join(currentPathObj, entry.name))
+				end)
+				tableext.extend(queue, childPaths)
 			end
-
-			curr = walker()
+		else
+			table.insert(rules, loadLintRule(currentPath))
 		end
-
-		return rules
-	else
-		return { loadLintRule(path) }
 	end
+
+	return rules
 end
 
 local function main(...: string)
@@ -109,7 +116,7 @@ local function main(...: string)
 	table.sort(
 		violations,
 		function(a: types.LintViolation, b: types.LintViolation) -- LUAUFIX: bidirecitonal inference should mean that annotations on a and b aren't needed
-		return a.location < b.location
+			return a.location < b.location
 		end
 	)
 

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -37,7 +37,7 @@ local function loadLintRule(path: string): types.LintRule
 		`{path} must return a table with a 'lint' function property`
 	)
 
-	return loaded :: types.LintRule -- We have to cast because we can't assert that loaded.lint is a more specific function type
+	return loaded :: types.LintRule -- We have to cast because we can only assert that loaded.lint is the top function type, rather than a more specific function type like (ast: syntax.AstStatBlock, sourcepath: path.path) -> { LintViolation }
 end
 
 local function loadLintRules(path: string): { types.LintRule }

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -62,7 +62,7 @@ local function loadLintRules(path: string): { types.LintRule }
 				end)
 				tableext.extend(queue, childPaths)
 			end
-		else
+		elseif pathLib.extname(currentPath) == ".luau" then
 			table.insert(rules, loadLintRule(currentPath))
 		end
 	end

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -1,33 +1,33 @@
 local cli = require("./cli")
 local fs = require("@std/fs")
 local luau = require("@std/luau")
-local path = require("@std/path")
+local pathLib = require("@std/path")
 local printer = require("@self/printer")
 local syntax = require("@std/syntax")
+local tableext = require("@std/tableext")
 local types = require("@self/types")
 
-local USAGE = "Usage: lute lint [OPTIONS] [RULE] [PATH]"
+local USAGE = "Usage: lute lint [OPTIONS] [PATH]"
 
 local function printHelp()
 	print(USAGE)
 	print([[
-Lint the specified Luau file using the specified lint rule.
+Lint the specified Luau file using the specified lint rule(s).
 
 OPTIONS:
   -h, --help              Show this help message
-
-RULE:
-  Path to a Luau file defining a lint rule.
+  -r, --rules [RULE]      Path to a single lint rule or a folder containing lint rules. If a folder is provided, all .luau files will be assumed to be lint rules.
 
 PATH:
   Path to the Luau file to be linted.
 
 EXAMPLES:
-  lute lint examples/lints/almost_swapped.luau bad_swap.luau
+  lute lint -r examples/lints/almost_swapped.luau bad_swap.luau
+  lute lint -r examples/lints/ lintee.luau
 ]])
 end
 
-local function loadLintRule(path: path.pathlike): types.LintRule
+local function loadLintRule(path: string): types.LintRule
 	local loaded = luau.loadbypath(path)
 	assert(loaded, `{path} failed to require`)
 	assert(typeof(loaded) == "table", `{path} must return a table`)
@@ -37,13 +37,36 @@ local function loadLintRule(path: path.pathlike): types.LintRule
 		`{path} must return a table with a 'lint' function property`
 	)
 
-	return loaded :: types.LintRule -- We have to cast because we can't assert that loaded.lint is a more specific functio type
+	return loaded :: types.LintRule -- We have to cast because we can't assert that loaded.lint is a more specific function type
+end
+
+local function loadLintRules(path: string): { types.LintRule }
+	assert(fs.exists(path), `Lint rule at path '{path}' does not exist`)
+
+	if fs.metadata(path).type == "dir" then
+		local rules = {}
+
+		local walker = fs.walk(path, { recursive = true })
+		local curr = walker()
+
+		while curr ~= nil do
+			if pathLib.extname(curr) == ".luau" then
+				table.insert(rules, loadLintRule(pathLib.format(curr)))
+			end
+
+			curr = walker()
+		end
+
+		return rules
+	else
+		return { loadLintRule(path) }
+	end
 end
 
 local function main(...: string)
 	local args = cli.parser()
 
-	args:add("rule", "positional", { help = "Linting rule to apply" })
+	args:add("rules", "option", { help = "Linting rule(s) to apply", aliases = { "r" } })
 	args:add("input", "positional", { help = "Input file to be linted" })
 	args:add("help", "flag", { help = "Show help message", aliases = { "h" } })
 	-- TODO: handle multiple rules, multiple input files, ignore blobs, json output option
@@ -55,9 +78,10 @@ local function main(...: string)
 		return
 	end
 
-	local rulePath = args:get("rule")
+	local rulePath = args:get("rules")
 	if rulePath == nil then
-		print("Error: No lint rule specified.\n\n" .. USAGE .. "\nUse --help for more information.")
+		-- TODO: support default rules
+		print("Error: No lint rules specified.\n\n" .. USAGE .. "\nUse --help for more information.")
 		return
 	end
 
@@ -66,10 +90,10 @@ local function main(...: string)
 		print("Error: No input file specified.\n\n" .. USAGE .. "\nUse --help for more information.")
 		return
 	end
-	local inputFilePath = path.parse(inputFile)
+	local inputFilePath = pathLib.parse(inputFile)
 
-	print(`Loading lint rule from '{rulePath}'`)
-	local lintRule = loadLintRule(rulePath)
+	print(`Loading lint rule(s) from '{rulePath}'`)
+	local lintRules = loadLintRules(rulePath)
 
 	print(`Reading input file '{inputFile}'`)
 	local fileContent = fs.readfiletostring(inputFilePath)
@@ -77,8 +101,14 @@ local function main(...: string)
 	print(`Parsing input file '{inputFile}'`)
 	local ast = syntax.parseblock(fileContent)
 
-	print("Applying lint rule")
-	local violations = lintRule.lint(ast, inputFilePath)
+	print("Applying lint rules")
+	local violations: { types.LintViolation } = {}
+	for _, rule in lintRules do
+		tableext.extend(violations, rule.lint(ast, inputFilePath))
+	end
+	table.sort(violations, function(a, b)
+		return syntax.span.cmp(a.location, b.location)
+	end)
 
 	print(`Printing {#violations} violations\n`)
 	printer.printLints(violations, fileContent)

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -201,6 +201,27 @@ static int indexSpan(lua_State* L)
     return 0;
 }
 
+static int ltSpan(lua_State* L)
+{
+    const Span* lhs = static_cast<Span*>(luaL_checkudata(L, 1, kSpanType));
+    const Span* rhs = static_cast<Span*>(luaL_checkudata(L, 2, kSpanType));
+
+    // Compare beginnings, and if they're equal, compare ends
+    if (lhs->beginLine < rhs->beginLine || (lhs->beginLine == rhs->beginLine && lhs->beginColumn < rhs->beginColumn))
+        lua_pushboolean(L, 1);
+    else if (lhs->beginLine == rhs->beginLine && lhs->beginColumn == rhs->beginColumn)
+    {
+        if (lhs->endLine < rhs->endLine || (lhs->endLine == rhs->endLine && lhs->endColumn < rhs->endColumn))
+            lua_pushboolean(L, 1);
+        else
+            lua_pushboolean(L, 0);
+    }
+    else
+        lua_pushboolean(L, 0);
+
+    return 1;
+}
+
 struct AstSerialize : public Luau::AstVisitor
 {
     lua_State* L;
@@ -601,8 +622,8 @@ struct AstSerialize : public Luau::AstVisitor
 
         size_t textLength = strlen(text);
 
-        Luau::Position endPosition{ position.line, position.column + static_cast<uint32_t>(textLength) };
-        serialize(Luau::Location { position, endPosition });
+        Luau::Position endPosition{position.line, position.column + static_cast<uint32_t>(textLength)};
+        serialize(Luau::Location{position, endPosition});
         lua_setfield(L, -2, "location");
 
         lua_pushlstring(L, text, textLength);
@@ -2855,6 +2876,9 @@ static int initLuauLibrary(lua_State* L)
 
     lua_pushcfunction(L, luau::indexSpan, "span.__index");
     lua_setfield(L, -2, "__index");
+
+    lua_pushcfunction(L, luau::ltSpan, "span.__lt");
+    lua_setfield(L, -2, "__lt");
 
     lua_setreadonly(L, -1, 1);
 

--- a/lute/std/libs/fs.luau
+++ b/lute/std/libs/fs.luau
@@ -18,6 +18,7 @@ export type watchhandle = fs.WatchHandle
 export type watchevent = fs.WatchEvent
 
 type pathlike = pathlib.pathlike
+type path = pathlib.path
 
 export type createdirectoryoptions = {
 	makeparents: boolean?,
@@ -140,7 +141,7 @@ end
 
 -- Note: for loops do not support yielding generalized iterators, so we cannot use fs.walk as `for path in fs.walk(...) do` directly. A while loop can be used instead.
 function fslib.walk(path: pathlike, options: walkoptions?): () -> path?
-	local queue = { pathlib.parse(path) }
+	local queue = { if typeof(path) == "string" then pathlib.parse(path) else path }
 
 	return function()
 		while #queue > 0 do
@@ -149,7 +150,7 @@ function fslib.walk(path: pathlike, options: walkoptions?): () -> path?
 				return nil
 			end
 
-			if fslib.type(current) == "dir" and options and options.recursive then
+			if fslib.type(current) == "dir" and options and options.recursive then -- LUAUFIX: error on options.recursive because it thinks options could still be nil
 				local entries = fslib.listdirectory(current)
 				for _, entry in entries do
 					local fullPath = pathlib.join(current, entry.name)

--- a/lute/std/libs/fs.luau
+++ b/lute/std/libs/fs.luau
@@ -141,7 +141,7 @@ end
 
 -- Note: for loops do not support yielding generalized iterators, so we cannot use fs.walk as `for path in fs.walk(...) do` directly. A while loop can be used instead.
 function fslib.walk(path: pathlike, options: walkoptions?): () -> path?
-	local queue = { if typeof(path) == "string" then pathlib.parse(path) else path }
+	local queue = { path }
 
 	return function()
 		while #queue > 0 do

--- a/lute/std/libs/syntax/init.luau
+++ b/lute/std/libs/syntax/init.luau
@@ -6,17 +6,6 @@ local luau = require("@lute/luau")
 export type span = types.span
 
 local span = table.freeze({
-	cmp = function(a: span, b: span): boolean
-		-- if a begins before b, a is less than b
-		-- if beginnings match, compare endings
-		if a.beginline < b.beginline or (a.beginline == b.beginline and a.begincolumn < b.begincolumn) then
-			return true
-		elseif a.beginline == b.beginline and a.begincolumn == b.begincolumn then
-			return a.endline < b.endline or (a.endline == b.endline and a.endcolumn < b.endcolumn)
-		else
-			return false
-		end
-	end,
 	create = luau.span.create,
 })
 

--- a/lute/std/libs/syntax/init.luau
+++ b/lute/std/libs/syntax/init.luau
@@ -6,6 +6,17 @@ local luau = require("@lute/luau")
 export type span = types.span
 
 local span = table.freeze({
+	cmp = function(a: span, b: span): boolean
+		-- if a begins before b, a is less than b
+		-- if beginnings match, compare endings
+		if a.beginline < b.beginline or (a.beginline == b.beginline and a.begincolumn < b.begincolumn) then
+			return true
+		elseif a.beginline == b.beginline and a.begincolumn == b.begincolumn then
+			return a.endline < b.endline or (a.endline == b.endline and a.endcolumn < b.endcolumn)
+		else
+			return false
+		end
+	end,
 	create = luau.span.create,
 })
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -6,10 +6,20 @@ local test = require("@std/test")
 
 local lutePath = path.format(process.execpath())
 local tmpDir = system.tmpdir()
+local rulesDir = path.format(path.join(".", "lints"))
+local almostSwappedExample = path.format(path.join("examples", "lints", "almost_swapped.luau"))
+local divideByZeroExample = path.format(path.join("examples", "lints", "divide_by_zero.luau"))
 
 local USAGE = "Usage: lute lint [OPTIONS] [PATH]"
 
 test.suite("lute lint", function(suite)
+	suite:beforeeach(function()
+		-- A test that creates rulesDir which fails won't cleanup after itself
+		if fs.exists(rulesDir) then
+			fs.removedirectory(rulesDir, { recursive = true })
+		end
+	end)
+
 	suite:case("lute lint help message", function(assert)
 		local result = process.run({ lutePath, "lint", "-h" })
 
@@ -43,8 +53,6 @@ test.suite("lute lint", function(suite)
 
 	suite:case("divide_by_zero", function(assert)
 		-- Setup
-		local rule = path.format(path.join("examples", "lints", "divide_by_zero.luau"))
-
 		-- Create a file that violates the rule
 		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
 		fs.writestringtofile(
@@ -56,7 +64,7 @@ local x = 1 / 0
 
 		-- Do
 		-- Run the transformer on the transformee
-		local result = process.run({ lutePath, "lint", "-r", rule, violatorPath })
+		local result = process.run({ lutePath, "lint", "-r", divideByZeroExample, violatorPath })
 
 		-- Check
 		assert.eq(result.exitcode, 0)
@@ -77,8 +85,6 @@ violator.luau:1:11-16 ──
 
 	suite:case("almost_swapped", function(assert)
 		-- Setup
-		local rule = path.format(path.join("examples", "lints", "almost_swapped.luau"))
-
 		-- Create a file that violates the rule
 		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
 		fs.writestringtofile(
@@ -105,7 +111,7 @@ end
 
 		-- Do
 		-- Run the transformer on the transformee
-		local result = process.run({ lutePath, "lint", "-r", rule, violatorPath })
+		local result = process.run({ lutePath, "lint", "-r", almostSwappedExample, violatorPath })
 
 		-- Check
 		assert.eq(result.exitcode, 0)
@@ -157,7 +163,19 @@ violator.luau:14:2-15:17 ──
 
 	suite:case("lute lint multiple rules", function(assert)
 		-- Setup
-		local ruleDir = path.format(path.join("examples", "lints"))
+		fs.createdirectory(rulesDir)
+		-- Copy almostSwapped.luau to rulesDir/almostSwapped.luau
+		fs.copy(almostSwappedExample, path.join(rulesDir, "almost_swapped.luau"))
+		-- Copy divide_by_zero to rulesDir/divide_by_zero/init.luau
+		local divideByZeroDir = path.join(rulesDir, "divide_by_zero")
+		fs.createdirectory(divideByZeroDir)
+		fs.copy(divideByZeroExample, path.join(divideByZeroDir, "init.luau"))
+		fs.writestringtofile(
+			path.join(rulesDir, "bogus.txt"),
+			[[
+not a luau file
+]]
+		)
 
 		-- Create a file that violates the rule
 		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
@@ -173,7 +191,7 @@ b = a
 
 		-- Do
 		-- Run the transformer on the transformee
-		local result = process.run({ lutePath, "lint", "-r", ruleDir, violatorPath })
+		local result = process.run({ lutePath, "lint", "-r", rulesDir, violatorPath })
 
 		-- Check
 		assert.eq(result.exitcode, 0)
@@ -204,6 +222,7 @@ violator.luau:3:1-4:6 ──
 
 		-- Teardown
 		fs.remove(violatorPath)
+		fs.removedirectory(rulesDir, { recursive = true })
 	end)
 end)
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -7,33 +7,35 @@ local test = require("@std/test")
 local lutePath = path.format(process.execpath())
 local tmpDir = system.tmpdir()
 
+local USAGE = "Usage: lute lint [OPTIONS] [PATH]"
+
 test.suite("lute lint", function(suite)
 	suite:case("lute lint help message", function(assert)
 		local result = process.run({ lutePath, "lint", "-h" })
 
 		assert.eq(result.exitcode, 0)
-		assert.neq(result.stdout:find("Usage: lute lint [OPTIONS] [RULE] [PATH]", 1, true), nil)
+		assert.neq(result.stdout:find(USAGE, 1, true), nil)
 
 		result = process.run({ lutePath, "lint", "--h" })
 
 		assert.eq(result.exitcode, 0)
-		assert.neq(result.stdout:find("Usage: lute lint [OPTIONS] [RULE] [PATH]", 1, true), nil)
+		assert.neq(result.stdout:find(USAGE, 1, true), nil)
 
 		result = process.run({ lutePath, "lint", "--help" })
 
 		assert.eq(result.exitcode, 0)
-		assert.neq(result.stdout:find("Usage: lute lint [OPTIONS] [RULE] [PATH]", 1, true), nil)
+		assert.neq(result.stdout:find(USAGE, 1, true), nil)
 	end)
 
 	suite:case("lute lint no rule", function(assert)
 		local result = process.run({ lutePath, "lint" })
 
 		assert.eq(result.exitcode, 0)
-		assert.neq(result.stdout:find("Error: No lint rule specified.", 1, true), nil)
+		assert.neq(result.stdout:find("Error: No lint rules specified.", 1, true), nil)
 	end)
 
 	suite:case("lute lint no rule", function(assert)
-		local result = process.run({ lutePath, "lint", "a_rule" })
+		local result = process.run({ lutePath, "lint", "-r", "a_rule.luau" })
 
 		assert.eq(result.exitcode, 0)
 		assert.neq(result.stdout:find("Error: No input file specified.", 1, true), nil)
@@ -54,7 +56,7 @@ local x = 1 / 0
 
 		-- Do
 		-- Run the transformer on the transformee
-		local result = process.run({ lutePath, "lint", rule, violatorPath })
+		local result = process.run({ lutePath, "lint", "-r", rule, violatorPath })
 
 		-- Check
 		assert.eq(result.exitcode, 0)
@@ -103,7 +105,7 @@ end
 
 		-- Do
 		-- Run the transformer on the transformee
-		local result = process.run({ lutePath, "lint", rule, violatorPath })
+		local result = process.run({ lutePath, "lint", "-r", rule, violatorPath })
 
 		-- Check
 		assert.eq(result.exitcode, 0)
@@ -147,6 +149,57 @@ violator.luau:14:2-15:17 ──
     │ ╰────────────────^
     │
 ]] -- todo: address tab shenanigans
+		assert.neq(result.stdout:find(expected, 1, true), nil)
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
+	suite:case("lute lint multiple rules", function(assert)
+		-- Setup
+		local ruleDir = path.format(path.join("examples", "lints"))
+
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+local x = 1 / 0
+
+a = b
+b = a
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "-r", ruleDir, violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.neq(result.stdout:find("warning[divide_by_zero]: Division by zero detected.", 1, true), nil)
+		local expected = [[
+violator.luau:1:11-16 ──
+   │
+ 1 │ local x = 1 / 0
+   │           ^^^^^
+   │
+]]
+		assert.neq(result.stdout:find(expected, 1, true), nil)
+
+		assert.neq(
+			result.stdout:find("warning[almost_swapped]: This looks like a failed attempt to swap.", 1, true),
+			nil
+		)
+		expected = [[
+violator.luau:3:1-4:6 ──
+   │
+ 3 │ ╭ a = b
+ 4 │ │ b = a
+   │ ╰─────^
+   │
+]]
 		assert.neq(result.stdout:find(expected, 1, true), nil)
 
 		-- Teardown


### PR DESCRIPTION
Adds support for passing multiple lint rules to `lute lint` by supporting either passing a single lint rule file or a directory containing multiple rules. I converted the rule positional argument into an optional one since at some point we'll presumably want to allow calling `lute lint` and getting a bunch of default rules.