### PR TITLE
Add AstExprGroup's missing kind tag

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -63,6 +63,7 @@ export type AstLocal = {
 
 export type AstExprGroup = {
 	location: span,
+	kind: "expr",
 	tag: "group",
 	openparens: Token<"(">,
 	expression: AstExpr,


### PR DESCRIPTION
Adding this field allowed my code (using the new type solver) to correctly narrow `AstExpr` to `AstExprGroup` after adding an additional kind check:
```
local function checkExpr(expr: luau.AstExpr): boolean
	...
	elseif expr.tag == "group" and expr.kind == "expr" then
		return checkExpr(expr.expression)
	end
end
```


I also saw some of the `AstType*` types don't all have `kind: "type",` which seems to be intentional to support having some of types with similar names like AstGenericTypePack vs AstGenericTypePack without needing so they can have overlapping `tag`/`kind` fields to avoid being overly verbose?