### PR TITLE
Cleans up the std path library and adds `path.relative`

### DIFF
--- a/lute/std/libs/path/init.luau
+++ b/lute/std/libs/path/init.luau
@@ -76,6 +76,14 @@ function pathlib.parse(path: pathlike): path
 	end
 end
 
+function pathlib.relative(from: pathlike, to: pathlike): path
+	if onWindows then
+		return win32.relative(from :: win32.pathlike, to :: win32.pathlike)
+	else
+		return posix.relative(from :: posix.pathlike, to :: posix.pathlike)
+	end
+end
+
 function pathlib.resolve(...: pathlike): path
 	if onWindows then
 		return win32.resolve(...)

--- a/lute/std/libs/path/pathinterface.luau
+++ b/lute/std/libs/path/pathinterface.luau
@@ -1,0 +1,5 @@
+export type pathinterface = {
+	__tostring: () -> string,
+}
+
+return table.freeze({})

--- a/lute/std/libs/path/posix/init.luau
+++ b/lute/std/libs/path/posix/init.luau
@@ -47,7 +47,9 @@ function posix.extname(path: pathlike): string
 end
 
 function posix.format(path: pathlike): string
-	path = if typeof(path) == "string" then posix.parse(path) else path
+	if typeof(path) == "string" then
+		return path
+	end
 
 	if #path.parts == 0 then
 		return if path.absolute then "/" else "."

--- a/lute/std/libs/path/posix/init.luau
+++ b/lute/std/libs/path/posix/init.luau
@@ -1,26 +1,19 @@
 local process = require("@lute/process")
 local posixtypes = require("@self/types")
 
-export type path = setmetatable<posixtypes.path, posixtypes.pathinterface>
+export type path = posixtypes.path
 export type pathlike = posixtypes.pathlike
 
 local posix = {}
-local path_mt = {}
+posix.pathmt = {} :: posixtypes.pathMT
 
 function posix.basename(path: pathlike): string?
-	if typeof(path) == "string" then
-		path = posix.parse(path)
-	end
-	path = path :: path
+	path = if typeof(path) == "string" then posix.parse(path) else path
 	return if #path.parts > 0 then path.parts[#path.parts] else nil
 end
 
 function posix.dirname(path: pathlike): string
-	if typeof(path) == "string" then
-		path = posix.parse(path)
-	end
-
-	path = path :: path
+	path = if typeof(path) == "string" then posix.parse(path) else path
 
 	if #path.parts == 0 then
 		return posix.format(path)
@@ -33,11 +26,7 @@ function posix.dirname(path: pathlike): string
 end
 
 function posix.extname(path: pathlike): string
-	if typeof(path) == "string" then
-		path = posix.parse(path)
-	end
-
-	path = path :: path
+	path = if typeof(path) == "string" then posix.parse(path) else path
 
 	if #path.parts == 0 then
 		return ""
@@ -58,11 +47,7 @@ function posix.extname(path: pathlike): string
 end
 
 function posix.format(path: pathlike): string
-	if typeof(path) == "string" then
-		return path
-	end
-
-	path = path :: path
+	path = if typeof(path) == "string" then posix.parse(path) else path
 
 	if #path.parts == 0 then
 		return if path.absolute then "/" else "."
@@ -72,31 +57,20 @@ function posix.format(path: pathlike): string
 end
 
 function posix.isabsolute(path: pathlike): boolean
-	if typeof(path) == "string" then
-		path = posix.parse(path)
-	end
-	path = path :: path
+	path = if typeof(path) == "string" then posix.parse(path) else path
 	return path.absolute
 end
 
 -- In place extends path with addend
 local function joinHelper(path: path, addend: pathlike): ()
-	if typeof(addend) == "string" then
-		addend = posix.parse(addend)
-	end
-	addend = addend :: path
+	addend = if typeof(addend) == "string" then posix.parse(addend) else addend
 
 	if addend.absolute then
 		local stringPath = posix.format(path)
 		local stringAddend = posix.format(addend)
-		error(table.concat({
-			"Could not join ",
-			(if path.absolute then "absolute" else "relative"),
-			" path ",
-			stringPath,
-			" and absolute path ",
-			stringAddend,
-		}))
+		error(
+			`Could not join {if path.absolute then "absolute" else "relative"} path {stringPath} and absolute path {stringAddend}`
+		)
 	end
 
 	table.move(addend.parts, 1, #addend.parts, #path.parts + 1, path.parts)
@@ -108,15 +82,15 @@ function posix.join(...: pathlike): path
 		return setmetatable({
 			parts = {},
 			absolute = false,
-		}, path_mt)
+		}, posix.pathmt)
 	end
 
 	local path: path = if typeof(parts[1]) == "string"
 		then posix.parse(parts[1])
 		else setmetatable({
-			parts = table.clone((parts[1] :: path).parts),
-			absolute = (parts[1] :: path).absolute,
-		}, path_mt)
+			parts = table.clone((parts[1] :: path).parts), -- LUAUFIX: Shouldn't need cast
+			absolute = (parts[1] :: path).absolute, -- LUAUFIX: Shouldn't need cast
+		}, posix.pathmt)
 
 	for i = 2, #parts do
 		joinHelper(path, parts[i])
@@ -126,10 +100,7 @@ function posix.join(...: pathlike): path
 end
 
 function posix.normalize(path: pathlike): path
-	if typeof(path) == "string" then
-		path = posix.parse(path)
-	end
-	path = path :: path
+	path = if typeof(path) == "string" then posix.parse(path) else path
 
 	local newParts = {}
 	for _, part in path.parts do
@@ -155,12 +126,12 @@ function posix.normalize(path: pathlike): path
 	return setmetatable({
 		parts = newParts,
 		absolute = path.absolute,
-	}, path_mt)
+	}, posix.pathmt)
 end
 
 function posix.parse(path: pathlike): path
 	if typeof(path) == "table" then
-		return setmetatable(path, path_mt)
+		return setmetatable(path, posix.pathmt)
 	end
 	if typeof(path) ~= "string" then
 		error("Expected string or path")
@@ -192,7 +163,7 @@ function posix.parse(path: pathlike): path
 	return setmetatable({
 		parts = parts,
 		absolute = isAbs,
-	}, path_mt)
+	}, posix.pathmt)
 end
 
 function posix.resolve(...: pathlike): path
@@ -227,7 +198,44 @@ function posix.resolve(...: pathlike): path
 	return posix.normalize(path)
 end
 
