### PR TITLE
lute lint: Support multiple lintee files

### DIFF
--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -19,7 +19,7 @@ OPTIONS:
   -r, --rules [RULE]      Path to a single lint rule or a folder containing lint rules. If a folder is provided, any subfolders containing init.luau files will be treated as modules exporting lint rules, while all other .luau files will be treated as individual lint rules.
 
 PATHS:
-  Path(s) to the Luau file(s) or folders containing Luau files to be linted.
+  Path(s) to the Luau file(s) or folders containing Luau files to be linted. Only files with .luau or .lua extensions will be linted.
 
 EXAMPLES:
   lute lint -r examples/lints/almost_swapped.luau bad_swap.luau
@@ -132,7 +132,8 @@ local function main(...: string)
 		while curr ~= nil do
 			local inputFilePath = pathLib.parse(curr)
 
-			if pathLib.extname(inputFilePath) == ".luau" then
+			local extension = pathLib.extname(inputFilePath)
+			if extension == ".luau" or extension == ".lua" then
 				local success, err = pcall(lintFile, inputFilePath, lintRules)
 				if success then
 					-- Violations are returned as the second return value from pcall

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -7,7 +7,7 @@ local syntax = require("@std/syntax")
 local tableext = require("@std/tableext")
 local types = require("@self/types")
 
-local USAGE = "Usage: lute lint [OPTIONS] [PATH]"
+local USAGE = "Usage: lute lint [OPTIONS] [...PATHS]"
 
 local function printHelp()
 	print(USAGE)
@@ -18,12 +18,12 @@ OPTIONS:
   -h, --help              Show this help message
   -r, --rules [RULE]      Path to a single lint rule or a folder containing lint rules. If a folder is provided, any subfolders containing init.luau files will be treated as modules exporting lint rules, while all other .luau files will be treated as individual lint rules.
 
-PATH:
-  Path to the Luau file to be linted.
+PATHS:
+  Path(s) to the Luau file(s) or folders containing Luau files to be linted.
 
 EXAMPLES:
   lute lint -r examples/lints/almost_swapped.luau bad_swap.luau
-  lute lint -r examples/lints/ lintee.luau
+  lute lint -r examples/lints/ lintee.luau src_code/
 ]])
 end
 
@@ -70,11 +70,33 @@ local function loadLintRules(path: string): { types.LintRule }
 	return rules
 end
 
+local function lintFile(inputFilePath: pathLib.path, lintRules: { types.LintRule }): { types.LintViolation }
+	print(`Reading input file '{inputFilePath}'`)
+	local fileContent = fs.readfiletostring(inputFilePath)
+
+	print(`Parsing input file '{inputFilePath}'`)
+	local ast = syntax.parseblock(fileContent)
+
+	print("Applying lint rules")
+	local violations: { types.LintViolation } = {}
+	for _, rule in lintRules do
+		tableext.extend(violations, rule.lint(ast, inputFilePath))
+	end
+
+	table.sort(
+		violations,
+		function(a: types.LintViolation, b: types.LintViolation) -- LUAUFIX: bidirecitonal inference should mean that annotations on a and b aren't needed
+			return a.location < b.location
+		end
+	)
+
+	return violations
+end
+
 local function main(...: string)
 	local args = cli.parser()
 
 	args:add("rules", "option", { help = "Linting rule(s) to apply", aliases = { "r" } })
-	args:add("input", "positional", { help = "Input file to be linted" })
 	args:add("help", "flag", { help = "Show help message", aliases = { "h" } })
 	-- TODO: handle multiple rules, multiple input files, ignore blobs, json output option
 
@@ -92,36 +114,48 @@ local function main(...: string)
 		return
 	end
 
-	local inputFile = args:get("input")
-	if inputFile == nil then
-		print("Error: No input file specified.\n\n" .. USAGE .. "\nUse --help for more information.")
+	local inputFiles = args:forwarded()
+	if inputFiles == nil or #inputFiles == 0 then
+		print("Error: No input files specified.\n\n" .. USAGE .. "\nUse --help for more information.")
 		return
 	end
-	local inputFilePath = pathLib.parse(inputFile)
 
 	print(`Loading lint rule(s) from '{rulePath}'`)
 	local lintRules = loadLintRules(rulePath)
 
