### PR TITLE
Adds autofix support to `lute lint`

### DIFF
--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -31,6 +31,8 @@ OPTIONS:
 						  as individual lint rules. If unspecified, the default lint rules are used.
   -j, --json              Output lint violations in JSON format matching the LSP diagnostic spec.
   -s, --string-input	  Lint the provided string input instead of reading from files.
+  --auto-fix			  Automatically apply fixes for lint violations that provide a suggested fix.
+						  Assumes that suggested fixes do not overlap.
 
 PATHS:
   Path(s) to the Luau file(s) or folders containing Luau files to be linted. Only files with .luau or .lua extensions will be linted.
@@ -244,18 +246,98 @@ local function lintString(
 	return violations
 end
 
-local function lintFile(inputFilePath: pathLib.path, lintRules: { types.LintRule }): { types.LintViolation }
+type fix = {
+	location: syntax.span,
+	replacement: string,
+}
+
+local function applySuggestedFixes(source: string, fixes: { fix }): string
+	local lines = source:split("\n")
+
+	-- Sort fixes by starting location descending to avoid messing up locations of earlier fixes
+	table.sort(fixes, function(a: fix, b: fix)
+		return not (a.location < b.location)
+	end)
+
+	for _, fix in fixes do
+		local beginLine = fix.location.beginline
+		local endLine = fix.location.endline
+		local beginColumn = fix.location.begincolumn
+		local endColumn = fix.location.endcolumn
+
+		if beginLine == endLine then
+			-- Single-line fix
+			local line = lines[beginLine]
+			lines[beginLine] = line:sub(1, beginColumn - 1) .. fix.replacement .. line:sub(endColumn)
+		else
+			-- Multi-line fix
+			local firstLine = lines[beginLine]
+			local lastLine = lines[endLine]
+
+			lines[beginLine] = firstLine:sub(1, beginColumn - 1) .. fix.replacement .. lastLine:sub(endColumn)
+
+			-- Remove the lines that were replaced
+			for i = beginLine + 1, endLine do
+				lines[i] = nil -- this is cheaper than doing table.remove, but we need to handle the resulting holes later
+			end
+		end
+	end
+
+	local newLines: { string } = {}
+	for _, line in lines do -- we rely on the assumption that we'll see the entries in the same order they were created in the array
+		table.insert(newLines, line)
+	end
+
+	return table.concat(newLines, "\n")
+end
+
+local function lintFile(
+	inputFilePath: pathLib.path,
+	lintRules: { types.LintRule },
+	autofixEnabled: boolean
+): { types.LintViolation }
 	if VERBOSE then
 		print(`Reading input file '{inputFilePath}'`)
 	end
 	local fileContent = fs.readfiletostring(inputFilePath)
 
-	return lintString(fileContent, lintRules, inputFilePath)
+	local violations = lintString(fileContent, lintRules, inputFilePath)
+
+	if not autofixEnabled then
+		return violations
+	end
+
+	local hasSuggestedFixes = tableext.any(violations, function(violation)
+		return violation.suggestedfix ~= nil
+	end)
+
+	if not hasSuggestedFixes then
+		return violations
+	end
+
+	if VERBOSE then
+		print(`Applying suggested fixes to file '{inputFilePath}'`)
+	end
+
+	local fixes: { fix } = {}
+	for _, violation in violations do
+		if violation.suggestedfix ~= nil then
+			local fixLocation = violation.suggestedfix.location or violation.location
+			table.insert(fixes, { location = fixLocation, replacement = violation.suggestedfix.fix })
+		end
+	end
+
+	local newContent = applySuggestedFixes(fileContent, fixes)
+
+	fs.writestringtofile(inputFilePath, newContent)
+
+	return lintString(newContent, lintRules, inputFilePath)
 end
 
 local function lintPaths(
 	inputFilePaths: { string },
-	lintRules: { types.LintRule }
+	lintRules: { types.LintRule },
+	autofixEnabled: boolean
 ): { [pathLib.path]: { types.LintViolation } }
 	if VERBOSE then
 		print("Filtering input files by gitignore")
@@ -271,7 +353,7 @@ local function lintPaths(
 		while curr ~= nil do
 			local inputFilePath = pathLib.parse(curr)
 
-			local success, err = pcall(lintFile, inputFilePath, lintRules)
+			local success, err = pcall(lintFile, inputFilePath, lintRules, autofixEnabled)
 			if success then
 				-- Violations are returned as the second return value from pcall
 				allViolations[inputFilePath] = err
@@ -297,6 +379,11 @@ local function main(...: string)
 		"string-input",
 		"option",
 		{ help = "Lint the provided string input instead of reading from files", aliases = { "s" } }
+	)
+	args:add(
+		"auto-fix",
+		"flag",
+		{ help = "Automatically apply fixes for lint violations that provide a suggested fix" }
 	)
 
 	args:parse({ ... })
@@ -330,6 +417,10 @@ local function main(...: string)
 	end
 
 	if stringInput ~= nil then
+		if args:has("auto-fix") then
+			print("Auto-fix has no effect on string input.")
+		end
+
 		local violations = lintString(stringInput, lintRules)
 
 		if args:has("json") then
@@ -351,7 +442,12 @@ local function main(...: string)
 			process.exit(0)
 		end
 	else
-		local allViolations = lintPaths(inputFiles :: { string }, lintRules) -- LUAUFIX: type refinement on line 305 should mean that cast on inputFiles isn't needed
+		local autofixEnabled = args:has("auto-fix")
+		if autofixEnabled and VERBOSE then
+			print("Auto-fix is enabled.")
+		end
+
+		local allViolations = lintPaths(inputFiles :: { string }, lintRules, autofixEnabled) -- LUAUFIX: type refinement on line 305 should mean that cast on inputFiles isn't needed
 
 		if args:has("json") then
 			print(json.serialize(lsp.workspaceDiagnosticReport(allViolations) :: json.object, true))

--- a/lute/cli/commands/lint/rules/parenthesized_conditions.luau
+++ b/lute/cli/commands/lint/rules/parenthesized_conditions.luau
@@ -2,6 +2,7 @@ local lintTypes = require("../types")
 local path = require("@std/path")
 local query = require("@std/syntax/query")
 local syntax = require("@std/syntax")
+local syntaxPrinter = require("@std/syntax/printer")
 
 local name = "parenthesized_conditions"
 local message = "Luau doesn't require parentheses around conditions. You can remove them for readability."
@@ -24,6 +25,9 @@ local function lint(ast: syntax.AstStatBlock, sourcepath: path.path?): { lintTyp
 					message = message,
 					severity = "info",
 					sourcepath = sourcepath,
+					suggestedfix = {
+						fix = syntaxPrinter.printnode(ifStat.condition.expression),
+					},
 				})
 			end
 
