### PR TITLE
Enables the `@lute` libraries in spawned VMs by implementing a new `LuteVfs`

### DIFF
--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -47,7 +47,7 @@ target_sources(Lute.CLI.lib PRIVATE
 
 target_compile_features(Lute.CLI.lib PUBLIC cxx_std_17)
 target_include_directories(Lute.CLI.lib PUBLIC include ${CLI_GENERATED_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR})
-target_link_libraries(Lute.CLI.lib PRIVATE Luau.Common Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Require Lute.Runtime Luau.CLI.lib zlibstatic)
+target_link_libraries(Lute.CLI.lib PRIVATE Luau.Common Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Luau Lute.Process Lute.Require Lute.Runtime Luau.CLI.lib zlibstatic)
 target_compile_options(Lute.CLI.lib PRIVATE ${LUTE_OPTIONS})
 
 add_executable(Lute.CLI)

--- a/lute/cli/src/requiresetup.cpp
+++ b/lute/cli/src/requiresetup.cpp
@@ -2,52 +2,20 @@
 
 #include "lute/bundlevfs.h"
 #include "lute/clivfs.h"
-#include "lute/crypto.h"
-#include "lute/fs.h"
-#include "lute/io.h"
-#include "lute/luau.h"
-#include "lute/net.h"
 #include "lute/packagerequirevfs.h"
-#include "lute/process.h"
 #include "lute/require.h"
 #include "lute/requirevfs.h"
 #include "lute/runtime.h"
-#include "lute/system.h"
-#include "lute/task.h"
-#include "lute/time.h"
 #include "lute/userlandvfs.h"
-#include "lute/vm.h"
 
 #include "Luau/CodeGen.h"
 #include "Luau/Require.h"
 
+#include "lualib.h"
+
 #include <memory>
 #include <string>
 #include <utility>
-
-static void luteopen_libs(lua_State* L)
-{
-    std::vector<std::pair<const char*, lua_CFunction>> libs = {{
-        {"@lute/crypto", luteopen_crypto},
-        {"@lute/fs", luteopen_fs},
-        {"@lute/luau", luteopen_luau},
-        {"@lute/net", luteopen_net},
-        {"@lute/process", luteopen_process},
-        {"@lute/task", luteopen_task},
-        {"@lute/vm", luteopen_vm},
-        {"@lute/system", luteopen_system},
-        {"@lute/time", luteopen_time},
-        {"@lute/io", luteopen_io},
-    }};
-
-    for (const auto& [name, func] : libs)
-    {
-        lua_pushcfunction(L, luarequire_registermodule, nullptr);
-        lua_pushstring(L, name);
-        func(L);
-        lua_call(L, 2, 0);
-    }
-}
 
 static void* createCliRequireContext(lua_State* L)
 {
@@ -138,8 +106,6 @@ lua_State* setupCliState(Runtime& runtime, std::function<void(lua_State*)> preSa
         runtime,
         [preSandboxInit = std::move(preSandboxInit)](lua_State* L)
         {
-            luteopen_libs(L);
-
             if (Luau::CodeGen::isSupported())
                 Luau::CodeGen::create(L);
 
@@ -160,8 +126,6 @@ lua_State* setupPkgCliState(
         runtime,
         [directDependencies = std::move(directDependencies), allDependencies = std::move(allDependencies)](lua_State* L)
         {
-            luteopen_libs(L);
-
             if (Luau::CodeGen::isSupported())
                 Luau::CodeGen::create(L);
 
@@ -180,7 +144,6 @@ lua_State* setupBundleState(
         runtime,
         [luaurcFiles = std::move(luaurcFiles), bundleMap = std::move(bundleMap)](lua_State* L)
         {
-            luteopen_libs(L);
             if (Luau::CodeGen::isSupported())
                 Luau::CodeGen::create(L);
 

--- a/lute/require/CMakeLists.txt
+++ b/lute/require/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(Lute.Require PRIVATE
     include/lute/bundlevfs.h
     include/lute/clivfs.h
     include/lute/filevfs.h
+    include/lute/lutevfs.h
     include/lute/modulepath.h
     include/lute/options.h
     include/lute/packagerequirevfs.h
@@ -15,6 +16,7 @@ target_sources(Lute.Require PRIVATE
     src/bundlevfs.cpp
     src/clivfs.cpp
     src/filevfs.cpp
+    src/lutevfs.cpp
     src/modulepath.cpp
     src/options.cpp
     src/packagerequirevfs.cpp
@@ -26,5 +28,5 @@ target_sources(Lute.Require PRIVATE
 
 target_compile_features(Lute.Require PUBLIC cxx_std_17)
 target_include_directories(Lute.Require PUBLIC include)
-target_link_libraries(Lute.Require PUBLIC Luau.Require PRIVATE Luau.CLI.lib Luau.Compiler Luau.CodeGen Lute.Std Lute.CLI.Commands Lute.Runtime)
+target_link_libraries(Lute.Require PUBLIC Luau.Require PRIVATE Luau.CLI.lib Luau.Compiler Luau.CodeGen Lute.Std Lute.CLI.Commands Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Runtime)
 target_compile_options(Lute.Require PRIVATE ${LUTE_OPTIONS})

--- a/lute/require/include/lute/lutevfs.h
+++ b/lute/require/include/lute/lutevfs.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "lute/modulepath.h"
+
+#include "Luau/DenseHash.h"
+
+#include "lua.h"
+
+#include <string>
+
+extern const Luau::DenseHashMap<std::string, lua_CFunction> kLuteModules;
+
+class LuteVfs
+{
+public:
+    NavigationStatus resetToPath(const std::string& path);
+
+    NavigationStatus toParent();
+    NavigationStatus toChild(const std::string& name);
+
+    bool isModulePresent() const;
+    std::string getIdentifier() const;
+    std::optional<std::string> getContents(const std::string& path) const;
+
+    ConfigStatus getConfigStatus() const;
+    std::optional<std::string> getConfig() const;
+
+private:
+    std::optional<ModulePath> modulePath;
+};

--- a/lute/require/include/lute/packagerequirevfs.h
+++ b/lute/require/include/lute/packagerequirevfs.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "lute/lutevfs.h"
 #include "lute/require.h"
 #include "lute/stdlibvfs.h"
 #include "lute/userlandvfs.h"
@@ -49,7 +50,7 @@ private:
 
     Package::UserlandVfs userlandVfs;
     StdLibVfs stdLibVfs;
-    std::string lutePath;
+    LuteVfs luteVfs;
 };
 
 } // namespace Package

--- a/lute/require/include/lute/requirevfs.h
+++ b/lute/require/include/lute/requirevfs.h
@@ -3,6 +3,7 @@
 #include "lute/bundlevfs.h"
 #include "lute/clivfs.h"
 #include "lute/filevfs.h"
+#include "lute/lutevfs.h"
 #include "lute/modulepath.h"
 #include "lute/require.h"
 #include "lute/stdlibvfs.h"
@@ -58,7 +59,7 @@ private:
 
     FileVfs fileVfs;
     StdLibVfs stdLibVfs;
+    LuteVfs luteVfs;
     std::optional<CliVfs> cliVfs = std::nullopt;
     std::optional<BundleVfs> bundleVfs = std::nullopt;
-    std::string lutePath;
 };

--- a/lute/require/src/lutevfs.cpp
+++ b/lute/require/src/lutevfs.cpp
@@ -1,0 +1,106 @@
+#include "lute/lutevfs.h"
+
+#include "lute/crypto.h"
+#include "lute/fs.h"
+#include "lute/io.h"
+#include "lute/luau.h"
+#include "lute/modulepath.h"
+#include "lute/net.h"
+#include "lute/process.h"
+#include "lute/system.h"
+#include "lute/task.h"
+#include "lute/time.h"
+#include "lute/vm.h"
+
+#include "Luau/DenseHash.h"
+
+#include "lua.h"
+
+const Luau::DenseHashMap<std::string, lua_CFunction> kLuteModules = []()
+{
+    Luau::DenseHashMap<std::string, lua_CFunction> map{""};
+    map["@lute/crypto.luau"] = luteopen_crypto;
+    map["@lute/fs.luau"] = luteopen_fs;
+    map["@lute/luau.luau"] = luteopen_luau;
+    map["@lute/net.luau"] = luteopen_net;
+    map["@lute/process.luau"] = luteopen_process;
+    map["@lute/task.luau"] = luteopen_task;
+    map["@lute/vm.luau"] = luteopen_vm;
+    map["@lute/system.luau"] = luteopen_system;
+    map["@lute/time.luau"] = luteopen_time;
+    map["@lute/io.luau"] = luteopen_io;
+    return map;
+}();
+
+static bool isLuteModule(const std::string& path)
+{
+    return kLuteModules.contains(path);
+}
+
+static bool isLuteDirectory(const std::string& path)
+{
+    return path == "@lute";
+}
+
+NavigationStatus LuteVfs::resetToPath(const std::string& path)
+{
+    if (path == "@lute")
+    {
+        modulePath = ModulePath::create("@lute", "", isLuteModule, isLuteDirectory);
+        return modulePath ? NavigationStatus::Success : NavigationStatus::NotFound;
+    }
+
+    std::string lutePrefix = "@lute/";
+
+    if (path.rfind(lutePrefix, 0) != 0)
+        return NavigationStatus::NotFound;
+
+    modulePath = ModulePath::create("@lute", path.substr(lutePrefix.size()), isLuteModule, isLuteDirectory);
+    return modulePath ? NavigationStatus::Success : NavigationStatus::NotFound;
+}
+
+NavigationStatus LuteVfs::toParent()
+{
+    LUAU_ASSERT(modulePath);
+    return modulePath->toParent();
+}
+
+NavigationStatus LuteVfs::toChild(const std::string& name)
+{
+    LUAU_ASSERT(modulePath);
+    return modulePath->toChild(name);
+}
+
+bool LuteVfs::isModulePresent() const
+{
+    LUAU_ASSERT(modulePath);
+    ResolvedRealPath result = modulePath->getRealPath();
+    LUAU_ASSERT(result.status == NavigationStatus::Success);
+    return result.type == ResolvedRealPath::PathType::File;
+}
+
+std::string LuteVfs::getIdentifier() const
+{
+    LUAU_ASSERT(modulePath);
+    ResolvedRealPath result = modulePath->getRealPath();
+    LUAU_ASSERT(result.status == NavigationStatus::Success);
+    return result.realPath;
+}
+
+std::optional<std::string> LuteVfs::getContents(const std::string& path) const
+{
+    // Lute modules have no source code.
+    return "";
+}
+
+ConfigStatus LuteVfs::getConfigStatus() const
+{
+    // Currently, we do not support .luaurc files in Lute commands.
+    return ConfigStatus::Absent;
+}
+
+std::optional<std::string> LuteVfs::getConfig() const
+{
+    // Currently, we do not support .luaurc files in Lute commands.
+    return std::nullopt;
+}

--- a/lute/require/src/packagerequirevfs.cpp
+++ b/lute/require/src/packagerequirevfs.cpp
@@ -59,6 +59,7 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
         status = stdLibVfs.resetToPath(std::string(path));
         break;
     case VFSType::Lute:
+        status = luteVfs.resetToPath(std::string(path));
         break;
     }
     return status;
@@ -74,8 +75,7 @@ NavigationStatus RequireVfs::toAliasOverride(lua_State* L, std::string_view alia
     else if (aliasUnprefixed == "lute")
     {
         vfsType = VFSType::Lute;
-        lutePath = "@lute";
-        return NavigationStatus::Success;
+        return luteVfs.resetToPath("@lute");
     }
 
     return NavigationStatus::NotFound;
@@ -101,7 +101,8 @@ NavigationStatus RequireVfs::toParent(lua_State* L)
         status = stdLibVfs.toParent();
         break;
     case VFSType::Lute:
-        luaL_error(L, "cannot get the parent of @lute");
+        status = luteVfs.toParent();
+        break;
     }
 
     return status;
@@ -116,7 +117,7 @@ NavigationStatus RequireVfs::toChild(lua_State* L, std::string_view name)
     case VFSType::Std:
         return stdLibVfs.toChild(std::string(name));
     case VFSType::Lute:
-        luaL_error(L, "'%s' is not a lute library", std::string(name).c_str());
+        return luteVfs.toChild(std::string(name));
     }
 
     return NavigationStatus::NotFound;
@@ -131,7 +132,7 @@ bool RequireVfs::isModulePresent(lua_State* L) const
     case VFSType::Std:
         return stdLibVfs.isModulePresent();
     case VFSType::Lute:
-        luaL_error(L, "@lute is not requirable");
+        return luteVfs.isModulePresent();
     }
 
     return false;
@@ -149,6 +150,7 @@ std::string RequireVfs::getContents(lua_State* L, const std::string& loadname) c
         contents = stdLibVfs.getContents(loadname);
         break;
     case VFSType::Lute:
+        contents = luteVfs.getContents(loadname);
         break;
     }
     return contents ? *contents : "";
@@ -166,6 +168,7 @@ std::string RequireVfs::getChunkname(lua_State* L) const
         chunkname = "@" + stdLibVfs.getIdentifier();
         break;
     case VFSType::Lute:
+        chunkname = "@" + luteVfs.getIdentifier();
         break;
     }
     return chunkname;
@@ -183,6 +186,7 @@ std::string RequireVfs::getLoadname(lua_State* L) const
         loadname = stdLibVfs.getIdentifier();
         break;
     case VFSType::Lute:
+        loadname = luteVfs.getIdentifier();
         break;
     }
     return loadname;
@@ -200,6 +204,7 @@ std::string RequireVfs::getCacheKey(lua_State* L) const
         cacheKey = stdLibVfs.getIdentifier();
         break;
     case VFSType::Lute:
+        cacheKey = luteVfs.getIdentifier();
         break;
     }
     return cacheKey;
@@ -217,6 +222,7 @@ ConfigStatus RequireVfs::getConfigStatus(lua_State* L) const
         status = stdLibVfs.getConfigStatus();
         break;
     case VFSType::Lute:
+        status = luteVfs.getConfigStatus();
         break;
     }
     return status;
