### PR TITLE
Add `tableext.toset`; reorder methods for better grouping

### DIFF
--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -67,8 +67,8 @@ function tableext.reverse<T>(tbl: { T }, inplace: boolean?)
 	return new
 end
 
-function tableext.toset<T>(tbl: { T }): { [T]: boolean }
-	local set = {}
+function tableext.toset<T>(tbl: { T }): { [T]: true }
+	local set: { [T]: true } = {}
 	for _, v in tbl do
 		set[v] = true
 	end

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -27,16 +27,6 @@ function tableext.filter<K, V>(table: { [K]: V }, predicate: (V) -> boolean): { 
 	return new
 end
 
-function tableext.extend<T>(tbl: { T }, ...: { T })
-	local extensions = table.pack(...)
-	extensions.n = nil :: any
-	for _, extension in extensions do
-		for _, entry in extension do
-			table.insert(tbl, entry)
-		end
-	end
-end
-
 function tableext.combine<K, V>(tbl: { [K]: V }, ...: { [K]: V }): { [K]: V }
 	local tables = table.pack(...)
 	tables.n = nil :: any
@@ -56,6 +46,24 @@ function tableext.keys<K, V>(tbl: { [K]: V }): { K }
 	return keys
 end
 
+function tableext.toset<T>(tbl: { T }): { [T]: true }
+	local set: { [T]: true } = {}
+	for _, v in tbl do
+		set[v] = true
+	end
+	return set
+end
+
+function tableext.extend<T>(tbl: { T }, ...: { T })
+	local extensions = table.pack(...)
+	extensions.n = nil :: any
+	for _, extension in extensions do
+		for _, entry in extension do
+			table.insert(tbl, entry)
+		end
+	end
+end
+
 function tableext.reverse<T>(tbl: { T }, inplace: boolean?)
 	local new = if inplace then tbl else {}
 	local i, j = 1, #tbl
@@ -65,14 +73,6 @@ function tableext.reverse<T>(tbl: { T }, inplace: boolean?)
 		j -= 1
 	end
 	return new
-end
-
-function tableext.toset<T>(tbl: { T }): { [T]: true }
-	local set: { [T]: true } = {}
-	for _, v in tbl do
-		set[v] = true
-	end
-	return set
 end
 
 return table.freeze(tableext)

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -47,7 +47,7 @@ function tableext.keys<K, V>(tbl: { [K]: V }): { K }
 end
 
 function tableext.toset<T>(tbl: { T }): { [T]: true }
-	local set: { [T]: true } = {}
+	local set = {}
 	for _, v in tbl do
 		set[v] = true
 	end

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -67,4 +67,12 @@ function tableext.reverse<T>(tbl: { T }, inplace: boolean?)
 	return new
 end
 
+function tableext.toset<T>(tbl: { T }): { [T]: boolean }
+	local set = {}
+	for _, v in tbl do
+		set[v] = true
+	end
+	return set
+end
+
 return table.freeze(tableext)

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -62,6 +62,27 @@ test.suite("TableExt", function(suite)
 		assert.tableeq(b, { 4, 5, 6 })
 		assert.tableeq(c, { 6, 5, 4 })
 	end)
+
+	suite:case("toset", function(assert)
+		local a = { 1, 2, 3, 2, 1 }
+		local setA = tableext.toset(a)
+		assert.eq(setA[1], true)
+		assert.eq(setA[2], true)
+		assert.eq(setA[3], true)
+		assert.eq(setA[4], nil)
+		assert.eq(setA[5], nil)
+		assert.eq(#tableext.keys(setA), 3)
+		assert.neq(#tableext.keys(setA), #a)
+
+		local b = { "a", "b", "c", "a" }
+		local setB = tableext.toset(b)
+		assert.eq(setB["a"], true)
+		assert.eq(setB["b"], true)
+		assert.eq(setB["c"], true)
+		assert.eq(setB["d"], nil)
+		assert.eq(#tableext.keys(setB), 3)
+		assert.neq(#tableext.keys(setB), #b)
+	end)
 end)
 
 test.run()


### PR DESCRIPTION
Felt like tableext should have a `toset` util.

I reordered tableext methods to group dictionary and array methods more distinctly 
(`keys` and `toset` are the boundary as they convert between the two table formats)

This repo seems to avoid comments where possible so I left out labeling those sections.

EDIT: I'm now realizing there's no ideal way to do this. The current implementation of toset of an array of numbers can create sparse arrays. 

We could possibly:
- expect users to treat this like a dictionary, even if it creates a sparse array.
- use `tostring()` to convert to string keys and not support tables. Update the signature to only allow primitive types that can be converted via tostring().
- create an object that would store the original type of the list then when trying to access the key, it would convert the key back to that type for its metaproperties like `__pair`.
  - to support tables, it would have to deep compare so identical tables with different pointers could still index the same key. Maybe add an optional arg that would allow for a custom comparison function for tables this if that's the original list's value type.
