### PR TITLE
Adds suggested fix as a lint violation field

### DIFF
--- a/lute/cli/commands/lint/printer.luau
+++ b/lute/cli/commands/lint/printer.luau
@@ -75,6 +75,10 @@ local function printLint(lint: types.LintViolation, sourceLines: { string }): ()
 		print(`{blankGutter}│`)
 		print()
 	end
+
+	if lint.suggestedfix then
+		print(`Suggested fix: {lint.suggestedfix.fix}\n`)
+	end
 end
 
 function printerLib.printLintsWithSource(lints: { types.LintViolation }, sourceContent: string): ()

--- a/lute/cli/commands/lint/rules/almost_swapped.luau
+++ b/lute/cli/commands/lint/rules/almost_swapped.luau
@@ -1,7 +1,9 @@
 local lintTypes = require("../types")
 local path = require("@std/path")
 local query = require("@std/syntax/query")
+local stringext = require("@std/stringext")
 local syntax = require("@std/syntax")
+local printer = require("@std/syntax/printer")
 local utils = require("@std/syntax/utils")
 
 local name = "almost_swapped"
@@ -78,7 +80,11 @@ local function lint(ast: syntax.AstStatBlock, sourcepath: path.path?): { lintTyp
 			local nextVar, nextVal = nextStat.variables[1].node, nextStat.values[1].node
 
 			if compFuncs.refExprsSame(currVar, nextVal) and compFuncs.refExprsSame(nextVar, currVal) then
-				table.insert(violations, { -- LUAUFIX: severity isn't inferred as a singleton, so table.insert is mad
+				local currVarStr = stringext.trim(printer.printnode(currVar))
+				local currValStr = stringext.trim(printer.printnode(currVal))
+				local suggestedFix = `{currVarStr}, {currValStr} = {currValStr}, {currVarStr}`
+
+				table.insert(violations, {
 					lintname = name,
 					location = syntax.span.create({
 						beginline = currStat.location.beginline,
@@ -87,8 +93,11 @@ local function lint(ast: syntax.AstStatBlock, sourcepath: path.path?): { lintTyp
 						endcolumn = nextStat.location.endcolumn,
 					}),
 					message = message,
-					severity = "warning",
+					severity = "warning" :: "warning", -- LUAUFIX: cast needed because severity isn't inferred as a singleton
 					sourcepath = sourcepath,
+					suggestedfix = {
+						fix = suggestedFix,
+					},
 				})
 			end
 		end

--- a/lute/cli/commands/lint/types.luau
+++ b/lute/cli/commands/lint/types.luau
@@ -10,8 +10,12 @@ export type LintViolation = {
 	read message: string,
 	read severity: severity,
 	read sourcepath: path.path?,
+	read suggestedfix: {
+		read location: syntax.span?, -- if nil, applies to whole violation location
+		read fix: string,
+	}?,
 	read tags: { tag }?,
-} -- TODO: add suggested fix
+}
 
 export type LintRule = {
 	read lint: (ast: syntax.AstStatBlock, sourcepath: path.path?) -> { LintViolation },

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -180,6 +180,10 @@ violator.luau:1:1-2:6 ──
 ]]
 		assert.strcontains(result.stdout, expected)
 
+		expected = "Suggested fix: a, b = b, a"
+
+		assert.strcontains(result.stdout, expected)
+
 		expected = [[
 violator.luau:6:1-7:6 ──
    │
@@ -188,6 +192,10 @@ violator.luau:6:1-7:6 ──
    │ ╰─────^
    │
 ]]
+		assert.strcontains(result.stdout, expected)
+
+		expected = "Suggested fix: x, y = y, x"
+
 		assert.strcontains(result.stdout, expected)
 
 		expected = [[
@@ -200,6 +208,10 @@ violator.luau:10:1-11:10 ──
 ]]
 		assert.strcontains(result.stdout, expected)
 
+		expected = "Suggested fix: t.a, t.b = t.b, t.a"
+
+		assert.strcontains(result.stdout, expected)
+
 		expected = [[
 violator.luau:14:2-15:17 ──
     │
@@ -207,7 +219,11 @@ violator.luau:14:2-15:17 ──
  15 │ │     t["b"] = t["a"]
     │ ╰───────────────────^
     │
-]] -- todo: address tab shenanigans
+]]
+		assert.strcontains(result.stdout, expected)
+
+		expected = 'Suggested fix: t["a"], t["b"] = t["b"], t["a"]'
+
 		assert.strcontains(result.stdout, expected)
 
 		-- Teardown


### PR DESCRIPTION
This lays the groundwork for the autofix work, and means that normal `lute lint` invocations can function as dry runs. 