### PR TITLE
Fix lint bug in `violationIsSuppressed`

### DIFF
--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -148,11 +148,9 @@ local function violationIsSuppressed(
 	-- We want to find the lint directive with the tightest scope that applies to this violation
 	local function nodeIsSuppressed(node: syntax.AstNode): boolean
 		if not node.location then -- not all nodes have location field (i.e ExprTableItem); continue recursing if we encounter these
-			print(`visiting {node.kind}, {node.tag}`)
 			return true
 		end
 
-		print(violation.location, violation.message)
 		if syntax.span.subsumes(violation.location, node.location) then
 			-- The first node which is fully contained within a violation has the tightest relevant directive
 			local directives = maybeParseDirectives(node, directiveCache)

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -147,6 +147,12 @@ local function violationIsSuppressed(
 
 	-- We want to find the lint directive with the tightest scope that applies to this violation
 	local function nodeIsSuppressed(node: syntax.AstNode): boolean
+		if not node.location then -- not all nodes have location field (i.e ExprTableItem); continue recursing if we encounter these
+			print(`visiting {node.kind}, {node.tag}`)
+			return true
+		end
+
+		print(violation.location, violation.message)
 		if syntax.span.subsumes(violation.location, node.location) then
 			-- The first node which is fully contained within a violation has the tightest relevant directive
 			local directives = maybeParseDirectives(node, directiveCache)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -1107,7 +1107,7 @@ return {
 		)
 
 		local result = process.run({ lutePath, "lint", "-r", tableItemRule, violatorPath })
-		assert.eq(result.exitcode, 0)
+		assert.eq(result.exitcode, 1)
 		assert.strnotcontains(result.stdout, `Error linting file '{violatorPath}'`)
 
 		fs.remove(violatorPath)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -1068,4 +1068,51 @@ violator.luau:5:12-17 ──
 		-- Teardown
 		fs.remove(violatorPath)
 	end)
+
+	suite:case("lute lint does not error on table item violations", function(assert)
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		local tableItemRule = path.format(path.join(tmpDir, "tableItemRule.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+local tbl = {
+	a = 1,
+	[b] = 2,
+	3,
+}
+]]
+		)
+
+		fs.writestringtofile(
+			tableItemRule,
+			[[
+local query = require("@std/syntax/query")
+local syntaxUtils = require("@std/syntax/utils")
+
+return {
+    name = "tableItem",
+    lint = function(ast, sourcepath)
+		return query.findallfromroot(ast, syntaxUtils.isExprTableItem):maptoarray(function(n)
+			return {
+				severity = "warn",
+				message = `linting table field at {n.value.location.beginline}, {n.value.location.endline}`,
+				lintname = "repro",
+				location = n.value.location,
+				sourcepath = sourcepath
+			}
+		end)
+	end
+}
+]]
+		)
+
+		local result = process.run({ lutePath, "lint", "-r", tableItemRule, violatorPath })
+		assert.eq(result.exitcode, 0)
+		assert.strnotcontains(result.stdout, `Error linting file '{violatorPath}'`)
+
+		fs.remove(violatorPath)
+		fs.remove(tableItemRule)
+	end)
 end)
+
+test.run()


### PR DESCRIPTION
## Problem
I ran into errors when implementing lint rules that caught violations within table items. 

For a minimal repro (w/ some debug output), use:
```luau
local luau = require("@lute/luau")
local path = require("@std/path")
local query = require("@std/syntax/query")
local syntaxUtils = require("@std/syntax/utils")

local function lint(ast: luau.AstStatBlock, sourcepath: path.path)
    return query.findallfromroot(ast, syntaxUtils.isExprTableItem):maptoarray(function(n: luau.AstExprTableItem)
        print("Evaluating table item location:", n.value.location.beginline, n.value.location.begincolumn)
        return {
            severity = "warn",
            message = `linting table field at {n.value.location.beginline}, {n.value.location.endline}`,
            lintname = "repro",
            location = n.value.location,
            sourcepath = sourcepath
        }
    end)
end

return {
    name = "reproBroken",
    lint = lint
}
```
Try running `lute lint -r path_to_repro_file path_to_repro_file`

You should encounter the following error message: `Error linting file '/Users/wmccarthy/git/roblox/luau-ui-ecosystem-lints/repro_nil_location.luau': @std/syntax/init.luau:14: attempt to index nil with 'beginline'`

If you follow the trace from `std/syntax/init.luau:14`, you'll see the error stems from calls to `syntax.span.subsumes` in `lint`'s init file ([see here](https://github.com/luau-lang/lute/blob/primary/lute/cli/commands/lint/init.luau#L150-L160)).
Here, `nodeIsSuppressed` is used as the default visitor function, in other words, it is called at every visited node as the visitor walks the tree. It relies on the assumption that every node has `location` field, which is not true. `ExprTableItem` nodes, specifically, do not have a location field. This explains the the encountered error.

## Solution

Simple check if `node.location` is nil and if so, return true to continue visitor recursion.

Add a test for sanity check.