### PR TITLE
Remove `net.serve` API from `@std`

### DIFF
--- a/examples/serve_html.luau
+++ b/examples/serve_html.luau
@@ -1,8 +1,8 @@
-local net = require("@std/net")
+local net = require("@lute/net")
 
 local server = net.serve({
 	port = 8080,
-	handler = function(req: net.receivedrequest): net.serverresponse
+	handler = function(req: net.ReceivedRequest): net.ServerResponse
 		local headers = ""
 		for key, value in req.headers do
 			headers ..= `\n  {key}: {value}`

--- a/lute/std/libs/net.luau
+++ b/lute/std/libs/net.luau
@@ -13,14 +13,4 @@ function netlib.request(url: string, metadata: metadata?): response
 	return net.request(url, metadata)
 end
 
-export type receivedrequest = net.ReceivedRequest
-export type serverresponse = net.ServerResponse
-export type handler = net.Handler
-export type configuration = net.Configuration
-export type server = net.Server
-
-function netlib.serve(config: handler | configuration): server
-	return net.serve(config)
-end
-
 return table.freeze(netlib)

--- a/tests/std/net.test.luau
+++ b/tests/std/net.test.luau
@@ -1,10 +1,10 @@
-local net = require("@std/net")
+local net = require("@lute/net")
 local test = require("@std/test")
 
 test.suite("NetTestSuite", function(suite)
 	suite:case("serve_locally_and_request", function(assert)
 		local server = net.serve({
-			handler = function(req: net.receivedrequest): net.serverresponse
+			handler = function(req: net.ReceivedRequest): net.ServerResponse
 				return {
 					status = 200,
 					body = "Hello, World!",


### PR DESCRIPTION
We're only going to expose this API under `@lute/net`.