@@ -234,6 +240,7 @@ std::string RequireVfs::getConfig(lua_State* L) const
         configContents = stdLibVfs.getConfig();
         break;
     case VFSType::Lute:
+        configContents = luteVfs.getConfig();
         break;
     }
     return configContents ? *configContents : "";

--- a/lute/require/src/require.cpp
+++ b/lute/require/src/require.cpp
@@ -1,5 +1,6 @@
 #include "lute/require.h"
 
+#include "lute/lutevfs.h"
 #include "lute/modulepath.h"
 #include "lute/options.h"
 
@@ -149,6 +150,16 @@ static luarequire_WriteResult get_config(lua_State* L, void* ctx, char* buffer, 
 
 static int load(lua_State* L, void* ctx, const char* path, const char* chunkname, const char* loadname)
 {
+    // Lute modules are built-in and don't need to be compiled or executed.
+    if (strncmp(loadname, "@lute/", 6) == 0)
+    {
+        const lua_CFunction* func = kLuteModules.find(loadname);
+        LUAU_ASSERT(func);
+        lua_pushcfunction(L, *func, nullptr);
+        lua_call(L, 0, 1);
+        return 1;
+    }
+
     // module needs to run in a new thread, isolated from the rest
     // note: we create ML on main thread so that it doesn't inherit environment of L
     lua_State* GL = lua_mainthread(L);

--- a/lute/require/src/requirevfs.cpp
+++ b/lute/require/src/requirevfs.cpp
@@ -71,6 +71,9 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
     case VFSType::Std:
         status = stdLibVfs.resetToPath(std::string(path));
         break;
+    case VFSType::Lute:
+        status = luteVfs.resetToPath(std::string(path));
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         status = cliVfs->resetToPath(std::string(path));
@@ -78,8 +81,6 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
     case VFSType::Bundle:
         LUAU_ASSERT(bundleVfs);
         status = bundleVfs->resetToPath(std::string(path));
-        break;
-    case VFSType::Lute:
         break;
     }
     return status;
@@ -95,8 +96,7 @@ NavigationStatus RequireVfs::toAliasOverride(lua_State* L, std::string_view alia
     else if (aliasUnprefixed == "lute")
     {
         vfsType = VFSType::Lute;
-        lutePath = "@lute";
-        return NavigationStatus::Success;
+        return luteVfs.resetToPath("@lute");
     }
 
     return NavigationStatus::NotFound;
@@ -118,6 +118,9 @@ NavigationStatus RequireVfs::toParent(lua_State* L)
     case VFSType::Std:
         status = stdLibVfs.toParent();
         break;
+    case VFSType::Lute:
+        status = luteVfs.toParent();
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         status = cliVfs->toParent();
@@ -125,9 +128,6 @@ NavigationStatus RequireVfs::toParent(lua_State* L)
     case VFSType::Bundle:
         LUAU_ASSERT(bundleVfs);
         status = bundleVfs->toParent();
-        break;
-    case VFSType::Lute:
-        luaL_error(L, "cannot get the parent of @lute");
         break;
     }
     return status;
@@ -141,15 +141,14 @@ NavigationStatus RequireVfs::toChild(lua_State* L, std::string_view name)
         return fileVfs.toChild(std::string(name));
     case VFSType::Std:
         return stdLibVfs.toChild(std::string(name));
+    case VFSType::Lute:
+        return luteVfs.toChild(std::string(name));
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         return cliVfs->toChild(std::string(name));
     case VFSType::Bundle:
         LUAU_ASSERT(bundleVfs);
         return bundleVfs->toChild(std::string(name));
-    case VFSType::Lute:
-        luaL_error(L, "'%s' is not a lute library", std::string(name).c_str());
-        break;
     }
     return NavigationStatus::NotFound;
 }
