### PR TITLE
tidy: Lute shouldn't pull in the filesystem header

### DIFF
--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(Lute.CLI.lib STATIC)
 target_sources(Lute.CLI.lib PRIVATE
     include/lute/climain.h
     include/lute/compile.h
+    include/lute/fileutils.h
     include/lute/luauflags.h
     include/lute/reporter.h
     include/lute/staticrequires.h
@@ -33,6 +34,7 @@ target_sources(Lute.CLI.lib PRIVATE
 
     src/climain.cpp
     src/compile.cpp
+    src/fileutils.cpp
     src/luauflags.cpp
     src/staticrequires.cpp
     src/tc.cpp

--- a/lute/cli/include/lute/fileutils.h
+++ b/lute/cli/include/lute/fileutils.h
@@ -1,0 +1,28 @@
+// This file is part of the Lute programming language and is licensed under MIT License
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace Lute
+{
+
+// Open a file with platform-specific handling (wfopen on Windows, fopen elsewhere)
+FILE* openFile(const std::string& path, const char* mode);
+
+// Write string content to a file
+bool writeFile(const std::string& path, const std::string& content);
+
+// Create a directory (non-recursive)
+bool createDirectory(const std::string& path);
+
+// Create directories recursively (equivalent to mkdir -p)
+bool createDirectories(const std::string& path);
+
+// Remove a file
+bool removeFile(const std::string& path);
+
+// Remove a directory (must be empty)
+bool removeDirectory(const std::string& path);
+
+} // namespace Lute

--- a/lute/cli/src/fileutils.cpp
+++ b/lute/cli/src/fileutils.cpp
@@ -11,12 +11,13 @@
 #include <direct.h>
 #include <windows.h>
 #else
-#include <sys/stat.h>
 #include <unistd.h>
+
+#include <sys/stat.h>
 #endif
 
 #include <cstring>
-#include <vector>
+#include "Luau/FileUtils.h"
 
 namespace Lute
 {
@@ -74,58 +75,38 @@ bool createDirectory(const std::string& path)
 #endif
 }
 
-static std::vector<std::string> splitPath(const std::string& path)
-{
-    std::vector<std::string> result;
-    size_t start = 0;
-
-    for (size_t i = 0; i < path.size(); ++i)
-    {
-        if (path[i] == '/' || path[i] == '\\')
-        {
-            if (i > start)
-                result.push_back(path.substr(start, i - start));
-            start = i + 1;
-        }
-    }
-
-    if (start < path.size())
-        result.push_back(path.substr(start));
-
-    return result;
-}
-
 bool createDirectories(const std::string& path)
 {
     if (path.empty())
         return false;
 
-    std::vector<std::string> components = splitPath(path);
+    std::vector<std::string_view> components = splitPath(path);
     std::string currentPath;
+    size_t offset = 0;
 
-    // Handle absolute paths
+    // Handle absolute paths - extract the root/prefix
+    if (isAbsolutePath(path))
+    {
 #ifdef _WIN32
-    // Check if path starts with drive letter (e.g., "C:")
-    if (path.size() >= 2 && path[1] == ':')
-    {
-        currentPath = path.substr(0, 2);
-    }
-    else if (path.size() >= 1 && (path[0] == '/' || path[0] == '\\'))
-    {
-        currentPath = path.substr(0, 1);
-    }
+        // Check if path starts with drive letter (e.g., "C:")
+        if (path.size() >= 2 && path[1] == ':')
+        {
+            currentPath = path.substr(0, 2);
+            offset = 1; // Skip the drive letter component in the loop
+        }
+        else if (path.size() >= 1 && (path[0] == '/' || path[0] == '\\'))
+        {
+            currentPath = path.substr(0, 1);
+        }
 #else
-    if (path.size() >= 1 && path[0] == '/')
-    {
         currentPath = "/";
-    }
 #endif
+    }
 
-    for (const std::string& component : components)
+    for (size_t i = offset; i < components.size(); ++i)
     {
-        if (!currentPath.empty() && currentPath.back() != '/' && currentPath.back() != '\\')
-            currentPath += '/';
-        currentPath += component;
+        const std::string_view component = components[i];
+        currentPath = joinPaths(currentPath, component);
 
         if (!createDirectory(currentPath))
         {

--- a/lute/cli/src/fileutils.cpp
+++ b/lute/cli/src/fileutils.cpp
@@ -1,0 +1,165 @@
+// This file is part of the Lute programming language and is licensed under MIT License
+#include "lute/fileutils.h"
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <direct.h>
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
+
+#include <cstring>
+#include <vector>
+
+namespace Lute
+{
+
+#ifdef _WIN32
+static std::wstring fromUtf8(const std::string& path)
+{
+    if (path.empty())
+        return std::wstring();
+
+    size_t result = MultiByteToWideChar(CP_UTF8, 0, path.data(), int(path.size()), nullptr, 0);
+    if (result == 0)
+        return std::wstring();
+
+    std::wstring buf(result, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, path.data(), int(path.size()), &buf[0], int(buf.size()));
+
+    return buf;
+}
+#endif
+
+FILE* openFile(const std::string& path, const char* mode)
+{
+#ifdef _WIN32
+    std::wstring wpath = fromUtf8(path);
+    std::wstring wmode = fromUtf8(mode);
+    if (wpath.empty() || wmode.empty())
+        return nullptr;
+    return _wfopen(wpath.c_str(), wmode.c_str());
+#else
+    return fopen(path.c_str(), mode);
+#endif
+}
+
+bool writeFile(const std::string& path, const std::string& content)
+{
+    FILE* file = openFile(path, "wb");
+    if (!file)
+        return false;
+
+    bool success = fwrite(content.data(), 1, content.size(), file) == content.size();
+    fclose(file);
+    return success;
+}
+
+bool createDirectory(const std::string& path)
+{
+#ifdef _WIN32
+    std::wstring wpath = fromUtf8(path);
+    if (wpath.empty())
+        return false;
+    return _wmkdir(wpath.c_str()) == 0 || errno == EEXIST;
+#else
+    return mkdir(path.c_str(), 0755) == 0 || errno == EEXIST;
+#endif
+}
+
+static std::vector<std::string> splitPath(const std::string& path)
+{
+    std::vector<std::string> result;
+    size_t start = 0;
+
+    for (size_t i = 0; i < path.size(); ++i)
+    {
+        if (path[i] == '/' || path[i] == '\\')
+        {
+            if (i > start)
+                result.push_back(path.substr(start, i - start));
+            start = i + 1;
+        }
+    }
+
+    if (start < path.size())
+        result.push_back(path.substr(start));
+
+    return result;
+}
+
+bool createDirectories(const std::string& path)
+{
+    if (path.empty())
+        return false;
+
+    std::vector<std::string> components = splitPath(path);
+    std::string currentPath;
+
+    // Handle absolute paths
+#ifdef _WIN32
+    // Check if path starts with drive letter (e.g., "C:")
+    if (path.size() >= 2 && path[1] == ':')
+    {
+        currentPath = path.substr(0, 2);
+    }
+    else if (path.size() >= 1 && (path[0] == '/' || path[0] == '\\'))
+    {
+        currentPath = path.substr(0, 1);
+    }
+#else
+    if (path.size() >= 1 && path[0] == '/')
+    {
+        currentPath = "/";
+    }
+#endif
+
+    for (const std::string& component : components)
+    {
+        if (!currentPath.empty() && currentPath.back() != '/' && currentPath.back() != '\\')
+            currentPath += '/';
+        currentPath += component;
+
+        if (!createDirectory(currentPath))
+        {
+            // Check if the directory already exists
+            if (errno != EEXIST)
+                return false;
+        }
+    }
+
+    return true;
+}
+
+bool removeFile(const std::string& path)
+{
+#ifdef _WIN32
+    std::wstring wpath = fromUtf8(path);
+    if (wpath.empty())
+        return false;
+    return _wunlink(wpath.c_str()) == 0;
+#else
+    return unlink(path.c_str()) == 0;
+#endif
+}
+
+bool removeDirectory(const std::string& path)
+{
+#ifdef _WIN32
+    std::wstring wpath = fromUtf8(path);
+    if (wpath.empty())
+        return false;
+    return _wrmdir(wpath.c_str()) == 0;
+#else
+    return rmdir(path.c_str()) == 0;
+#endif
+}
+
+} // namespace Lute

--- a/tests/src/require.test.cpp
+++ b/tests/src/require.test.cpp
@@ -1,14 +1,12 @@
 #include "lute/climain.h"
 #include "lute/uvutils.h"
+#include "lute/fileutils.h"
 
 #include "Luau/FileUtils.h"
 
 #include "lua.h"
 
 #include "uv.h"
-
-#include <filesystem>
-#include <fstream>
 
 #include "cliruntimefixture.h"
 #include "doctest.h"
@@ -240,15 +238,12 @@ TEST_CASE_FIXTURE(LuteFixture, "require_check_tilde_path")
     std::string homeDir = *result.get_if<std::string>();
 
     // Create test directory and test file
-    std::filesystem::path testDir = std::filesystem::path(homeDir) / "lute_test_special";
-    std::filesystem::path testFile = testDir / "foo.luau";
-    std::filesystem::create_directories(testDir);
+    std::string testDir = joinPaths(homeDir, "lute_test_special");
+    std::string testFile = joinPaths(testDir, "foo.luau");
+    REQUIRE(Lute::createDirectories(testDir));
 
     // Write test module file
-    std::ofstream file(testFile);
-    REQUIRE(file.is_open());
-    file << "return { foo = \"bar\" }\n";
-    file.close();
+    REQUIRE(Lute::writeFile(testFile, "return { foo = \"bar\" }\n"));
 
     // Run the test
     for (const std::string& luteProjectRoot : {getLuteProjectRootRelative(), getLuteProjectRootAbsolute()})
@@ -259,6 +254,6 @@ TEST_CASE_FIXTURE(LuteFixture, "require_check_tilde_path")
     }
 
     // Clean up
-    std::filesystem::remove(testFile);
-    std::filesystem::remove(testDir);
+    Lute::removeFile(testFile);
+    Lute::removeDirectory(testDir);
 }

--- a/tests/src/require.test.cpp
+++ b/tests/src/require.test.cpp
@@ -1,6 +1,6 @@
 #include "lute/climain.h"
-#include "lute/uvutils.h"
 #include "lute/fileutils.h"
+#include "lute/uvutils.h"
 
 #include "Luau/FileUtils.h"
 


### PR DESCRIPTION
This [PR](https://github.com/luau-lang/lute/pull/573) introduced a dependency on `std::filesystem` in the `Lute.Test` target. There are some known problems with this header, and it was suggested in that PR by @aatxe that we should manually implement the platform specific file I/O operations that we need as part of a `FileUtils` library in lute, so that we can remove our dependency on this header. This PR implements the necessary operations that we need and removes our dependency on `std::filesystem`.