### PR TITLE
lute lint: warning suppression comments

### DIFF
--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -113,6 +113,15 @@ local function maybeParseSuppressions(
 	local rules = cache[node]
 	if rules == nil then
 		rules = parseSuppressions(node)
+
+		if node.kind == "stat" and node.tag == "block" then
+			-- The logic here is a little different, since we only want suppression to apply to the first statement
+			-- Store a sentinel value at this node to avoid reparsing suppressions
+			cache[node] = {}
+			-- Parse the rules that this node suppresses and attach them to the first statement of the block
+			cache[node.statements[1]] = rules
+		end
+
 		cache[node] = rules
 	end
 	return rules
@@ -126,23 +135,6 @@ local function violationIsSuppressed(
 	local violationSuppressed = false
 
 	local function nodeIsSuppressed(node: syntax.AstNode): boolean
-		if node.kind == "stat" and node.tag == "block" then
-			-- The logic here is a little different, since we only want suppression to apply to the first statement
-			-- If the block is empty, early exit
-			if #node.statements == 0 then
-				return false
-			end
-
-			if suppressionCache[node] == nil then
-				-- Store a sentinel value at this node to avoid reparsing suppressions
-				suppressionCache[node] = {}
-				-- Parse the rules that this node suppresses and attach them to the first statement of the block
-				suppressionCache[node.statements[1]] = parseSuppressions(node)
-				-- Recurse into the block
-				return true
-			end
-		end
-
 		if syntax.span.subsumes(violation.location, node.location) then
 			-- The first node which is fully contained within a violation can suppress it
 			local rules = maybeParseSuppressions(node, suppressionCache)
@@ -158,11 +150,11 @@ local function violationIsSuppressed(
 			return false
 		end
 
-		local rules = suppressionCache[node]
-		if rules == nil then
-			-- Find all rules that this node suppresses
-			rules = parseSuppressions(node)
-			suppressionCache[node] = rules
+		local rules = maybeParseSuppressions(node, suppressionCache)
+
+		-- AstStatBlock suppressions should only apply to the first statement, not the block itself
+		if node.kind == "stat" and node.tag == "block" then
+			return true
 		end
 
 		if rules[violation.lintname] then

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -106,7 +106,10 @@ local function parseSuppressions(node: syntax.AstNode): { [string]: boolean }
 	return suppressions
 end
 
-local function maybeParseSuppressions(node: syntax.AstNode, cache: { [syntax.AstNode]: { [string]: boolean } }): { [string]: boolean }
+local function maybeParseSuppressions(
+	node: syntax.AstNode,
+	cache: { [syntax.AstNode]: { [string]: boolean } }
+): { [string]: boolean }
 	local rules = cache[node]
 	if rules == nil then
 		rules = parseSuppressions(node)
@@ -139,7 +142,7 @@ local function violationIsSuppressed(
 				return true
 			end
 		end
-		
+
 		if syntax.span.subsumes(violation.location, node.location) then
 			-- The first node which is fully contained within a violation can suppress it
 			local rules = maybeParseSuppressions(node, suppressionCache)

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -106,6 +106,15 @@ local function parseSuppressions(node: syntax.AstNode): { [string]: boolean }
 	return suppressions
 end
 
+local function maybeParseSuppressions(node: syntax.AstNode, cache: { [syntax.AstNode]: { [string]: boolean } }): { [string]: boolean }
+	local rules = cache[node]
+	if rules == nil then
+		rules = parseSuppressions(node)
+		cache[node] = rules
+	end
+	return rules
+end
+
 local function violationIsSuppressed(
 	violation: types.LintViolation,
 	ast: syntax.AstStatBlock,
@@ -114,11 +123,6 @@ local function violationIsSuppressed(
 	local violationSuppressed = false
 
 	local function nodeIsSuppressed(node: syntax.AstNode): boolean
-		if not syntax.span.subsumes(node.location, violation.location) then
-			-- Violation doesn't come from this node, so don't recurse deeper
-			return false
-		end
-
 		if node.kind == "stat" and node.tag == "block" then
 			-- The logic here is a little different, since we only want suppression to apply to the first statement
 			-- If the block is empty, early exit
@@ -134,6 +138,21 @@ local function violationIsSuppressed(
 				-- Recurse into the block
 				return true
 			end
+		end
+		
+		if syntax.span.subsumes(violation.location, node.location) then
+			-- The first node which is fully contained within a violation can suppress it
+			local rules = maybeParseSuppressions(node, suppressionCache)
+			if rules[violation.lintname] then
+				violationSuppressed = true
+			end
+			-- No other fully contained nodes can suppress, so we can stop recursing
+			return false
+		end
+
+		if not syntax.span.subsumes(node.location, violation.location) then
+			-- Violation doesn't come from this node, so don't recurse deeper
+			return false
 		end
 
 		local rules = suppressionCache[node]

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -84,11 +84,26 @@ local function loadDefaultRules(): { types.LintRule }
 	local rules = {}
 	for _, ruleName in DEFAULT_RULES do
 		local path = `@self/rules/{ruleName}`
-		local rule = require(path)
+		local rule: types.LintRule = require(path) :: any -- Anycast to silence error from dynamic require
 		assertIsLintRule(rule, path)
 		table.insert(rules, rule)
 	end
 	return rules
+end
+
+local function parseSuppressions(node: syntax.AstNode): { [string]: boolean }
+	local suppressions: { [string]: boolean } = {}
+
+	local leadingTrivia = triviaUtils.leftmosttrivia(node)
+	for _, trivia in leadingTrivia do
+		if trivia.tag == "blockcomment" or trivia.tag == "comment" then
+			for rule in trivia.text:gmatch("lute%-lint%-ignore%((.+)%)") do
+				suppressions[rule] = true
+			end
+		end
+	end
+
+	return suppressions
 end
 
 local function violationIsSuppressed(
@@ -99,33 +114,42 @@ local function violationIsSuppressed(
 	local violationSuppressed = false
 
 	local function nodeIsSuppressed(node: syntax.AstNode): boolean
-		if syntax.span.subsumes(node.location, violation.location) then
-			local rules = suppressionCache[node]
-			if rules == nil then
-				-- Find all rules that this node suppresses
-				local leadingTrivia = triviaUtils.leftmosttrivia(node)
-				rules = {}
-				for _, trivia in leadingTrivia do
-					if trivia.tag == "blockcomment" or trivia.tag == "comment" then
-						for rule in trivia.text:gmatch("lute%-lint%-ignore%((.+)%)") do
-							rules[rule] = true
-						end
-					end
-				end
-				suppressionCache[node] = rules
-			end
-
-			if rules[violation.lintname] then
-				violationSuppressed = true
-				-- If the node is suppressed, we don't need to recurse deeper
-				return false
-			else
-				-- A deeper node might suppress this rule
-				return true
-			end
-		else
+		if not syntax.span.subsumes(node.location, violation.location) then
 			-- Violation doesn't come from this node, so don't recurse deeper
 			return false
+		end
+
+		if node.kind == "stat" and node.tag == "block" then
+			-- The logic here is a little different, since we only want suppression to apply to the first statement
+			-- If the block is empty, early exit
+			if #node.statements == 0 then
+				return false
+			end
+
+			if suppressionCache[node] == nil then
+				-- Store a sentinel value at this node to avoid reparsing suppressions
+				suppressionCache[node] = {}
+				-- Parse the rules that this node suppresses and attach them to the first statement of the block
+				suppressionCache[node.statements[1]] = parseSuppressions(node)
+				-- Recurse into the block
+				return true
+			end
+		end
+
+		local rules = suppressionCache[node]
+		if rules == nil then
+			-- Find all rules that this node suppresses
+			rules = parseSuppressions(node)
+			suppressionCache[node] = rules
+		end
+
+		if rules[violation.lintname] then
+			violationSuppressed = true
+			-- If the node is suppressed, we don't need to recurse deeper
+			return false
+		else
+			-- A deeper node might suppress this rule
+			return true
 		end
 	end
 

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -94,7 +94,7 @@ end
 local function violationIsSuppressed(
 	violation: types.LintViolation,
 	ast: syntax.AstStatBlock,
-	suppressionCache: { [syntax.AstNode]: { string } }
+	suppressionCache: { [syntax.AstNode]: { [string]: boolean } }
 ): boolean
 	local violationSuppressed = false
 
@@ -108,15 +108,14 @@ local function violationIsSuppressed(
 				for _, trivia in leadingTrivia do
 					if trivia.tag == "blockcomment" or trivia.tag == "comment" then
 						for rule in trivia.text:gmatch("lute%-lint%-ignore%((.+)%)") do
-							print(`Found suppression for rule '{rule}'`)
-							table.insert(rules, rule)
+							rules[rule] = true
 						end
 					end
 				end
 				suppressionCache[node] = rules
 			end
 
-			if table.find(rules, violation.lintname) then
+			if rules[violation.lintname] then
 				violationSuppressed = true
 				-- If the node is suppressed, we don't need to recurse deeper
 				return false

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -5,7 +5,9 @@ local pathLib = require("@std/path")
 local printer = require("@self/printer")
 local syntax = require("@std/syntax")
 local tableext = require("@std/tableext")
+local triviaUtils = require("@std/syntax/utils/trivia")
 local types = require("@self/types")
+local visitor = require("@std/syntax/visitor")
 
 local DEFAULT_RULES = { "almost_swapped", "divide_by_zero" }
 local USAGE = "Usage: lute lint [OPTIONS] [...PATHS]"
@@ -89,6 +91,52 @@ local function loadDefaultRules(): { types.LintRule }
 	return rules
 end
 
+local function violationIsSuppressed(
+	violation: types.LintViolation,
+	ast: syntax.AstStatBlock,
+	suppressionCache: { [syntax.AstNode]: { string } }
+): boolean
+	local violationSuppressed = false
+
+	local function nodeIsSuppressed(node: syntax.AstNode): boolean
+		if syntax.span.subsumes(node.location, violation.location) then
+			local rules = suppressionCache[node]
+			if rules == nil then
+				-- Find all rules that this node suppresses
+				local leadingTrivia = triviaUtils.leftmosttrivia(node)
+				rules = {}
+				for _, trivia in leadingTrivia do
+					if trivia.tag == "blockcomment" or trivia.tag == "comment" then
+						for rule in trivia.text:gmatch("lute%-lint%-ignore%((.+)%)") do
+							print(`Found suppression for rule '{rule}'`)
+							table.insert(rules, rule)
+						end
+					end
+				end
+				suppressionCache[node] = rules
+			end
+
+			if table.find(rules, violation.lintname) then
+				violationSuppressed = true
+				-- If the node is suppressed, we don't need to recurse deeper
+				return false
+			else
+				-- A deeper node might suppress this rule
+				return true
+			end
+		else
+			-- Violation doesn't come from this node, so don't recurse deeper
+			return false
+		end
+	end
+
+	local suppressionVisitor = visitor.create(nodeIsSuppressed)
+
+	visitor.visitblock(ast, suppressionVisitor)
+
+	return violationSuppressed
+end
+
 local function lintFile(inputFilePath: pathLib.path, lintRules: { types.LintRule }): { types.LintViolation }
 	print(`Reading input file '{inputFilePath}'`)
 	local fileContent = fs.readfiletostring(inputFilePath)
@@ -98,11 +146,16 @@ local function lintFile(inputFilePath: pathLib.path, lintRules: { types.LintRule
 
 	print("Applying lint rules")
 	local violations: { types.LintViolation } = {}
+	local suppressionCache = {}
 	for _, rule in lintRules do
 		local success, err = pcall(rule.lint, ast, inputFilePath)
 		if success then
 			-- On success, err contains the returned violations
-			tableext.extend(violations, err)
+			for _, violation in err do
+				if not violationIsSuppressed(violation, ast, suppressionCache) then
+					table.insert(violations, violation)
+				end
+			end
 		else
 			print(`Error applying lint rule '{rule.name}': {err}`)
 		end

--- a/lute/cli/commands/lint/printer.luau
+++ b/lute/cli/commands/lint/printer.luau
@@ -37,10 +37,14 @@ local function printLint(lint: types.LintViolation, sourceLines: { string }): ()
 		local gutterSize = math.floor(math.log10(location.endline)) + 3 -- + 2 for padding around line number
 		local blankGutter = string.rep(" ", gutterSize)
 
-		local renderedSourceLines = { ` {location.beginline} │ ╭ {sourceLines[location.beginline]}` }
+		local renderedSourceLines =
+			{ ` {string.format(`%-{gutterSize - 2}d`, location.beginline)} │ ╭ {sourceLines[location.beginline]}` } -- LUAUFIX: the string.format call shouldn't error
 		local maxSourceLineLength = #renderedSourceLines[1]
 		for lineNum = location.beginline + 1, location.endline do
-			table.insert(renderedSourceLines, ` {lineNum} │ │ {sourceLines[lineNum]}`)
+			table.insert(
+				renderedSourceLines,
+				` {string.format(`%-{gutterSize - 2}d`, lineNum)} │ │ {sourceLines[lineNum]}` -- LUAUFIX: the string.format call shouldn't error
+			)
 			maxSourceLineLength = math.max(maxSourceLineLength, #renderedSourceLines[#renderedSourceLines])
 		end
 

--- a/lute/cli/commands/lint/printer.luau
+++ b/lute/cli/commands/lint/printer.luau
@@ -38,12 +38,12 @@ local function printLint(lint: types.LintViolation, sourceLines: { string }): ()
 		local blankGutter = string.rep(" ", gutterSize)
 
 		local renderedSourceLines =
-			{ ` {string.format(`%-{gutterSize - 2}d`, location.beginline)} │ ╭ {sourceLines[location.beginline]}` } -- LUAUFIX: the string.format call shouldn't error
+			{ ` {string.format(`%-{gutterSize - 2}d`, location.beginline)} │ ╭ {sourceLines[location.beginline]}` }
 		local maxSourceLineLength = #renderedSourceLines[1]
 		for lineNum = location.beginline + 1, location.endline do
 			table.insert(
 				renderedSourceLines,
-				` {string.format(`%-{gutterSize - 2}d`, lineNum)} │ │ {sourceLines[lineNum]}` -- LUAUFIX: the string.format call shouldn't error
+				` {string.format(`%-{gutterSize - 2}d`, lineNum)} │ │ {sourceLines[lineNum]}`
 			)
 			maxSourceLineLength = math.max(maxSourceLineLength, #renderedSourceLines[#renderedSourceLines])
 		end

--- a/lute/std/libs/syntax/init.luau
+++ b/lute/std/libs/syntax/init.luau
@@ -5,9 +5,22 @@ local luau = require("@lute/luau")
 
 export type span = types.span
 
-local span = table.freeze({
+local span = {
 	create = luau.span.create,
-})
+}
+
+function span.subsumes(haystack: span, needle: span): boolean
+	return (
+		if haystack.beginline == needle.beginline
+			then haystack.begincolumn <= needle.begincolumn
+			else haystack.beginline < needle.beginline
+	)
+		and (
+			if haystack.endline == needle.endline
+				then haystack.endcolumn >= needle.endcolumn
+				else haystack.endline > needle.endline
+		)
+end
 
 export type Whitespace = types.Whitespace
 export type SingleLineComment = types.SingleLineComment
@@ -164,4 +177,9 @@ export type AstNode = types.AstNode
 
 export type ParseResult = types.ParseResult
 
-return table.freeze({ parseblock = parser.parseblock, parseexpr = parser.parseexpr, parse = parser.parse, span = span })
+return table.freeze({
+	parseblock = parser.parseblock,
+	parseexpr = parser.parseexpr,
+	parse = parser.parse,
+	span = table.freeze(span),
+})

--- a/lute/std/libs/test/assert.luau
+++ b/lute/std/libs/test/assert.luau
@@ -139,7 +139,7 @@ end
 
 function assertions.strnotcontains(haystack: string, needle: string, msg: string?)
 	if haystack:find(needle, 1, true) ~= nil then
-		error(if msg then msg else `Expected "{haystack}" to not contain "{needle}".`)
+		error({ msg = if msg then msg else `Expected "{haystack}" to not contain "{needle}".` })
 	end
 end
 

--- a/lute/std/libs/test/assert.luau
+++ b/lute/std/libs/test/assert.luau
@@ -135,6 +135,12 @@ function assertions.strcontains(haystack: string, needle: string, msg: string?, 
 	end
 end
 
+function assertions.strnotcontains(haystack: string, needle: string, msg: string?)
+	if haystack:find(needle, 1, true) ~= nil then
+		error(if msg then msg else `Expected "{haystack}" to not contain "{needle}".`)
+	end
+end
+
 export type asserts = typeof(assertions)
 
 return table.freeze(assertions)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -472,7 +472,6 @@ b = a
 
 		-- Check
 		assert.eq(result.exitcode, 0)
-		print(result.stdout)
 
 		assert.strnotcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.")
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -489,6 +489,100 @@ violator.luau:9:1-10:6 ──
 		-- Teardown
 		fs.remove(violatorPath)
 	end)
+
+	suite:case("suppression is limited to following statement", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+-- lute-lint-ignore(divide_by_zero)
+local x = 1 / 0
+
+if true then
+	local y = 10 / 0
+end
+
+local z = 1 / 0
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "-r", divideByZeroExample, violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.strcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.", nil, 2)
+		local expected = [[
+violator.luau:5:12-18 ──
+   │
+ 5 │ 	local y = 10 / 0
+   │            ^^^^^^
+   │
+]]
+		assert.strcontains(result.stdout, expected)
+
+		expected = [[
+violator.luau:8:11-16 ──
+   │
+ 8 │ 	local z = 1 / 0
+   │              ^^^^^
+   │
+]]
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
+	suite:case("suppression is limited to following statement2", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+local x = 1 / 0
+
+-- lute-lint-ignore(divide_by_zero)
+if true then
+	local y = 10 / 0
+end
+
+local z = 1 / 0
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "-r", divideByZeroExample, violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.strcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.", nil, 2)
+		local expected = [[
+violator.luau:1:11-16 ──
+   │
+ 1 │ local x = 1 / 0
+   │           ^^^^^
+   │
+]]
+		assert.strcontains(result.stdout, expected)
+
+		expected = [[
+violator.luau:8:11-16 ──
+   │
+ 8 │ local z = 1 / 0
+   │           ^^^^^
+   │
+]]
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
 end)
 
 test.run()

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -797,6 +797,38 @@ violator.luau:3:1-4:6 ──
 		-- Teardown
 		fs.remove(violatorPath)
 	end)
+
+	suite:case("nested suppressions", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+-- lute-lint-ignore(divide_by_zero)
+local function foo()
+    local x = 1/0
+    local function bar()
+        -- lute-lint-ignore(almost_swapped)
+        a = b
+		b = a
+    end
+end
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", violatorPath })
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.strnotcontains(result.stdout, "warning[almost_swapped]: This looks like a failed attempt to swap.")
+		assert.strnotcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.")
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
 end)
 
 test.run()

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -446,6 +446,50 @@ violator.luau:3:1-4:6 ──
 		-- Teardown
 		fs.remove(violatorPath)
 	end)
+
+	suite:case("lute lint warning suppression", function(assert)
+		-- Create a file that violates the default almost_swapped and divide_by_zero rules
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+-- lute-lint-ignore(divide_by_zero)
+local x = 1 / 0
+
+-- lute-lint-ignore(divide_by_zero)
+if true then
+	local y = 10 / 0
+end
+
+a = b
+b = a
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+		print(result.stdout)
+
+		assert.strnotcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.")
+
+		assert.strcontains(result.stdout, "warning[almost_swapped]: This looks like a failed attempt to swap.")
+		local expected = [[
+violator.luau:9:1-10:6 ──
+    │
+ 9  │ ╭ a = b
+ 10 │ │ b = a
+    │ ╰─────^
+    │
+]]
+		assert.strcontains(result.stdout, expected)
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
 end)
 
 test.run()

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -528,10 +528,11 @@ violator.luau:5:12-18 ──
 		expected = [[
 violator.luau:8:11-16 ──
    │
- 8 │ 	local z = 1 / 0
-   │              ^^^^^
+ 8 │ local z = 1 / 0
+   │           ^^^^^
    │
 ]]
+		assert.strcontains(result.stdout, expected)
 
 		-- Teardown
 		fs.remove(violatorPath)
@@ -579,6 +580,219 @@ violator.luau:8:11-16 ──
    │           ^^^^^
    │
 ]]
+		assert.strcontains(result.stdout, expected)
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
+	suite:case("suppression is limited to following statement3", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+local function foo()
+	-- lute-lint-ignore(divide_by_zero)
+	local y = 3 / 0
+
+	return 3 / 0
+end
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "-r", divideByZeroExample, violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.strcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.", nil, 1)
+		local expected = [[
+violator.luau:5:9-14 ──
+   │
+ 5 │ 	return 3 / 0
+   │         ^^^^^
+   │
+]]
+		assert.strcontains(result.stdout, expected)
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
+	suite:case("suppression is limited to following statement4", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+if true then
+	-- lute-lint-ignore(divide_by_zero)
+	local y = 3 / 0
+
+	return 3 / 0
+end
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "-r", divideByZeroExample, violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.strcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.", nil, 1)
+		local expected = [[
+violator.luau:5:9-14 ──
+   │
+ 5 │ 	return 3 / 0
+   │         ^^^^^
+   │
+]]
+		assert.strcontains(result.stdout, expected)
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
+	suite:case("suppression is limited to following statement5", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+while true do
+	-- lute-lint-ignore(divide_by_zero)
+	local y = 3 / 0
+
+	return 3 / 0
+end
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "-r", divideByZeroExample, violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.strcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.", nil, 1)
+		local expected = [[
+violator.luau:5:9-14 ──
+   │
+ 5 │ 	return 3 / 0
+   │         ^^^^^
+   │
+]]
+		assert.strcontains(result.stdout, expected)
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
+	suite:case("suppression is limited to following statement6", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+local t = {}
+for _, _ in t do
+	-- lute-lint-ignore(divide_by_zero)
+	local y = 3 / 0
+
+	return 3 / 0
+end
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "-r", divideByZeroExample, violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.strcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.", nil, 1)
+		local expected = [[
+violator.luau:6:9-14 ──
+   │
+ 6 │ 	return 3 / 0
+   │         ^^^^^
+   │
+]]
+		assert.strcontains(result.stdout, expected)
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
+	suite:case("suppression for multi node violation", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+-- lute-lint-ignore(almost_swapped)
+a = b
+b = a
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.strnotcontains(result.stdout, "warning[almost_swapped]: This looks like a failed attempt to swap.")
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
+	suite:case("suppression for multi node violation", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+-- lute-lint-ignore(almost_swapped)
+a = b
+b = a
+a = b
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", violatorPath })
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.strcontains(result.stdout, "warning[almost_swapped]: This looks like a failed attempt to swap.", nil, 1)
+
+		local expected = [[
+violator.luau:3:1-4:6 ──
+   │
+ 3 │ ╭ b = a
+ 4 │ │ a = b
+   │ ╰─────^
+   │
+]]
+
+		assert.strcontains(result.stdout, expected)
 
 		-- Teardown
 		fs.remove(violatorPath)


### PR DESCRIPTION
Implement warning suppression by checking if any ancestor nodes contain leading trivia with comments which suppress the relevant rule. This lets us do nice things like suppress in the following case:
```luau
-- lute-lint-ignore(divide_by_zero)
if true then
	local y = 10 / 0
end
```

The story is a bit more complicated with violations which span multiple nodes: We check if there are any suppressing nodes which subsume the violation, _or_ whether the first node completely contained in the violation suppresses the warning. This is roughly similar to what Selene does, and allows suppressing cases like the following:
```luau
-- lute-lint-ignore(almost_swapped)
a = b
b = a
```
We'll need some follow up work to do (file) global warning suppression.
