### PR TITLE
Lute.Require: delete all "fake root" logic and replace with new `to_alias_fallback` Luau.Require API

### DIFF
--- a/lute/require/include/lute/packagerequirevfs.h
+++ b/lute/require/include/lute/packagerequirevfs.h
@@ -16,6 +16,7 @@ public:
 
     NavigationStatus reset(lua_State* L, std::string_view requirerChunkname) override;
     NavigationStatus jumpToAlias(lua_State* L, std::string_view path) override;
+    NavigationStatus toAliasFallback(lua_State* L, std::string_view aliasUnprefixed) override;
 
     NavigationStatus toParent(lua_State* L) override;
     NavigationStatus toChild(lua_State* L, std::string_view name) override;
@@ -48,8 +49,6 @@ private:
     Package::UserlandVfs userlandVfs;
     StdLibVfs stdLibVfs;
     std::string lutePath;
-
-    bool atFakeRoot = false;
 };
 
 } // namespace Package

--- a/lute/require/include/lute/require.h
+++ b/lute/require/include/lute/require.h
@@ -18,6 +18,7 @@ public:
 
     virtual NavigationStatus reset(lua_State* L, std::string_view requirerChunkname) = 0;
     virtual NavigationStatus jumpToAlias(lua_State* L, std::string_view path) = 0;
+    virtual NavigationStatus toAliasFallback(lua_State* L, std::string_view aliasUnprefixed) = 0;
 
     virtual NavigationStatus toParent(lua_State* L) = 0;
     virtual NavigationStatus toChild(lua_State* L, std::string_view name) = 0;

--- a/lute/require/include/lute/requirevfs.h
+++ b/lute/require/include/lute/requirevfs.h
@@ -23,6 +23,7 @@ public:
 
     NavigationStatus reset(lua_State* L, std::string_view requirerChunkname) override;
     NavigationStatus jumpToAlias(lua_State* L, std::string_view path) override;
+    NavigationStatus toAliasFallback(lua_State* L, std::string_view aliasUnprefixed) override;
 
     NavigationStatus toParent(lua_State* L) override;
     NavigationStatus toChild(lua_State* L, std::string_view name) override;
@@ -59,6 +60,4 @@ private:
     std::optional<CliVfs> cliVfs = std::nullopt;
     std::optional<BundleVfs> bundleVfs = std::nullopt;
     std::string lutePath;
-
-    bool atFakeRoot = false;
 };

--- a/lute/require/include/lute/userlandvfs.h
+++ b/lute/require/include/lute/userlandvfs.h
@@ -3,7 +3,9 @@
 #include "lute/filevfs.h"
 #include "lute/modulepath.h"
 
-#include <map>
+#include "Luau/DenseHash.h"
+#include "Luau/StringUtils.h"
+
 #include <optional>
 #include <string>
 #include <utility>
@@ -17,9 +19,17 @@ struct Identifier
     std::string name;
     std::string version;
 
-    bool operator<(const Identifier& other) const
+    bool operator==(const Identifier& other) const
     {
-        return std::tie(name, version) < std::tie(other.name, other.version);
+        return std::tie(name, version) == std::tie(other.name, other.version);
+    }
+};
+
+struct IdentifierHashDefault
+{
+    size_t operator()(const Identifier& id) const
+    {
+        return Luau::detail::DenseHashDefault<std::string>()(Luau::format("%s:%s", id.name.c_str(), id.version.c_str()));
     }
 };
 
@@ -73,7 +83,9 @@ public:
     std::string getCurrentPath() const;
 
 private:
-    UserlandVfs(std::vector<Identifier> directDependencies, std::map<Identifier, Info> allDependencies);
+    using DependencyMap = Luau::DenseHashMap<Identifier, Info, IdentifierHashDefault>;
+
+    UserlandVfs(std::vector<Identifier> directDependencies, DependencyMap allDependencies);
 
     NavigationStatus jumpToDependencySubtree(const Identifier& dependency);
 
