### PR TITLE
Supports parsing Luau-syntax lock files in `lute pkgrun <file>`

### DIFF
--- a/lute/cli/src/packagerun.cpp
+++ b/lute/cli/src/packagerun.cpp
@@ -1,9 +1,11 @@
 #include "lute/packagerun.h"
 
+#include "lute/userlandvfs.h"
+
 #include "Luau/FileUtils.h"
+#include "Luau/LuauConfig.h"
 
 #include <optional>
-#include <regex>
 #include <string>
 #include <string_view>
 
@@ -22,7 +24,7 @@ std::optional<std::string> getAbsolutePathToNearestLockfile(std::string entryFil
     std::optional<std::string> currentPath = getParentPath(entryFile);
     while (currentPath)
     {
-        std::string lockfilePath = joinPaths(*currentPath, "loom.lock");
+        std::string lockfilePath = joinPaths(*currentPath, "loom.lock.luau");
         if (isFile(lockfilePath))
             return lockfilePath;
 
@@ -32,19 +34,63 @@ std::optional<std::string> getAbsolutePathToNearestLockfile(std::string entryFil
     return std::nullopt;
 }
 
+static std::string toLower(std::string_view str)
+{
+    std::string result;
+    result.resize(str.size());
+    for (size_t i = 0; i < str.size(); i++)
+        result[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(str[i])));
+    return result;
+}
+
 static std::vector<Package::Identifier> extractIdentifiers(std::string lockfileContents)
 {
-    std::vector<Package::Identifier> packages;
+    // TODO: support timing out Luau-syntax configurations
+    std::optional<Luau::ConfigTable> configOpt = Luau::extractConfig(lockfileContents, {});
+    if (!configOpt)
+        return {};
 
-    // TODO: regex matching is a temporary solution; the lockfile format is
-    // likely to change, and we will use a stable parsing solution then.
-    auto it = lockfileContents.cbegin();
-    std::smatch match;
-    std::regex re{R"LUTE(name = "([^"]+)"[\r\n]+version = "?([^"\r\n]+)"?)LUTE"};
-    while (std::regex_search(it, lockfileContents.cend(), match, re))
+    Luau::ConfigTable config = std::move(*configOpt);
+    if (!config.contains("package"))
+        return {};
+
+    Luau::ConfigTable* packageTable = config["package"].get_if<Luau::ConfigTable>();
+    if (!packageTable)
+        return {};
+
+    std::vector<Package::Identifier> packages;
+    packages.resize(packageTable->size());
+
+    for (const auto& [k, v] : *packageTable)
     {
-        packages.push_back(Package::Identifier{match[1].str(), match[2].str()});
-        it = match.suffix().first;
+        const double* key = k.get_if<double>();
+        if (!key)
+            return {};
+
+        const size_t index = static_cast<size_t>(*key);
+        if (index < 1 || packageTable->size() < index)
+            return {};
+
+        const Luau::ConfigTable* package = v.get_if<Luau::ConfigTable>();
+        if (!package)
+            return {};
+
+        if (!package->contains("name") || !package->contains("rev"))
+            return {};
+
+        const Luau::ConfigValue* name = (*package).find("name");
+        const Luau::ConfigValue* rev = (*package).find("rev");
+
+        const std::string* nameStr = name->get_if<std::string>();
+        const std::string* revStr = rev->get_if<std::string>();
+
+        if (!nameStr || !revStr)
+            return {};
+
+        Package::Identifier entry{};
+        entry.name = toLower(*nameStr);
+        entry.version = *revStr;
+        packages[index - 1] = std::move(entry);
     }
 
     return packages;

--- a/lute/cli/src/packagerun.cpp
+++ b/lute/cli/src/packagerun.cpp
@@ -36,10 +36,16 @@ std::optional<std::string> getAbsolutePathToNearestLockfile(std::string entryFil
 
 static std::string toLower(std::string_view str)
 {
-    std::string result;
-    result.resize(str.size());
-    for (size_t i = 0; i < str.size(); i++)
-        result[i] = static_cast<char>(std::tolower(static_cast<unsigned char>(str[i])));
+    std::string result(str);
+    std::transform(
+        result.begin(),
+        result.end(),
+        result.begin(),
+        [](unsigned char c)
+        {
+            return std::tolower(c);
+        }
+    );
     return result;
 }
 

--- a/lute/cli/src/packagerun.cpp
+++ b/lute/cli/src/packagerun.cpp
@@ -86,18 +86,15 @@ static std::vector<Package::Identifier> extractIdentifiers(std::string lockfileC
         if (!package->contains("name") || !package->contains("rev"))
             return {};
 
-        const Luau::ConfigValue* name = (*package).find("name");
-        const Luau::ConfigValue* rev = (*package).find("rev");
+        const std::string* name = (*package).find("name")->get_if<std::string>();
+        const std::string* rev = (*package).find("rev")->get_if<std::string>();
 
-        const std::string* nameStr = name->get_if<std::string>();
-        const std::string* revStr = rev->get_if<std::string>();
-
-        if (!nameStr || !revStr)
+        if (!name || !rev)
             return {};
 
         Package::Identifier entry{};
-        entry.name = toLower(*nameStr);
-        entry.version = *revStr;
+        entry.name = toLower(*name);
+        entry.version = *rev;
         packages[index - 1] = std::move(entry);
     }
 

--- a/lute/cli/src/packagerun.cpp
+++ b/lute/cli/src/packagerun.cpp
@@ -5,6 +5,8 @@
 #include "Luau/FileUtils.h"
 #include "Luau/LuauConfig.h"
 
+#include <algorithm>
+#include <cctype>
 #include <optional>
 #include <string>
 #include <string_view>

--- a/tests/src/packages/pkgrun_with_lockfile/loom.lock
+++ b/tests/src/packages/pkgrun_with_lockfile/loom.lock
@@ -1,9 +1,0 @@
-version = 1
-
-[[package]]
-name = "dep"
-version = "1.2.3"
-
-[[package]]
-name = "internaldep"
-version = "4.5.6"

--- a/tests/src/packages/pkgrun_with_lockfile/loom.lock.luau
+++ b/tests/src/packages/pkgrun_with_lockfile/loom.lock.luau
@@ -1,13 +1,13 @@
 return {
-  version = 1,
-  package = {
-    {
-      name = "dep",
-      rev = "v1.2.3",
-    },
-    {
-      name = "internaldep",
-      rev = "v4.5.6",
-    }
-  }
+	version = 1,
+	package = {
+		{
+			name = "dep",
+			rev = "v1.2.3",
+		},
+		{
+			name = "internaldep",
+			rev = "v4.5.6",
+		},
+	},
 }

--- a/tests/src/packages/pkgrun_with_lockfile/loom.lock.luau
+++ b/tests/src/packages/pkgrun_with_lockfile/loom.lock.luau
@@ -1,0 +1,13 @@
+return {
+  version = 1,
+  package = {
+    {
+      name = "dep",
+      rev = "v1.2.3",
+    },
+    {
+      name = "internaldep",
+      rev = "v4.5.6",
+    }
+  }
+}


### PR DESCRIPTION
We make use of the existing Luau-syntax configuration file extraction API to parse our Luau-syntax lock file (`loom.lock.luau`). The temporary regex hack has been deleted.