-	print(`Reading input file '{inputFile}'`)
-	local fileContent = fs.readfiletostring(inputFilePath)
+	local allViolations = {}
+	while #inputFiles > 0 do
+		local inputFile = table.remove(inputFiles, #inputFiles)
+		assert(inputFile ~= nil, "We should never pop from an empty inputFiles")
+		local inputFilePath = pathLib.parse(inputFile)
 
-	print(`Parsing input file '{inputFile}'`)
-	local ast = syntax.parseblock(fileContent)
+		if fs.type(inputFilePath) == "dir" then
+			print(`Queuing files in directory '{inputFilePath}' for linting`)
 
-	print("Applying lint rules")
-	local violations: { types.LintViolation } = {}
-	for _, rule in lintRules do
-		tableext.extend(violations, rule.lint(ast, inputFilePath))
-	end
-	table.sort(
-		violations,
-		function(a: types.LintViolation, b: types.LintViolation) -- LUAUFIX: bidirecitonal inference should mean that annotations on a and b aren't needed
-			return a.location < b.location
+			local entries = fs.listdirectory(inputFilePath)
+			local subPaths = tableext.map(entries, function(entry)
+				return pathLib.format(pathLib.join(inputFilePath, entry.name))
+			end)
+			tableext.extend(inputFiles, subPaths)
+		elseif pathLib.extname(inputFilePath) == ".luau" then
+			local success, err = pcall(lintFile, inputFilePath, lintRules)
+			if success then
+				-- Violations are returned as the second return value from pcall
+				allViolations[inputFilePath] = err
+			else
+				print(`Error linting file '{inputFilePath}': {err}`)
+			end
+		else
+			print(`Skipping non-Luau file '{inputFilePath}'`)
 		end
-	)
+	end
 
-	print(`Printing {#violations} violations\n`)
-	printer.printLints(violations, fileContent)
+	print(`Printing violations from {#allViolations} files\n`)
+	for sourcePath, violations in allViolations do
+		if #violations > 0 then
+			printer.printLints(violations, sourcePath)
+		end
+	end
 end
 
 main(...)

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -124,29 +124,27 @@ local function main(...: string)
 	local lintRules = loadLintRules(rulePath)
 
 	local allViolations = {}
-	while #inputFiles > 0 do
-		local inputFile = table.remove(inputFiles, #inputFiles)
-		assert(inputFile ~= nil, "We should never pop from an empty inputFiles")
-		local inputFilePath = pathLib.parse(inputFile)
 
-		if fs.type(inputFilePath) == "dir" then
-			print(`Queuing files in directory '{inputFilePath}' for linting`)
+	for _, inputPath in inputFiles do
+		local walker = fs.walk(inputPath, { recursive = true })
 
-			local entries = fs.listdirectory(inputFilePath)
-			local subPaths = tableext.map(entries, function(entry)
-				return pathLib.format(pathLib.join(inputFilePath, entry.name))
-			end)
-			tableext.extend(inputFiles, subPaths)
-		elseif pathLib.extname(inputFilePath) == ".luau" then
-			local success, err = pcall(lintFile, inputFilePath, lintRules)
-			if success then
-				-- Violations are returned as the second return value from pcall
-				allViolations[inputFilePath] = err
+		local curr = walker()
+		while curr ~= nil do
+			local inputFilePath = pathLib.parse(curr)
+
+			if pathLib.extname(inputFilePath) == ".luau" then
+				local success, err = pcall(lintFile, inputFilePath, lintRules)
+				if success then
+					-- Violations are returned as the second return value from pcall
+					allViolations[inputFilePath] = err
+				else
+					print(`Error linting file '{inputFilePath}': {err}`)
+				end
 			else
-				print(`Error linting file '{inputFilePath}': {err}`)
+				print(`Skipping non-Luau file '{inputFilePath}'`)
 			end
-		else
-			print(`Skipping non-Luau file '{inputFilePath}'`)
+
+			curr = walker()
 		end
 	end
 

--- a/lute/cli/commands/lint/printer.luau
+++ b/lute/cli/commands/lint/printer.luau
@@ -1,3 +1,4 @@
+local fs = require("@std/fs")
 local path = require("@std/path")
 local types = require("./types")
 
@@ -60,12 +61,16 @@ local function printLint(lint: types.LintViolation, sourceLines: { string }): ()
 	end
 end
 
-function printerLib.printLints(lints: { types.LintViolation }, sourceContent: string): ()
+local function printLints(lints: { types.LintViolation }, sourceContent: string): ()
 	local sourceLines = sourceContent:split("\n")
 
 	for _, lint in lints do
 		printLint(lint, sourceLines)
 	end
+end
+
+function printerLib.printLints(lints: { types.LintViolation }, sourcePath: path.path): ()
+	printLints(lints, fs.readfiletostring(sourcePath))
 end
 
 return table.freeze(printerLib)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -306,7 +306,7 @@ violator2.luau:5:1-6:6 ──
    │
 ]]
 		assert.neq(result.stdout:find(expected, 1, true), nil)
