### PR TITLE
Improves lute runtime performance when scheduling many threads

### DIFF
--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -3,6 +3,7 @@
 #include "lute/ref.h"
 
 #include "Luau/Variant.h"
+#include "Luau/VecDeque.h"
 
 #include <atomic>
 #include <condition_variable>
@@ -80,7 +81,7 @@ struct Runtime
     std::mutex dataCopyMutex;
     std::unique_ptr<lua_State, void (*)(lua_State*)> dataCopy;
 
-    std::vector<ThreadToContinue> runningThreads;
+    Luau::VecDeque<ThreadToContinue> runningThreads;
 
 private:
     std::mutex continuationMutex;

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -67,7 +67,7 @@ RuntimeStep Runtime::runOnce()
         return StepEmpty{};
 
     auto next = std::move(runningThreads.front());
-    runningThreads.erase(runningThreads.begin());
+    runningThreads.pop_front();
 
     next.ref->push(GL);
     lua_State* L = lua_tothread(GL, -1);

--- a/tools/profile.luau
+++ b/tools/profile.luau
@@ -1,0 +1,32 @@
+local task = require("@lute/task")
+
+local started = os.clock()
+
+local amount = 100000
+local batches = 5
+local per_batch = amount / batches
+
+for current = 1, batches do
+	local thread = coroutine.running()
+
+	print(`Batch {current} / {batches}`)
+
+	for i = 1, per_batch do
+		--print("Spawning thread #" .. i)
+		task.spawn(function()
+			task.wait(0.1)
+			--_TEST_ASYNC_WORK(0.1)
+			if i == per_batch then
+				print("Last thread in batch #" .. current)
+				assert(coroutine.status(thread) == "suspended", `Thread {i} has status {coroutine.status(thread)}`)
+				task.spawn(thread)
+			end
+		end)
+	end
+
+	coroutine.yield()
+end
+local took = os.clock() - started
+print(`Spawned {amount} sleeping threads in {took}s`)
+
+return -1

--- a/tools/profile.sh
+++ b/tools/profile.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+DEFAULT_SCRIPTNAME=${1:-profile.luau}
+echo "profiling $DEFAULT_SCRIPTNAME"
+xctrace record --template 'Time Profiler' --launch -- ./build/xcode/debug/lute/cli/lute $DEFAULT_SCRIPTNAME


### PR DESCRIPTION
The lute runtime currently schedules coroutines in a std::vector, and we always pop off the first thread in the vector to run. For small numbers of coroutines, this is okay, but when you get to 10k+ this becomes very inefficient as we have to move all the other elements one over `O(n)`. This PR just replaces the `std::vector` with a `Luau::VecDeque`, making the pop operation `O(1)`.

I've also included a profiling script that I used to profile lute since I keep forgetting the `xctrace` incantation - it can be invoked by:
```
./tools/profile.sh /path/to/.luau(defaults to profile.luau)
```