@@ -89,7 +101,7 @@ private:
     std::optional<Subtree> currentSubtree = std::nullopt;
 
     std::vector<Identifier> directDependencies;
-    std::map<Identifier, Info> allDependencies;
+    DependencyMap allDependencies;
 };
 
 } // namespace Package

--- a/lute/require/include/lute/userlandvfs.h
+++ b/lute/require/include/lute/userlandvfs.h
@@ -44,13 +44,13 @@ public:
     bool isModulePresent() const;
 
     std::string getCurrentPath() const;
+    Info getInfo() const;
 
 private:
-    Subtree(ModulePath currentModulePath, std::string generatedRootLuaurc);
+    Subtree(ModulePath currentModulePath, Info info);
 
     ModulePath currentModulePath;
-    std::string generatedRootLuaurc;
-    bool atGeneratedRoot = false;
+    Info info;
 };
 
 class UserlandVfs
@@ -59,7 +59,7 @@ public:
     static UserlandVfs create(std::vector<Identifier> directDependencies, std::vector<std::pair<Identifier, Info>> allDependencies);
 
     NavigationStatus resetToPath(const std::string& path);
-    NavigationStatus jumpToDependencySubtree(const std::string& identifierStringified);
+    NavigationStatus toAliasFallback(std::string_view aliasUnprefixed);
 
     NavigationStatus toParent();
     NavigationStatus toChild(const std::string& name);
@@ -73,8 +73,9 @@ public:
     std::string getCurrentPath() const;
 
 private:
-    UserlandVfs(std::map<Identifier, Info> allDependencies, std::string generatedRootLuaurc);
-    NavigationStatus jumpToDependencySubtreeImpl(Identifier identifier);
+    UserlandVfs(std::vector<Identifier> directDependencies, std::map<Identifier, Info> allDependencies);
+
+    NavigationStatus jumpToDependencySubtree(const Identifier& dependency);
 
     enum class VFSType
     {
@@ -86,10 +87,9 @@ private:
 
     FileVfs fileVfs;
     std::optional<Subtree> currentSubtree = std::nullopt;
-    std::map<Identifier, Info> allDependencies;
 
-    bool atDiskFakeRoot = false;
-    std::string generatedRootLuaurc;
+    std::vector<Identifier> directDependencies;
+    std::map<Identifier, Info> allDependencies;
 };
 
 } // namespace Package

--- a/lute/require/src/clivfs.cpp
+++ b/lute/require/src/clivfs.cpp
@@ -23,6 +23,9 @@ static std::optional<std::string> readCliModule(const std::string& path)
 
 static bool isCliDirectory(const std::string& path)
 {
+    if (path == "@cli")
+        return true;
+
     CliModuleResult result = getCliModule(path);
     return result.type == CliModuleType::Directory;
 }

