### PR TITLE
@std/test Tech Debt: Refactor how we provide debug information via assertions + make runtime error detection less brittle

### DIFF
--- a/lute/std/libs/test/assert.luau
+++ b/lute/std/libs/test/assert.luau
@@ -1,28 +1,17 @@
 --!strict
 -- @std/test/assert
 -- Standard assertion library for Luau
+
+local failure = require("./failure")
 local stringext = require("@std/stringext")
+local types = require("./types")
 
-local assertions = {}
+-- types
+type failure = types.failure
+type asserts = types.asserts
 
-function assertions.eq<T>(lhs: T, rhs: T, msg: string?)
-	if lhs ~= rhs then
-		error({ msg = msg or `{lhs} ~= {rhs}` })
-	end
-end
-
-function assertions.neq<T>(lhs: T, rhs: T, msg: string?)
-	if lhs == rhs then
-		error({ msg = msg or `{lhs} == {rhs}` })
-	end
-end
-
-function assertions.errors(callback: () -> (), msg: string?)
-	local success = pcall(callback)
-	if success then
-		error({ msg = msg or `{callback} did not throw error.` })
-	end
-end
+-- more utils
+local assertion = failure.assertion
 
 -- Helper to format values for error messages
 local function formatValue(val: any): string
@@ -74,25 +63,52 @@ local function tablesEqual(t1: unknown, t2: unknown, path: string): (boolean, st
 	return true, nil
 end
 
--- Table equality assertionsion with deep comparison
-function assertions.tableeq(lhs: { [unknown]: unknown }, rhs: { [unknown]: unknown })
-	local equal, msg = tablesEqual(lhs, rhs, "")
-	if not equal then
-		error({ msg = msg or "tables are not equal" })
+local function eq<T>(lhs: T, rhs: T, msg: string?): failure?
+	if lhs == rhs then
+		return nil
 	end
+
+	return assertion(msg or `{lhs} ~= {rhs}`)
 end
 
-function assertions.buffereq(lhs: buffer, rhs: buffer)
+local function neq<T>(lhs: T, rhs: T, msg: string?): failure?
+	if lhs ~= rhs then
+		return nil
+	end
+
+	return assertion(msg or `{lhs} == {rhs}`)
+end
+
+local function errors(callback: () -> (), msg: string?): failure?
+	local success = pcall(callback)
+	-- if the callback failed, then this assert passes
+	if not success then
+		return nil
+	end
+
+	return assertion(msg or `{callback} did not throw error.`)
+end
+
+-- Table equality assertionsion with deep comparison
+local function tableeq(lhs: { [unknown]: unknown }, rhs: { [unknown]: unknown }): failure?
+	local equal, msg = tablesEqual(lhs, rhs, "")
+	if equal then
+		return nil
+	end
+	return assertion(msg or "tables are not equal")
+end
+
+local function buffereq(lhs: buffer, rhs: buffer): failure?
 	if typeof(lhs) ~= "buffer" then
-		error({ msg = `lhs is of type {typeof(lhs)}, not buffer` })
+		return assertion(`lhs is of type {typeof(lhs)}, not buffer`)
 	end
 
 	if typeof(rhs) ~= "buffer" then
-		error({ msg = `rhs is of type {typeof(rhs)}, not buffer` })
+		return assertion(`rhs is of type {typeof(rhs)}, not buffer`)
 	end
 
 	if buffer.len(lhs) ~= buffer.len(rhs) then
-		error({ msg = "buffers are of unequal length" })
+		return assertion("buffers are of unequal length")
 	end
 
 	local len = buffer.len(lhs)
@@ -101,48 +117,73 @@ function assertions.buffereq(lhs: buffer, rhs: buffer)
 		local right = buffer.readu8(rhs, offset)
 
 		if left ~= right then
-			error({ msg = string.format("lhs[%d] = %02x, but rhs[%d] = %02x", offset, left, offset, right) })
+			return assertion(string.format("lhs[%d] = %02x, but rhs[%d] = %02x", offset, left, offset, right))
 		end
 	end
+	return nil
 end
 
-function assertions.erroreq<A...>(func: (A...) -> ...unknown, expectedErrorMessage: string, ...: A...)
+local function erroreq<A...>(func: (A...) -> ...unknown, expectedErrorMessage: string, ...: A...): failure?
 	local success, err = pcall(func, ...)
 	if success then
-		error({ msg = "Function did not error as expected." })
+		return assertion("Function did not error as expected.")
 	end
 
 	local actualErrorMessage = tostring(err)
 	-- pcall appends filename and line number of the error, so we check suffix only
 	if not stringext.hassuffix(actualErrorMessage, expectedErrorMessage) then
-		error({ msg = `Expected suffix of error message "{expectedErrorMessage}", but got "{actualErrorMessage}"` })
+		return assertion(`Expected suffix of error message "{expectedErrorMessage}", but got "{actualErrorMessage}"`)
 	end
+
+	return nil
 end
 
-function assertions.strcontains(haystack: string, needle: string, msg: string?, instances: number?)
+local function strcontains(haystack: string, needle: string, msg: string?, instances: number?): failure?
 	instances = instances or 1
 
 	if instances <= 0 then
-		error({ msg = "instances must be greater than 0" })
+		return assertion("instances must be greater than 0")
 	end
 
 	if instances == 1 then
 		if haystack:find(needle, 1, true) == nil then
-			error({ msg = if msg then msg else `Expected "{haystack}" to contain "{needle}".` })
+			return assertion(if msg then msg else `Expected "{haystack}" to contain "{needle}".`)
 		end
 	else
 		if #haystack:split(needle) ~= instances + 1 then
-			error({ msg = if msg then msg else `Expected "{haystack}" to contain "{needle}" {instances} times.` })
+			return assertion(if msg then msg else `Expected "{haystack}" to contain "{needle}" {instances} times.`)
 		end
 	end
+	return nil
 end
 
-function assertions.strnotcontains(haystack: string, needle: string, msg: string?)
+local function strnotcontains(haystack: string, needle: string, msg: string?): failure?
 	if haystack:find(needle, 1, true) ~= nil then
-		error({ msg = if msg then msg else `Expected "{haystack}" to not contain "{needle}".` })
+		return assertion(if msg then msg else `Expected "{haystack}" to not contain "{needle}".`)
+	end
+
+	return nil
+end
+
+-- utility for taking an assertion and wrapping it as a check that must complete successfully or will return control flow to the error handler
+local function reqassert<T...>(req: (T...) -> failure?): (T...) -> failure?
+	return function(...): failure?
+		local result: failure? = req(...)
+		if result ~= nil then
+			error(result)
+		end
+
+		return nil
 	end
 end
 
-export type asserts = typeof(assertions)
-
-return table.freeze(assertions)
+return table.freeze({
+	eq = reqassert(eq),
+	neq = reqassert(neq),
+	errors = reqassert(errors),
+	tableeq = reqassert(tableeq),
+	buffereq = reqassert(buffereq),
+	erroreq = reqassert(erroreq),
+	strcontains = reqassert(strcontains),
+	strnotcontains = reqassert(strnotcontains),
+}) :: asserts

--- a/lute/std/libs/test/failure.luau
+++ b/lute/std/libs/test/failure.luau
@@ -1,0 +1,30 @@
+--!strict
+-- @std/test/failure
+-- utilities for working with test failures
+local types = require("./types")
+
+type failure = types.failure
+
+local failures = {}
+-- Generates the debug information needed to describe assertion failure locations
+function failures.assertion(msg: string): failure
+	-- we need to go 5 function calls up to get to the actual assertion that invoked this
+	local filename, linenumber = debug.info(4, "sl")
+	local name = debug.info(2, "n")
+	return { assertion = name, msg = msg, filename = filename, linenumber = linenumber, __tag = "assertion" }
+end
+
+-- Generates the debug information needed to describe assertion failure locations
+function failures.lifecycle(hook: hook, err): failure
+	-- we need to go 5 function calls up to get to the actual assertion that invoked this
+	local filename, linenumber = debug.info(3, "sl")
+	return { hook = hook, msg = tostring(err), filename = filename, linenumber = linenumber, __tag = "lifecycle" }
+end
+
+-- Generates the debug information needed to describe runtime error failure
+function failures.runtimeerror(err): failure
+	-- we need to go 5 function calls up to get to the actual assertion that invoked this
+	return { msg = tostring(err), stacktrace = debug.traceback(tostring(err)), __tag = "runtime_error" }
+end
+
+return table.freeze(failures)

--- a/lute/std/libs/test/reporter.luau
+++ b/lute/std/libs/test/reporter.luau
@@ -13,12 +13,16 @@ local reporter = {}
 
 local function printFailedTest(failed: FailedTest)
 	print(`❌ {failed.test}`)
-	if failed.assertion ~= nil then
-		print(`   {failed.filename}:{failed.linenumber}`)
-		print(`   	{failed.assertion}: {failed.error}`)
+	if failed.failure.__tag == "assertion" then
+		print(`\t{failed.failure.filename}:{failed.failure.linenumber}`)
+		print(`\t\t{failed.failure.assertion}: {failed.failure.msg}`)
+	elseif failed.failure.__tag == "lifecycle" then
+		print(`\t{failed.failure.filename}:{failed.failure.linenumber}`)
+		print(`\t\t{failed.failure.hook}: {failed.failure.msg}`)
 	else
-		print(`   Failed with: Runtime error in {failed.test} in:`)
-		print(`   	{failed.filename}:{failed.linenumber}`)
+		print(`\tRuntime error: {failed.failure.msg}`)
+		print(`Stacktrace:`)
+		print(failed.failure.stacktrace)
 	end
 	print()
 end

--- a/lute/std/libs/test/runner.luau
+++ b/lute/std/libs/test/runner.luau
@@ -2,9 +2,9 @@
 -- @std/test/runner
 -- Standard test runner library for Luau
 
-local types = require("./types")
 local asserts = require("./assert")
-local path = require("@std/path")
+local failure = require("./failure")
+local types = require("./types")
 
 type Test = types.test
 type TestCase = types.testcase
@@ -31,14 +31,11 @@ function runner.run(env: TestEnvironment): TestRunResult
 			for _, tc in suite.cases do
 				local failedtest: FailedTest = {
 					test = `{suite.name}.{tc.name}`,
-					assertion = "beforeall",
-					error = `beforeall hook failed: {err}`,
-					filename = "",
-					linenumber = 0,
+					failure = failure.lifecycle("beforeall", err),
 				}
 				table.insert(failures, failedtest)
 			end
-			return tostring(err)
+			return err
 		end
 	end
 
@@ -48,13 +45,10 @@ function runner.run(env: TestEnvironment): TestRunResult
 			failed += 1
 			local failedtest: FailedTest = {
 				test = testFullName,
-				assertion = "beforeeach",
-				error = `beforeeach hook failed: {err}`,
-				filename = "",
-				linenumber = 0,
+				failure = failure.lifecycle("beforeeach", err),
 			}
 			table.insert(failures, failedtest)
-			return tostring(err)
+			return err
 		end
 	end
 
@@ -63,13 +57,10 @@ function runner.run(env: TestEnvironment): TestRunResult
 		return function(err)
 			local failedtest: FailedTest = {
 				test = testFullName,
-				assertion = "aftereach",
-				error = `aftereach hook failed: {err}`,
-				filename = "",
-				linenumber = 0,
+				failure = failure.lifecycle("aftereach", err),
 			}
 			table.insert(failures, failedtest)
-			return tostring(err)
+			return err
 		end
 	end
 
@@ -79,13 +70,10 @@ function runner.run(env: TestEnvironment): TestRunResult
 			failed += 1
 			local failedtest: FailedTest = {
 				test = suiteName,
-				assertion = "afterall",
-				error = `afterall hook failed: {err}`,
-				filename = "",
-				linenumber = 0,
+				failure = failure.lifecycle("afterall", err),
 			}
 			table.insert(failures, failedtest)
-			return tostring(err)
+			return err
 		end
 	end
 
@@ -93,19 +81,10 @@ function runner.run(env: TestEnvironment): TestRunResult
 	for _, tc in env.anonymous do
 		total += 1
 		local function handlefailure(err)
-			local fileName, lineNumber = debug.info(4, "sl")
-			local assertName: string = debug.info(3, "n")
-
-			if assertName == "xpcall" then
-				fileName, lineNumber = debug.info(2, "sl")
-			end
-
+			local wasruntimefailure = not (typeof(err) == "table" and err.__tag and err.__tag == "assertion")
 			local failedtest: FailedTest = {
 				test = tc.name,
-				assertion = if assertName == "xpcall" then nil else assertName,
-				error = if assertName == "xpcall" then nil else err.msg,
-				filename = path.format(fileName),
-				linenumber = lineNumber,
+				failure = if wasruntimefailure then failure.runtimeerror(err) else err,
 			}
 			table.insert(failures, failedtest)
 			failed += 1
@@ -132,19 +111,10 @@ function runner.run(env: TestEnvironment): TestRunResult
 			total += 1
 			local testFullName = `{suite.name}.{tc.name}`
 			local function handlefailure(err)
-				local fileName, lineNumber = debug.info(4, "sl")
-				local assertName = debug.info(3, "n")
-
-				if assertName == "xpcall" then
-					fileName, lineNumber = debug.info(2, "sl")
-				end
-
+				local wasruntimefailure = not (typeof(err) == "table" and err.__tag and err.__tag == "assertion")
 				local failedtest: FailedTest = {
 					test = testFullName,
-					assertion = if assertName == "xpcall" then nil else assertName,
-					error = if assertName == "xpcall" then nil else err.msg,
-					filename = path.format(fileName),
-					linenumber = lineNumber,
+					failure = if wasruntimefailure then failure.runtimeerror(err) else err,
 				}
 				table.insert(failures, failedtest)
 			end

--- a/lute/std/libs/test/types.luau
+++ b/lute/std/libs/test/types.luau
@@ -3,9 +3,41 @@
 -- Standard test types library for Luau
 
 -- Test Reporting
-local assert = require("./assert")
 
-export type test = (assert.asserts) -> ()
+export type hook = "beforeeach" | "beforeall" | "aftereach" | "afterall"
+export type failure =
+	{
+		assertion: string, -- name of the assertion
+		msg: string, -- failure message
+		filename: string, -- filename
+		linenumber: number, -- linenumber
+		__tag: "assertion",
+	}
+	| {
+		hook: hook, -- the name of the hook that broke
+		msg: string, -- failure message
+		filename: string, -- filename
+		linenumber: number, -- linenumber
+		__tag: "lifecycle",
+	}
+	| {
+		msg: string, -- failure message
+		stacktrace: string, -- stacktrace
+		__tag: "runtime_error",
+	}
+
+export type asserts = {
+	eq: <T>(T, T, string?) -> failure?,
+	neq: <T>(T, T, string?) -> failure?,
+	errors: (() -> (), string?) -> failure?,
+	tableeq: ({ [unknown]: unknown }, { [unknown]: unknown }) -> failure?,
+	buffereq: (buffer, buffer) -> failure?,
+	erroreq: <A...>((A...) -> ...unknown, string, A...) -> failure?,
+	strcontains: (string, string, string?, number?) -> failure?,
+	strnotcontains: (string, string, string?) -> failure?,
+}
+
+export type test = (asserts) -> ()
 
 export type testcase = { name: string, case: test }
 
@@ -25,10 +57,7 @@ export type testsuite = {
 
 export type failedtest = {
 	test: string, -- name of the test case that failed
-	assertion: string?, -- if an assertion failed, name of the assertion that failed (e.g., "assert.eq")
-	error: string?, -- the error message to report with a failed assertion
-	filename: string, -- source file where the failure occurred
-	linenumber: number, -- line number of the failure
+	failure: failure,
 }
 
 export type testrunresult = {

--- a/tests/std/test.test.luau
+++ b/tests/std/test.test.luau
@@ -51,11 +51,13 @@ test.run()
 		assert.eq(result.exitcode, 1)
 		assert.eq(result.stdout:find("xpcall", 1, true), nil)
 		-- Check that the error points to filepath + correct line number
-		assert.strcontains(result.stdout, `Failed with: Runtime error in nil_field_suite.access_field_of_nil in:`)
+		assert.strcontains(result.stdout, `Runtime error`)
 		assert.strcontains(
 			result.stdout,
 			`{if system.win32 then path.format(testFilePath):gsub("\\", "/") else path.format(testFilePath)}:6`
 		)
+		assert.strcontains(result.stdout, `nil_field_access_test.test.luau:6: attempt to index nil with 'field'`)
+		assert.strcontains(result.stdout, `nil_field_access_test.test.luau:10`)
 
 		fs.remove(testFilePath)
 	end)
@@ -84,11 +86,13 @@ test.run()
 		assert.eq(result.exitcode, 1)
 		assert.eq(result.stdout:find("xpcall", 1, true), nil)
 		-- Check that the error points to filepath + correct line number
-		assert.strcontains(result.stdout, `Failed with: Runtime error in access_field_of_nil in:`)
+		assert.strcontains(result.stdout, `Runtime error`)
 		assert.strcontains(
 			result.stdout,
 			`{if system.win32 then path.format(testFilePath):gsub("\\", "/") else path.format(testFilePath)}:5`
 		)
+		assert.strcontains(result.stdout, `nil_field_access_test.test.luau:5: attempt to index nil with 'field'`)
+		assert.strcontains(result.stdout, `nil_field_access_test.test.luau:8`)
 
 		fs.remove(testFilePath)
 	end)


### PR DESCRIPTION
This PR attempts to refactor the test library to be slightly more maintainable. While trying to bring https://github.com/luau-lang/lute/pull/519 up to date, I experienced a lot of brittleness with our test libraries ability to detect when a test failed due to runtime errors. The test runner also produces debug information in an adhoc manner multiple times in different places, which really sucks.

This PR ports over the [frktest](https://github.com/itsfrank/frktest/blob/main/src/assert_impl.luau) implementation of assertions. Rather than having `assertions` immediately yield control flow via `error`, all assertions internally return a typed `failure?`. When this failure is emitted, we extract all of the debug information needed for tests, exactly once at the point of the assertion 'failure'. This means that the test runner no longer has to know how to produce debug information (woo separation of concerns!), and the actual assertion implementation is responsible for this.  

Another freebie is that we only have to produce stacktraces in exactly one place - I've gone ahead and added that, along with updating the runtime error tests.

## Future Work
- The stacktraces currently produces are not very good - this is because `lute run` compiles the script with all optimizations on, and the inling negatively impacts the quality of stacktraces. I discussed an option with @vrn-sn to lower the optimization level for .test.luau files.
- The current implementation of `asserts` behaves like `REQUIRE` - control flow is immediately stopped at this point.
Since all assertion implementations are wrapped by a function that determines how to handle the control flow, we can now also provide an implementation of `CHECK`, where you can fail a test and resume control flow.