### PR TITLE
CLI refactor: move out require setup code into separate source files

### DIFF
--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(Lute.CLI.lib PRIVATE
     include/lute/fileutils.h
     include/lute/luauflags.h
     include/lute/reporter.h
+    include/lute/requiresetup.h
     include/lute/staticrequires.h
     include/lute/tc.h
     include/lute/uvstate.h
@@ -36,6 +37,7 @@ target_sources(Lute.CLI.lib PRIVATE
     src/compile.cpp
     src/fileutils.cpp
     src/luauflags.cpp
+    src/requiresetup.cpp
     src/staticrequires.cpp
     src/tc.cpp
     src/uvstate.cpp

--- a/lute/cli/include/lute/climain.h
+++ b/lute/cli/include/lute/climain.h
@@ -6,7 +6,6 @@ struct lua_State;
 struct Runtime;
 class LuteReporter;
 
-lua_State* setupCliState(Runtime& runtime, std::function<void(lua_State*)> preSandboxInit = nullptr);
 int cliMain(int argc, char** argv, LuteReporter& reporter);
 bool runBytecode(
     Runtime& runtime,

--- a/lute/cli/include/lute/requiresetup.h
+++ b/lute/cli/include/lute/requiresetup.h
@@ -3,6 +3,7 @@
 #include "Luau/DenseHash.h"
 
 #include <functional>
+#include <string>
 
 struct lua_State;
 struct Runtime;

--- a/lute/cli/include/lute/requiresetup.h
+++ b/lute/cli/include/lute/requiresetup.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Luau/DenseHash.h"
+
+#include <functional>
+
+struct lua_State;
+struct Runtime;
+
+lua_State* setupCliState(Runtime& runtime, std::function<void(lua_State*)> preSandboxInit = nullptr);
+lua_State* setupBundleState(
+    Runtime& runtime,
+    Luau::DenseHashMap<std::string, std::string> luaurcFiles,
+    Luau::DenseHashMap<std::string, std::string> bundleMap
+);

--- a/lute/cli/include/lute/tc.h
+++ b/lute/cli/include/lute/tc.h
@@ -2,4 +2,7 @@
 
 #include "lute/reporter.h"
 
+#include <string>
+#include <vector>
+
 int typecheck(const std::vector<std::string>& sourceFiles, LuteReporter& reporter);

--- a/lute/cli/include/lute/tc.h
+++ b/lute/cli/include/lute/tc.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include "Luau/FileResolver.h"
-#include "Luau/FileUtils.h"
-#include "Luau/Frontend.h"
-
 #include "lute/reporter.h"
 
 int typecheck(const std::vector<std::string>& sourceFiles, LuteReporter& reporter);

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -1,41 +1,27 @@
 #include "lute/climain.h"
 
-#include "lute/bundlevfs.h"
 #include "lute/clicommands.h"
-#include "lute/clivfs.h"
 #include "lute/compile.h"
-#include "lute/crypto.h"
-#include "lute/fs.h"
-#include "lute/io.h"
-#include "lute/luau.h"
 #include "lute/luauflags.h"
-#include "lute/net.h"
+#include "lute/modulepath.h"
 #include "lute/options.h"
 #include "lute/process.h"
 #include "lute/ref.h"
 #include "lute/reporter.h"
-#include "lute/require.h"
-#include "lute/requirevfs.h"
+#include "lute/requiresetup.h"
 #include "lute/runtime.h"
 #include "lute/staticrequires.h"
-#include "lute/system.h"
-#include "lute/task.h"
 #include "lute/tc.h"
-#include "lute/time.h"
 #include "lute/version.h"
-#include "lute/vm.h"
 
 #include "Luau/CodeGen.h"
 #include "Luau/Common.h"
 #include "Luau/Compiler.h"
 #include "Luau/DenseHash.h"
 #include "Luau/FileUtils.h"
-#include "Luau/Require.h"
 
 #include "lua.h"
 #include "lualib.h"
-
-#include "uv.h"
 
 #include <memory>
 
@@ -115,120 +101,6 @@ Compile Options:
 	--show-require-graph    Print the require dependency graph.
 	-h, --help              Display this usage message.
 )";
-
-void* createCliRequireContext(lua_State* L)
-{
-    void* ctx = lua_newuserdatadtor(
-        L,
-        sizeof(RequireCtx),
-        [](void* ptr)
-        {
-            std::destroy_at(static_cast<RequireCtx*>(ptr));
-        }
-    );
-
-    if (!ctx)
-        luaL_error(L, "unable to allocate RequireCtx");
-
-    ctx = new (ctx) RequireCtx{std::make_unique<RequireVfs>(CliVfs{})};
-
-    // Store RequireCtx in the registry to keep it alive for the lifetime of
-    // this lua_State. Memory address is used as a key to avoid collisions.
-    lua_pushlightuserdata(L, ctx);
-    lua_insert(L, -2);
-    lua_settable(L, LUA_REGISTRYINDEX);
-
-    return ctx;
-}
-
-static void luteopen_libs(lua_State* L)
-{
-    std::vector<std::pair<const char*, lua_CFunction>> libs = {{
-        {"@lute/crypto", luteopen_crypto},
-        {"@lute/fs", luteopen_fs},
-        {"@lute/luau", luteopen_luau},
-        {"@lute/net", luteopen_net},
-        {"@lute/process", luteopen_process},
-        {"@lute/task", luteopen_task},
-        {"@lute/vm", luteopen_vm},
-        {"@lute/system", luteopen_system},
-        {"@lute/time", luteopen_time},
-        {"@lute/io", luteopen_io},
-    }};
-
-    for (const auto& [name, func] : libs)
-    {
-        lua_pushcfunction(L, luarequire_registermodule, nullptr);
-        lua_pushstring(L, name);
-        func(L);
-        lua_call(L, 2, 0);
-    }
-}
-
-void* createBundleRequireContext(
-    lua_State* L,
-    Luau::DenseHashMap<std::string, std::string> luaurcFiles,
-    Luau::DenseHashMap<std::string, std::string> bundleMap
-)
-{
-    void* ctx = lua_newuserdatadtor(
-        L,
-        sizeof(RequireCtx),
-        [](void* ptr)
-        {
-            std::destroy_at(static_cast<RequireCtx*>(ptr));
-        }
-    );
-
-    if (!ctx)
-        luaL_error(L, "unable to allocate RequireCtx");
-    ctx = new (ctx) RequireCtx{std::make_unique<RequireVfs>(BundleVfs{std::move(luaurcFiles), std::move(bundleMap)})};
-
-    // Store RequireCtx in the registry to keep it alive for the lifetime of
-    // this lua_State. Memory address is used as a key to avoid collisions.
-    lua_pushlightuserdata(L, ctx);
-    lua_insert(L, -2);
-    lua_settable(L, LUA_REGISTRYINDEX);
-
-    return ctx;
-}
-
-lua_State* setupCliState(Runtime& runtime, std::function<void(lua_State*)> preSandboxInit)
-{
-    return setupState(
-        runtime,
-        [preSandboxInit = std::move(preSandboxInit)](lua_State* L)
-        {
-            luteopen_libs(L);
-
-            if (Luau::CodeGen::isSupported())
-                Luau::CodeGen::create(L);
-
-            luaopen_require(L, requireConfigInit, createCliRequireContext(L));
-            if (preSandboxInit)
-                preSandboxInit(L);
-        }
-    );
-}
-
-lua_State* setupBundleState(
-    Runtime& runtime,
-    Luau::DenseHashMap<std::string, std::string> luaurcFiles,
-    Luau::DenseHashMap<std::string, std::string> bundleMap
-)
-{
-    return setupState(
-        runtime,
-        [luaurcFiles = std::move(luaurcFiles), bundleMap = std::move(bundleMap)](lua_State* L)
-        {
-            luteopen_libs(L);
-            if (Luau::CodeGen::isSupported())
-                Luau::CodeGen::create(L);
-
-            luaopen_require(L, requireConfigInit, createBundleRequireContext(L, std::move(luaurcFiles), std::move(bundleMap)));
-        }
-    );
-}
 
 static bool setupArguments(lua_State* L, int argc, char** argv)
 {

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -222,7 +222,7 @@ static std::pair<bool, std::string> getWithRequireByStringSemantics(std::string 
         result = {false, "File or directory not found."};
         break;
     }
-    
+
     return result;
 };
 

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -23,15 +23,13 @@
 #include "lua.h"
 #include "lualib.h"
 
-#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #ifdef _WIN32
 #include <Windows.h>
 #endif
-
-#include <memory>
-#include <string>
-#include <vector>
 
 static const char* HELP_STRING = R"(Usage: lute <command> [options] [arguments...]
 

--- a/lute/cli/src/fileutils.cpp
+++ b/lute/cli/src/fileutils.cpp
@@ -16,8 +16,9 @@
 #include <sys/stat.h>
 #endif
 
-#include <cstring>
 #include "Luau/FileUtils.h"
+
+#include <cstring>
 
 namespace Lute
 {

--- a/lute/cli/src/main.cpp
+++ b/lute/cli/src/main.cpp
@@ -1,6 +1,6 @@
 #include "lute/climain.h"
-#include "lute/uvstate.h"
 #include "lute/clireporter.h"
+#include "lute/uvstate.h"
 
 int main(int argc, char** argv)
 {

--- a/lute/cli/src/requiresetup.cpp
+++ b/lute/cli/src/requiresetup.cpp
@@ -1,0 +1,134 @@
+#include "lute/requiresetup.h"
+
+#include "lute/bundlevfs.h"
+#include "lute/clivfs.h"
+#include "lute/crypto.h"
+#include "lute/fs.h"
+#include "lute/io.h"
+#include "lute/luau.h"
+#include "lute/net.h"
+#include "lute/process.h"
+#include "lute/require.h"
+#include "lute/requirevfs.h"
+#include "lute/runtime.h"
+#include "lute/system.h"
+#include "lute/task.h"
+#include "lute/time.h"
+#include "lute/vm.h"
+
+#include "Luau/CodeGen.h"
+#include "Luau/Require.h"
+
+static void luteopen_libs(lua_State* L)
+{
+    std::vector<std::pair<const char*, lua_CFunction>> libs = {{
+        {"@lute/crypto", luteopen_crypto},
+        {"@lute/fs", luteopen_fs},
+        {"@lute/luau", luteopen_luau},
+        {"@lute/net", luteopen_net},
+        {"@lute/process", luteopen_process},
+        {"@lute/task", luteopen_task},
+        {"@lute/vm", luteopen_vm},
+        {"@lute/system", luteopen_system},
+        {"@lute/time", luteopen_time},
+        {"@lute/io", luteopen_io},
+    }};
+
+    for (const auto& [name, func] : libs)
+    {
+        lua_pushcfunction(L, luarequire_registermodule, nullptr);
+        lua_pushstring(L, name);
+        func(L);
+        lua_call(L, 2, 0);
+    }
+}
+
+static void* createCliRequireContext(lua_State* L)
+{
+    void* ctx = lua_newuserdatadtor(
+        L,
+        sizeof(RequireCtx),
+        [](void* ptr)
+        {
+            std::destroy_at(static_cast<RequireCtx*>(ptr));
+        }
+    );
+
+    if (!ctx)
+        luaL_error(L, "unable to allocate RequireCtx");
+
+    ctx = new (ctx) RequireCtx{std::make_unique<RequireVfs>(CliVfs{})};
+
+    // Store RequireCtx in the registry to keep it alive for the lifetime of
+    // this lua_State. Memory address is used as a key to avoid collisions.
+    lua_pushlightuserdata(L, ctx);
+    lua_insert(L, -2);
+    lua_settable(L, LUA_REGISTRYINDEX);
+
+    return ctx;
+}
+
+static void* createBundleRequireContext(
+    lua_State* L,
+    Luau::DenseHashMap<std::string, std::string> luaurcFiles,
+    Luau::DenseHashMap<std::string, std::string> bundleMap
+)
+{
+    void* ctx = lua_newuserdatadtor(
+        L,
+        sizeof(RequireCtx),
+        [](void* ptr)
+        {
+            std::destroy_at(static_cast<RequireCtx*>(ptr));
+        }
+    );
+
+    if (!ctx)
+        luaL_error(L, "unable to allocate RequireCtx");
+    ctx = new (ctx) RequireCtx{std::make_unique<RequireVfs>(BundleVfs{std::move(luaurcFiles), std::move(bundleMap)})};
+
+    // Store RequireCtx in the registry to keep it alive for the lifetime of
+    // this lua_State. Memory address is used as a key to avoid collisions.
+    lua_pushlightuserdata(L, ctx);
+    lua_insert(L, -2);
+    lua_settable(L, LUA_REGISTRYINDEX);
+
+    return ctx;
+}
+
+lua_State* setupCliState(Runtime& runtime, std::function<void(lua_State*)> preSandboxInit)
+{
+    return setupState(
+        runtime,
+        [preSandboxInit = std::move(preSandboxInit)](lua_State* L)
+        {
+            luteopen_libs(L);
+
+            if (Luau::CodeGen::isSupported())
+                Luau::CodeGen::create(L);
+
+            luaopen_require(L, requireConfigInit, createCliRequireContext(L));
+            if (preSandboxInit)
+                preSandboxInit(L);
+        }
+    );
+}
+
+lua_State* setupBundleState(
+    Runtime& runtime,
+    Luau::DenseHashMap<std::string, std::string> luaurcFiles,
+    Luau::DenseHashMap<std::string, std::string> bundleMap
+)
+{
+    return setupState(
+        runtime,
+        [luaurcFiles = std::move(luaurcFiles), bundleMap = std::move(bundleMap)](lua_State* L)
+        {
+            luteopen_libs(L);
+            if (Luau::CodeGen::isSupported())
+                Luau::CodeGen::create(L);
+
+            luaopen_require(L, requireConfigInit, createBundleRequireContext(L, std::move(luaurcFiles), std::move(bundleMap)));
+        }
+    );
+}

--- a/lute/cli/src/requiresetup.cpp
+++ b/lute/cli/src/requiresetup.cpp
@@ -19,6 +19,10 @@
 #include "Luau/CodeGen.h"
 #include "Luau/Require.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+
 static void luteopen_libs(lua_State* L)
 {
     std::vector<std::pair<const char*, lua_CFunction>> libs = {{

--- a/lute/cli/src/tc.cpp
+++ b/lute/cli/src/tc.cpp
@@ -5,8 +5,8 @@
 
 #include "Luau/BuiltinDefinitions.h"
 #include "Luau/Error.h"
-#include "Luau/PrettyPrinter.h"
-#include "Luau/TypeAttach.h"
+#include "Luau/FileUtils.h"
+#include "Luau/Frontend.h"
 
 static const std::string kLuteDefinitions = R"LUTE_TYPES(
 -- Net api

--- a/lute/cli/src/tc.cpp
+++ b/lute/cli/src/tc.cpp
@@ -1,12 +1,12 @@
 #include "lute/tc.h"
 
+#include "lute/configresolver.h"
+#include "lute/moduleresolver.h"
+
 #include "Luau/BuiltinDefinitions.h"
 #include "Luau/Error.h"
 #include "Luau/PrettyPrinter.h"
 #include "Luau/TypeAttach.h"
-
-#include "lute/configresolver.h"
-#include "lute/moduleresolver.h"
 
 static const std::string kLuteDefinitions = R"LUTE_TYPES(
 -- Net api

--- a/tests/src/cliruntimefixture.cpp
+++ b/tests/src/cliruntimefixture.cpp
@@ -1,13 +1,12 @@
 #include "cliruntimefixture.h"
 
+#include "lute/climain.h"
+#include "lute/requiresetup.h"
+
 #include "Luau/Compiler.h"
 
 #include "lua.h"
 #include "lualib.h"
-
-#include "Luau/Compiler.h"
-
-#include "Luau/Compiler.h"
 
 static int report(lua_State* L)
 {

--- a/tests/src/cliruntimefixture.h
+++ b/tests/src/cliruntimefixture.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "lute/climain.h"
+
 #include "lute/runtime.h"
 
 #include "lutefixture.h"


### PR DESCRIPTION
Move all setup for the various CLI-facing virtual filesystems into their own files: `requiresetup.{h,cpp}`. Our `climain.cpp` file was getting a bit confusing to parse (and would have gotten worse after merging #657).

Ran clang-format, and also made some trivial changes to clean up some other files in CLI.