### PR TITLE
Comment out print statements in `compile_command_e2e` unit test

### DIFF
--- a/tests/src/staticrequires/lib/helper.luau
+++ b/tests/src/staticrequires/lib/helper.luau
@@ -1,7 +1,7 @@
 -- Helper module that also requires another module
 local shared = require("../shared")
 
-print("Helper module")
+-- print("Helper module")
 return {
 	help = function()
 		return "helper"

--- a/tests/src/staticrequires/main.luau
+++ b/tests/src/staticrequires/main.luau
@@ -1,6 +1,6 @@
 -- test that you can require in an alias aware fashion
 local example = require("@example/option")
-print(`Required {example.file} from alias @example`)
+-- print(`Required {example.file} from alias @example`)
 
 -- Entry point that requires other modules
 local utils = require("./utils")
@@ -11,7 +11,7 @@ local path = require("@std/path")
 
 -- Use standard library to verify it works in compiled bundles
 local cwd = path.format(process.cwd())
-print("Main module running from: " .. cwd)
+-- print("Main module running from: " .. cwd)
 
 return {
 	utils = utils,

--- a/tests/src/staticrequires/other/module.luau
+++ b/tests/src/staticrequires/other/module.luau
@@ -1,6 +1,6 @@
 -- test that we can require using an alias from other/.luaurc
 local example = require("@otherlib/example")
-print(`Required {example.file} from alias @otherlib`)
+-- print(`Required {example.file} from alias @otherlib`)
 
 return {
 	example = example,

--- a/tests/src/staticrequires/shared.luau
+++ b/tests/src/staticrequires/shared.luau
@@ -1,5 +1,5 @@
 -- Shared module
-print("Shared module")
+-- print("Shared module")
 return {
 	version = "1.0",
 }

--- a/tests/src/staticrequires/utils.luau
+++ b/tests/src/staticrequires/utils.luau
@@ -1,5 +1,5 @@
 -- Utilities module
-print("Utils module")
+-- print("Utils module")
 return {
 	add = function(a, b)
 		return a + b


### PR DESCRIPTION
These prints are a little distracting, so we're commenting them out. They're left in place and can be uncommented locally  since they're useful for debugging.