### PR TITLE
lute lint: fix tab pretty printing

### DIFF
--- a/lute/cli/commands/lint/printer.luau
+++ b/lute/cli/commands/lint/printer.luau
@@ -1,8 +1,11 @@
 local fs = require("@std/fs")
 local path = require("@std/path")
+local stringext = require("@std/stringext")
 local types = require("./types")
 
 local printerLib = {}
+
+local TAB_SIZE = 4
 
 local function printLint(lint: types.LintViolation, sourceLines: { string }): ()
 	print(`{lint.severity}[{lint.lintname}]: {lint.message}\n`)
@@ -14,7 +17,13 @@ local function printLint(lint: types.LintViolation, sourceLines: { string }): ()
 		local gutterSize = math.floor(math.log10(location.endline)) + 3 -- + 2 for padding around line number
 		local blankGutter = string.rep(" ", gutterSize)
 
-		local sourceLine = ` {location.beginline} │ {sourceLines[location.beginline]}`
+		-- Compute the number of tabs before the violation and within the violation
+		local prelintTabs = stringext.count(sourceLines[location.beginline], "\t", 1, location.begincolumn - 1)
+		local lintTabs =
+			stringext.count(sourceLines[location.beginline], "\t", location.begincolumn, location.endcolumn)
+		-- Convert tabs in the source line to spaces
+		local sourceLine =
+			` {location.beginline} │ {sourceLines[location.beginline]:gsub("\t", string.rep(" ", TAB_SIZE))}`
 
 		local filepathLine =
 			`{blankGutter}┌── {filepath}:{location.beginline}:{location.begincolumn}-{location.endcolumn} ──`
