### PR TITLE
Adds a global ignore directive to `lute lint`

### DIFF
--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -139,9 +139,10 @@ end
 local function violationIsSuppressed(
 	violation: types.LintViolation,
 	ast: syntax.AstStatBlock,
-	directiveCache: { [syntax.AstNode]: { [string]: boolean } }
+	directiveCache: { [syntax.AstNode]: { [string]: boolean } },
+	globalIgnores: { [string]: true }
 ): boolean
-	local violationSuppressed = false
+	local violationSuppressed = globalIgnores[violation.lintname] == true
 
 	-- We want to find the lint directive with the tightest scope that applies to this violation
 	local function nodeIsSuppressed(node: syntax.AstNode): boolean
@@ -183,6 +184,20 @@ local function violationIsSuppressed(
 	return violationSuppressed
 end
 
+local function parseGlobalIgnores(trivia: { syntax.Trivia }): { [string]: true }
+	local globalIgnores: { [string]: true } = {}
+
+	for _, triv in trivia do
+		if triv.tag == "blockcomment" or triv.tag == "comment" then
+			for rule in triv.text:gmatch("lute%-lint%-global%-ignore%((.+)%)") do
+				globalIgnores[rule] = true
+			end
+		end
+	end
+
+	return globalIgnores
+end
+
 local function lintFile(inputFilePath: pathLib.path, lintRules: { types.LintRule }): { types.LintViolation }
 	if VERBOSE then
 		print(`Reading input file '{inputFilePath}'`)
@@ -195,6 +210,11 @@ local function lintFile(inputFilePath: pathLib.path, lintRules: { types.LintRule
 	local ast = syntax.parseblock(fileContent)
 
 	if VERBOSE then
+		print(`Parsing global lint ignores in '{inputFilePath}'`)
+	end
+	local globalIgnores = parseGlobalIgnores(triviaUtils.leftmosttrivia(ast))
+
+	if VERBOSE then
 		print("Applying lint rules")
 	end
 	local violations: { types.LintViolation } = {}
@@ -204,7 +224,7 @@ local function lintFile(inputFilePath: pathLib.path, lintRules: { types.LintRule
 		if success then
 			-- On success, err contains the returned violations
 			for _, violation in err do
-				if not violationIsSuppressed(violation, ast, directiveCache) then
+				if not violationIsSuppressed(violation, ast, directiveCache, globalIgnores) then
 					table.insert(violations, violation)
 				end
 			end

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -1007,10 +1007,50 @@ violator.luau:1:11-16 ──
 		expected = [[
 violator.luau:6:12-18 ──
    │
- 6 │    local y = 10 / 0
-   │            ^^^^^^
+ 6 │     local y = 10 / 0
+   │               ^^^^^^
    │
 ]]
+		assert.strcontains(result.stdout, expected)
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
+	suite:case("lute lint global ignore directive", function(assert)
+		-- Create a file that violates the default almost_swapped and divide_by_zero rules
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+-- lute-lint-global-ignore(divide_by_zero)
+local x = 1 / 0
+-- lute-lint-report(divide_by_zero)
+if true then
+	local z = 3 / 0
+	-- lute-lint-ignore(divide_by_zero)
+	local y = 10 / 0
+end
+    ]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		assert.strcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.", nil, 1)
+
+		local expected = [[
+violator.luau:5:12-17 ──
+   │
+ 5 │     local z = 3 / 0
+   │               ^^^^^
+   │
+]]
+		assert.strcontains(result.stdout, expected)
 
 		-- Teardown
 		fs.remove(violatorPath)


### PR DESCRIPTION
Adds a global ignore directive to lute lint, which is only parsed if included at the top of a file.