### PR TITLE
Sets `lute` to enable all `Luau*` flags by default

### DIFF
--- a/lute/cli/src/luauflags.cpp
+++ b/lute/cli/src/luauflags.cpp
@@ -33,6 +33,6 @@ void setLuauFlags()
 {
     enableAllLuauFlags();
 
-    // Individual flags can be overriden here as needed, e.g.:
+    // Individual flags can be overridden here as needed, e.g.:
     // setLuauFlag("LuauSomeFlagThatCausedARegression", false);
 }

--- a/lute/cli/src/luauflags.cpp
+++ b/lute/cli/src/luauflags.cpp
@@ -1,11 +1,21 @@
 #include "lute/luauflags.h"
 
 #include "Luau/Common.h"
+#include "Luau/ExperimentalFlags.h"
 
 #include <stdexcept>
 #include <string_view>
 
-static void setLuauFlag(std::string_view name, bool state)
+static void enableAllLuauFlags()
+{
+    for (Luau::FValue<bool>* flag = Luau::FValue<bool>::list; flag; flag = flag->next)
+    {
+        if (strncmp(flag->name, "Luau", 4) == 0 && !Luau::isAnalysisFlagExperimental(flag->name))
+            flag->value = true;
+    }
+}
+
+[[maybe_unused]] static void setLuauFlag(std::string_view name, bool state)
 {
     for (Luau::FValue<bool>* flag = Luau::FValue<bool>::list; flag; flag = flag->next)
     {
@@ -21,6 +31,8 @@ static void setLuauFlag(std::string_view name, bool state)
 
 void setLuauFlags()
 {
-    setLuauFlag("LuauAutocompleteAttributes", true);
-    setLuauFlag("LuauCstStatDoWithStatsStart", true);
+    enableAllLuauFlags();
+
+    // Individual flags can be overriden here as needed, e.g.:
+    // setLuauFlag("LuauSomeFlagThatCausedARegression", false);
 }


### PR DESCRIPTION
This now matches the default behavior of Luau's CLI tools. We can still use `setLuauFlag` to disable any problematic flags.