@@ -26,9 +35,9 @@ local function printLint(lint: types.LintViolation, sourceLines: { string }): ()
 		print(`{blankGutter}│`)
 		print(sourceLine)
 		print(
-			`{blankGutter}│ {string.rep(" ", location.begincolumn - 1)}{string.rep(
+			`{blankGutter}│ {string.rep(" ", location.begincolumn - 1 + (prelintTabs * (TAB_SIZE - 1)))}{string.rep(
 				"^",
-				location.endcolumn - location.begincolumn
+				location.endcolumn - location.begincolumn + (lintTabs * (TAB_SIZE - 1))
 			)}`
 		)
 		print(`{blankGutter}│`)

--- a/lute/cli/commands/lint/printer.luau
+++ b/lute/cli/commands/lint/printer.luau
@@ -46,13 +46,16 @@ local function printLint(lint: types.LintViolation, sourceLines: { string }): ()
 		local gutterSize = math.floor(math.log10(location.endline)) + 3 -- + 2 for padding around line number
 		local blankGutter = string.rep(" ", gutterSize)
 
-		local renderedSourceLines =
-			{ ` {string.format(`%-{gutterSize - 2}d`, location.beginline)} │ ╭ {sourceLines[location.beginline]}` }
+		local subbedSourceLine = sourceLines[location.beginline]:gsub("\t", string.rep(" ", TAB_SIZE))
+		local renderedSourceLines = {
+			` {string.format(`%-{gutterSize - 2}d`, location.beginline)} │ ╭ {subbedSourceLine}`,
+		}
 		local maxSourceLineLength = #renderedSourceLines[1]
 		for lineNum = location.beginline + 1, location.endline do
+			subbedSourceLine = sourceLines[lineNum]:gsub("\t", string.rep(" ", TAB_SIZE))
 			table.insert(
 				renderedSourceLines,
-				` {string.format(`%-{gutterSize - 2}d`, lineNum)} │ │ {sourceLines[lineNum]}`
+				` {string.format(`%-{gutterSize - 2}d`, lineNum)} │ │ {subbedSourceLine}`
 			)
 			maxSourceLineLength = math.max(maxSourceLineLength, #renderedSourceLines[#renderedSourceLines])
 		end
@@ -68,7 +71,7 @@ local function printLint(lint: types.LintViolation, sourceLines: { string }): ()
 		for _, line in renderedSourceLines do
 			print(line)
 		end
-		print(`{blankGutter}│ ╰─{string.rep("─", location.endcolumn - 2)}^`)
+		print(`{blankGutter}│ ╰{string.rep("─", maxSourceLineLength - gutterSize - 8)}^`)
 		print(`{blankGutter}│`)
 		print()
 	end

--- a/lute/std/libs/stringext.luau
+++ b/lute/std/libs/stringext.luau
@@ -38,4 +38,22 @@ function stringext.trim(str: string): string
 	return str:match("^%s*(.-)%s*$") :: string
 end
 
+-- Counts the number of occurrences of pattern in str between startPos and endPos (inclusive)
+function stringext.count(str: string, pattern: string, startPos: number?, endPos: number?): number
+	if startPos and endPos then
+		str = str:sub(startPos, endPos)
+	elseif startPos then
+		str = str:sub(startPos)
+	elseif endPos then
+		str = str:sub(1, endPos)
+	end
+
+	local count = 0
+	for _ in str:gmatch(pattern) do
+		count += 1
+	end
+
+	return count
+end
+
 return table.freeze(stringext)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -519,8 +519,8 @@ local z = 1 / 0
 		local expected = [[
 violator.luau:5:12-18 ──
    │
- 5 │ 	local y = 10 / 0
-   │            ^^^^^^
+ 5 │     local y = 10 / 0
+   │               ^^^^^^
    │
 ]]
 		assert.strcontains(result.stdout, expected)
@@ -613,8 +613,8 @@ end
 		local expected = [[
 violator.luau:5:9-14 ──
    │
- 5 │ 	return 3 / 0
-   │         ^^^^^
+ 5 │     return 3 / 0
+   │            ^^^^^
    │
 ]]
 		assert.strcontains(result.stdout, expected)
@@ -650,8 +650,8 @@ end
 		local expected = [[
 violator.luau:5:9-14 ──
    │
- 5 │ 	return 3 / 0
-   │         ^^^^^
+ 5 │     return 3 / 0
+   │            ^^^^^
    │
 ]]
 		assert.strcontains(result.stdout, expected)
@@ -687,8 +687,8 @@ end
 		local expected = [[
 violator.luau:5:9-14 ──
    │
- 5 │ 	return 3 / 0
-   │         ^^^^^
+ 5 │     return 3 / 0
+   │            ^^^^^
    │
 ]]
 		assert.strcontains(result.stdout, expected)
@@ -725,8 +725,8 @@ end
 		local expected = [[
 violator.luau:6:9-14 ──
    │
- 6 │ 	return 3 / 0
-   │         ^^^^^
+ 6 │     return 3 / 0
+   │            ^^^^^
    │
 ]]
 		assert.strcontains(result.stdout, expected)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -148,9 +148,9 @@ violator.luau:10:1-11:10 ──
 		expected = [[
 violator.luau:14:2-15:17 ──
     │
- 14 │ ╭ 	t["a"] = t["b"]
- 15 │ │ 	t["b"] = t["a"]
-    │ ╰────────────────^
+ 14 │ ╭     t["a"] = t["b"]
+ 15 │ │     t["b"] = t["a"]
+    │ ╰───────────────────^
     │
 ]] -- todo: address tab shenanigans
 		assert.strcontains(result.stdout, expected)

--- a/tests/std/stringext.test.luau
+++ b/tests/std/stringext.test.luau
@@ -24,6 +24,17 @@ test.suite("StringExt", function(suite)
 		assert.eq(stringext.trim(""), "")
 		assert.eq(stringext.trim("   "), "")
 	end)
+
+	suite:case("count", function(assert)
+		assert.eq(stringext.count("hello world", "o"), 2)
+		assert.eq(stringext.count("hello world", "l", 4), 2) -- from position 4 to end
+		assert.eq(stringext.count("hello world", "l", nil, 5), 2) -- from start to position 5
+		assert.eq(stringext.count("hello world", "l", 4, 9), 1) -- from position 4 to position 9
+		assert.eq(stringext.count("aaaaaa", "aa"), 3) -- overlapping patterns
+		assert.eq(stringext.count("no matches here", "z"), 0)
+		assert.eq(stringext.count("hello world", "%s"), 1) -- patterns supported too
+		assert.eq(stringext.count("hello world", "[hw]"), 2) -- count h and w
+	end)
 end)
 
 test.run()


### PR DESCRIPTION
Fix tab pretty printing by substituting them with 4 spaces + other adjustments. I added `stringext.count` along the way 