@@ -162,15 +161,15 @@ bool RequireVfs::isModulePresent(lua_State* L) const
         return fileVfs.isModulePresent();
     case VFSType::Std:
         return stdLibVfs.isModulePresent();
+    case VFSType::Lute:
+        return luteVfs.isModulePresent();
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         return cliVfs->isModulePresent();
     case VFSType::Bundle:
         LUAU_ASSERT(bundleVfs);
         return bundleVfs->isModulePresent();
-    case VFSType::Lute:
-        luaL_error(L, "@lute is not requirable");
-        break;
     }
 
     return false;
@@ -188,6 +187,9 @@ std::string RequireVfs::getContents(lua_State* L, const std::string& loadname) c
     case VFSType::Std:
         contents = stdLibVfs.getContents(loadname);
         break;
+    case VFSType::Lute:
+        contents = luteVfs.getContents(loadname);
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         contents = cliVfs->getContents(loadname);
@@ -195,8 +197,6 @@ std::string RequireVfs::getContents(lua_State* L, const std::string& loadname) c
     case VFSType::Bundle:
         LUAU_ASSERT(bundleVfs);
         contents = bundleVfs->getContents(loadname);
-        break;
-    case VFSType::Lute:
         break;
     }
 
@@ -214,6 +214,9 @@ std::string RequireVfs::getChunkname(lua_State* L) const
     case VFSType::Std:
         chunkname = "@" + stdLibVfs.getIdentifier();
         break;
