### PR TITLE
Infra: opt out of concurrency grouping for CI running on the `primary` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,10 @@ on:
   pull_request:
     branches: ["primary"]
 
+# CI on the "primary" branch opts out of concurrency grouping by using the run's
+# unique run_id.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/primary' && github.run_id || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
If two PRs are merged in to `primary` close to each other, our CI badge temporarily switches to a failing icon because our concurrency grouping logic cancels the first commit's CI run (treated as a failure). Instead, we opt out of concurrency grouping using the run's unique `run_id` if the current ref matches the ref pointed at by `primary`.