### PR TITLE
Disables bootstrapping in CI on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
           - os: ubuntu-latest
             options: --c-compiler clang --cxx-compiler clang++ --enable-asan
             use-bootstrap: true
-          - os: macos-latest
-            options: --enable-asan
-            use-bootstrap: true
       fail-fast: false
 
     steps:


### PR DESCRIPTION
@vrn-sn pointed out that the times are quite bad for bootstrapping in CI, but we also want to retain the benefits of confirming that it is still working on a per-PR basis. The compromise position here is that the marginal difference between macOS without bootstrap on GH Actions runners and Linux with bootstrap on GH Actions runners is quite small (8 minutes vs 9 minutes). We'll remove the macOS bootstrap since that one is prone to timing out, but the Linux bootstrap is only marginally slower than our existing CI and gets us most of the benefit of knowing if `luthier` broke somehow.