### PR TITLE
Extends `lute lint` to support linting an input string

### DIFF
--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -206,12 +206,12 @@ local function lintString(
 	inputFilePath: pathLib.path?
 ): { types.LintViolation }
 	if VERBOSE then
-		print(`Parsing input {if inputFilePath then `file {inputFilePath}` else "string"}`)
+		print(`Parsing input {if inputFilePath then `file '{inputFilePath}'` else "string"}`)
 	end
 	local ast = syntax.parseblock(source)
 
 	if VERBOSE then
-		print(`Parsing global lint ignores in input {if inputFilePath then `file {inputFilePath}` else "string"}`)
+		print(`Parsing global lint ignores in input {if inputFilePath then `file '{inputFilePath}'` else "string"}`)
 	end
 	local globalIgnores = parseGlobalIgnores(triviaUtils.leftmosttrivia(ast))
 

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -30,6 +30,7 @@ OPTIONS:
 						  modules exporting lint rules, while all other .luau files will be treated 
 						  as individual lint rules. If unspecified, the default lint rules are used.
   -j, --json              Output lint violations in JSON format matching the LSP diagnostic spec.
+  -s, --string-input	  Lint the provided string input instead of reading from files.
 
 PATHS:
   Path(s) to the Luau file(s) or folders containing Luau files to be linted. Only files with .luau or .lua extensions will be linted.
@@ -199,19 +200,18 @@ local function parseGlobalIgnores(trivia: { syntax.Trivia }): { [string]: true }
 	return globalIgnores
 end
 
-local function lintFile(inputFilePath: pathLib.path, lintRules: { types.LintRule }): { types.LintViolation }
+local function lintString(
+	source: string,
+	lintRules: { types.LintRule },
+	inputFilePath: pathLib.path?
+): { types.LintViolation }
 	if VERBOSE then
-		print(`Reading input file '{inputFilePath}'`)
+		print(`Parsing input {if inputFilePath then `file {inputFilePath}` else "string"}`)
 	end
-	local fileContent = fs.readfiletostring(inputFilePath)
+	local ast = syntax.parseblock(source)
 
 	if VERBOSE then
-		print(`Parsing input file '{inputFilePath}'`)
-	end
-	local ast = syntax.parseblock(fileContent)
-
-	if VERBOSE then
-		print(`Parsing global lint ignores in '{inputFilePath}'`)
+		print(`Parsing global lint ignores in input {if inputFilePath then `file {inputFilePath}` else "string"}`)
 	end
 	local globalIgnores = parseGlobalIgnores(triviaUtils.leftmosttrivia(ast))
 
