### PR TITLE
lute lint: gracefully handle rules that error

### DIFF
--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -111,11 +111,17 @@ local function main(...: string)
 	print("Applying lint rules")
 	local violations: { types.LintViolation } = {}
 	for _, rule in lintRules do
-		tableext.extend(violations, rule.lint(ast, inputFilePath))
+		local success, err = pcall(rule.lint, ast, inputFilePath)
+		if success then
+			-- On success, err contains the returned violations
+			tableext.extend(violations, err)
+		else
+			print(`Error applying lint rule '{rule.name}': {err}`)
+		end
 	end
 	table.sort(
 		violations,
-		function(a: types.LintViolation, b: types.LintViolation) -- LUAUFIX: bidirecitonal inference should mean that annotations on a and b aren't needed
+		function(a: types.LintViolation, b: types.LintViolation) -- LUAUFIX: bidirectional inference should mean that annotations on a and b aren't needed
 			return a.location < b.location
 		end
 	)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -276,9 +276,8 @@ violator.luau:1:1-2:6 ──
 
 		assert.neq(
 			result.stdout:find(
-				"Error applying lint rule 'AlwaysErrors': ./lints/erroring_rule.luau:4: This rule always errors",
-				1,
-				true
+				"Error applying lint rule 'AlwaysErrors': %.[/\\]lints[/\\]erroring_rule%.luau:4: This rule always errors",
+				1
 			),
 			nil
 		)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -224,6 +224,69 @@ violator.luau:3:1-4:6 ──
 		fs.remove(violatorPath)
 		fs.removedirectory(rulesDir, { recursive = true })
 	end)
+
+	suite:case("lute lint multiple rules but one errors", function(assert)
+		-- Setup
+		fs.createdirectory(rulesDir)
+		-- Copy almostSwapped.luau to rulesDir/almostSwapped.luau
+		fs.copy(almostSwappedExample, path.join(rulesDir, "almost_swapped.luau"))
+		-- Create a rule that fails
+		fs.writestringtofile(
+			path.join(rulesDir, "erroring_rule.luau"),
+			[[
+return table.freeze({
+	name = "AlwaysErrors",
+	lint = function(ast, sourcepath)
+		error("This rule always errors")
+	end,
+})
+]]
+		)
+
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+a = b
+b = a
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "-r", rulesDir, violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.neq(
+			result.stdout:find("warning[almost_swapped]: This looks like a failed attempt to swap.", 1, true),
+			nil
+		)
+		local expected = [[
+violator.luau:1:1-2:6 ──
+   │
+ 1 │ ╭ a = b
+ 2 │ │ b = a
+   │ ╰─────^
+   │
+]]
+		assert.neq(result.stdout:find(expected, 1, true), nil)
+
+		assert.neq(
+			result.stdout:find(
+				"Error applying lint rule 'AlwaysErrors': ./lints/erroring_rule.luau:4: This rule always errors",
+				1,
+				true
+			),
+			nil
+		)
+
+		-- Teardown
+		fs.remove(violatorPath)
+		fs.removedirectory(rulesDir, { recursive = true })
+	end)
 end)
 
 test.run()


### PR DESCRIPTION
Currently, if a single lint rule errors, it'll exit the whole lint. If we wrap the lint rule calls in `pcall` instead, we can gracefully continue calling the other lint rules too.