-
+		print("STDOUT:", result.stdout)
 		expected = "Skipping non%-Luau file '.+/module/not_luau%.txt'"
 		assert.neq(result.stdout:find(expected, 1, false), nil)
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -10,13 +10,18 @@ local rulesDir = path.format(path.join(".", "lints"))
 local almostSwappedExample = path.format(path.join("examples", "lints", "almost_swapped.luau"))
 local divideByZeroExample = path.format(path.join("examples", "lints", "divide_by_zero.luau"))
 
-local USAGE = "Usage: lute lint [OPTIONS] [PATH]"
+local USAGE = "Usage: lute lint [OPTIONS] [...PATHS]"
 
 test.suite("lute lint", function(suite)
 	suite:beforeeach(function()
 		-- A test that creates rulesDir which fails won't cleanup after itself
 		if fs.exists(rulesDir) then
 			fs.removedirectory(rulesDir, { recursive = true })
+		end
+
+		local modulePath = path.join(tmpDir, "module")
+		if fs.exists(modulePath) then
+			fs.removedirectory(modulePath, { recursive = true })
 		end
 	end)
 
@@ -44,11 +49,11 @@ test.suite("lute lint", function(suite)
 		assert.neq(result.stdout:find("Error: No lint rules specified.", 1, true), nil)
 	end)
 
-	suite:case("lute lint no rule", function(assert)
+	suite:case("lute lint no input file", function(assert)
 		local result = process.run({ lutePath, "lint", "-r", "a_rule.luau" })
 
 		assert.eq(result.exitcode, 0)
-		assert.neq(result.stdout:find("Error: No input file specified.", 1, true), nil)
+		assert.neq(result.stdout:find("Error: No input files specified.", 1, true), nil)
 	end)
 
 	suite:case("divide_by_zero", function(assert)
@@ -223,6 +228,114 @@ violator.luau:3:1-4:6 ──
 		-- Teardown
 		fs.remove(violatorPath)
 		fs.removedirectory(rulesDir, { recursive = true })
+	end)
+
+	suite:case("lute lint multiple input files", function(assert)
+		-- Setup
+		-- Create multiple files that violate the rule
+		local violatorPath1 = path.format(path.join(tmpDir, "violator1.luau"))
+		fs.writestringtofile(
+			violatorPath1,
+			[[
+local x = 1 / 0
+
+a = b
+b = a
+    ]]
+		)
+
+		local modulePath = path.join(tmpDir, "module")
+		fs.createdirectory(modulePath)
+		local violatorPath2 = path.format(path.join(modulePath, "violator2.luau"))
+		fs.writestringtofile(
+			violatorPath2,
+			[[
+local y = 10 / 0
+
+local x = 0
+local y = "hello"
+x = y
+y = x
+    ]]
+		)
+		fs.writestringtofile(path.format(path.join(modulePath, "not_luau.txt")), "blablabla")
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "-r", "examples/lints", violatorPath1, path.format(modulePath) })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.eq(#result.stdout:split("warning[divide_by_zero]: Division by zero detected."), 3)
+		local expected = [[
+violator1.luau:1:11-16 ──
+   │
+ 1 │ local x = 1 / 0
+   │           ^^^^^
+   │
+]]
+		assert.neq(result.stdout:find(expected, 1, true), nil)
+
+		expected = [[
+violator2.luau:1:11-17 ──
+   │
+ 1 │ local y = 10 / 0
+   │           ^^^^^^
+   │
+]]
+		assert.neq(result.stdout:find(expected, 1, true), nil)
+
+		assert.eq(#result.stdout:split("warning[almost_swapped]: This looks like a failed attempt to swap."), 3)
+		expected = [[
+violator1.luau:3:1-4:6 ──
+   │
+ 3 │ ╭ a = b
+ 4 │ │ b = a
+   │ ╰─────^
+   │
+]]
+		assert.neq(result.stdout:find(expected, 1, true), nil)
+
+		expected = [[
+violator2.luau:5:1-6:6 ──
+   │
+ 5 │ ╭ x = y
+ 6 │ │ y = x
+   │ ╰─────^
+   │
+]]
+		assert.neq(result.stdout:find(expected, 1, true), nil)
+
+		expected = "Skipping non%-Luau file '.+/module/not_luau%.txt'"
+		assert.neq(result.stdout:find(expected, 1, false), nil)
+
+		-- Teardown
+		fs.remove(violatorPath1)
+		fs.removedirectory(modulePath, { recursive = true })
+	end)
+
+	suite:case("lute lint file errors", function(assert)
+		-- Setup
+		-- Create multiple files that violate the rule
+		local lintee = path.format(path.join(tmpDir, "lintee.luau"))
+		fs.writestringtofile(lintee, "bogus")
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "-r", "examples/lints", lintee })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		local expected = [[
+lintee.luau': @std/syntax/parser.luau:12: parsing failed:
+(0, 0) - (0, 5): Incomplete statement: expected assignment or a function call
+]]
+		assert.neq(result.stdout:find(expected, 1, true), nil)
+
+		-- Teardown
+		fs.remove(lintee)
 	end)
 end)
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -246,7 +246,7 @@ b = a
 
 		local modulePath = path.join(tmpDir, "module")
 		fs.createdirectory(modulePath)