-function path_mt:__tostring(): string
+function posix.relative(from: pathlike, to: pathlike): path
+	from = if typeof(from) == "string" then posix.parse(from) else from
+	to = if typeof(to) == "string" then posix.parse(to) else to
+
+	if from.absolute ~= to.absolute then
+		error("Cannot compute relative path between absolute and relative paths")
+	end
+
+	local commonPrefixLength = 0
+
+	for i = 1, math.min(#from.parts, #to.parts) do
+		if from.parts[i] ~= to.parts[i] then
+			break
+		end
+		commonPrefixLength += 1
+	end
+
+	local relativeParts = {}
+
+	if #from.parts > commonPrefixLength then
+		for i = commonPrefixLength + 1, #from.parts do
+			table.insert(relativeParts, "..")
+		end
+	end
+
+	if #to.parts > commonPrefixLength then
+		for i = commonPrefixLength + 1, #to.parts do
+			table.insert(relativeParts, to.parts[i])
+		end
+	end
+
+	return setmetatable({
+		parts = relativeParts,
+		absolute = false,
+	}, posix.pathmt)
+end
+
+function posix.pathmt:__tostring(): string
 	return posix.format(self :: path)
 end
 

--- a/lute/std/libs/path/posix/types.luau
+++ b/lute/std/libs/path/posix/types.luau
@@ -1,13 +1,11 @@
-export type pathMT = {
-	__tostring: () -> string,
-}
+local pathinterface = require("../pathinterface")
 
 export type pathdata = {
 	parts: { string },
 	absolute: boolean,
 }
 
-export type path = setmetatable<pathdata, pathMT>
+export type path = setmetatable<pathdata, pathinterface.pathinterface>
 
 export type pathlike = string | path | pathdata
 

--- a/lute/std/libs/path/posix/types.luau
+++ b/lute/std/libs/path/posix/types.luau
@@ -1,12 +1,14 @@
-export type pathinterface = {
+export type pathMT = {
 	__tostring: () -> string,
 }
 
-export type path = {
+export type pathdata = {
 	parts: { string },
 	absolute: boolean,
 }
 
-export type pathlike = string | path
+export type path = setmetatable<pathdata, pathMT>
+
+export type pathlike = string | path | pathdata
 
 return {}

--- a/lute/std/libs/path/types.luau
+++ b/lute/std/libs/path/types.luau
@@ -1,7 +1,7 @@
 local posixtypes = require("@std/path/posix/types")
 local win32types = require("@std/path/win32/types")
 
-export type path = posixtypes.path | win32types.path
+export type path = posixtypes.pathdata | win32types.pathdata
 export type pathlike = string | path
 
 return {}

--- a/lute/std/libs/path/types.luau
+++ b/lute/std/libs/path/types.luau
@@ -1,7 +1,7 @@
 local posixtypes = require("@std/path/posix/types")
 local win32types = require("@std/path/win32/types")
 
-export type path = posixtypes.pathdata | win32types.pathdata
+export type path = posixtypes.path | win32types.path
 export type pathlike = string | path
 
 return {}

--- a/lute/std/libs/path/win32/init.luau
+++ b/lute/std/libs/path/win32/init.luau
@@ -66,7 +66,9 @@ function win32.drive(path: pathlike): path
 end
 
 function win32.format(path: pathlike): string
-	path = if typeof(path) == "string" then win32.parse(path) else path
+	if typeof(path) == "string" then
+		return path
+	end
 
 	if #path.parts == 0 then
 		if path.kind == "unc" then

--- a/lute/std/libs/path/win32/init.luau
+++ b/lute/std/libs/path/win32/init.luau
@@ -2,26 +2,19 @@ local process = require("@lute/process")
 local win32types = require("@self/types")
 
 export type pathkind = win32types.pathkind
-export type path = setmetatable<win32types.path, win32types.pathinterface>
+export type path = win32types.path
 export type pathlike = win32types.pathlike
 
 local win32 = {}
-local path_mt = {}
+win32.pathmt = {} :: win32types.pathMT
 
 function win32.basename(path: pathlike): string?
-	if typeof(path) == "string" then
-		path = win32.parse(path)
-	end
-	path = path :: path
+	path = if typeof(path) == "string" then win32.parse(path) else path
 	return if #path.parts > 0 then path.parts[#path.parts] else nil
 end
 
 function win32.dirname(path: pathlike): string
-	if typeof(path) == "string" then
-		path = win32.parse(path)
-	end
-
-	path = path :: path
+	path = if typeof(path) == "string" then win32.parse(path) else path
 
 	if #path.parts == 0 then
 		return win32.format(path)
@@ -29,17 +22,13 @@ function win32.dirname(path: pathlike): string
 		return win32.format({
 			parts = { table.unpack(path.parts, 1, #path.parts - 1) },
 			kind = path.kind,
-			driveLetter = path.driveLetter,
+			drive = path.drive,
 		})
 	end
 end
 
 function win32.extname(path: pathlike): string
-	if typeof(path) == "string" then
-		path = win32.parse(path)
-	end
-
-	path = path :: path
+	path = if typeof(path) == "string" then win32.parse(path) else path
 
 	if #path.parts == 0 then
 		return ""
@@ -60,35 +49,30 @@ function win32.extname(path: pathlike): string
 end
 
 function win32.drive(path: pathlike): path
-	if typeof(path) == "string" then
-		path = win32.parse(path)
-	end
+	path = if typeof(path) == "string" then win32.parse(path) else path
 
-	path = path :: path
-
-	if path.driveLetter == nil then
+	if path.drive == nil then
 		error("Path does not have a drive letter: " .. win32.format(path))
 	end
 
-	return setmetatable({
-		parts = {},
-		kind = "absolute",
-		driveLetter = path.driveLetter,
-	}, path_mt)
+	return setmetatable(
+		{
+			parts = {},
+			kind = "absolute",
+			drive = path.drive,
+		} :: win32types.pathdata,
+		win32.pathmt
+	)
 end
 
 function win32.format(path: pathlike): string
-	if typeof(path) == "string" then
-		return path
-	end
-
-	path = path :: path
+	path = if typeof(path) == "string" then win32.parse(path) else path
 
 	if #path.parts == 0 then
 		if path.kind == "unc" then
 			return "\\\\"
-		elseif path.driveLetter ~= nil then
-			return table.concat({ path.driveLetter, ":", (if path.kind == "absolute" then "\\" else "") })
+		elseif path.drive ~= nil then
+			return table.concat({ path.drive, ":", (if path.kind == "absolute" then "\\" else "") })
 		else
 			return "."
 		end
@@ -96,8 +80,8 @@ function win32.format(path: pathlike): string
 		local parts = table.concat(path.parts, "\\")
 		if path.kind == "unc" then
 			return "\\\\" .. parts
-		elseif path.driveLetter ~= nil then
-			return table.concat({ path.driveLetter, ":", (if path.kind == "absolute" then "\\" else ""), parts })
+		elseif path.drive ~= nil then
+			return table.concat({ path.drive, ":", (if path.kind == "absolute" then "\\" else ""), parts })
 		else
 			return parts
 		end
@@ -105,71 +89,53 @@ function win32.format(path: pathlike): string
 end
 
 function win32.isabsolute(path: pathlike): boolean
-	if typeof(path) == "string" then
-		path = win32.parse(path)
-	end
-	path = path :: path
-	return path.kind == "absolute" or path.kind == "unc"
+	path = if typeof(path) == "string" then win32.parse(path) else path
+	return path.kind ~= "relative"
 end
 
 -- In place extends path with addend
 local function joinHelper(path: path, addend: pathlike): ()
-	if typeof(addend) == "string" then
-		addend = win32.parse(addend)
-	end
-	addend = addend :: path
+	addend = if typeof(addend) == "string" then win32.parse(addend) else addend
 
-	if addend.kind == "absolute" or addend.kind == "unc" then
-		local stringPath = win32.format(path)
-		local stringAddend = win32.format(addend)
-		error(table.concat({
-			"Could not join ",
-			path.kind,
-			" path ",
-			stringPath,
-			" and ",
-			addend.kind,
-			" path ",
-			stringAddend,
-		}))
+	if addend.kind ~= "relative" then
+		error(`Could not join {path.kind} path {win32.format(path)} and {addend.kind} path {win32.format(addend)}`)
 	end
 
-	local driveLettersIncompatible = path.driveLetter ~= nil
-		and addend.driveLetter ~= nil
-		and addend.driveLetter:lower() ~= path.driveLetter:lower()
+	local driveLettersIncompatible = path.drive ~= nil
+		and addend.drive ~= nil
+		and addend.drive:lower() ~= path.drive:lower()
 
 	if driveLettersIncompatible then
-		local stringPath = win32.format(path)
-		local stringAddend = win32.format(addend)
-		error(
-			table.concat({ "Could not join paths with incompatible drive letters: ", stringPath, " and ", stringAddend })
-		)
+		error(`Could not join paths with incompatible drive letters: {win32.format(path)} and {win32.format(addend)}`)
 	end
 
 	table.move(addend.parts, 1, #addend.parts, #path.parts + 1, path.parts)
 
-	if path.driveLetter == nil and addend.driveLetter ~= nil then
-		path.driveLetter = addend.driveLetter
+	if path.drive == nil and addend.drive ~= nil then
+		path.drive = addend.drive
 	end
 end
 
 function win32.join(...: pathlike): path
 	local parts = { ... }
 	if #parts == 0 then
-		return setmetatable({
-			parts = {},
-			kind = "relative",
-			driveLetter = nil,
-		}, path_mt)
+		return setmetatable(
+			{
+				parts = {},
+				kind = "relative",
+				drive = nil,
+			} :: win32types.pathdata, -- Cast needed because of table invariance
+			win32.pathmt
+		)
 	end
 
 	local path: path = if typeof(parts[1]) == "string"
 		then win32.parse(parts[1])
 		else setmetatable({
-			parts = table.clone((parts[1] :: path).parts),
-			kind = (parts[1] :: path).kind,
-			driveLetter = (parts[1] :: path).driveLetter,
-		}, path_mt)
+			parts = table.clone((parts[1] :: path).parts), -- LUAUFIX: Shouldn't need cast, refinement should remove string from possible types of parts[1]
+			kind = (parts[1] :: path).kind, -- LUAUFIX: Shouldn't need cast, refinement should remove string from possible types of parts[1]
+			drive = (parts[1] :: path).drive, -- LUAUFIX: Shouldn't need cast, refinement should remove string from possible types of parts[1]
+		}, win32.pathmt)
 
 	for i = 2, #parts do
 		joinHelper(path, parts[i])
@@ -179,10 +145,7 @@ function win32.join(...: pathlike): path
 end
 
 function win32.normalize(path: pathlike): path
-	if typeof(path) == "string" then
-		path = win32.parse(path)
-	end
-	path = path :: path
+	path = if typeof(path) == "string" then win32.parse(path) else path
 
 	local newParts = {}
 	for _, part in path.parts do
@@ -208,13 +171,13 @@ function win32.normalize(path: pathlike): path
 	return setmetatable({
 		parts = newParts,
 		kind = path.kind,
-		driveLetter = path.driveLetter,
-	}, path_mt)
+		drive = path.drive,
+	}, win32.pathmt)
 end
 
 function win32.parse(path: pathlike): path
 	if typeof(path) == "table" then
-		return setmetatable(path, path_mt)
+		return setmetatable(path, win32.pathmt)
 	end
 	if typeof(path) ~= "string" then
 		error("Expected string or path")
@@ -263,8 +226,50 @@ function win32.parse(path: pathlike): path
 	return setmetatable({
 		parts = parts,
 		kind = kind,
-		driveLetter = driveLetter,
-	}, path_mt)
+		drive = driveLetter,
+	}, win32.pathmt)
+end
+
+function win32.relative(from: pathlike, to: pathlike): path
+	from = if typeof(from) == "string" then win32.parse(from) else from
+	to = if typeof(to) == "string" then win32.parse(to) else to
+
+	if from.kind ~= to.kind then
+		error("Cannot compute relative path between different kinds of paths")
+	end
+
+	if from.drive ~= to.drive then
+		error("Cannot compute relative path between different drives")
+	end
+
+	local commonPrefixLength = 0
+
+	for i = 1, math.min(#from.parts, #to.parts) do
+		if from.parts[i] ~= to.parts[i] then
+			break
+		end
+		commonPrefixLength += 1
+	end
+
+	local relativeParts = {}
+
+	if #from.parts > commonPrefixLength then
+		for i = commonPrefixLength + 1, #from.parts do
+			table.insert(relativeParts, "..")
+		end
+	end
+
+	if #to.parts > commonPrefixLength then
+		for i = commonPrefixLength + 1, #to.parts do
+			table.insert(relativeParts, to.parts[i])
+		end
+	end
+
+	return setmetatable({
+		parts = relativeParts,
+		kind = "relative",
+		drive = nil :: string?,
+	}, win32.pathmt)
 end
 
 function win32.resolve(...: pathlike): path
@@ -299,7 +304,7 @@ function win32.resolve(...: pathlike): path
 	return win32.normalize(path)
 end
 
-function path_mt:__tostring(): string
+function win32.pathmt:__tostring(): string
 	return win32.format(self :: path)
 end
 

--- a/lute/std/libs/path/win32/types.luau
+++ b/lute/std/libs/path/win32/types.luau
@@ -1,8 +1,6 @@
-export type pathkind = "unc" | "absolute" | "relative"
+local pathinterface = require("../pathinterface")
 
-export type pathMT = {
-	__tostring: () -> string,
-}
+export type pathkind = "unc" | "absolute" | "relative"
 
 export type pathdata = {
 	parts: { string },
@@ -10,7 +8,7 @@ export type pathdata = {
 	drive: string?,
 }
 
-export type path = setmetatable<pathdata, pathMT>
+export type path = setmetatable<pathdata, pathinterface.pathinterface>
 
 export type pathlike = string | pathdata | path
 

--- a/lute/std/libs/path/win32/types.luau
+++ b/lute/std/libs/path/win32/types.luau
@@ -1,15 +1,17 @@
 export type pathkind = "unc" | "absolute" | "relative"
 
-export type pathinterface = {
+export type pathMT = {
 	__tostring: () -> string,
 }
 
-export type path = {
+export type pathdata = {
 	parts: { string },
 	kind: pathkind,
-	driveLetter: string?,
+	drive: string?,
 }
 
-export type pathlike = string | path
+export type path = setmetatable<pathdata, pathMT>
+
+export type pathlike = string | pathdata | path
 
 return {}

--- a/tests/std/path/path.posix.test.luau
+++ b/tests/std/path/path.posix.test.luau
@@ -43,10 +43,10 @@ test.suite("PathPosixParseSuite", function(suite)
 	end)
 
 	suite:case("parse_pathobj_returns_same", function(assert)
-		local originalPath: posix.path = {
+		local originalPath: posix.path = setmetatable({
 			parts = { "folder", "file.txt" },
 			absolute = false,
-		}
+		}, posix.pathmt)
 		local result = path.posix.parse(originalPath)
 		assert.eq(result, originalPath)
 	end)
@@ -84,10 +84,10 @@ test.suite("PathPosixBasenameSuite", function(suite)
 	end)
 
 	suite:case("basename_pathobj", function(assert)
-		local pathobj: posix.path = {
+		local pathobj: posix.path = setmetatable({
 			parts = { "folder", "subfolder", "file.txt" },
 			absolute = false,
-		}
+		}, posix.pathmt)
 		local result = path.posix.basename(pathobj)
 		assert.eq(result, "file.txt")
 	end)
@@ -95,37 +95,37 @@ end)
 
 test.suite("PathPosixFormatSuite", function(suite)
 	suite:case("format_posix_absolute_path", function(assert)
-		local pathobj: posix.path = {
+		local pathobj: posix.path = setmetatable({
 			parts = { "home", "user", "documents", "file.txt" },
 			absolute = true,
-		}
+		}, posix.pathmt)
 		local result = path.posix.format(pathobj)
 		assert.eq(result, "/home/user/documents/file.txt")
 	end)
 
 	suite:case("format_posix_relative_path", function(assert)
-		local pathobj: posix.path = {
+		local pathobj: posix.path = setmetatable({
 			parts = { "documents", "file.txt" },
 			absolute = false,
-		}
+		}, posix.pathmt)
 		local result = path.posix.format(pathobj)
 		assert.eq(result, "documents/file.txt")
 	end)
 
 	suite:case("format_empty_relative_path", function(assert)
-		local pathobj: posix.path = {
+		local pathobj: posix.path = setmetatable({
 			parts = {},
 			absolute = false,
-		}
+		}, posix.pathmt)
 		local result = path.posix.format(pathobj)
 		assert.eq(result, ".")
 	end)
 
 	suite:case("format_root_path", function(assert)
-		local pathobj: posix.path = {
+		local pathobj: posix.path = setmetatable({
 			parts = {},
 			absolute = true,
-		}
+		}, posix.pathmt)
 		local result = path.posix.format(pathobj)
 		assert.eq(result, "/")
 	end)
@@ -168,10 +168,10 @@ test.suite("PathPosixDirnameSuite", function(suite)
 	end)
 
 	suite:case("dirname_pathobj", function(assert)
-		local pathobj: posix.path = {
+		local pathobj: posix.path = setmetatable({
 			parts = { "folder", "subfolder", "file.txt" },
 			absolute = false,
-		}
+		}, posix.pathmt)
 		local result = path.posix.dirname(pathobj)
 		assert.eq(result, "folder/subfolder")
 	end)
@@ -219,10 +219,10 @@ test.suite("PathPosixExtnameSuite", function(suite)
 	end)
 
 	suite:case("extname_pathobj", function(assert)
-		local pathobj: posix.path = {
+		local pathobj: posix.path = setmetatable({
 			parts = { "folder", "file.pdf" },
 			absolute = false,
-		}
+		}, posix.pathmt)
 		local result = path.posix.extname(pathobj)
 		assert.eq(result, ".pdf")
 	end)
@@ -265,19 +265,19 @@ test.suite("PathPosixIsAbsoluteSuite", function(suite)
 	end)
 
 	suite:case("absolute_pathobj_absolute", function(assert)
-		local pathobj: posix.path = {
+		local pathobj: posix.path = setmetatable({
 			parts = { "home", "user", "file.txt" },
 			absolute = true,
-		}
+		}, posix.pathmt)
 		local result = path.posix.isabsolute(pathobj)
 		assert.eq(result, true)
 	end)
 
 	suite:case("absolute_pathobj_relative", function(assert)
-		local pathobj: posix.path = {
+		local pathobj: posix.path = setmetatable({
 			parts = { "folder", "file.txt" },
 			absolute = false,
-		}
+		}, posix.pathmt)
 		local result = path.posix.isabsolute(pathobj)
 		assert.eq(result, false)
 	end)
@@ -346,10 +346,10 @@ test.suite("PathPosixNormalizeSuite", function(suite)
 	end)
 
 	suite:case("normalize_pathobj", function(assert)
-		local pathobj: posix.path = {
+		local pathobj: posix.path = setmetatable({
 			parts = { "home", ".", "user", "..", "documents" },
 			absolute = true,
-		}
+		}, posix.pathmt)
 		local result = path.posix.normalize(pathobj)
 		assert.eq(result.absolute, true)
 		assert.eq(#result.parts, 2)
@@ -443,10 +443,10 @@ test.suite("PathPosixJoinSuite", function(suite)
 	end)
 
 	suite:case("join_pathobj_and_string", function(assert)
-		local pathobj: posix.path = {
+		local pathobj: posix.path = setmetatable({
 			parts = { "home", "user" },
 			absolute = true,
-		}
+		}, posix.pathmt)
 		local result = path.posix.join(pathobj, "documents/file.txt")
 		assert.eq(result.absolute, true)
 		assert.eq(#result.parts, 4)
@@ -548,6 +548,44 @@ test.suite("PathPosixToStringSuite", function(suite)
 		local pathobj: posix.path = posix.parse(filePath)
 		local result = tostring(pathobj)
 		assert.eq(result, filePath)
+	end)
+end)
+
+test.suite("PathPosixRelativeSuite", function(suite)
+	suite:case("relative_same_path", function(assert)
+		local from = posix.parse("/home/user/documents")
+		local to = posix.parse("/home/user/documents")
+		local result = path.posix.relative(from, to)
+		assert.eq(result.absolute, false)
+		assert.eq(#result.parts, 0)
+	end)
+
+	suite:case("relative_subdirectory", function(assert)
+		local from = posix.parse("/home/user")
+		local to = posix.parse("/home/user/documents/file.txt")
+		local result = path.posix.relative(from, to)
+		assert.eq(result.absolute, false)
+		assert.eq(#result.parts, 2)
+		assert.eq(result.parts[1], "documents")
+		assert.eq(result.parts[2], "file.txt")
+	end)
+
+	suite:case("relative_parent_directory", function(assert)
+		local from = posix.parse("/home/user/documents")
+		local to = posix.parse("/home/user/file.txt")
+		local result = path.posix.relative(from, to)
+		assert.eq(result.absolute, false)
+		assert.eq(#result.parts, 2)
+		assert.eq(result.parts[1], "..")
+		assert.eq(result.parts[2], "file.txt")
+	end)
+
+	suite:case("relative_different_absolute_values", function(assert)
+		local from = posix.parse("/home/user/documents")
+		local to = posix.parse("home/user/file.txt")
+		assert.erroreq(function()
+			path.posix.relative(from, to)
+		end, "Cannot compute relative path between absolute and relative paths")
 	end)
 end)
 

--- a/tests/std/path/path.win32.test.luau
+++ b/tests/std/path/path.win32.test.luau
@@ -9,7 +9,7 @@ test.suite("PathWin32ParseSuite", function(suite)
 	suite:case("parse_windows_absolute_path", function(assert)
 		local result: win32.path = path.win32.parse("C:\\Users\\username\\Documents\\file.txt")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 4)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "username")
@@ -20,7 +20,7 @@ test.suite("PathWin32ParseSuite", function(suite)
 	suite:case("parse_windows_unc_path", function(assert)
 		local result: win32.path = path.win32.parse("\\\\server\\share\\folder\\file.txt")
 		assert.eq(result.kind, "unc")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 4)
 		assert.eq(result.parts[1], "server")
 		assert.eq(result.parts[2], "share")
@@ -31,24 +31,24 @@ test.suite("PathWin32ParseSuite", function(suite)
 	suite:case("parse_empty_string", function(assert)
 		local result: win32.path = path.win32.parse("")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 0)
 	end)
 
 	suite:case("parse_single_file", function(assert)
 		local result: win32.path = path.win32.parse("file.txt")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 1)
 		assert.eq(result.parts[1], "file.txt")
 	end)
 
 	suite:case("parse_pathobj_returns_same", function(assert)
-		local originalPath: win32.path = {
+		local originalPath: win32.path = setmetatable({
 			parts = { "folder", "file.txt" },
 			kind = "relative",
-			driveLetter = nil,
-		}
+			drive = nil :: string?,
+		}, win32.pathmt)
 		local result = path.win32.parse(originalPath)
 		assert.eq(result, originalPath)
 	end)
@@ -56,7 +56,7 @@ test.suite("PathWin32ParseSuite", function(suite)
 	suite:case("parse_mixed_separators", function(assert)
 		local result: win32.path = path.win32.parse("/home/user\\documents/file.txt")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 4)
 		assert.eq(result.parts[1], "home")
 		assert.eq(result.parts[2], "user")
@@ -67,7 +67,7 @@ test.suite("PathWin32ParseSuite", function(suite)
 	suite:case("parse_windows_relative_with_drive", function(assert)
 		local result: win32.path = path.win32.parse("C:Documents\\file.txt")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 2)
 		assert.eq(result.parts[1], "Documents")
 		assert.eq(result.parts[2], "file.txt")
@@ -106,11 +106,11 @@ test.suite("PathWin32BasenameSuite", function(suite)
 	end)
 
 	suite:case("basename_pathobj", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = { "folder", "subfolder", "file.txt" },
 			kind = "relative",
-			driveLetter = nil,
-		}
+			drive = nil :: string?,
+		}, win32.pathmt)
 		local result = path.win32.basename(pathobj)
 		assert.eq(result, "file.txt")
 	end)
@@ -123,68 +123,68 @@ end)
 
 test.suite("PathWin32FormatSuite", function(suite)
 	suite:case("format_windows_absolute_path", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = { "Users", "username", "Documents", "file.txt" },
 			kind = "absolute",
-			driveLetter = "C",
-		}
+			drive = "C" :: string?,
+		}, win32.pathmt)
 		local result = path.win32.format(pathobj)
 		assert.eq(result, "C:\\Users\\username\\Documents\\file.txt")
 	end)
 
 	suite:case("format_windows_relative_with_drive", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = { "Documents", "file.txt" },
 			kind = "relative",
-			driveLetter = "C",
-		}
+			drive = "C" :: string?,
+		}, win32.pathmt)
 		local result = path.win32.format(pathobj)
 		assert.eq(result, "C:Documents\\file.txt")
 	end)
 
 	suite:case("format_windows_unc_path", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = { "server", "share", "folder", "file.txt" },
 			kind = "unc",
-			driveLetter = nil,
-		}
+			drive = nil :: string?,
+		}, win32.pathmt)
 		local result = path.win32.format(pathobj)
 		assert.eq(result, "\\\\server\\share\\folder\\file.txt")
 	end)
 
 	suite:case("format_empty_relative_path", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = {},
 			kind = "relative",
-			driveLetter = nil,
-		}
+			drive = nil :: string?,
+		}, win32.pathmt)
 		local result = path.win32.format(pathobj)
 		assert.eq(result, ".")
 	end)
 
 	suite:case("format_empty_relative_path_with_drive", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = {},
 			kind = "relative",
-			driveLetter = "C",
-		}
+			drive = "C" :: string?,
+		}, win32.pathmt)
 		local result = path.win32.format(pathobj)
 		assert.eq(result, "C:")
 	end)
 
 	suite:case("format_root_path_with_drive", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = {},
 			kind = "absolute",
-			driveLetter = "C",
-		}
+			drive = "C" :: string?,
+		}, win32.pathmt)
 		local result = path.win32.format(pathobj)
 		assert.eq(result, "C:\\")
 	end)
 
 	suite:case("format_string_returns_same", function(assert)
 		local result = path.win32.format("/home/user/file.txt")
-		assert.eq(result, "/home/user/file.txt")
+		assert.eq(result, "home\\user\\file.txt")
 	end)
 end)
 