@@ -244,52 +244,27 @@ local function lintFile(inputFilePath: pathLib.path, lintRules: { types.LintRule
 	return violations
 end
 
-local function main(...: string)
-	local args = cli.parser()
-
-	args:add("rules", "option", { help = "Linting rule(s) to apply", aliases = { "r" } })
-	args:add("help", "flag", { help = "Show help message", aliases = { "h" } })
-	args:add("verbose", "flag", { help = "Enable verbose output", aliases = { "v" } })
-	args:add("json", "flag", { help = "Output lint violations in JSON format", aliases = { "j" } })
-	-- TODO: ignore blobs
-
-	args:parse({ ... })
-
-	if args:has("help") then
-		printHelp()
-		return
+local function lintFile(inputFilePath: pathLib.path, lintRules: { types.LintRule }): { types.LintViolation }
+	if VERBOSE then
+		print(`Reading input file '{inputFilePath}'`)
 	end
+	local fileContent = fs.readfiletostring(inputFilePath)
 
-	VERBOSE = args:has("verbose")
+	return lintString(fileContent, lintRules, inputFilePath)
+end
 
-	local inputFiles = args:forwarded()
-	if inputFiles == nil or #inputFiles == 0 then
-		print("Error: No input files specified.\n\n" .. USAGE .. "\nUse --help for more information.")
-		process.exit(1)
-	end
-
+local function lintPaths(
+	inputFilePaths: { string },
+	lintRules: { types.LintRule }
+): { [pathLib.path]: { types.LintViolation } }
 	if VERBOSE then
 		print("Filtering input files by gitignore")
 	end
-	local inputFilePaths = files.getSourceFiles(inputFiles, VERBOSE)
-
-	local lintRules: { types.LintRule }
-	local rulePath = args:get("rules")
-	if rulePath == nil then
-		if VERBOSE then
-			print("Using default lint rules.")
-		end
-		lintRules = loadDefaultRules()
-	else
-		if VERBOSE then
-			print(`Loading lint rule(s) from '{rulePath}'`)
-		end
-		lintRules = loadLintRules(rulePath)
-	end
+	local inputFiles = files.getSourceFiles(inputFilePaths, VERBOSE)
 
 	local allViolations: { [pathLib.path]: { types.LintViolation } } = {}
 
-	for _, inputPath in inputFilePaths do
+	for _, inputPath in inputFiles do
 		local walker = fs.walk(inputPath, { recursive = true })
 
 		local curr = walker()
@@ -308,20 +283,94 @@ local function main(...: string)
 		end
 	end
 
-	if args:has("json") then
-		print(json.serialize(lsp.workspaceDiagnosticReport(allViolations) :: json.object, true))
+	return allViolations
+end
+
+local function main(...: string)
+	local args = cli.parser()
+
+	args:add("rules", "option", { help = "Linting rule(s) to apply", aliases = { "r" } })
+	args:add("help", "flag", { help = "Show help message", aliases = { "h" } })
+	args:add("verbose", "flag", { help = "Enable verbose output", aliases = { "v" } })
+	args:add("json", "flag", { help = "Output lint violations in JSON format", aliases = { "j" } })
+	args:add(
+		"string-input",
+		"option",
+		{ help = "Lint the provided string input instead of reading from files", aliases = { "s" } }
+	)
+
+	args:parse({ ... })
+
+	if args:has("help") then
+		printHelp()
+		return
+	end
+
+	VERBOSE = args:has("verbose")
+
+	local inputFiles = args:forwarded()
+	local stringInput = args:get("string-input")
+	if (inputFiles == nil or #inputFiles == 0) and not stringInput then
+		print("Error: No input files or string input specified.\n\n" .. USAGE .. "\nUse --help for more information.")
+		process.exit(1)
+	end
+
+	local lintRules: { types.LintRule }
+	local rulePath = args:get("rules")
+	if rulePath == nil then
+		if VERBOSE then
+			print("Using default lint rules.")
+		end
+		lintRules = loadDefaultRules()
 	else
 		if VERBOSE then
-			print(`Printing violations from {#allViolations} files\n`)
+			print(`Loading lint rule(s) from '{rulePath}'`)
 		end
-		local violationsFound = false
-		for sourcePath, violations in allViolations do
-			if #violations > 0 then
-				violationsFound = true
-				printer.printLints(violations, sourcePath)
+		lintRules = loadLintRules(rulePath)
+	end
+
+	if stringInput ~= nil then
+		local violations = lintString(stringInput, lintRules)
+
+		if args:has("json") then
+			local diagnostics = tableext.map(violations, lsp.diagnostic)
+			print(json.serialize(diagnostics :: json.array, true))
+		elseif #violations > 0 then
+			if VERBOSE then
+				print(`Printing violations from string input\n`)
 			end
+
+			printer.printLintsWithSource(violations, stringInput)
+
+			process.exit(1)
+		else
+			if VERBOSE then
+				print("No lint violations found.")
+			end
+
+			process.exit(0)
 		end
-		process.exit(if violationsFound then 1 else 0)
+	else
+		local allViolations = lintPaths(inputFiles :: { string }, lintRules) -- LUAUFIX: type refinement on line 305 should mean that cast on inputFiles isn't needed
+
+		if args:has("json") then
+			print(json.serialize(lsp.workspaceDiagnosticReport(allViolations) :: json.object, true))
+		else
+			if VERBOSE then
+				print(`Printing violations from {#allViolations} files\n`)
+			end
+
+			local violationsFound = false
+
+			for sourcePath, violations in allViolations do
+				if #violations > 0 then
+					violationsFound = true
+					printer.printLintsWithPath(violations, sourcePath)
+				end
+			end
+
+			process.exit(if violationsFound then 1 else 0)
+		end
 	end
 end
 

--- a/lute/cli/commands/lint/lsp/init.luau
+++ b/lute/cli/commands/lint/lsp/init.luau
@@ -25,7 +25,7 @@ local function tag(t: lintTypes.tag): number
 	end
 end
 
-local function diagnostic(lint: lintTypes.LintViolation): lspTypes.Diagnostic
+function lsp.diagnostic(lint: lintTypes.LintViolation): lspTypes.Diagnostic
 	return table.freeze({
 		range = table.freeze({
 			start = table.freeze({
@@ -39,7 +39,7 @@ local function diagnostic(lint: lintTypes.LintViolation): lspTypes.Diagnostic
 		}),
 		severity = severity(lint.severity),
 		code = lint.lintname,
-		source = "lute lint", -- LUAUFIX: Errors because this isn't inferred as a singleton
+		source = "lute lint" :: "lute lint", -- LUAUFIX: Errors because this isn't inferred as a singleton
 		message = lint.message,
 		tags = if lint.tags then table.freeze(tableext.map(lint.tags, tag)) else nil,
 	})
@@ -51,7 +51,7 @@ local function workspaceDocumentDiagnosticReport(
 ): lspTypes.WorkspaceDocumentDiagnosticReport
 	local report = { items = {}, uri = pathLib.format(path) }
 	for _, violation in violations do
-		table.insert(report.items, diagnostic(violation))
+		table.insert(report.items, lsp.diagnostic(violation))
 	end
 	return table.freeze(report)
 end

--- a/lute/cli/commands/lint/lsp/init.luau
+++ b/lute/cli/commands/lint/lsp/init.luau
@@ -39,7 +39,7 @@ function lsp.diagnostic(lint: lintTypes.LintViolation): lspTypes.Diagnostic
 		}),
 		severity = severity(lint.severity),
 		code = lint.lintname,
-		source = "lute lint" :: "lute lint", -- LUAUFIX: Errors because this isn't inferred as a singleton
+		source = "lute lint" :: "lute lint", -- LUAUFIX: Annotation needed, otherwise this errors because string isn't inferred as a singleton
 		message = lint.message,
 		tags = if lint.tags then table.freeze(tableext.map(lint.tags, tag)) else nil,
 	})

--- a/lute/cli/commands/lint/printer.luau
+++ b/lute/cli/commands/lint/printer.luau
@@ -11,7 +11,7 @@ local function printLint(lint: types.LintViolation, sourceLines: { string }): ()
 	print(`{lint.severity}[{lint.lintname}]: {lint.message}\n`)
 
 	local location = lint.location
-	local filepath = path.format(lint.sourcepath)
+	local filepath = if lint.sourcepath then path.format(lint.sourcepath) else "input"
 
 	if location.beginline == location.endline then
 		local gutterSize = math.floor(math.log10(location.endline)) + 3 -- + 2 for padding around line number
@@ -77,7 +77,7 @@ local function printLint(lint: types.LintViolation, sourceLines: { string }): ()
 	end
 end
 
-local function printLints(lints: { types.LintViolation }, sourceContent: string): ()
+function printerLib.printLintsWithSource(lints: { types.LintViolation }, sourceContent: string): ()
 	local sourceLines = sourceContent:split("\n")
 
 	for _, lint in lints do
@@ -85,8 +85,8 @@ local function printLints(lints: { types.LintViolation }, sourceContent: string)
 	end
 end
 
-function printerLib.printLints(lints: { types.LintViolation }, sourcePath: path.path): ()
-	printLints(lints, fs.readfiletostring(sourcePath))
+function printerLib.printLintsWithPath(lints: { types.LintViolation }, sourcePath: path.path): ()
+	printerLib.printLintsWithSource(lints, fs.readfiletostring(sourcePath))
 end
 
 return table.freeze(printerLib)

--- a/lute/cli/commands/lint/rules/almost_swapped.luau
+++ b/lute/cli/commands/lint/rules/almost_swapped.luau
@@ -57,7 +57,7 @@ end
 
 -- Report instances of attempted swaps like:
 -- a = b; b = a
-local function lint(ast: syntax.AstStatBlock, sourcepath: path.path): { lintTypes.LintViolation }
+local function lint(ast: syntax.AstStatBlock, sourcepath: path.path?): { lintTypes.LintViolation }
 	local violations = {}
 
 	local nodes = query.findallfromroot(ast, utils.isStatBlock).nodes

--- a/lute/cli/commands/lint/rules/divide_by_zero.luau
+++ b/lute/cli/commands/lint/rules/divide_by_zero.luau
@@ -7,7 +7,7 @@ local utils = require("@std/syntax/utils")
 local name = "divide_by_zero"
 local message = "Division by zero detected."
 
-local function lint(ast: syntax.AstStatBlock, sourcepath: path.path): { lintTypes.LintViolation }
+local function lint(ast: syntax.AstStatBlock, sourcepath: path.path?): { lintTypes.LintViolation }
 	return query
 		.findallfromroot(ast, utils.isExprBinary)
 		:filter(function(bin)

--- a/lute/cli/commands/lint/types.luau
+++ b/lute/cli/commands/lint/types.luau
@@ -9,12 +9,12 @@ export type LintViolation = {
 	read location: syntax.span,
 	read message: string,
 	read severity: severity,
-	read sourcepath: path.path,
+	read sourcepath: path.path?,
 	read tags: { tag }?,
 } -- TODO: add suggested fix
 
 export type LintRule = {
-	read lint: (ast: syntax.AstStatBlock, sourcepath: path.path) -> { LintViolation },
+	read lint: (ast: syntax.AstStatBlock, sourcepath: path.path?) -> { LintViolation },
 	read name: string,
 }
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -46,7 +46,7 @@ test.suite("lute lint", function(suite)
 		local result = process.run({ lutePath, "lint", "-r", "a_rule.luau" })
 
 		assert.eq(result.exitcode, 1)
-		assert.strcontains(result.stdout, "Error: No input files specified.")
+		assert.strcontains(result.stdout, "Error: No input files or string input specified.")
 	end)
 
 	suite:case("lute lint error code 0 with no violations", function(assert)
@@ -1084,10 +1084,10 @@ b = a
 
 		assert.strcontains(result.stdout, "warning[almost_swapped]: This looks like a failed attempt to swap.")
 		local expected = [[
-input:3:1-4:6 ──
+   ┌── input:1:1-2:6 ──
    │
- 3 │ ╭ a = b
- 4 │ │ b = a
+ 1 │ ╭ a = b
+ 2 │ │ b = a
    │ ╰─────^
    │
 ]]
@@ -1134,28 +1134,25 @@ input:3:1-4:6 ──
 		-- Check
 		assert.eq(result.exitcode, 0)
 
-		local expected = [[
-{
-    "items": [
-        {
-            "items": [
-                {
-                    "message": "Division by zero detected.", 
-                    "source": "lute lint", 
-                    "code": "divide_by_zero", 
-                    "severity": 2, 
-                    "range": {
-                        "start": {
-                            "character": 10, 
-                            "line": 0
-                        }, 
-                        "end": {
-                            "character": 15, 
-                            "line": 0
-                        }
-                    }
-                }
-            ],]]
+		local expected = [=[
+[
+    {
+        "message": "Division by zero detected.", 
+        "source": "lute lint", 
+        "code": "divide_by_zero", 
+        "severity": 2, 
+        "range": {
+            "start": {
+                "character": 10, 
+                "line": 0
+            }, 
+            "end": {
+                "character": 15, 
+                "line": 0
+            }
+        }
+    }
+]]=]
 		assert.strcontains(result.stdout, expected)
 	end)
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -1069,6 +1069,96 @@ violator.luau:5:12-17 ──
 		fs.remove(violatorPath)
 	end)
 
+	suite:case("lute lint string input", function(assert)
+		local inputString = [[
+a = b
+b = a
+]]
+
+		-- Do
+		-- Run the linter on string input
+		local result = process.run({ lutePath, "lint", "-s", inputString })
+
+		-- Check
+		assert.eq(result.exitcode, 1)
+
+		assert.strcontains(result.stdout, "warning[almost_swapped]: This looks like a failed attempt to swap.")
+		local expected = [[
+input:3:1-4:6 ──
+   │
+ 3 │ ╭ a = b
+ 4 │ │ b = a
+   │ ╰─────^
+   │
+]]
+		assert.strcontains(result.stdout, expected)
+	end)
+
+	suite:case("lute lint string input verbose", function(assert)
+		local inputString = "local x = 1 / 0"
+
+		-- Do
+		-- Run the linter on string input with verbose flag
+		local result = process.run({ lutePath, "lint", "-v", "-s", inputString })
+
+		-- Check
+		assert.eq(result.exitcode, 1)
+
+		assert.strcontains(result.stdout, "Using default lint rules.")
+		assert.strcontains(result.stdout, "Parsing input string")
+		assert.strcontains(result.stdout, "Parsing global lint ignores in input string")
+		assert.strcontains(result.stdout, "Applying lint rules")
+		assert.strcontains(result.stdout, "Printing violations from string input")
+		assert.strcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.")
+	end)
+
+	suite:case("lute lint string input with no violations", function(assert)
+		local inputString = "local x = 1 + 2"
+
+		-- Do
+		-- Run the linter on string input
+		local result = process.run({ lutePath, "lint", "-v", "-s", inputString })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+		assert.strcontains(result.stdout, "No lint violations found.")
+	end)
+
+	suite:case("lute lint string input json output", function(assert)
+		local inputString = "local x = 1 / 0"
+
+		-- Do
+		-- Run the linter on string input with json flag
+		local result = process.run({ lutePath, "lint", "-j", "-s", inputString })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		local expected = [[
+{
+    "items": [
+        {
+            "items": [
+                {
+                    "message": "Division by zero detected.", 
+                    "source": "lute lint", 
+                    "code": "divide_by_zero", 
+                    "severity": 2, 
+                    "range": {
+                        "start": {
+                            "character": 10, 
+                            "line": 0
+                        }, 
+                        "end": {
+                            "character": 15, 
+                            "line": 0
+                        }
+                    }
+                }
+            ],]]
+		assert.strcontains(result.stdout, expected)
+	end)
+
 	suite:case("lute lint ignore (table item)", function(assert)
 		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
 		fs.writestringtofile(


### PR DESCRIPTION
The bulk of the changes are refactoring some of the linting logic to extract the common logic between linting a file and a string. Also, paths in reported lint violations are now optional since they're not relevant to linting string input.

The broader context for this PR is that it allows linting to be consumed by VSCode (and maybe other) extensions, since the source of truth for file contents is whatever the editor/LSP server has in memory, rather than what's on disk in the file.