@@ -35,6 +39,9 @@ local function lint(ast: syntax.AstStatBlock, sourcepath: path.path?): { lintTyp
 						message = message,
 						severity = "info",
 						sourcepath = sourcepath,
+						suggestedfix = {
+							fix = syntaxPrinter.printnode(elseIfStat.condition.expression),
+						},
 					})
 				end
 			end
@@ -57,6 +64,9 @@ local function lint(ast: syntax.AstStatBlock, sourcepath: path.path?): { lintTyp
 				message = message,
 				severity = "info",
 				sourcepath = sourcepath,
+				suggestedfix = {
+					fix = syntaxPrinter.printnode((n.condition :: syntax.AstExprGroup).expression),
+				},
 			})
 		end)
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -1299,4 +1299,95 @@ violator.luau:15:7-15 ──
 		-- Teardown
 		fs.remove(violatorPath)
 	end)
+
+	suite:case("auto-fix", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+a = b
+b = a
+
+local x = 0
+local y = "hello"
+x = y
+y = x
+
+local t = { a = 1, b = 2 }
+t.a = t.b
+t.b = t.a
+
+if true then
+	t["a"] = t["b"]
+	t["b"] = t["a"]
+end
+]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "--auto-fix", violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0) -- After applying the auto-fix, there are no more violations
+
+		local fixedContents = fs.readfiletostring(violatorPath)
+		local expectedFixedContents = [[
+a, b = b, a
+
+local x = 0
+local y = "hello"
+x, y = y, x
+
+local t = { a = 1, b = 2 }
+t.a, t.b = t.b, t.a
+
+if true then
+	t["a"], t["b"] = t["b"], t["a"]
+end
+]]
+		assert.eq(fixedContents, expectedFixedContents)
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
+	suite:case("report violations remaining after auto-fix", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+a = b
+b = a
+
+local x = 3 / 0
+]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "--auto-fix", violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 1) -- After applying the auto-fix, there is still a violation
+
+		local fixedContents = fs.readfiletostring(violatorPath)
+		local expectedFixedContents = [[
+a, b = b, a
+
+local x = 3 / 0
+]]
+		assert.eq(fixedContents, expectedFixedContents)
+
+		assert.strcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.")
+
+		assert.strnotcontains(result.stdout, "warning[almost_swapped]: This looks like a failed attempt to swap.")
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
 end)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -232,6 +232,60 @@ violator.luau:14:2-15:17 ──
 		fs.remove(violatorPath)
 	end)
 