@@ -215,11 +215,11 @@ test.suite("PathWin32DirnameSuite", function(suite)
 	end)
 
 	suite:case("dirname_pathobj", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = { "folder", "subfolder", "file.txt" },
 			kind = "relative",
-			driveLetter = nil,
-		}
+			drive = nil :: string?,
+		}, win32.pathmt)
 		local result = path.win32.dirname(pathobj)
 		assert.eq(result, "folder\\subfolder")
 	end)
@@ -277,11 +277,11 @@ test.suite("PathWin32ExtnameSuite", function(suite)
 	end)
 
 	suite:case("extname_pathobj", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = { "folder", "file.pdf" },
 			kind = "relative",
-			driveLetter = nil,
-		}
+			drive = nil :: string?,
+		}, win32.pathmt)
 		local result = path.win32.extname(pathobj)
 		assert.eq(result, ".pdf")
 	end)
@@ -306,39 +306,39 @@ test.suite("PathWin32GetDriveSuite", function(suite)
 	suite:case("getdrive_absolute_path_string", function(assert)
 		local result = path.win32.drive("C:\\Users\\username\\Documents\\file.txt")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 0)
 	end)
 
 	suite:case("getdrive_relative_path_with_drive", function(assert)
 		local result = path.win32.drive("D:Documents\\file.txt")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "D")