+    case VFSType::Lute:
+        chunkname = "@" + luteVfs.getIdentifier();
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         chunkname = "@" + cliVfs->getIdentifier();
@@ -221,8 +224,6 @@ std::string RequireVfs::getChunkname(lua_State* L) const
     case VFSType::Bundle:
         LUAU_ASSERT(bundleVfs);
         chunkname = "@" + bundleVfs->getIdentifier();
-        break;
-    case VFSType::Lute:
         break;
     }
     return chunkname;
@@ -239,6 +240,9 @@ std::string RequireVfs::getLoadname(lua_State* L) const
     case VFSType::Std:
         loadname = stdLibVfs.getIdentifier();
         break;
+    case VFSType::Lute:
+        loadname = luteVfs.getIdentifier();
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         loadname = cliVfs->getIdentifier();
@@ -246,8 +250,6 @@ std::string RequireVfs::getLoadname(lua_State* L) const
     case VFSType::Bundle:
         LUAU_ASSERT(bundleVfs);
         loadname = bundleVfs->getIdentifier();
-        break;
-    case VFSType::Lute:
         break;
     }
     return loadname;
@@ -264,6 +266,9 @@ std::string RequireVfs::getCacheKey(lua_State* L) const
     case VFSType::Std:
         cacheKey = stdLibVfs.getIdentifier();
         break;
