### PR TITLE
Ensures that do blocks are seralized

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -274,6 +274,15 @@ export type AstStatBlock = {
 	statements: { AstStat },
 }
 
+export type AstStatDo = {
+	location: span,
+	kind: "stat",
+	tag: "do",
+	dokeyword: Token<"do">,
+	body: { AstStat }, -- TODO: change to AstStatBlock when Luau adds AstStatDo on the C++ side
+	endkeyword: Token<"end">,
+}
+
 export type AstElseIfStat = {
 	elseifkeyword: Token<"elseif">,
 	condition: AstExpr,
@@ -439,6 +448,7 @@ export type AstStatTypeFunction = {
 
 export type AstStat = { kind: "stat" } & (
 	| AstStatBlock
+	| AstStatDo
 	| AstStatIf
 	| AstStatWhile
 	| AstStatRepeat

--- a/lute/cli/src/luauflags.cpp
+++ b/lute/cli/src/luauflags.cpp
@@ -22,4 +22,5 @@ static void setLuauFlag(std::string_view name, bool state)
 void setLuauFlags()
 {
     setLuauFlag("LuauAutocompleteAttributes", true);
+    setLuauFlag("LuauCstStatDoWithStatsStart", true);
 }

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -1252,13 +1252,35 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeStat(Luau::AstStatBlock* node)
     {
-        lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize + 1);
+        const auto cstNode = cstNodeMap.find(node);
+        const Luau::CstStatDo* cstDo = cstNode ? (*cstNode)->as<Luau::CstStatDo>() : nullptr;
 
-        serializeNodePreamble(node, "block", "stat");
+        if (cstDo)
+        {
+            lua_rawcheckstack(L, 2);
+            lua_createtable(L, 0, preambleSize + 3);
 
-        serializeStats(node->body);
-        lua_setfield(L, -2, "statements");
+            serializeNodePreamble(node, "do", "stat");
+
+            serializeToken(node->location.begin, "do");
+            lua_setfield(L, -2, "dokeyword");
+
+            serializeStats(node->body);
+            lua_setfield(L, -2, "body");
+
+            serializeToken(cstDo->endPosition, "end");
+            lua_setfield(L, -2, "endkeyword");
+        }
+        else
+        {
+            lua_rawcheckstack(L, 2);
+            lua_createtable(L, 0, preambleSize + 1);
+
+            serializeNodePreamble(node, "block", "stat");
+
+            serializeStats(node->body);
+            lua_setfield(L, -2, "statements");
+        }
     }
 
     void serializeStat(Luau::AstStatIf* node)

--- a/lute/std/libs/syntax/init.luau
+++ b/lute/std/libs/syntax/init.luau
@@ -89,6 +89,8 @@ export type AstExpr = types.AstExpr
 
 export type AstStatBlock = types.AstStatBlock
 
+export type AstStatDo = types.AstStatDo
+
 export type AstElseIfStat = types.AstElseIfStat
 
 export type AstStatIf = types.AstStatIf

--- a/lute/std/libs/syntax/types.luau
+++ b/lute/std/libs/syntax/types.luau
@@ -69,6 +69,8 @@ export type AstExpr = luau.AstExpr
 
 export type AstStatBlock = luau.AstStatBlock
 
+export type AstStatDo = luau.AstStatDo
+
 export type AstElseIfStat = luau.AstElseIfStat
 
 export type AstStatIf = luau.AstStatIf

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -9,6 +9,7 @@ local visitorlib = {}
 export type Visitor = {
 	visitBlock: (types.AstStatBlock) -> boolean,
 	visitBlockEnd: (types.AstStatBlock) -> (),
+	visitStatDo: (types.AstStatDo) -> boolean,
 	visitIf: (types.AstStatIf) -> boolean,
 	visitWhile: (types.AstStatWhile) -> boolean,
 	visitRepeat: (types.AstStatRepeat) -> boolean,
@@ -78,6 +79,7 @@ end
 local defaultVisitor: Visitor = {
 	visitBlock = alwaysVisit :: any,
 	visitBlockEnd = alwaysVisit :: any,
+	visitStatDo = alwaysVisit :: any,
 	visitIf = alwaysVisit :: any,
 	visitWhile = alwaysVisit :: any,
 	visitRepeat = alwaysVisit :: any,
@@ -176,6 +178,16 @@ local function visitBlock(block: types.AstStatBlock, visitor: Visitor)
 		end
 
 		visitor.visitBlockEnd(block)
+	end
+end
+
+local function visitStatDo(node: types.AstStatDo, visitor: Visitor)
+	if visitor.visitStatDo(node) then
+		visitToken(node.dokeyword, visitor)
+		for _, statement in node.body do
+			visitStatement(statement, visitor)
+		end
+		visitToken(node.endkeyword, visitor)
 	end
 end
 
@@ -838,6 +850,8 @@ end
 function visitStatement(statement: types.AstStat, visitor: Visitor)
 	if statement.tag == "block" then
 		visitBlock(statement, visitor)
+	elseif statement.tag == "do" then
+		visitStatDo(statement, visitor)
 	elseif statement.tag == "conditional" then
 		visitIf(statement, visitor)
 	elseif statement.tag == "expression" then
@@ -920,6 +934,7 @@ local function create(visit: ((types.AstNode) -> boolean)?): Visitor
 		return {
 			visitBlock = visit,
 			visitBlockEnd = visit,
+			visitStatDo = visit,
 			visitIf = visit,
 			visitWhile = visit,
 			visitRepeat = visit,

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -122,23 +122,24 @@ test.suite("Parser", function(suite)
 		assert.eq(leadingToken.leadingtrivia[2].text, "\n")
 	end)
 
-	suite:case("roundtrippableAst", function(assert)
-		local function visitDirectory(directory: string)
-			for _, entry in fs.listdirectory(directory) do
-				if entry.type ~= "file" then
-					continue
-				end
+	local function visitDirectory(directory: string)
+		for _, entry in fs.listdirectory(directory) do
+			if entry.type ~= "file" then
+				continue
+			end
+
+			suite:case(`roundtrippableAst_{entry.name}`, function(assert)
 				local p = path.join(directory, entry.name)
 				local source = fs.readfiletostring(path.format(p))
 				local result = printer.printfile(parser.parse(source))
 
 				assert.eq(source, result)
-			end
+			end)
 		end
+	end
 
-		visitDirectory("examples")
-		visitDirectory("tests/parserExamples")
-	end)
+	visitDirectory("examples")
+	visitDirectory("tests/parserExamples")
 
 	suite:case("lineOffsetsField", function(assert)
 		local singleLineCode = "local x = 1"

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -8,7 +8,7 @@ local syntax = require("@std/syntax")
 local T = require("@std/luau")
 
 local function assertEqualsLocation(
-	assert: asserts.Asserts,
+	assert: asserts.asserts,
 	actual: T.span,
 	startLine: number,
 	startColumn: number,
@@ -128,7 +128,7 @@ test.suite("Parser", function(suite)
 				continue
 			end
 
-			suite:case(`roundtrippableAst_{entry.name}`, function(assert)
+			suite:case(`roundtrippable_Ast_{entry.name}`, function(assert)
 				local p = path.join(directory, entry.name)
 				local source = fs.readfiletostring(path.format(p))
 				local result = printer.printfile(parser.parse(source))
@@ -501,7 +501,7 @@ test.suite("parseExpr", function(suite)
 	end)
 end)
 
-local function checkIsBlock(node: any, assert: asserts.Asserts)
+local function checkIsBlock(node: any, assert: asserts.asserts)
 	assert.eq(node.kind, "stat")
 	assert.eq(node.tag, "block")
 end
@@ -511,6 +511,18 @@ test.suite("parse", function(suite)
 		local block = parser.parseblock("")
 		checkIsBlock(block, assert)
 		assert.eq(#block.statements, 0)
+	end)
+
+	suite:case("parseDoStatement", function(assert)
+		local block = parser.parseblock("do print('Hello, World!') end")
+		checkIsBlock(block, assert)
+		assert.eq(#block.statements, 1)
+
+		local doStat = block.statements[1] :: syntax.AstStatDo
+		assert.eq(doStat.tag, "do")
+		assert.eq(doStat.dokeyword.text, "do")
+		assert.eq(#doStat.body, 1)
+		assert.eq(doStat.endkeyword.text, "end")
 	end)
 
 	suite:case("parseIfStatement", function(assert)


### PR DESCRIPTION
Now that we have Luau properly parsing do blocks into the CST, we can do the work of serializing them in lute.
Addresses #581