+		assert.eq(result.drive, "D")
 		assert.eq(#result.parts, 0)
 	end)
 
 	suite:case("getdrive_path_object", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = { "Users", "username", "Documents" },
 			kind = "absolute",
-			driveLetter = "E",
-		}
+			drive = "E" :: string?,
+		}, win32.pathmt)
 		local result = path.win32.drive(pathobj)
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "E")
+		assert.eq(result.drive, "E")
 		assert.eq(#result.parts, 0)
 	end)
 
 	suite:case("getdrive_root_path", function(assert)
 		local result = path.win32.drive("F:\\")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "F")
+		assert.eq(result.drive, "F")
 		assert.eq(#result.parts, 0)
 	end)
 
 	suite:case("getdrive_error_on_empty_path", function(assert)
 		assert.errors(function()
-			return path.win32.drive("")
+			path.win32.drive("")
 		end)
 	end)
 end)
@@ -375,21 +375,21 @@ test.suite("PathWin32IsAbsoluteSuite", function(suite)
 	end)
 
 	suite:case("isAbsolute_pathobj_absolute", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = { "home", "user", "file.txt" },
 			kind = "absolute",
-			driveLetter = "C",
-		}
+			drive = "C" :: string?,
+		}, win32.pathmt)
 		local result = path.win32.isabsolute(pathobj)
 		assert.eq(result, true)
 	end)
 
 	suite:case("isAbsolute_pathobj_relative", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = { "folder", "file.txt" },
 			kind = "relative",
-			driveLetter = nil,
-		}
+			drive = nil :: string?,
+		}, win32.pathmt)
 		local result = path.win32.isabsolute(pathobj)
 		assert.eq(result, false)
 	end)
