### PR TITLE
Add `aftman` as an option for lute installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The `generate` step in particular is necessary to producing a full `lute` execut
 
 ### Building Lute with `lute` installed
 
-The most straightforward, and generally recommended, way to build a local version of `lute` is to have already installed an existing version of `lute`. Today, you can do that using a toolchain manager like [`foreman`](https://github.com/Roblox/foreman), [`rokit`](https://github.com/rojo-rbx/rokit), and [mise-en-place](https://mise.jdx.dev/), or by manually installing a prebuilt binary from our [Releases](https://github.com/luau-lang/lute/releases). With a copy of `lute` present on your system, you can then run the following to perform a clean build:
+The most straightforward, and generally recommended, way to build a local version of `lute` is to have already installed an existing version of `lute`. Today, you can do that using a toolchain manager like [`foreman`](https://github.com/Roblox/foreman), [`aftman`](https://github.com/LPGhatguy/aftman), [`rokit`](https://github.com/rojo-rbx/rokit), and [mise-en-place](https://mise.jdx.dev/), or by manually installing a prebuilt binary from our [Releases](https://github.com/luau-lang/lute/releases). With a copy of `lute` present on your system, you can then run the following to perform a clean build:
 
 ```bash
 # with `lute` on your path...

--- a/aftman.toml
+++ b/aftman.toml
@@ -1,0 +1,3 @@
+[tools]
+stylua = "JohnnyMorganz/StyLua@2.3.0"
+lute = "luau-lang/lute@0.1.0-nightly.20251205"


### PR DESCRIPTION
[Aftman](https://github.com/LPGhatguy/aftman) is a successor of foreman that my team uses for its build tools. 
Although it looks like from their website that it's no longer being maintained. 
I wanted to add this as an option for people to use for installing lute, but I understand if the fact that it's no longer being maintained means the team doesn't want to support aftman as an installation option.

```
❯ aftman install
Tool luau-lang/lute has never been installed before. Install it? yes
Tool JohnnyMorganz/StyLua has never been installed before. Install it? yes
[INFO  aftman::tool_storage] Installing tool: luau-lang/lute@0.1.0-nightly.20251205
[INFO  aftman::tool_storage] Downloading luau-lang/lute v0.1.0-nightly.20251205 (lute-macos-aarch64.zip)...
[INFO  aftman::tool_storage] luau-lang/lute v0.1.0-nightly.20251205 installed successfully.
[INFO  aftman::tool_storage] Installing tool: JohnnyMorganz/StyLua@2.3.0
[INFO  aftman::tool_storage] Downloading JohnnyMorganz/StyLua v2.3.0 (stylua-macos-aarch64.zip)...
[INFO  aftman::tool_storage] JohnnyMorganz/StyLua v2.3.0 installed successfully.
```