+    case VFSType::Lute:
+        cacheKey = luteVfs.getIdentifier();
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         cacheKey = cliVfs->getIdentifier();
@@ -271,8 +276,6 @@ std::string RequireVfs::getCacheKey(lua_State* L) const
     case VFSType::Bundle:
         LUAU_ASSERT(bundleVfs);
         cacheKey = bundleVfs->getIdentifier();
-        break;
-    case VFSType::Lute:
         break;
     }
     return cacheKey;
@@ -289,6 +292,9 @@ ConfigStatus RequireVfs::getConfigStatus(lua_State* L) const
     case VFSType::Std:
         status = stdLibVfs.getConfigStatus();
         break;
+    case VFSType::Lute:
+        status = luteVfs.getConfigStatus();
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         status = cliVfs->getConfigStatus();
@@ -296,8 +302,6 @@ ConfigStatus RequireVfs::getConfigStatus(lua_State* L) const
     case VFSType::Bundle:
         LUAU_ASSERT(bundleVfs);
         status = bundleVfs->getConfigStatus();
-        break;
-    case VFSType::Lute:
         break;
     }
     return status;
@@ -314,6 +318,9 @@ std::string RequireVfs::getConfig(lua_State* L) const
     case VFSType::Std:
         configContents = stdLibVfs.getConfig();
         break;