@@ -399,7 +399,7 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_removes_current_directory", function(assert)
 		local result = path.win32.normalize("C:\\Users\\.\\username\\Documents")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "username")
@@ -409,7 +409,7 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_resolves_parent_directory", function(assert)
 		local result = path.win32.normalize("C:\\Users\\username\\..\\Documents")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 2)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "Documents")
@@ -418,7 +418,7 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_multiple_dots", function(assert)
 		local result = path.win32.normalize("C:\\Users\\username\\.\\Documents\\..\\files\\.\\")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "username")
@@ -428,7 +428,7 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_relative_path", function(assert)
 		local result = path.win32.normalize("Documents\\.\\subfolder\\..\\file.txt")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 2)
 		assert.eq(result.parts[1], "Documents")
 		assert.eq(result.parts[2], "file.txt")
@@ -437,7 +437,7 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_removes_empty_segments", function(assert)
 		local result = path.win32.normalize("C:\\Users\\\\username\\\\\\Documents")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "username")
@@ -447,14 +447,14 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_parent_beyond_root", function(assert)
 		local result = path.win32.normalize("C:\\Users\\..\\..\\")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 0)
 	end)
 
 	suite:case("normalize_unc_path", function(assert)
 		local result = path.win32.normalize("\\\\server\\share\\.\\folder\\..\\files")
 		assert.eq(result.kind, "unc")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "server")
 		assert.eq(result.parts[2], "share")