-		local violatorPath2 = path.format(path.join(modulePath, "violator2.luau"))
+		local violatorPath2 = path.format(path.join(modulePath, "violator2.lua"))
 		fs.writestringtofile(
 			violatorPath2,
 			[[
@@ -278,7 +278,7 @@ violator1.luau:1:11-16 ──
 		assert.neq(result.stdout:find(expected, 1, true), nil)
 
 		expected = [[
-violator2.luau:1:11-17 ──
+violator2.lua:1:11-17 ──
    │
  1 │ local y = 10 / 0
    │           ^^^^^^
@@ -298,7 +298,7 @@ violator1.luau:3:1-4:6 ──
 		assert.neq(result.stdout:find(expected, 1, true), nil)
 
 		expected = [[
-violator2.luau:5:1-6:6 ──
+violator2.lua:5:1-6:6 ──
    │
  5 │ ╭ x = y
  6 │ │ y = x
@@ -306,8 +306,7 @@ violator2.luau:5:1-6:6 ──
    │
 ]]
 		assert.neq(result.stdout:find(expected, 1, true), nil)
-		print("STDOUT:", result.stdout)
-		expected = "Skipping non%-Luau file '.+/module/not_luau%.txt'"
+		expected = "Skipping non%-Luau file '.+[/\\]module[/\\]not_luau%.txt'"
 		assert.neq(result.stdout:find(expected, 1, false), nil)
 
 		-- Teardown
@@ -315,15 +314,26 @@ violator2.luau:5:1-6:6 ──
 		fs.removedirectory(modulePath, { recursive = true })
 	end)
 
-	suite:case("lute lint file errors", function(assert)
+	suite:case("lute lint multiple files with errors recovers", function(assert)
 		-- Setup
 		-- Create multiple files that violate the rule
 		local lintee = path.format(path.join(tmpDir, "lintee.luau"))
 		fs.writestringtofile(lintee, "bogus")
 
+		local violatorPath = path.format(path.join(tmpDir, "violator1.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+local x = 1 / 0
+
+a = b
+b = a
+    ]]
+		)
+
 		-- Do
 		-- Run the transformer on the transformee
-		local result = process.run({ lutePath, "lint", "-r", "examples/lints", lintee })
+		local result = process.run({ lutePath, "lint", "-r", "examples/lints", lintee, violatorPath })
 
 		-- Check
 		assert.eq(result.exitcode, 0)
@@ -334,8 +344,15 @@ lintee.luau': @std/syntax/parser.luau:12: parsing failed:
 ]]
 		assert.neq(result.stdout:find(expected, 1, true), nil)
 
+		assert.neq(result.stdout:find("warning[divide_by_zero]: Division by zero detected.", 1, true), nil)
+		assert.neq(
+			result.stdout:find("warning[almost_swapped]: This looks like a failed attempt to swap.", 1, true),
+			nil
+		)
+
 		-- Teardown
 		fs.remove(lintee)
+		fs.remove(violatorPath)
 	end)
 end)
 


### PR DESCRIPTION
Update lute lint to support multiple input files by assuming that all non option arguments are paths to be linted. If a directory is passed, we recursively walk the directory for all the files to be linted. We error handle any files that error while linting so we can keep linting other files.