+	suite:case("almost swapped auto-fix", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+a = b
+b = a
+
+local x = 0
+local y = "hello"
+x = y
+y = x
+
+local t = { a = 1, b = 2 }
+t.a = t.b
+t.b = t.a
+
+if true then
+	t["a"] = t["b"]
+	t["b"] = t["a"]
+end
+]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "--auto-fix", violatorPath })
+
+		-- Check
+		assert.eq(result.exitcode, 0) -- After applying the auto-fix, there are no more violations
+
+		local fixedContents = fs.readfiletostring(violatorPath)
+		local expectedFixedContents = [[
+a, b = b, a
+
+local x = 0
+local y = "hello"
+x, y = y, x
+
+local t = { a = 1, b = 2 }
+t.a, t.b = t.b, t.a
+
+if true then
+	t["a"], t["b"] = t["b"], t["a"]
+end
+]]
+		assert.eq(fixedContents, expectedFixedContents)
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
 	suite:case("lute lint multiple rules", function(assert)
 		-- Setup
 		fs.createdirectory(rulesDir)
@@ -1300,54 +1354,57 @@ violator.luau:15:7-15 ──
 		fs.remove(violatorPath)
 	end)
 
-	suite:case("auto-fix", function(assert)
+	suite:case("parenthesized_conditions auto-fix", function(assert)
 		-- Setup
 		-- Create a file that violates the rule
 		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
 		fs.writestringtofile(
 			violatorPath,
 			[[
-a = b
-b = a
-
-local x = 0
-local y = "hello"
-x = y
-y = x
-
-local t = { a = 1, b = 2 }
-t.a = t.b
-t.b = t.a
-
-if true then
-	t["a"] = t["b"]
-	t["b"] = t["a"]
+if (3 > 0) then
+	print("Hello, world!")
+elseif (false) then
+	print("This won't print.")
 end
+
+local x = if (2 < 1) then 10 elseif (true) then 3 else 20
+
+while ("hello" == "world") do
+	print("Nope.")
+end
+
+repeat
+	print("Still nope.")
+until (5 == 5)
 ]]
 		)
 
 		-- Do
 		-- Run the transformer on the transformee
-		local result = process.run({ lutePath, "lint", "--auto-fix", violatorPath })
+		local result = process.run({ lutePath, "lint", "--auto-fix", "-r", parenthesizedConditionsRule, violatorPath })
 
 		-- Check
-		assert.eq(result.exitcode, 0) -- After applying the auto-fix, there are no more violations
+		assert.eq(result.exitcode, 0)
 
 		local fixedContents = fs.readfiletostring(violatorPath)
 		local expectedFixedContents = [[
-a, b = b, a
-
-local x = 0
-local y = "hello"
-x, y = y, x
-
-local t = { a = 1, b = 2 }
-t.a, t.b = t.b, t.a
-
-if true then
-	t["a"], t["b"] = t["b"], t["a"]
+if 3 > 0 then
+	print("Hello, world!")
+elseif false then
+	print("This won't print.")
 end
+
+local x = if 2 < 1 then 10 elseif true then 3 else 20
+
+while "hello" == "world" do
+	print("Nope.")
+end
+
+repeat
+	print("Still nope.")
+until 5 == 5
 ]]
+
 		assert.eq(fixedContents, expectedFixedContents)
 
 		-- Teardown


### PR DESCRIPTION
Adds support for autofixing reported lint violations (if the lint rules provide suggested fixes). The core logic for applying the fixes is pretty simple: split the content by line and do the replacements to the relevant lines. For now, we don't handle the cases where suggested fixes overlap (although my approach would probably be to just ignore fixes that overlap with previously applied fixes). We rerun the lints after applying fixes and report any violations that are still left. It's possible that those reported violations have suggested fixes, but we ignore them to prevent the chance of looping between suggested fixes infinitely.