### PR TITLE
Fix `parseGlob` handling of `.` character

### DIFF
--- a/lute/cli/commands/lib/ignore.luau
+++ b/lute/cli/commands/lib/ignore.luau
@@ -97,8 +97,8 @@ local function parseGlob(glob: string): Glob
 			-- Match any single character, except for directory separator
 			table.insert(lua_parts, `[^{separator}]`)
 			idx = idx + 1
-		elseif char == "-" then
-			table.insert(lua_parts, "%-")
+		elseif char == "-" or char == "." then
+			table.insert(lua_parts, `%{char}`)
 			idx = idx + 1
 		elseif char == "/" or char == "\\" then
 			table.insert(lua_parts, separator)

--- a/tests/cli/lib/files.test.luau
+++ b/tests/cli/lib/files.test.luau
@@ -271,4 +271,3 @@ test.suite("cli/lib/files", function(suite)
 		fs.removedirectory(testPath, { recursive = true })
 	end)
 end)
-

--- a/tests/cli/lib/files.test.luau
+++ b/tests/cli/lib/files.test.luau
@@ -26,6 +26,11 @@ test.suite("cli/lib/files", function(suite)
 		local shouldNotIgnorePath = path.join(testPath, "readme.luau")
 		fs.writestringtofile(shouldNotIgnorePath, "")
 
+		local shouldNotIgnoreDirectory = path.join(testPath, "lua")
+		fs.createdirectory(shouldNotIgnoreDirectory)
+		local shouldNotIgnoreNestedPath = path.join(shouldNotIgnoreDirectory, "readme.luau")
+		fs.writestringtofile(shouldNotIgnoreNestedPath, "")
+
 		-- Do
 		local results = files.getSourceFiles({ path.format(testPath) })
 
@@ -36,6 +41,7 @@ test.suite("cli/lib/files", function(suite)
 		end
 		assert.eq(resultPaths[path.format(shouldIgnorePath)], nil)
 		assert.eq(resultPaths[path.format(shouldNotIgnorePath)], true)
+		assert.eq(resultPaths[path.format(shouldNotIgnoreNestedPath)], true)
 
 		-- Teardown
 		fs.removedirectory(testPath, { recursive = true })
@@ -265,3 +271,5 @@ test.suite("cli/lib/files", function(suite)
 		fs.removedirectory(testPath, { recursive = true })
 	end)
 end)
+
+test.run()

--- a/tests/cli/lib/files.test.luau
+++ b/tests/cli/lib/files.test.luau
@@ -272,4 +272,3 @@ test.suite("cli/lib/files", function(suite)
 	end)
 end)
 
-test.run()


### PR DESCRIPTION
### Problem

The `parseGlob` function in `ignore` does not currently escape the `.` character; `.` is a magic character in lua, so if we don't escape it, it will match ANY character instead of the literal `.` we intend to match for.

This leads to issues where directories are incorrectly matched and ignored due to file extension globs from the parsed `gitignore`.

For instance, if we have `*.something` in our gitignore, any directory path ending in `something` will be ignored. I've added a small case to the `files` test covering this sort of scenario.

### Solution

Ensure `.` is escaped properly in `parseGlob`