### PR TITLE
Creates a new `@std/net` library with the `request` API exposed

### DIFF
--- a/definitions/net.luau
+++ b/definitions/net.luau
@@ -6,14 +6,14 @@ export type Metadata = {
 	headers: { [string]: string }?,
 }
 
-export type Request = {
+export type Response = {
 	body: string,
 	headers: { [string]: string },
 	status: number,
 	ok: boolean,
 }
 
-function net.request(url: string, metadata: Metadata?): Request
+function net.request(url: string, metadata: Metadata?): Response
 	error("not implemented")
 end
 

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -43,4 +43,4 @@ function luau.resolverequire(modulepath: string, frompath: path.pathlike): strin
 	return luteLuau.resolverequire(modulepath, `@{frompathString}`)
 end
 
-return luau
+return table.freeze(luau)

--- a/lute/std/libs/net.luau
+++ b/lute/std/libs/net.luau
@@ -10,7 +10,7 @@ export type metadata = luteNet.Metadata
 export type response = luteNet.Response
 
 function net.request(url: string, metadata: metadata?): response
-    return luteNet.request(url, metadata)
+	return luteNet.request(url, metadata)
 end
 
 return net

--- a/lute/std/libs/net.luau
+++ b/lute/std/libs/net.luau
@@ -13,4 +13,4 @@ function net.request(url: string, metadata: metadata?): response
 	return luteNet.request(url, metadata)
 end
 
-return net
+return table.freeze(net)

--- a/lute/std/libs/net.luau
+++ b/lute/std/libs/net.luau
@@ -1,0 +1,16 @@
+--!strict
+-- @std/net
+-- stdlib for `@lute/net`
+
+local luteNet = require("@lute/net")
+
+local net = {}
+
+export type metadata = luteNet.Metadata
+export type response = luteNet.Response
+
+function net.request(url: string, metadata: metadata?): response
+    return luteNet.request(url, metadata)
+end
+
+return net

--- a/tests/std/net.test.luau
+++ b/tests/std/net.test.luau
@@ -1,0 +1,16 @@
+local net = require("@std/net")
+local test = require("@std/test")
+
+test.suite("NetTestSuite", function(suite)
+    suite:case("request", function(assert)
+        -- Assumption: if this test is running in CI, then the repository's
+        -- GitHub page is reachable.
+        local response = net.request("https://github.com/luau-lang/lute", {
+            method = "GET",
+        })
+        assert.eq(true, response.ok)
+        assert.eq(200, response.status)
+	end)
+end)
+
+test.run()

--- a/tests/std/net.test.luau
+++ b/tests/std/net.test.luau
@@ -2,14 +2,14 @@ local net = require("@std/net")
 local test = require("@std/test")
 
 test.suite("NetTestSuite", function(suite)
-    suite:case("request", function(assert)
-        -- Assumption: if this test is running in CI, then the repository's
-        -- GitHub page is reachable.
-        local response = net.request("https://github.com/luau-lang/lute", {
-            method = "GET",
-        })
-        assert.eq(true, response.ok)
-        assert.eq(200, response.status)
+	suite:case("request", function(assert)
+		-- Assumption: if this test is running in CI, then the repository's
+		-- GitHub page is reachable.
+		local response = net.request("https://github.com/luau-lang/lute", {
+			method = "GET",
+		})
+		assert.eq(true, response.ok)
+		assert.eq(200, response.status)
 	end)
 end)
 


### PR DESCRIPTION
This is needed for the package manager. Very barebones for now, and we will still need to expose the other parts of `@lute/net` under `@std/net`.