### PR TITLE
Runs `lute test` as part of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,18 +53,7 @@ jobs:
         run: rm .luaurc && mv .luaurc.ci .luaurc
 
       - name: Run Luau Tests (POSIX)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: find tests -name "*.test.luau" | xargs -I {} "${{ steps.build_lute.outputs.exe_path }}" run {}
-
-      - name: Run Luau Tests (Windows)
-        if: runner.os == 'Windows'
-        shell: cmd
-        run: |
-          set _errorFlag=0
-          for /r tests %%f in (*.test.luau) do "${{ steps.build_lute.outputs.exe_path }}" run "%%f" || (set _errorFlag=1)
-          if %_errorFlag% neq 0 exit /b 1
-        
+        run: ${{ steps.build_lute.outputs.exe_path }} test
 
   run-lute-cxx-unittests:
     runs-on: ${{ matrix.os }}

--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -32,28 +32,10 @@ EXAMPLES:
 ]])
 end
 
---[[
- Any of the tests we load will use the instance of std/test initialized in this module (cli/commands/test/init.luau)
- Tests that run via lute test don't need to explicitly call test.run, so we'll pass an empty run function so that we don't
- execute any tests, while giving us time to remove unecessary run() calls (doing this because this doesn't support running tests just yet)
- The reason we have to inject a custom require here is because each `loadbypath` on a test file will return the "@std/test" instance provided by
- the EmbeddedStdVFS. However, running `lute test` from the root of the lute repo will use a distinct @std/test instance, which is provided by the .luaurc when running
- this file, which means the test environment won't get populated. The consequence of this is that `lute test` will work perfectly everywhere except inside of
- the lute repo, which sucks. Intercepting @std/test requires works correctly and ensures that the correct @std/test instance gets populated
-]]
---
-local function lutetestrequire(req: string)
-	if req == "@std/test" then
-		return table.freeze({ case = test.case, suite = test.suite, run = function() end })
-	end
-	return require(req) :: any
-end
-
 local function loadtests(testfiles: { path.path })
-	local fenv: { [unknown]: unknown } = setmetatable({ ["require"] = lutetestrequire }, { __index = _G })
 	-- Load all test files first
 	for _, p in testfiles do
-		local success, err = pcall(luau.loadbypath, p, fenv)
+		local success, err = pcall(luau.loadbypath, p, nil)
 
 		if not success then
 			print(`Error loading {path.format(p)}: {err}`)

--- a/tests/batteries/base64.test.luau
+++ b/tests/batteries/base64.test.luau
@@ -72,5 +72,3 @@ test.suite("Base64", function(suite)
 		end)
 	end
 end)
-
-test.run()

--- a/tests/batteries/collections/deque.test.luau
+++ b/tests/batteries/collections/deque.test.luau
@@ -93,5 +93,3 @@ test.suite("deque", function(suite)
 		assert.eq(deq:peekback(), 2)
 	end)
 end)
-
-test.run()

--- a/tests/batteries/difftext.test.luau
+++ b/tests/batteries/difftext.test.luau
@@ -491,5 +491,3 @@ test.suite("printdiff", function(suite)
 		assert.eq(lines[103], composeDetailedAddition("modified", {}, "    101| "))
 	end)
 end)
-
-test.run()

--- a/tests/cli/compile.test.luau
+++ b/tests/cli/compile.test.luau
@@ -48,5 +48,3 @@ test.suite("Lute CLI Compile", function(suite)
 		fs.remove(compileePath)
 	end)
 end)
-
-test.run()

--- a/tests/cli/discovery/example.spec.luau
+++ b/tests/cli/discovery/example.spec.luau
@@ -5,5 +5,3 @@ test.suite("ExampleSuite", function(suite)
 		assert.eq(2 + 2, 4)
 	end)
 end)
-
-test.run()

--- a/tests/cli/discovery/smoke.test.luau
+++ b/tests/cli/discovery/smoke.test.luau
@@ -11,5 +11,3 @@ test.suite("SmokeSuite", function(suite)
 end)
 
 test.case("Passing", function(assert) end)
-
-test.run()

--- a/tests/cli/lib/files.test.luau
+++ b/tests/cli/lib/files.test.luau
@@ -265,5 +265,3 @@ test.suite("cli/lib/files", function(suite)
 		fs.removedirectory(testPath, { recursive = true })
 	end)
 end)
-
-test.run()

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -1069,5 +1069,3 @@ violator.luau:5:12-17 ──
 		fs.remove(violatorPath)
 	end)
 end)
-
-test.run()

--- a/tests/cli/loadbypath.test.luau
+++ b/tests/cli/loadbypath.test.luau
@@ -56,5 +56,3 @@ test.suite("Lute CLI Run", function(suite)
 		end
 	end)
 end)
-
-test.run()

--- a/tests/cli/run.test.luau
+++ b/tests/cli/run.test.luau
@@ -38,5 +38,3 @@ test.suite("lute-run", function(suite)
 		assert.strnotcontains(result.stdout, "Hello world")
 	end)
 end)
-
-test.run()

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -71,5 +71,3 @@ test.suite("LuteTestCommand", function(suite)
 		assert.neq(result.stdout:find("Passed: 1", 1, true), nil)
 	end)
 end)
