### PR TITLE
Add `resolverequire` API to standard library with filepath semantics

### DIFF
--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -38,4 +38,9 @@ function luau.typeofmodule(modulepath: path.pathlike): string
 	return luteLuau.typeofmodule(modulePathStr)
 end
 
+function luau.resolverequire(modulepath: string, frompath: path.pathlike): string
+	local frompathString = if typeof(frompath) == "string" then frompath else path.format(frompath)
+	return luteLuau.resolverequire(modulepath, `@{frompathString}`)
+end
+
 return luau


### PR DESCRIPTION
Internally, we simply need to prepend a `@` to the filepath to create a valid chunkname, but the new API does this automatically to hide the chunkname implementation details from users.