+    case VFSType::Lute:
+        configContents = luteVfs.getConfig();
+        break;
     case VFSType::Cli:
         LUAU_ASSERT(cliVfs);
         configContents = cliVfs->getConfig();
@@ -321,8 +328,6 @@ std::string RequireVfs::getConfig(lua_State* L) const
     case VFSType::Bundle:
         LUAU_ASSERT(bundleVfs);
         configContents = bundleVfs->getConfig();
-        break;
-    case VFSType::Lute:
         break;
     }
     return configContents ? *configContents : "";

--- a/tests/lute/vm.test.luau
+++ b/tests/lute/vm.test.luau
@@ -6,14 +6,16 @@ local system = require("@std/system")
 
 test.suite("LuteVmSuite", function(suite)
 	suite:case("child_vm_has_access_to_builtins", function(assert)
-        local tmpdir = system.tmpdir()
-        local child_vm = path.join(tmpdir, "child_vm.luau")
-        local parent_vm = path.join(tmpdir, "parent_vm.luau")
+		local tmpdir = system.tmpdir()
+		local child_vm = path.join(tmpdir, "child_vm.luau")
+		local parent_vm = path.join(tmpdir, "parent_vm.luau")
 
-        do
-            local handle = fs.open(child_vm, "w+")
-            assert.eq(fs.exists(child_vm), true)
-            fs.write(handle, [[
+		do
+			local handle = fs.open(child_vm, "w+")
+			assert.eq(fs.exists(child_vm), true)
+			fs.write(
+				handle,
+				[[
                 local std_test_exists = require("@std/test") ~= nil
                 local std_test_consistent = require("@std/test") == require("@std/test")
                 local lute_vm_exists = require("@lute/vm") ~= nil
@@ -35,29 +37,33 @@ test.suite("LuteVmSuite", function(suite)
                 end
 
                 return exported
-            ]])
-            fs.close(handle)
-        end
+            ]]
+			)
+			fs.close(handle)
+		end
 
-        do
-            local handle = fs.open(parent_vm, "w+")
-            assert.eq(fs.exists(parent_vm), true)
-            fs.write(handle, [[
+		do
+			local handle = fs.open(parent_vm, "w+")
+			assert.eq(fs.exists(parent_vm), true)
+			fs.write(
+				handle,
+				[[
                 local vm = require("@lute/vm")
                 local result = vm.create("./child_vm")
                 assert(result.std_test_exists())
                 assert(result.std_test_consistent())
                 assert(result.lute_vm_exists())
                 assert(result.lute_vm_consistent())
-            ]])
-            fs.close(handle)
-        end
+            ]]
+			)
+			fs.close(handle)
+		end
 
-        local result = process.run({ path.format(process.execpath()), path.format(parent_vm)})
+		local result = process.run({ path.format(process.execpath()), path.format(parent_vm) })
 		assert.eq(result.exitcode, 0)
 
-        fs.remove(child_vm)
-        fs.remove(parent_vm)
+		fs.remove(child_vm)
+		fs.remove(parent_vm)
 	end)
 end)
 

--- a/tests/lute/vm.test.luau
+++ b/tests/lute/vm.test.luau
@@ -1,0 +1,64 @@
+local test = require("@std/test")
+local fs = require("@std/fs")
+local path = require("@std/path")
+local process = require("@std/process")
+local system = require("@std/system")
+
+test.suite("LuteVmSuite", function(suite)
+	suite:case("child_vm_has_access_to_builtins", function(assert)
+        local tmpdir = system.tmpdir()
+        local child_vm = path.join(tmpdir, "child_vm.luau")
+        local parent_vm = path.join(tmpdir, "parent_vm.luau")
+
+        do
+            local handle = fs.open(child_vm, "w+")
+            assert.eq(fs.exists(child_vm), true)
+            fs.write(handle, [[
+                local std_test_exists = require("@std/test") ~= nil
+                local std_test_consistent = require("@std/test") == require("@std/test")
+                local lute_vm_exists = require("@lute/vm") ~= nil
+                local lute_vm_consistent = require("@lute/vm") == require("@lute/vm")
+
+                local exported = {}
+
+                function exported.std_test_exists()
+                    return std_test_exists
+                end
+                function exported.std_test_consistent()
+                    return std_test_consistent
+                end
+                function exported.lute_vm_exists()
+                    return lute_vm_exists
+                end
+                function exported.lute_vm_consistent()
+                    return lute_vm_consistent
+                end
+
+                return exported
+            ]])
+            fs.close(handle)
+        end
+
+        do
+            local handle = fs.open(parent_vm, "w+")
+            assert.eq(fs.exists(parent_vm), true)
+            fs.write(handle, [[
+                local vm = require("@lute/vm")
+                local result = vm.create("./child_vm")
+                assert(result.std_test_exists())
+                assert(result.std_test_consistent())
+                assert(result.lute_vm_exists())
+                assert(result.lute_vm_consistent())
+            ]])
+            fs.close(handle)
+        end
+
+        local result = process.run({ path.format(process.execpath()), path.format(parent_vm)})
+		assert.eq(result.exitcode, 0)
+
+        fs.remove(child_vm)
+        fs.remove(parent_vm)
+	end)
+end)
+
+test.run()


### PR DESCRIPTION
Resolves #691. As @Nicell points out in #692, we have some libuv memory safety issues that have been revealed with this change, so they'll need to be fixed outside of this PR.