### PR TITLE
Make `@std` and `@lute` aliases nonoverridable

### DIFF
--- a/lute/require/include/lute/packagerequirevfs.h
+++ b/lute/require/include/lute/packagerequirevfs.h
@@ -16,6 +16,7 @@ public:
 
     NavigationStatus reset(lua_State* L, std::string_view requirerChunkname) override;
     NavigationStatus jumpToAlias(lua_State* L, std::string_view path) override;
+    NavigationStatus toAliasOverride(lua_State* L, std::string_view aliasUnprefixed) override;
     NavigationStatus toAliasFallback(lua_State* L, std::string_view aliasUnprefixed) override;
 
     NavigationStatus toParent(lua_State* L) override;

--- a/lute/require/include/lute/require.h
+++ b/lute/require/include/lute/require.h
@@ -18,6 +18,7 @@ public:
 
     virtual NavigationStatus reset(lua_State* L, std::string_view requirerChunkname) = 0;
     virtual NavigationStatus jumpToAlias(lua_State* L, std::string_view path) = 0;
+    virtual NavigationStatus toAliasOverride(lua_State* L, std::string_view aliasUnprefixed) = 0;
     virtual NavigationStatus toAliasFallback(lua_State* L, std::string_view aliasUnprefixed) = 0;
 
     virtual NavigationStatus toParent(lua_State* L) = 0;

--- a/lute/require/include/lute/requirevfs.h
+++ b/lute/require/include/lute/requirevfs.h
@@ -23,6 +23,7 @@ public:
 
     NavigationStatus reset(lua_State* L, std::string_view requirerChunkname) override;
     NavigationStatus jumpToAlias(lua_State* L, std::string_view path) override;
+    NavigationStatus toAliasOverride(lua_State* L, std::string_view aliasUnprefixed) override;
     NavigationStatus toAliasFallback(lua_State* L, std::string_view aliasUnprefixed) override;
 
     NavigationStatus toParent(lua_State* L) override;

--- a/lute/require/src/packagerequirevfs.cpp
+++ b/lute/require/src/packagerequirevfs.cpp
@@ -1,5 +1,7 @@
 #include "lute/packagerequirevfs.h"
 
+#include "lute/modulepath.h"
+
 #include "Luau/FileUtils.h"
 
 #include "lua.h"
@@ -62,7 +64,7 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
     return status;
 }
 
-NavigationStatus RequireVfs::toAliasFallback(lua_State* L, std::string_view aliasUnprefixed)
+NavigationStatus RequireVfs::toAliasOverride(lua_State* L, std::string_view aliasUnprefixed)
 {
     if (aliasUnprefixed == "std")
     {
@@ -76,8 +78,15 @@ NavigationStatus RequireVfs::toAliasFallback(lua_State* L, std::string_view alia
         return NavigationStatus::Success;
     }
 
-    vfsType = VFSType::Userland;
-    return userlandVfs.toAliasFallback(aliasUnprefixed);
+    return NavigationStatus::NotFound;
+}
+
+NavigationStatus RequireVfs::toAliasFallback(lua_State* L, std::string_view aliasUnprefixed)
+{
+    NavigationStatus status = userlandVfs.toAliasFallback(aliasUnprefixed);
+    if (status == NavigationStatus::Success)
+        vfsType = VFSType::Userland;
+    return status;
 }
 
 NavigationStatus RequireVfs::toParent(lua_State* L)

--- a/lute/require/src/require.cpp
+++ b/lute/require/src/require.cpp
@@ -87,6 +87,12 @@ static luarequire_NavigateResult jump_to_alias(lua_State* L, void* ctx, const ch
     return convert(reqCtx->vfs->jumpToAlias(L, path));
 }
 
+static luarequire_NavigateResult to_alias_override(lua_State* L, void* ctx, const char* alias_unprefixed)
+{
+    RequireCtx* reqCtx = static_cast<RequireCtx*>(ctx);
+    return convert(reqCtx->vfs->toAliasOverride(L, alias_unprefixed));
+}
+
 static luarequire_NavigateResult to_alias_fallback(lua_State* L, void* ctx, const char* alias_unprefixed)
 {
     RequireCtx* reqCtx = static_cast<RequireCtx*>(ctx);
@@ -211,6 +217,7 @@ void requireConfigInit(luarequire_Configuration* config)
     config->is_require_allowed = is_require_allowed;
     config->reset = reset;
     config->jump_to_alias = jump_to_alias;
+    config->to_alias_override = to_alias_override;
     config->to_alias_fallback = to_alias_fallback;
     config->to_parent = to_parent;
     config->to_child = to_child;

--- a/lute/require/src/requirevfs.cpp
+++ b/lute/require/src/requirevfs.cpp
@@ -85,7 +85,7 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
     return status;
 }
 
-NavigationStatus RequireVfs::toAliasFallback(lua_State* L, std::string_view aliasUnprefixed)
+NavigationStatus RequireVfs::toAliasOverride(lua_State* L, std::string_view aliasUnprefixed)
 {
     if (aliasUnprefixed == "std")
     {
@@ -99,6 +99,11 @@ NavigationStatus RequireVfs::toAliasFallback(lua_State* L, std::string_view alia
         return NavigationStatus::Success;
     }
 
+    return NavigationStatus::NotFound;
+}
+
+NavigationStatus RequireVfs::toAliasFallback(lua_State* L, std::string_view aliasUnprefixed)
+{
     return NavigationStatus::NotFound;
 }
 


### PR DESCRIPTION
We use the new `to_alias_override` Luau.Require callback to ensure that the `@std` and `@lute` aliases always point at the embedded libraries, not ones on disk that the user may have set up using `.luaurc` or `.config.luau` files.

@Vighnesh-V, this means that `@std/test` will always point at the embedded module now.