### PR TITLE
Adds any and all (for array-like tables) to tableext

### DIFF
--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -27,6 +27,24 @@ function tableext.filter<K, V>(table: { [K]: V }, predicate: (V) -> boolean): { 
 	return new
 end
 
+function tableext.any<T>(arr: { T }, predicate: (T) -> boolean): boolean
+	for _, v in arr do
+		if predicate(v) then
+			return true
+		end
+	end
+	return false
+end
+
+function tableext.all<T>(arr: { T }, predicate: (T) -> boolean): boolean
+	for _, v in arr do
+		if not predicate(v) then
+			return false
+		end
+	end
+	return true
+end
+
 function tableext.extend<T>(tbl: { T }, ...: { T })
 	local extensions = table.pack(...)
 	extensions.n = nil :: any

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -109,6 +109,12 @@ test.suite("TableExt", function(suite)
 			return v > 5
 		end)
 		assert.eq(hasGreaterThanFive, false)
+
+		a = {}
+		local anyInEmpty = tableext.any(a, function(v: number)
+			return true
+		end)
+		assert.eq(anyInEmpty, false)
 	end)
 
 	suite:case("all", function(assert)
@@ -122,5 +128,11 @@ test.suite("TableExt", function(suite)
 			return v < 8
 		end)
 		assert.eq(allLessThanEight, false)
+
+		a = {}
+		local allInEmpty = tableext.all(a, function(v: number)
+			return false
+		end)
+		assert.eq(allInEmpty, true)
 	end)
 end)

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -97,4 +97,30 @@ test.suite("TableExt", function(suite)
 		assert.eq(#tableext.keys(setB), 3)
 		assert.neq(#tableext.keys(setB), #b)
 	end)
+
+	suite:case("any", function(assert)
+		local a = { 1, 2, 3, 4, 5 }
+		local hasEven = tableext.any(a, function(v: number)
+			return v % 2 == 0
+		end)
+		assert.eq(hasEven, true)
+
+		local hasGreaterThanFive = tableext.any(a, function(v: number)
+			return v > 5
+		end)
+		assert.eq(hasGreaterThanFive, false)
+	end)
+
+	suite:case("all", function(assert)
+		local a = { 2, 4, 6, 8 }
+		local allEven = tableext.all(a, function(v: number)
+			return v % 2 == 0
+		end)
+		assert.eq(allEven, true)
+
+		local allLessThanEight = tableext.all(a, function(v: number)
+			return v < 8
+		end)
+		assert.eq(allLessThanEight, false)
+	end)
 end)


### PR DESCRIPTION
I had a need for `any` when working on something else, and added `all` along the way