-
-test.run()

--- a/tests/cli/transform.test.luau
+++ b/tests/cli/transform.test.luau
@@ -147,5 +147,3 @@ test.suite("lute transform", function(suite)
 		fs.remove(outputPath)
 	end)
 end)
-
-test.run()

--- a/tests/lute/task.test.luau
+++ b/tests/lute/task.test.luau
@@ -23,5 +23,3 @@ test.suite("LuteTaskSuite", function(suite)
 		assert.eq(endTime - startTime >= 0.5, true)
 	end)
 end)
-
-test.run()

--- a/tests/lute/vm.test.luau
+++ b/tests/lute/vm.test.luau
@@ -66,5 +66,3 @@ test.suite("LuteVmSuite", function(suite)
 		fs.remove(parent_vm)
 	end)
 end)
-
-test.run()

--- a/tests/runtime/crypto.test.luau
+++ b/tests/runtime/crypto.test.luau
@@ -121,5 +121,3 @@ test.suite("CryptoRuntimeTests", function(suite)
 		end)
 	end)
 end)
-
-test.run()

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -261,5 +261,3 @@ test.suite("FsSuite", function(suite)
 		fs.removedirectory(baseDir, { recursive = true })
 	end)
 end)
-
-test.run()

--- a/tests/std/json.test.luau
+++ b/tests/std/json.test.luau
@@ -85,5 +85,3 @@ test.suite("JSONParsingTestSuite", function(suite)
 		end
 	end)
 end)
-
-test.run()

--- a/tests/std/luau.test.luau
+++ b/tests/std/luau.test.luau
@@ -45,5 +45,3 @@ test.suite("LuauTypeOfModuleSuite", function(suite)
 		assert.eq(resolvedPath, expected)
 	end)
 end)
-
-test.run()

--- a/tests/std/net.test.luau
+++ b/tests/std/net.test.luau
@@ -22,5 +22,3 @@ test.suite("NetTestSuite", function(suite)
 		server.close()
 	end)
 end)
-
-test.run()

--- a/tests/std/path/path.posix.test.luau
+++ b/tests/std/path/path.posix.test.luau
@@ -588,5 +588,3 @@ test.suite("PathPosixRelativeSuite", function(suite)
 		end, "Cannot compute relative path between absolute and relative paths")
 	end)
 end)
-
-test.run()

--- a/tests/std/path/path.win32.test.luau
+++ b/tests/std/path/path.win32.test.luau
@@ -817,5 +817,3 @@ test.suite("PathWin32RelativeSuite", function(suite)
 		assert.eq(result.parts[2], "file.txt")
 	end)
 end)
-
-test.run()

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -135,5 +135,3 @@ test.suite("ProcessSuite", function(suite)
 		end, "process options must be a table")
 	end)
 end)
-
-test.run()

--- a/tests/std/stringext.test.luau
+++ b/tests/std/stringext.test.luau
@@ -36,5 +36,3 @@ test.suite("StringExt", function(suite)
 		assert.eq(stringext.count("hello world", "[hw]"), 2) -- count h and w
 	end)
 end)
-
-test.run()

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -1193,5 +1193,3 @@ test.suite("parse types", function(suite)
 		assert.eq(variadicType.type.tag, "reference")
 	end)
 end)
-
-test.run()

--- a/tests/std/syntax/printer.test.luau
+++ b/tests/std/syntax/printer.test.luau
@@ -894,5 +894,3 @@ function foo() return end
 		end, assert)
 	end)
 end)
-
-test.run()

--- a/tests/std/syntax/query.test.luau
+++ b/tests/std/syntax/query.test.luau
@@ -244,5 +244,3 @@ test.suite("AST Query", function(suite)
 		assert.eq(evenOnly[3], 4)
 	end)
 end)
-
-test.run()

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -63,5 +63,3 @@ test.suite("TableExt", function(suite)
 		assert.tableeq(c, { 6, 5, 4 })
 	end)
 end)
-
-test.run()

--- a/tests/std/test.test.luau
+++ b/tests/std/test.test.luau
@@ -338,5 +338,3 @@ test.run()
 		)
 	end)
 end)
-
-test.run()

--- a/tests/std/time.test.luau
+++ b/tests/std/time.test.luau
@@ -155,5 +155,3 @@ test.suite("TimeSuite", function(suite)
 		assert.eq(tostring(d), "0.123000456")
 	end)
 end)
-
-test.run()


### PR DESCRIPTION
Thanks to recent changes to how require works, namely that `@std` requires will always resolve to the single builtin instance in the runtime (ignoring aliases), `lute test` can now handle transitive and batteries requires correctly without needing to intercept requires at all. This was the last blocker remaining before `lute test` could be used in CI. 
This PR:
a) updates CI to call `lute test`
b) removes the require interception that `lute test` did
b) removes the explicit call to test.run() within the test files in our repo, since test discovery handles this

I've left `test.run()` in for now, in case there is some desire to use the testing library without `lute test` (and the standard library tests in `std.test.luau` exercise this behaviour).  I'm open to opinions about what to do with it, and can address those in a followup.

Resolves issue #634 