@@ -464,7 +464,7 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_relative_with_drive", function(assert)
 		local result = path.win32.normalize("C:Documents\\.\\subfolder\\..\\file.txt")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 2)
 		assert.eq(result.parts[1], "Documents")
 		assert.eq(result.parts[2], "file.txt")
@@ -473,7 +473,7 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_parent_directory_only", function(assert)
 		local result = path.win32.normalize("..")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 1)
 		assert.eq(result.parts[1], "..")
 	end)
@@ -481,7 +481,7 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_multiple_parent_directories", function(assert)
 		local result = path.win32.normalize("..\\..\\..")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "..")
 		assert.eq(result.parts[2], "..")
@@ -491,7 +491,7 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_parent_then_folder", function(assert)
 		local result = path.win32.normalize("..\\folder\\file.txt")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "..")
 		assert.eq(result.parts[2], "folder")
@@ -501,20 +501,20 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_folder_then_multiple_parents", function(assert)
 		local result = path.win32.normalize("folder\\subfolder\\..\\..\\other")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 1)
 		assert.eq(result.parts[1], "other")
 	end)
 
 	suite:case("normalize_pathobj", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = { "Users", ".", "username", "..", "Documents" },
 			kind = "absolute",
-			driveLetter = "C",
-		}
+			drive = "C" :: string?,
+		}, win32.pathmt)
 		local result = path.win32.normalize(pathobj)
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 2)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "Documents")
@@ -523,7 +523,7 @@ test.suite("PathWin32NormalizeSuite", function(suite)
 	suite:case("normalize_relative_with_drive_and_parent", function(assert)
 		local result = path.win32.normalize("C:..\\folder\\file.txt")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "..")
 		assert.eq(result.parts[2], "folder")
@@ -535,7 +535,7 @@ test.suite("PathWin32JoinSuite", function(suite)
 	suite:case("join_absolute_and_relative", function(assert)
 		local result = path.win32.join("C:\\Users\\username", "Documents", "file.txt")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 4)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "username")
@@ -546,7 +546,7 @@ test.suite("PathWin32JoinSuite", function(suite)
 	suite:case("join_relative_paths", function(assert)
 		local result = path.win32.join("Documents", "subfolder", "file.txt")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "Documents")
 		assert.eq(result.parts[2], "subfolder")
@@ -556,7 +556,7 @@ test.suite("PathWin32JoinSuite", function(suite)
 	suite:case("join_drive_relative_paths", function(assert)
 		local result = path.win32.join("C:Documents", "subfolder", "file.txt")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "Documents")
 		assert.eq(result.parts[2], "subfolder")
@@ -566,7 +566,7 @@ test.suite("PathWin32JoinSuite", function(suite)
 	suite:case("join_unc_and_relative", function(assert)
 		local result = path.win32.join("\\\\server\\share", "folder", "file.txt")
 		assert.eq(result.kind, "unc")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 4)
 		assert.eq(result.parts[1], "server")
 		assert.eq(result.parts[2], "share")
@@ -577,19 +577,19 @@ test.suite("PathWin32JoinSuite", function(suite)
 	suite:case("join_no_arguments", function(assert)
 		local result = path.win32.join()
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 0)
 	end)
 
 	suite:case("join_pathobj_and_string", function(assert)
-		local pathobj: win32.path = {
+		local pathobj: win32.path = setmetatable({
 			parts = { "Users", "username" },
 			kind = "absolute",
-			driveLetter = "C",
-		}
+			drive = "C" :: string?,
+		}, win32.pathmt)
 		local result = path.win32.join(pathobj, "Documents\\file.txt")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 4)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "username")
@@ -599,7 +599,7 @@ test.suite("PathWin32JoinSuite", function(suite)
 		assert.eq(pathobj.parts[1], "Users")
 		assert.eq(pathobj.parts[2], "username")
 		assert.eq(pathobj.kind, "absolute")
-		assert.eq(pathobj.driveLetter, "C")
+		assert.eq(pathobj.drive, "C")
 	end)
 
 	suite:case("join_error_on_absolute_addend", function(assert)
@@ -626,7 +626,7 @@ test.suite("PathWin32JoinSuite", function(suite)
 	suite:case("join_compatible_drives", function(assert)
 		local result = path.win32.join("C:Documents", "C:subfolder")
 		assert.eq(result.kind, "relative")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 2)
 		assert.eq(result.parts[1], "Documents")
 		assert.eq(result.parts[2], "subfolder")
@@ -637,7 +637,7 @@ test.suite("PathWin32ResolveSuite", function(suite)
 	suite:case("resolve_absolute_path", function(assert)
 		local result = path.win32.resolve("C:\\Users\\username\\Documents\\file.txt")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 4)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "username")
@@ -661,7 +661,7 @@ test.suite("PathWin32ResolveSuite", function(suite)
 	suite:case("resolve_multiple_paths", function(assert)
 		local result = path.win32.resolve("C:\\Users", "username", "..\\admin", "Documents")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "admin")
@@ -671,7 +671,7 @@ test.suite("PathWin32ResolveSuite", function(suite)
 	suite:case("resolve_with_absolute_in_middle", function(assert)
 		local result = path.win32.resolve("relative", "D:\\absolute\\path", "more")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "D")
+		assert.eq(result.drive, "D")
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "absolute")
 		assert.eq(result.parts[2], "path")
@@ -681,7 +681,7 @@ test.suite("PathWin32ResolveSuite", function(suite)
 	suite:case("resolve_unc_path", function(assert)
 		local result = path.win32.resolve("\\\\server\\share\\folder")
 		assert.eq(result.kind, "unc")
-		assert.eq(result.driveLetter, nil)
+		assert.eq(result.drive, nil)
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "server")
 		assert.eq(result.parts[2], "share")
@@ -698,15 +698,14 @@ test.suite("PathWin32ResolveSuite", function(suite)
 
 	suite:case("resolve_drive_relative_path", function(assert)
 		-- Get the drive letter from the current working directory
-		local cwd = process.cwd()
-		local cwdPath = path.win32.parse(cwd)
-		local driveLetter = if system.win32 then path.win32.drive(cwdPath).driveLetter else "C"
+		local cwdPath = path.win32.parse(process.cwd() :: win32.pathlike)
+		local drive = if system.win32 then path.win32.drive(cwdPath).drive :: string else "C"
 
-		local testPath = driveLetter .. ":Documents\\file.txt"
+		local testPath = drive .. ":Documents\\file.txt"
 		local result = path.win32.resolve(testPath)
 		-- Absolute unix paths will be parsed as relative Windows paths because they don't have drive letters
 		assert.eq(result.kind, if system.win32 then "absolute" else "relative")
-		assert.eq(result.driveLetter, driveLetter)
+		assert.eq(result.drive, drive)
 		-- The exact parts depend on cwd, but should be absolute
 		local endIndex = #result.parts
 		assert.eq(result.parts[endIndex - 1], "Documents")
@@ -716,7 +715,7 @@ test.suite("PathWin32ResolveSuite", function(suite)
 	suite:case("resolve_with_dot_segments", function(assert)
 		local result = path.win32.resolve("C:\\Users\\username", "..\\admin\\.\\Documents")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 3)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "admin")
@@ -726,7 +725,7 @@ test.suite("PathWin32ResolveSuite", function(suite)
 	suite:case("resolve_empty_strings", function(assert)
 		local result = path.win32.resolve("", "", "C:\\Users\\username")
 		assert.eq(result.kind, "absolute")
-		assert.eq(result.driveLetter, "C")
+		assert.eq(result.drive, "C")
 		assert.eq(#result.parts, 2)
 		assert.eq(result.parts[1], "Users")
 		assert.eq(result.parts[2], "username")
@@ -746,6 +745,76 @@ test.suite("PathWin32ToStringSuite", function(suite)
 		local pathObj: win32.path = path.win32.parse(filePath)
 		local result = tostring(pathObj)
 		assert.eq(result, filePath)
+	end)
+end)
+
+test.suite("PathWin32RelativeSuite", function(suite)
+	suite:case("relative_same_path", function(assert)
+		local from = win32.parse("C:\\Users\\username\\Documents")
+		local to = win32.parse("C:\\Users\\username\\Documents")
+		local result = path.win32.relative(from, to)
+		assert.eq(result.kind, "relative")
+		assert.eq(#result.parts, 0)
+		assert.eq(result.drive, nil)
+	end)
+
+	suite:case("relative_subdirectory", function(assert)
+		local from = win32.parse("C:\\Users\\username")
+		local to = win32.parse("C:\\Users\\username\\Documents\\file.txt")
+		local result = path.win32.relative(from, to)
+		assert.eq(result.kind, "relative")
+		assert.eq(#result.parts, 2)
+		assert.eq(result.parts[1], "Documents")
+		assert.eq(result.parts[2], "file.txt")
+		assert.eq(result.drive, nil)
+	end)
+
+	suite:case("relative_parent_directory", function(assert)
+		local from = win32.parse("C:\\Users\\username\\Documents")
+		local to = win32.parse("C:\\Users\\username\\file.txt")
+		local result = path.win32.relative(from, to)
+		assert.eq(result.kind, "relative")
+		assert.eq(#result.parts, 2)
+		assert.eq(result.parts[1], "..")
+		assert.eq(result.parts[2], "file.txt")
+		assert.eq(result.drive, nil)
+	end)
+
+	suite:case("relative_different_kinds", function(assert)
+		local from = win32.parse("C:\\Users\\username\\Documents")
+		local to = win32.parse("Documents\\file.txt")
+		assert.erroreq(function()
+			path.win32.relative(from, to)
+		end, "Cannot compute relative path between different kinds of paths")
+	end)
+
+	suite:case("relative_different_drives", function(assert)
+		local from = win32.parse("C:\\Users\\username")
+		local to = win32.parse("D:\\Documents\\file.txt")
+		assert.erroreq(function()
+			path.win32.relative(from, to)
+		end, "Cannot compute relative path between different drives")
+	end)
+
+	suite:case("relative_unc_paths", function(assert)
+		local from = win32.parse("\\\\server\\share\\folder1")
+		local to = win32.parse("\\\\server\\share\\folder2\\file.txt")
+		local result = path.win32.relative(from, to)
+		assert.eq(result.kind, "relative")
+		assert.eq(#result.parts, 3)
+		assert.eq(result.parts[1], "..")
+		assert.eq(result.parts[2], "folder2")
+		assert.eq(result.parts[3], "file.txt")
+	end)
+
+	suite:case("relative_with_drive_letter_same_drive", function(assert)
+		local from = win32.parse("C:Documents")
+		local to = win32.parse("C:Documents\\subfolder\\file.txt")
+		local result = path.win32.relative(from, to)
+		assert.eq(result.kind, "relative")
+		assert.eq(#result.parts, 2)
+		assert.eq(result.parts[1], "subfolder")
+		assert.eq(result.parts[2], "file.txt")
 	end)
 end)
 

--- a/tests/std/path/path.win32.test.luau
+++ b/tests/std/path/path.win32.test.luau
@@ -184,7 +184,7 @@ test.suite("PathWin32FormatSuite", function(suite)
 
 	suite:case("format_string_returns_same", function(assert)
 		local result = path.win32.format("/home/user/file.txt")
-		assert.eq(result, "home\\user\\file.txt")
+		assert.eq(result, "/home/user/file.txt")
 	end)
 end)
 

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -2,6 +2,7 @@ local pathlib = require("@std/path")
 local process = require("@std/process")
 local system = require("@std/system")
 local test = require("@std/test")
+local windowsPath = require("@std/path/win32")
 
 test.suite("ProcessSuite", function(suite)
 	suite:case("homedir_and_cwd_and_execpath", function(assert)
@@ -29,20 +30,20 @@ test.suite("ProcessSuite", function(suite)
 		local rootdir: string = "/"
 		local root: pathlib.path? = nil
 		if system.win32 then
-			root = pathlib.win32.drive(process.cwd())
+			root = pathlib.win32.drive(process.cwd() :: windowsPath.path)
 			rootdir = pathlib.format(root)
 		end
 		local r = process.run({ "pwd" }, { cwd = rootdir })
 		if system.win32 then
-			assert(root ~= nil and root.driveLetter ~= nil)
-			check.tableeq(r, {
+			assert(root ~= nil and (root :: windowsPath.path).drive ~= nil)
+			check.tableeq(r, { -- LUAUFIX: ProcessResult </: { [unknown] : unknown } seems wrong
 				exitcode = 0,
-				stdout = `/{root.driveLetter:lower()}\n`,
+				stdout = `/{root.drive:lower()}\n`,
 				stderr = "",
 				ok = true,
 			})
 		else
-			check.tableeq(r, {
+			check.tableeq(r, { -- LUAUFIX: ProcessResult </: { [unknown] : unknown } seems wrong
 				exitcode = 0,
 				stdout = "/\n",
 				stderr = "",
@@ -51,7 +52,7 @@ test.suite("ProcessSuite", function(suite)
 		end
 
 		local r2 = process.system("echo hello!")
-		check.tableeq(r2, {
+		check.tableeq(r2, { -- LUAUFIX: ProcessResult </: { [unknown] : unknown } seems wrong
 			exitcode = 0,
 			stdout = "hello!\n",
 			stderr = "",
@@ -61,7 +62,7 @@ test.suite("ProcessSuite", function(suite)
 
 	suite:case("run_nonzero_exitcode", function(assert)
 		local r = process.run({ "sh", "-c", "exit 41" })
-		assert.tableeq(r, {
+		assert.tableeq(r, { -- LUAUFIX: ProcessResult </: { [unknown] : unknown } seems wrong
 			exitcode = 41,
 			stdout = "",
 			stderr = "",


### PR DESCRIPTION
I cleaned up the types in paths so that `path = setmetatable<pathdata, pathMT>`, which I think is a little more digestible. I also added a `path.relative` function, which I need to get my gitignore fixes working on Windows