--- a/lute/require/src/packagerequirevfs.cpp
+++ b/lute/require/src/packagerequirevfs.cpp
@@ -26,8 +26,6 @@ bool RequireVfs::isRequireAllowed(lua_State* L, std::string_view requirerChunkna
 
 NavigationStatus RequireVfs::reset(lua_State* L, std::string_view requirerChunkname)
 {
-    atFakeRoot = false;
-
     if ((requirerChunkname.size() >= 6 && requirerChunkname.substr(0, 6) == "@@std/"))
     {
         vfsType = VFSType::Std;
@@ -49,25 +47,6 @@ NavigationStatus RequireVfs::reset(lua_State* L, std::string_view requirerChunkn
 
 NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
 {
-    if (path == "$std")
-    {
-        atFakeRoot = false;
-        vfsType = VFSType::Std;
-        return stdLibVfs.resetToPath("@std");
-    }
-    else if (path == "$lute")
-    {
-        vfsType = VFSType::Lute;
-        lutePath = "@lute";
-        return NavigationStatus::Success;
-    }
-    else if (!path.empty() && path[0] == '$')
-    {
-        // "$name:version" is interpreted as an identifier.
-        vfsType = VFSType::Userland;
-        return userlandVfs.jumpToDependencySubtree(std::string(path));
-    }
-
     NavigationStatus status = NavigationStatus::NotFound;
     switch (vfsType)
     {
@@ -81,6 +60,24 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
         break;
     }
     return status;
+}
+
+NavigationStatus RequireVfs::toAliasFallback(lua_State* L, std::string_view aliasUnprefixed)
+{
+    if (aliasUnprefixed == "std")
+    {
+        vfsType = VFSType::Std;
+        return stdLibVfs.resetToPath("@std");
+    }
+    else if (aliasUnprefixed == "lute")
+    {
+        vfsType = VFSType::Lute;
+        lutePath = "@lute";
+        return NavigationStatus::Success;
+    }
+
+    vfsType = VFSType::Userland;
+    return userlandVfs.toAliasFallback(aliasUnprefixed);
 }
 
 NavigationStatus RequireVfs::toParent(lua_State* L)
@@ -98,22 +95,11 @@ NavigationStatus RequireVfs::toParent(lua_State* L)
         luaL_error(L, "cannot get the parent of @lute");
     }
 
-    if (status == NavigationStatus::NotFound)
-    {
-        if (atFakeRoot)
-            return NavigationStatus::NotFound;
-
-        atFakeRoot = true;
-        return NavigationStatus::Success;
-    }
-
     return status;
 }
 
 NavigationStatus RequireVfs::toChild(lua_State* L, std::string_view name)
 {
-    atFakeRoot = false;
-
     switch (vfsType)
     {
     case VFSType::Userland:
@@ -212,9 +198,6 @@ std::string RequireVfs::getCacheKey(lua_State* L) const
 
 ConfigStatus RequireVfs::getConfigStatus(lua_State* L) const
 {
-    if (atFakeRoot)
-        return ConfigStatus::PresentJson;
-
     ConfigStatus status = ConfigStatus::Ambiguous;
     switch (vfsType)
     {
@@ -232,17 +215,6 @@ ConfigStatus RequireVfs::getConfigStatus(lua_State* L) const
 
 std::string RequireVfs::getConfig(lua_State* L) const
 {
-    if (atFakeRoot)
-    {
-        std::string globalConfig = "{\n"
-                                   "    \"aliases\": {\n"
-                                   "        \"std\": \"$std\",\n"
-                                   "        \"lute\": \"$lute\",\n"
-                                   "    }\n"
-                                   "}\n";
-        return globalConfig;
-    }
-
     std::optional<std::string> configContents;
     switch (vfsType)
     {

--- a/lute/require/src/require.cpp
+++ b/lute/require/src/require.cpp
@@ -87,6 +87,12 @@ static luarequire_NavigateResult jump_to_alias(lua_State* L, void* ctx, const ch
     return convert(reqCtx->vfs->jumpToAlias(L, path));
 }
 
+static luarequire_NavigateResult to_alias_fallback(lua_State* L, void* ctx, const char* alias_unprefixed)
+{
+    RequireCtx* reqCtx = static_cast<RequireCtx*>(ctx);
+    return convert(reqCtx->vfs->toAliasFallback(L, alias_unprefixed));
+}
+
 static luarequire_NavigateResult to_parent(lua_State* L, void* ctx)
 {
     RequireCtx* reqCtx = static_cast<RequireCtx*>(ctx);
@@ -205,6 +211,7 @@ void requireConfigInit(luarequire_Configuration* config)
     config->is_require_allowed = is_require_allowed;
     config->reset = reset;
     config->jump_to_alias = jump_to_alias;
+    config->to_alias_fallback = to_alias_fallback;
     config->to_parent = to_parent;
     config->to_child = to_child;
     config->is_module_present = is_module_present;

--- a/lute/require/src/requirevfs.cpp
+++ b/lute/require/src/requirevfs.cpp
@@ -30,8 +30,6 @@ bool RequireVfs::isRequireAllowed(lua_State* L, std::string_view requirerChunkna
 
 NavigationStatus RequireVfs::reset(lua_State* L, std::string_view requirerChunkname)
 {
-    atFakeRoot = false;
-
     if ((requirerChunkname.size() >= 6 && requirerChunkname.substr(0, 6) == "@@std/"))
     {
         vfsType = VFSType::Std;
@@ -64,19 +62,6 @@ NavigationStatus RequireVfs::reset(lua_State* L, std::string_view requirerChunkn
 
 NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
 {
-    if (path == "$std")
-    {
-        atFakeRoot = false;
-        vfsType = VFSType::Std;
-        return stdLibVfs.resetToPath("@std");
-    }
-    else if (path == "$lute")
-    {
-        vfsType = VFSType::Lute;
-        lutePath = "@lute";
-        return NavigationStatus::Success;
-    }
-
     NavigationStatus status = NavigationStatus::NotFound;
     switch (vfsType)
     {
@@ -100,10 +85,26 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
     return status;
 }
 
+NavigationStatus RequireVfs::toAliasFallback(lua_State* L, std::string_view aliasUnprefixed)
+{
+    if (aliasUnprefixed == "std")
+    {
+        vfsType = VFSType::Std;
+        return stdLibVfs.resetToPath("@std");
+    }
+    else if (aliasUnprefixed == "lute")
+    {
+        vfsType = VFSType::Lute;
+        lutePath = "@lute";
+        return NavigationStatus::Success;
+    }
+
+    return NavigationStatus::NotFound;
+}
+
 NavigationStatus RequireVfs::toParent(lua_State* L)
 {
     NavigationStatus status = NavigationStatus::NotFound;
-
     switch (vfsType)
     {
     case VFSType::Disk:
@@ -124,23 +125,11 @@ NavigationStatus RequireVfs::toParent(lua_State* L)
         luaL_error(L, "cannot get the parent of @lute");
         break;
     }
-
-    if (status == NavigationStatus::NotFound)
-    {
-        if (atFakeRoot)
-            return NavigationStatus::NotFound;
-
-        atFakeRoot = true;
-        return NavigationStatus::Success;
-    }
-
     return status;
 }
 
 NavigationStatus RequireVfs::toChild(lua_State* L, std::string_view name)
 {
-    atFakeRoot = false;
-
     switch (vfsType)
     {
     case VFSType::Disk:
@@ -157,7 +146,6 @@ NavigationStatus RequireVfs::toChild(lua_State* L, std::string_view name)
         luaL_error(L, "'%s' is not a lute library", std::string(name).c_str());
         break;
     }
-
     return NavigationStatus::NotFound;
 }
 
@@ -287,9 +275,6 @@ std::string RequireVfs::getCacheKey(lua_State* L) const
 
 ConfigStatus RequireVfs::getConfigStatus(lua_State* L) const
 {
-    if (atFakeRoot)
-        return ConfigStatus::PresentJson;
-
     ConfigStatus status = ConfigStatus::Absent;
     switch (vfsType)
     {
@@ -315,17 +300,6 @@ ConfigStatus RequireVfs::getConfigStatus(lua_State* L) const
 
 std::string RequireVfs::getConfig(lua_State* L) const
 {
-    if (atFakeRoot)
-    {
-        std::string globalConfig = "{\n"
-                                   "    \"aliases\": {\n"
-                                   "        \"std\": \"$std\",\n"
-                                   "        \"lute\": \"$lute\",\n"
-                                   "    }\n"
-                                   "}\n";
-        return globalConfig;
-    }
-
     std::optional<std::string> configContents;
     switch (vfsType)
     {

--- a/lute/require/src/userlandvfs.cpp
+++ b/lute/require/src/userlandvfs.cpp
@@ -13,21 +13,10 @@
 namespace Package
 {
 
-static std::string generateRootLuaurc(const std::vector<Identifier>& dependencies)
-{
-    std::string rootLuaurc = "{\n    \"aliases\": {\n";
-    for (const Identifier& dep : dependencies)
-    {
-        rootLuaurc += "        \"" + dep.name + "\": \"$" + dep.name + ":" + dep.version + "\",\n";
-    }
-    rootLuaurc += "    }\n}\n";
-    return rootLuaurc;
-}
-
 std::optional<Subtree> Subtree::create(Info info)
 {
     std::string_view entryFile = info.entryFile;
-    if (entryFile.find(info.rootDirectory) != 0)
+    if (entryFile.rfind(info.rootDirectory, 0) != 0)
         return std::nullopt;
 
     if (entryFile.size() <= info.rootDirectory.size())
@@ -42,41 +31,27 @@ std::optional<Subtree> Subtree::create(Info info)
     if (!currentModulePath)
         return std::nullopt;
 
-    return Subtree{std::move(*currentModulePath), generateRootLuaurc(info.dependencies)};
+    return Subtree{std::move(*currentModulePath), std::move(info)};
 }
 
-Subtree::Subtree(ModulePath currentModulePath, std::string generatedRootLuaurc)
+Subtree::Subtree(ModulePath currentModulePath, Info info)
     : currentModulePath(std::move(currentModulePath))
-    , generatedRootLuaurc(std::move(generatedRootLuaurc))
+    , info(std::move(info))
 {
 }
 
 NavigationStatus Subtree::toParent()
 {
-    NavigationStatus status = currentModulePath.toParent();
-    if (status == NavigationStatus::NotFound)
-    {
-        if (atGeneratedRoot)
-            return NavigationStatus::NotFound;
-
-        atGeneratedRoot = true;
-        return NavigationStatus::Success;
-    }
-
-    return status;
+    return currentModulePath.toParent();
 }
 
 NavigationStatus Subtree::toChild(const std::string& name)
 {
-    atGeneratedRoot = false;
     return currentModulePath.toChild(name);
 }
 
 ConfigStatus Subtree::getConfigStatus() const
 {
-    if (atGeneratedRoot)
-        return ConfigStatus::PresentJson;
-
     bool luaurcExists = isFile(currentModulePath.getPotentialConfigPath(Luau::kConfigName));
     bool luauConfigExists = isFile(currentModulePath.getPotentialConfigPath(Luau::kLuauConfigName));
 
@@ -92,9 +67,6 @@ ConfigStatus Subtree::getConfigStatus() const
 
 std::optional<std::string> Subtree::getConfig() const
 {
-    if (atGeneratedRoot)
-        return generatedRootLuaurc;
-
     ConfigStatus status = getConfigStatus();
     LUAU_ASSERT(status == ConfigStatus::PresentJson || status == ConfigStatus::PresentLuau);
 
@@ -108,9 +80,6 @@ std::optional<std::string> Subtree::getConfig() const
 
 bool Subtree::isModulePresent() const
 {
-    if (atGeneratedRoot)
-        return false;
-
     ResolvedRealPath result = currentModulePath.getRealPath();
     if (result.status != NavigationStatus::Success)
         return false;
@@ -127,6 +96,11 @@ std::string Subtree::getCurrentPath() const
     return result.realPath;
 }
 
+Info Subtree::getInfo() const
+{
+    return info;
+}
+
 UserlandVfs UserlandVfs::create(std::vector<Identifier> directDependencies, std::vector<std::pair<Identifier, Info>> allDependencies)
 {
     std::map<Identifier, Info> allDependenciesMap;
@@ -135,12 +109,12 @@ UserlandVfs UserlandVfs::create(std::vector<Identifier> directDependencies, std:
         allDependenciesMap[std::move(identifier)] = std::move(info);
     }
 
-    return UserlandVfs{std::move(allDependenciesMap), generateRootLuaurc(directDependencies)};
+    return UserlandVfs{std::move(directDependencies), std::move(allDependenciesMap)};
 }
 
-UserlandVfs::UserlandVfs(std::map<Identifier, Info> allDependencies, std::string generatedRootLuaurc)
-    : allDependencies(std::move(allDependencies))
-    , generatedRootLuaurc(std::move(generatedRootLuaurc))
+UserlandVfs::UserlandVfs(std::vector<Identifier> directDependencies, std::map<Identifier, Info> allDependencies)
+    : directDependencies(std::move(directDependencies))
+    , allDependencies(std::move(allDependencies))
 {
 }
 
@@ -148,47 +122,50 @@ NavigationStatus UserlandVfs::resetToPath(const std::string& path)
 {
     for (const auto& [identifier, info] : allDependencies)
     {
-        if (path.find(info.rootDirectory) == 0)
-        {
-            return jumpToDependencySubtreeImpl(identifier);
-        }
+        if (path.rfind(info.rootDirectory, 0) == 0)
+            return jumpToDependencySubtree(identifier);
     }
 
     currentSubtree = std::nullopt;
     vfsType = VFSType::Disk;
-    atDiskFakeRoot = false;
 
     return fileVfs.resetToPath(path);
 }
 
-NavigationStatus UserlandVfs::jumpToDependencySubtree(const std::string& identifierStringified)
+NavigationStatus UserlandVfs::toAliasFallback(std::string_view aliasUnprefixed)
 {
-    if (identifierStringified.empty() || identifierStringified[0] != '$')
-        return NavigationStatus::NotFound;
+    std::vector<Identifier> availableDependencies;
+    switch (vfsType)
+    {
+    case VFSType::Disk:
+        availableDependencies = directDependencies;
+        break;
+    case VFSType::Subtree:
+        LUAU_ASSERT(currentSubtree);
+        availableDependencies = currentSubtree->getInfo().dependencies;
+    }
 
-    Identifier identifier;
-    size_t colonPos = identifierStringified.find(':');
-    if (colonPos == std::string::npos)
-        return NavigationStatus::NotFound;
+    for (const Identifier& identifier : availableDependencies)
+    {
+        if (identifier.name == aliasUnprefixed)
+            return jumpToDependencySubtree(identifier);
+    }
 
-    identifier.name = identifierStringified.substr(1, colonPos - 1);
-    identifier.version = identifierStringified.substr(colonPos + 1);
-
-    return jumpToDependencySubtreeImpl(identifier);
+    return NavigationStatus::NotFound;
 }
 
-NavigationStatus UserlandVfs::jumpToDependencySubtreeImpl(Identifier identifier)
+NavigationStatus UserlandVfs::jumpToDependencySubtree(const Identifier& dependency)
 {
-    if (allDependencies.find(identifier) == allDependencies.end())
+    auto it = allDependencies.find(dependency);
+    if (it == allDependencies.end())
         return NavigationStatus::NotFound;
 
-    std::optional<Subtree> st = Subtree::create(allDependencies.at(identifier));
+    std::optional<Subtree> st = Subtree::create(it->second);
     if (!st)
         return NavigationStatus::NotFound;
 
     currentSubtree = std::move(*st);
     vfsType = VFSType::Subtree;
-    atDiskFakeRoot = false;
 
     return NavigationStatus::Success;
 }
@@ -207,22 +184,11 @@ NavigationStatus UserlandVfs::toParent()
         break;
     }
 
-    if (status == NavigationStatus::NotFound)
-    {
-        if (atDiskFakeRoot)
-            return NavigationStatus::NotFound;
-
-        atDiskFakeRoot = true;
-        return NavigationStatus::Success;
-    }
-
     return status;
 }
 
 NavigationStatus UserlandVfs::toChild(const std::string& name)
 {
-    atDiskFakeRoot = false;
-
     NavigationStatus status = NavigationStatus::NotFound;
     switch (vfsType)
     {
@@ -239,9 +205,6 @@ NavigationStatus UserlandVfs::toChild(const std::string& name)
 
 ConfigStatus UserlandVfs::getConfigStatus() const
 {
-    if (atDiskFakeRoot)
-        return ConfigStatus::PresentJson;
-
     ConfigStatus status = ConfigStatus::Ambiguous;
     switch (vfsType)
     {
@@ -258,9 +221,6 @@ ConfigStatus UserlandVfs::getConfigStatus() const
 
 std::optional<std::string> UserlandVfs::getConfig() const
 {
-    if (atDiskFakeRoot)
-        return generatedRootLuaurc;
-
     std::optional<std::string> config;
     switch (vfsType)
     {
@@ -277,9 +237,6 @@ std::optional<std::string> UserlandVfs::getConfig() const
 
 bool UserlandVfs::isModulePresent() const
 {
-    if (atDiskFakeRoot)
-        return false;
-
     bool isPresent = false;
     switch (vfsType)
     {

--- a/lute/require/src/userlandvfs.cpp
+++ b/lute/require/src/userlandvfs.cpp
@@ -103,7 +103,7 @@ Info Subtree::getInfo() const
 
 UserlandVfs UserlandVfs::create(std::vector<Identifier> directDependencies, std::vector<std::pair<Identifier, Info>> allDependencies)
 {
-    std::map<Identifier, Info> allDependenciesMap;
+    DependencyMap allDependenciesMap{{}};
     for (auto& [identifier, info] : allDependencies)
     {
         allDependenciesMap[std::move(identifier)] = std::move(info);
@@ -112,7 +112,7 @@ UserlandVfs UserlandVfs::create(std::vector<Identifier> directDependencies, std:
     return UserlandVfs{std::move(directDependencies), std::move(allDependenciesMap)};
 }
 
-UserlandVfs::UserlandVfs(std::vector<Identifier> directDependencies, std::map<Identifier, Info> allDependencies)
+UserlandVfs::UserlandVfs(std::vector<Identifier> directDependencies, DependencyMap allDependencies)
     : directDependencies(std::move(directDependencies))
     , allDependencies(std::move(allDependencies))
 {
@@ -156,11 +156,11 @@ NavigationStatus UserlandVfs::toAliasFallback(std::string_view aliasUnprefixed)
 
 NavigationStatus UserlandVfs::jumpToDependencySubtree(const Identifier& dependency)
 {
-    auto it = allDependencies.find(dependency);
-    if (it == allDependencies.end())
+    Info* info = allDependencies.find(dependency);
+    if (!info)
         return NavigationStatus::NotFound;
 
-    std::optional<Subtree> st = Subtree::create(it->second);
+    std::optional<Subtree> st = Subtree::create(*info);
     if (!st)
         return NavigationStatus::NotFound;
 


### PR DESCRIPTION
### Problem

The "fake root" hack we use in the `require` virtual filesystem needs to be removed.

1. It's inefficient: it requires us to repeatedly copy an injected `.luaurc` around to require built-in libraries like `@std`.
2. It's difficult to reason about: forces our virtual filesystems to diverge from the structures they're meant to represent.
3. It's semantically incorrect:
    - The presence of a fake root node allows users to `require` "up" (using `../`) into fake filesystem nodes.
    - The existing hack also forces us to inject `.luaurc` files that don't conform to the official spec for `.luaurc` files (e.g. mapping `@std` to `$std` isn't permitted by the spec since aliases must map to paths, but the implementation allows this to avoid being opinionated on what a "valid path" could look like in an abstract context).

### Solution

In [Luau release 0.701](https://github.com/luau-lang/luau/releases/tag/0.701), we introduced a new `to_alias_fallback` API to natively support host-defined aliases, such as Lute's `@std` alias. This PR migrates Lute's require implementations to this new API. This includes `Package::RequireVfs`, which can now automatically redirect aliases to pre-declared dependencies when executing code in the package-aware virtual filesystem.