### PR TITLE
Fixes issues with gitignore parsing in commands lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,6 @@ __pycache__
 .clangd
 compile_commands.json
 *~
-extern/libuv/libuv-static.pc
-extern/libuv/DartConfiguration.tcl
 extern/*/
 generated
 **/generated-types.luau

--- a/lute/cli/commands/lib/files.luau
+++ b/lute/cli/commands/lib/files.luau
@@ -53,7 +53,7 @@ local function getSourceFiles(paths: { string }, verbose: boolean?): { path.path
 		local pathObj = path.parse(filepath)
 
 		if not path.isabsolute(pathObj) then
-			pathObj = path.join(process.cwd(), pathObj)
+			pathObj = path.resolve(process.cwd(), pathObj)
 		end
 
 		filepath = path.format(pathObj)

--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -166,7 +166,7 @@ local function matchesGlob(glob: Glob, filepath: string, isDirectory: boolean): 
 	-- both: at start of path OR after any directory separator
 	if glob.matchAnywhere then
 		local matchAtStart = filepath:match("^" .. glob.pattern) ~= nil
-		local matchAfterDir = filepath:match("/" .. glob.pattern) ~= nil
+		local matchAfterDir = filepath:match(separator .. glob.pattern) ~= nil
 
 		return matchAtStart or matchAfterDir
 	else
@@ -183,7 +183,6 @@ local function isIgnored(ignoreData: GitignoreData, filepath: string, isDirector
 
 	local relativePath = path.format(path.relative(ignoreData.location, filepath))
 	print(`  relativePath: {relativePath}`)
-	print(`  relative path length: {#relativePath}`)
 
 	for _, ignore in ignoreData.ignores do
 		if matchesGlob(ignore, relativePath, isDirectory) then

--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -100,6 +100,9 @@ local function parseGlob(glob: string): Glob
 		elseif char == "-" then
 			table.insert(lua_parts, "%-")
 			idx = idx + 1
+		elseif char == "/" or char == "\\" then
+			table.insert(lua_parts, separator)
+			idx = idx + 1
 		else
 			table.insert(lua_parts, char)
 			idx = idx + 1

--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -158,10 +158,6 @@ local function parseGitignore(filepath: path.path): GitignoreData
 end
 
 local function matchesGlob(glob: Glob, filepath: string, isDirectory: boolean): boolean
-	print(
-		`Checking if "{filepath}" (isDirectory={isDirectory}) matches glob pattern "{glob.pattern}" ({glob.matchAnywhere}, {glob.onlyMatchDirectories})`
-	)
-
 	if glob.onlyMatchDirectories and not isDirectory then
 		return false
 	end
@@ -178,14 +174,9 @@ local function matchesGlob(glob: Glob, filepath: string, isDirectory: boolean): 
 end
 
 local function isIgnored(ignoreData: GitignoreData, filepath: string, isDirectory: boolean)
-	print(`isIgnored({path.format(filepath)}, isDirectory={isDirectory})`)
-	for _, ignore in ignoreData.ignores do
-		print(`  ignore: {ignore.pattern}`)
-	end
 	local matched, ignored = false, false
 
 	local relativePath = path.format(path.relative(ignoreData.location, filepath))
-	print(`  relativePath: {relativePath}`)
 
 	for _, ignore in ignoreData.ignores do
 		if matchesGlob(ignore, relativePath, isDirectory) then
@@ -204,8 +195,6 @@ local function isIgnored(ignoreData: GitignoreData, filepath: string, isDirector
 			end
 		end
 	end
-
-	print(`  matched: {matched}, ignored: {ignored}`)
 
 	if not matched and ignoreData.next then
 		return isIgnored(ignoreData.next, filepath, isDirectory)

--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -155,6 +155,10 @@ local function parseGitignore(filepath: path.path): GitignoreData
 end
 
 local function matchesGlob(glob: Glob, filepath: string, isDirectory: boolean): boolean
+	print(
+		`Checking if "{filepath}" matches glob pattern "{glob.pattern}" ({glob.matchAnywhere}, {glob.onlyMatchDirectories})`
+	)
+
 	if glob.onlyMatchDirectories and not isDirectory then
 		return false
 	end

--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -183,6 +183,7 @@ local function isIgnored(ignoreData: GitignoreData, filepath: string, isDirector
 
 	local relativePath = path.format(path.relative(ignoreData.location, filepath))
 	print(`  relativePath: {relativePath}`)
+	print(`  relative path length: {#relativePath}`)
 
 	for _, ignore in ignoreData.ignores do
 		if matchesGlob(ignore, relativePath, isDirectory) then

--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -1,6 +1,9 @@
 local fs = require("@std/fs")
 local path = require("@std/path")
 local stringext = require("@std/stringext")
+local system = require("@std/system")
+
+local separator = if system.win32 then "\\" else "/"
 
 --- Performs ignore resolution on a set of
 local IgnoreResolver = {}
@@ -86,13 +89,13 @@ local function parseGlob(glob: string): Glob
 					idx = idx + 2
 				end
 			else
-				-- Single asterisk `*` (matches anything except /)
-				table.insert(lua_parts, "[^/]*")
+				-- Single asterisk `*` (matches anything except directory separator)
+				table.insert(lua_parts, `[^{separator}]*`)
 				idx = idx + 1
 			end
 		elseif char == "?" then
-			-- Match any single character, except for /
-			table.insert(lua_parts, "[^/]")
+			-- Match any single character, except for directory separator
+			table.insert(lua_parts, `[^{separator}]`)
 			idx = idx + 1
 		elseif char == "-" then
 			table.insert(lua_parts, "%-")

--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -1,5 +1,4 @@
-local fs = require("@lute/fs")
-
+local fs = require("@std/fs")
 local path = require("@std/path")
 local stringext = require("@std/stringext")
 
@@ -7,7 +6,7 @@ local stringext = require("@std/stringext")
 local IgnoreResolver = {}
 IgnoreResolver.__index = IgnoreResolver
 
-type Glob = { pattern: string, onlyMatchDirectories: boolean }
+type Glob = { pattern: string, onlyMatchDirectories: boolean, matchAnywhere: boolean }
 
 type GitignoreData = {
 	location: string,
@@ -50,7 +49,9 @@ local function parseGlob(glob: string): Glob
 	-- i.e., anchor the pattern to the start
 	if glob:find("/") then
 		table.insert(lua_parts, "^")
-		if glob:sub(1, 1) == "." then
+		if glob:sub(1, 2) == "./" then
+			idx = 3
+		elseif glob:sub(1, 1) == "/" or glob:sub(1, 1) == "." then
 			idx = 2
 		end
 	else
@@ -59,7 +60,6 @@ local function parseGlob(glob: string): Glob
 		-- We can't match for two distinct patterns bc Lua lacks an OR pattern operator
 		-- Instead add unique marker we check for in matchesGlob, indicating we match
 		-- against the two distinct patterns: anchored at beginning, or after a slash
-		table.insert(lua_parts, "MATCH_ANYWHERE:")
 		matchAnywhere = true
 	end
 
@@ -108,7 +108,11 @@ local function parseGlob(glob: string): Glob
 		table.insert(lua_parts, "$")
 	end
 
-	return { pattern = table.concat(lua_parts), onlyMatchDirectories = onlyMatchDirectories }
+	return {
+		pattern = table.concat(lua_parts),
+		onlyMatchDirectories = onlyMatchDirectories,
+		matchAnywhere = matchAnywhere,
+	}
 end
 
 local function parseGitignoreContents(location: string, contents: string): GitignoreData
@@ -151,13 +155,11 @@ local function matchesGlob(glob: Glob, filepath: string, isDirectory: boolean): 
 	if glob.onlyMatchDirectories and not isDirectory then
 		return false
 	end
-	-- If the pattern starts with our matchAnywhere marker, we need to test
+	-- If the pattern is marked with matchAnywhere, we need to test
 	-- both: at start of path OR after any directory separator
-	if glob.pattern:match("^MATCH_ANYWHERE:") then
-		local actualPattern = glob.pattern:gsub("^MATCH_ANYWHERE:(.*)$", "%1")
-
-		local matchAtStart = filepath:match("^" .. actualPattern) ~= nil
-		local matchAfterDir = filepath:match("/" .. actualPattern) ~= nil
+	if glob.matchAnywhere then
+		local matchAtStart = filepath:match("^" .. glob.pattern) ~= nil
+		local matchAfterDir = filepath:match("/" .. glob.pattern) ~= nil
 
 		return matchAtStart or matchAfterDir
 	else
@@ -169,7 +171,7 @@ local function isIgnored(ignoreData: GitignoreData, filepath: string, isDirector
 	local matched, ignored = false, false
 
 	-- TODO: compute relative path correctly
-	local relativePath = stringext.removeprefix(filepath, ignoreData.location)
+	local relativePath = stringext.removeprefix(filepath, `{ignoreData.location}/`)
 
 	for _, ignore in ignoreData.ignores do
 		if matchesGlob(ignore, relativePath, isDirectory) then

--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -155,10 +155,6 @@ local function parseGitignore(filepath: path.path): GitignoreData
 end
 
 local function matchesGlob(glob: Glob, filepath: string, isDirectory: boolean): boolean
-	print(
-		`Checking if "{filepath}" matches glob pattern "{glob.pattern}" ({glob.matchAnywhere}, {glob.onlyMatchDirectories})`
-	)
-
 	if glob.onlyMatchDirectories and not isDirectory then
 		return false
 	end
@@ -177,8 +173,7 @@ end
 local function isIgnored(ignoreData: GitignoreData, filepath: string, isDirectory: boolean)
 	local matched, ignored = false, false
 
-	-- TODO: compute relative path correctly
-	local relativePath = stringext.removeprefix(filepath, `{ignoreData.location}/`)
+	local relativePath = path.format(path.relative(ignoreData.location, filepath))
 
 	for _, ignore in ignoreData.ignores do
 		if matchesGlob(ignore, relativePath, isDirectory) then
@@ -251,7 +246,7 @@ function IgnoreResolver._readIgnoreRecursive(self: IgnoreResolver, directory: st
 	end
 
 	if not baseIgnores then
-		baseIgnores = { location = "", ignores = {}, whitelists = {}, next = nil } :: GitignoreData
+		baseIgnores = { location = directory, ignores = {}, whitelists = {}, next = nil } :: GitignoreData
 	end
 	assert(baseIgnores, "Luau")
 

--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -156,7 +156,7 @@ end
 
 local function matchesGlob(glob: Glob, filepath: string, isDirectory: boolean): boolean
 	print(
-		`Checking if "{filepath}" matches glob pattern "{glob.pattern}" ({glob.matchAnywhere}, {glob.onlyMatchDirectories})`
+		`Checking if "{filepath}" (isDirectory={isDirectory}) matches glob pattern "{glob.pattern}" ({glob.matchAnywhere}, {glob.onlyMatchDirectories})`
 	)
 
 	if glob.onlyMatchDirectories and not isDirectory then

--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -202,6 +202,8 @@ local function isIgnored(ignoreData: GitignoreData, filepath: string, isDirector
 		end
 	end
 
+	print(`  matched: {matched}, ignored: {ignored}`)
+
 	if not matched and ignoreData.next then
 		return isIgnored(ignoreData.next, filepath, isDirectory)
 	end

--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -155,6 +155,10 @@ local function parseGitignore(filepath: path.path): GitignoreData
 end
 
 local function matchesGlob(glob: Glob, filepath: string, isDirectory: boolean): boolean
+	print(
+		`Checking if "{filepath}" matches glob pattern "{glob.pattern}" ({glob.matchAnywhere}, {glob.onlyMatchDirectories})`
+	)
+
 	if glob.onlyMatchDirectories and not isDirectory then
 		return false
 	end
@@ -171,9 +175,14 @@ local function matchesGlob(glob: Glob, filepath: string, isDirectory: boolean): 
 end
 
 local function isIgnored(ignoreData: GitignoreData, filepath: string, isDirectory: boolean)
+	print(`isIgnored({path.format(filepath)}, isDirectory={isDirectory})`)
+	for _, ignore in ignoreData.ignores do
+		print(`  ignore: {ignore.pattern}`)
+	end
 	local matched, ignored = false, false
 
 	local relativePath = path.format(path.relative(ignoreData.location, filepath))
+	print(`  relativePath: {relativePath}`)
 
 	for _, ignore in ignoreData.ignores do
 		if matchesGlob(ignore, relativePath, isDirectory) then

--- a/tests/cli/lib/files.test.luau
+++ b/tests/cli/lib/files.test.luau
@@ -1,0 +1,269 @@
+local files = require("@commands/lib/files")
+local fs = require("@std/fs")
+local path = require("@std/path")
+local system = require("@std/system")
+local test = require("@std/test")
+
+local tmpdir = system.tmpdir()
+local testPath = path.join(tmpdir, "gitignore_test")
+
+test.suite("cli/lib/files", function(suite)
+	suite:beforeeach(function()
+		if fs.exists(testPath) then
+			fs.removedirectory(testPath, { recursive = true })
+		end
+	end)
+
+	suite:case("parse simple file pattern", function(assert)
+		-- Setup
+		fs.createdirectory(testPath)
+		local gitignorePath = path.join(testPath, ".gitignore")
+		fs.writestringtofile(gitignorePath, "*.lua\n")
+
+		local shouldIgnorePath = path.join(testPath, "debug.lua")
+		fs.writestringtofile(shouldIgnorePath, "")
+
+		local shouldNotIgnorePath = path.join(testPath, "readme.luau")
+		fs.writestringtofile(shouldNotIgnorePath, "")
+
+		-- Do
+		local results = files.getSourceFiles({ path.format(testPath) })
+
+		-- Check
+		local resultPaths = {}
+		for _, p in results do
+			resultPaths[path.format(p)] = true
+		end
+		assert.eq(resultPaths[path.format(shouldIgnorePath)], nil)
+		assert.eq(resultPaths[path.format(shouldNotIgnorePath)], true)
+
+		-- Teardown
+		fs.removedirectory(testPath, { recursive = true })
+	end)
+
+	suite:case("parse directory pattern", function(assert)
+		-- Setup
+		fs.createdirectory(testPath)
+		local gitignorePath = path.join(testPath, ".gitignore")
+		fs.writestringtofile(gitignorePath, "node_modules/\n")
+
+		local dirPath = path.join(testPath, "node_modules")
+		fs.createdirectory(dirPath)
+		local shouldIgnoreFile = path.join(dirPath, "package.luau")
+		fs.writestringtofile(shouldIgnoreFile, "")
+
+		local nestedDirPath = path.join(testPath, "a", "node_modules")
+		fs.createdirectory(nestedDirPath, { makeparents = true })
+		local shouldIgnoreNestedFile = path.join(nestedDirPath, "nested_package.luau")
+		fs.writestringtofile(shouldIgnoreNestedFile, "")
+
+		local shouldNotIgnoreFile = path.join(testPath, "node_modules.luau")
+		fs.writestringtofile(shouldNotIgnoreFile, "")
+
+		-- Do
+		local results = files.getSourceFiles({ path.format(testPath) })
+
+		-- Check
+		local resultPaths = {}
+		for _, p in results do
+			resultPaths[path.format(p)] = true
+		end
+		assert.eq(resultPaths[path.format(shouldIgnoreFile)], nil)
+		assert.eq(resultPaths[path.format(shouldIgnoreNestedFile)], nil)
+		assert.eq(resultPaths[path.format(shouldNotIgnoreFile)], true)
+
+		-- Teardown
+		fs.removedirectory(testPath, { recursive = true })
+	end)
+
+	suite:case("parse negation pattern", function(assert)
+		-- Setup
+		fs.createdirectory(testPath)
+		local gitignorePath = path.join(testPath, ".gitignore")
+		fs.writestringtofile(gitignorePath, "*.lua\n!important.lua\n")
+
+		local shouldIgnorePath = path.join(testPath, "debug.lua")
+		fs.writestringtofile(shouldIgnorePath, "")
+
+		local shouldNotIgnorePath = path.join(testPath, "important.lua")
+		fs.writestringtofile(shouldNotIgnorePath, "")
+
+		-- Do
+		local results = files.getSourceFiles({ path.format(testPath) })
+
+		-- Check
+		local resultPaths = {}
+		for _, p in results do
+			resultPaths[path.format(p)] = true
+		end
+		assert.eq(resultPaths[path.format(shouldIgnorePath)], nil)
+		assert.eq(resultPaths[path.format(shouldNotIgnorePath)], true)
+
+		-- Teardown
+		fs.removedirectory(testPath, { recursive = true })
+	end)
+
+	suite:case("parse leading double asterisk pattern", function(assert)
+		-- Setup
+		fs.createdirectory(testPath)
+		local gitignorePath = path.join(testPath, ".gitignore")
+		fs.writestringtofile(gitignorePath, "**/temp/foo\n")
+
+		local subdir = path.join(testPath, "src", "temp", "foo")
+		fs.createdirectory(subdir, { makeparents = true })
+
+		local shouldIgnorePath = path.join(subdir, "template.luau")
+		fs.writestringtofile(shouldIgnorePath, "")
+
+		local shouldntIgnorePath = path.join(testPath, "src", "temp", "hello.luau")
+		fs.writestringtofile(shouldntIgnorePath, "")
+
+		-- Do
+		local results = files.getSourceFiles({ path.format(testPath) })
+
+		-- Check
+		local resultPaths = {}
+		for _, p in results do
+			resultPaths[path.format(p)] = true
+		end
+		assert.eq(resultPaths[path.format(shouldIgnorePath)], nil)
+		assert.eq(resultPaths[path.format(shouldntIgnorePath)], true)
+
+		-- Teardown
+		fs.removedirectory(testPath, { recursive = true })
+	end)
+
+	suite:case("parse trailing double asterisk pattern", function(assert)
+		-- Setup
+		fs.createdirectory(testPath)
+		local gitignorePath = path.join(testPath, ".gitignore")
+		fs.writestringtofile(gitignorePath, "temp/foo/**\n")
+
+		local subdir = path.join(testPath, "temp", "foo", "src")
+		fs.createdirectory(subdir, { makeparents = true })
+
+		local shouldIgnorePath = path.join(subdir, "template.luau")
+		fs.writestringtofile(shouldIgnorePath, "")
+
+		local shouldIgnorePath2 = path.join(testPath, "temp", "foo", "template.luau")
+		fs.writestringtofile(shouldIgnorePath2, "")
+
+		local shouldntIgnorePath = path.join(testPath, "temp", "hello.luau")
+		fs.writestringtofile(shouldntIgnorePath, "")
+
+		-- Do
+		local results = files.getSourceFiles({ path.format(testPath) })
+
+		-- Check
+		local resultPaths = {}
+		for _, p in results do
+			resultPaths[path.format(p)] = true
+		end
+		assert.eq(resultPaths[path.format(shouldIgnorePath)], nil)
+		assert.eq(resultPaths[path.format(shouldIgnorePath2)], nil)
+		assert.eq(resultPaths[path.format(shouldntIgnorePath)], true)
+
+		-- Teardown
+		fs.removedirectory(testPath, { recursive = true })
+	end)
+
+	suite:case("parse middle double asterisk pattern", function(assert)
+		-- Setup
+		fs.createdirectory(testPath)
+		local gitignorePath = path.join(testPath, ".gitignore")
+		fs.writestringtofile(gitignorePath, "temp/**/foo\n")
+
+		local subdir = path.join(testPath, "temp", "src", "foo")
+		fs.createdirectory(subdir, { makeparents = true })
+
+		local shouldIgnorePath = path.join(subdir, "template.luau")
+		fs.writestringtofile(shouldIgnorePath, "")
+
+		local subdir2 = path.join(testPath, "temp", "src", "test", "foo")
+		fs.createdirectory(subdir2, { makeparents = true })
+
+		local shouldIgnorePath2 = path.join(subdir2, "template.luau")
+		fs.writestringtofile(shouldIgnorePath2, "")
+
+		local shouldntIgnorePath = path.join(testPath, "temp", "hello.luau")
+		fs.writestringtofile(shouldntIgnorePath, "")
+
+		-- Do
+		local results = files.getSourceFiles({ path.format(testPath) })
+
+		-- Check
+		local resultPaths = {}
+		for _, p in results do
+			resultPaths[path.format(p)] = true
+		end
+		assert.eq(resultPaths[path.format(shouldIgnorePath)], nil)
+		assert.eq(resultPaths[path.format(shouldIgnorePath2)], nil)
+		assert.eq(resultPaths[path.format(shouldntIgnorePath)], true)
+
+		-- Teardown
+		fs.removedirectory(testPath, { recursive = true })
+	end)
+
+	suite:case("parse rooted pattern", function(assert)
+		-- Setup
+		fs.createdirectory(testPath)
+		local gitignorePath = path.join(testPath, ".gitignore")
+		fs.writestringtofile(gitignorePath, "/build\n")
+
+		fs.createdirectory(path.join(testPath, "build"), { makeparents = true })
+
+		local shouldIgnorePath = path.join(testPath, "build", "foo.luau")
+		fs.writestringtofile(shouldIgnorePath, "")
+
+		fs.createdirectory(path.join(testPath, "src", "build"), { makeparents = true })
+
+		local shouldNotIgnorePath = path.join(testPath, "src", "build", "bar.luau")
+		fs.writestringtofile(shouldNotIgnorePath, "")
+
+		-- Do
+		local results = files.getSourceFiles({ path.format(testPath) })
+
+		-- Check
+		local resultPaths = {}
+		for _, p in results do
+			resultPaths[path.format(p)] = true
+		end
+		assert.eq(resultPaths[(path.format(shouldIgnorePath))], nil)
+		assert.eq(resultPaths[path.format(shouldNotIgnorePath)], true)
+
+		-- Teardown
+		fs.removedirectory(testPath, { recursive = true })
+	end)
+
+	suite:case("parse question mark pattern", function(assert)
+		-- Setup
+		fs.createdirectory(testPath)
+		local gitignorePath = path.join(testPath, ".gitignore")
+		fs.writestringtofile(gitignorePath, "file?.luau\n")
+
+		local shouldIgnorePath1 = path.join(testPath, "file1.luau")
+		fs.writestringtofile(shouldIgnorePath1, "")
+
+		local shouldIgnorePath2 = path.join(testPath, "fileA.luau")
+		fs.writestringtofile(shouldIgnorePath2, "")
+
+		local shouldNotIgnorePath = path.join(testPath, "file10.luau")
+		fs.writestringtofile(shouldNotIgnorePath, "")
+
+		-- Do
+		local results = files.getSourceFiles({ path.format(testPath) })
+		-- Check
+		local resultPaths = {}
+		for _, p in results do
+			resultPaths[path.format(p)] = true
+		end
+		assert.eq(resultPaths[path.format(shouldIgnorePath1)], nil)
+		assert.eq(resultPaths[path.format(shouldIgnorePath2)], nil)
+		assert.eq(resultPaths[path.format(shouldNotIgnorePath)], true)
+
+		-- Teardown
+		fs.removedirectory(testPath, { recursive = true })
+	end)
+end)
+
+test.run()


### PR DESCRIPTION
I encountered some `.gitignore` parsing bugs when I was trying to run `lute lint` in the lint directory. I've:
- Ported over a fix that went into `luau-lang/codemod` but for some reason didn't make it into `lute transform` when I initially ported it
- Added some additional fixups needed in `.gitignore` parsing
- Removed some redundant rules from our actual `.gitignore`
- Added tests for `cli/lib/files` which is built on the ignore parsing. the ignore stuff doesn't have a very nice api surface, so i opted to test it using the `files` stuff instead
- Use system-specific path separators so it works on Windows (I would love to eventually port this stuff to just run on path objects so the OS stuff is abstracted away)