### PR TITLE
adds timeout for `run-lutecli-luau-tests` workflow in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   run-lutecli-luau-tests:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
 
     strategy:
       matrix:


### PR DESCRIPTION
leaving unlabeled to not include in release notes

This is because `fs_watch` test is hanging, see https://github.com/luau-lang/lute/issues/639 and https://github.com/luau-lang/lute/actions/runs/20073090896/job/57580297775
Setting a 15 minute timeout per discussion but still working on actual fix for fs.watch test 