### PR TITLE
Exposes `net.serve` through `@std/net` and adds its missing return type

### DIFF
--- a/definitions/net.luau
+++ b/definitions/net.luau
@@ -41,7 +41,13 @@ export type Configuration = {
 	handler: Handler,
 }
 
-function net.serve(config: Handler | Configuration)
+export type Server = {
+	hostname: string,
+	port: number,
+	close: () -> (),
+}
+
+function net.serve(config: Handler | Configuration): Server
 	error("not implemented")
 end
 

--- a/examples/serve_html.luau
+++ b/examples/serve_html.luau
@@ -1,8 +1,8 @@
-local net = require("@lute/net")
+local net = require("@std/net")
 
 local server = net.serve({
 	port = 8080,
-	handler = function(req)
+	handler = function(req: net.receivedrequest): net.serverresponse
 		local headers = ""
 		for key, value in req.headers do
 			headers ..= `\n  {key}: {value}`

--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -532,7 +532,7 @@ int lua_serve(lua_State* L)
 {
     uWS::Loop::get(uv_default_loop());
 
-    std::string hostname = "0.0.0.0";
+    std::string hostname = "localhost";
     int port = 3000;
     bool reusePort = false;
     std::optional<uWS::SocketContextOptions> tlsOptions;

--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -532,7 +532,7 @@ int lua_serve(lua_State* L)
 {
     uWS::Loop::get(uv_default_loop());
 
-    std::string hostname = "localhost";
+    std::string hostname = "127.0.0.1";
     int port = 3000;
     bool reusePort = false;
     std::optional<uWS::SocketContextOptions> tlsOptions;

--- a/lute/std/libs/net.luau
+++ b/lute/std/libs/net.luau
@@ -2,15 +2,25 @@
 -- @std/net
 -- stdlib for `@lute/net`
 
-local luteNet = require("@lute/net")
+local net = require("@lute/net")
 
-local net = {}
+local netlib = {}
 
-export type metadata = luteNet.Metadata
-export type response = luteNet.Response
+export type metadata = net.Metadata
+export type response = net.Response
 
-function net.request(url: string, metadata: metadata?): response
-	return luteNet.request(url, metadata)
+function netlib.request(url: string, metadata: metadata?): response
+	return net.request(url, metadata)
 end
 
-return table.freeze(net)
+export type receivedrequest = net.ReceivedRequest
+export type serverresponse = net.ServerResponse
+export type handler = net.Handler
+export type configuration = net.Configuration
+export type server = net.Server
+
+function netlib.serve(config: handler | configuration): server
+	return net.serve(config)
+end
+
+return table.freeze(netlib)

--- a/tests/std/net.test.luau
+++ b/tests/std/net.test.luau
@@ -12,7 +12,7 @@ test.suite("NetTestSuite", function(suite)
 			end,
 		})
 
-		local response = net.request(`{server.hostname}:{server.port}`, {
+		local response = net.request(`localhost:{server.port}`, {
 			method = "GET",
 		})
 		assert.eq(true, response.ok)

--- a/tests/std/net.test.luau
+++ b/tests/std/net.test.luau
@@ -12,7 +12,7 @@ test.suite("NetTestSuite", function(suite)
 			end,
 		})
 
-		local response = net.request(`localhost:{server.port}`, {
+		local response = net.request(`{server.hostname}:{server.port}`, {
 			method = "GET",
 		})
 		assert.eq(true, response.ok)

--- a/tests/std/net.test.luau
+++ b/tests/std/net.test.luau
@@ -2,14 +2,24 @@ local net = require("@std/net")
 local test = require("@std/test")
 
 test.suite("NetTestSuite", function(suite)
-	suite:case("request", function(assert)
-		-- Assumption: if this test is running in CI, then the repository's
-		-- GitHub page is reachable.
-		local response = net.request("https://github.com/luau-lang/lute", {
+	suite:case("serve_locally_and_request", function(assert)
+		local server = net.serve({
+			handler = function(req: net.receivedrequest): net.serverresponse
+				return {
+					status = 200,
+					body = "Hello, World!",
+				}
+			end,
+		})
+
+		local response = net.request(`{server.hostname}:{server.port}`, {
 			method = "GET",
 		})
 		assert.eq(true, response.ok)
 		assert.eq(200, response.status)
+		assert.eq("Hello, World!", response.body)
+
+		server.close()
 	end)
 end)
 


### PR DESCRIPTION
1. Expose `net.serve` in `@std/net` as a wrapper for `@lute/net`'s version.
2. Add a `Server` return type to this function that seemed to have been missed when it was first added.
3. Update the `net.test.luau` unit test to create a local server and request from it instead of hitting an arbitrary URL (this was causing some flakiness).
4. Add types to our example file `examples/serve_html.luau` so that it passes a type check.