### PR TITLE
Updates CI to automatically generate release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,7 @@ jobs:
           name: ${{ steps.tag_release.outputs.tag }}
           draft: true
           prerelease: ${{ github.event.inputs.nightly || github.event_name == 'schedule' }}
+          generate_release_notes: true
           files: release/*.zip
 
       - name: Wait for Tag Creation in GitHub

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,25 @@ There are some additional style considerations that we do not have automated enf
 5. Small, incremental contributions are always preferred over sweeping changes. You should expect that any large sweeping change will be rejected summarily without review.
    If you're interested in working on something that _requires_ such a change, you should open an issue first to discuss the idea and get buy-in from the team.
 
+## Pull Request Guidelines
+
+When submitting a pull request:
+
+1. **PR Title:** Your PR title should be a clear, one-line sentence that makes sense as a changelog entry. This title will appear in the release notes, so write it to be informative to users. Focus on what changed from a user's perspective.
+   - Good: "Adds support for custom error handlers in the CLI"
+   - Good: "Fixes memory leak in filesystem operations"
+   - Bad: "Update code"
+   - Bad: "WIP: testing changes"
+
+2. **PR Labels:** Please label your PR with one of the following labels so it appears in the correct section of the release notes:
+   - `documentation` - Documentation improvements
+   - `std` - Changes to the standard library
+   - `batteries` - Changes to batteries (additional libraries that are useful for writing lute code)
+   - `cli` - Changes to the command line - either the c++ subcommands (run, compile, etc) or lute tooling (lint, transform, test)
+   - `runtime` - Changes to the C++ runtime
+   - `infra` - Changes to CI/CD, build system, or project infrastructure
+   - `bug` - Bug fixes
+
 ## Licensing
 
 By providing code in an issue or opening a pull request, you agree to license that code under the MIT License, and indicate that you have the legal right to do so.


### PR DESCRIPTION
This PR adds support for auto-generating release notes for Lute. I've also updated the contribution guidelines to suggest a) making PR titles descriptive, user-facing one liners, and b) adding labels to PR's so that the release notes will place changes in the appropriate categories.