### PR TITLE
Ensures `fs.remove` is asynchronous

### DIFF
--- a/lute/fs/include/lute/fs.h
+++ b/lute/fs/include/lute/fs.h
@@ -35,7 +35,7 @@ int writestringtofile(lua_State* L);
 int readasync(lua_State* L);
 
 /* Removes a file */
-int fs_remove(lua_State* L);
+int remove(lua_State* L);
 
 /* Creates a folder */
 int fs_mkdir(lua_State* L);
@@ -74,7 +74,7 @@ static const luaL_Reg lib[] = {
     {"write", write},
     {"close", close},
 
-    {"remove", fs_remove},
+    {"remove", remove},
 
     {"stat", fs_stat},
     {"exists", fs_exists},

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -230,7 +230,7 @@ int open(lua_State* L)
     return open_impl(L, path, openFlags, *modeFlags);
 }
 
-int fs_remove(lua_State* L)
+int remove(lua_State* L)
 {
     uv_fs_t unlink_req;
     int err = uv_fs_unlink(uv_default_loop(), &unlink_req, luaL_checkstring(L, 1), nullptr);

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -232,14 +232,19 @@ int open(lua_State* L)
 
 int remove(lua_State* L)
 {
-    uv_fs_t unlink_req;
-    int err = uv_fs_unlink(uv_default_loop(), &unlink_req, luaL_checkstring(L, 1), nullptr);
-    uv_fs_req_cleanup(&unlink_req);
+    int nArgs = lua_gettop(L);
+    if (nArgs < 1)
+    {
+        luaL_errorL(L, "Error: no file supplied\n");
+    }
 
-    if (err)
-        luaL_errorL(L, "%s", uv_strerror(err));
+    if (nArgs > 1)
+    {
+        luaL_errorL(L, "Error: too many arguments supplied\n");
+    }
+    const char* path = luaL_checkstring(L, 1);
 
-    return 0;
+    return remove_impl(L, path);
 }
 
 int fs_mkdir(lua_State* L)

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -237,4 +237,34 @@ int close_impl(lua_State* L, UVFile* handle)
     return lua_yield(L, 0);
 }
 
+int remove_impl(lua_State* L, const char* path)
+{
+    uvutils::ScopedUVRequest<FSRequest> req(L);
+    uv_fs_unlink(
+        uv_default_loop(),
+        &req->req,
+        path,
+        [](uv_fs_t* req)
+        {
+            auto r = uvutils::retake<FSRequest>(req);
+            auto result = req->result;
+            if (result < 0)
+            {
+                r->fail("Error removing file %s: %s", req->path, uv_strerror(result));
+                return;
+            }
+
+            r->succeed(
+                [](lua_State* L)
+                {
+                    return 0;
+                }
+            );
+        }
+    );
+
+    return lua_yield(L, 0);
+
+}
+
 } // namespace fs

--- a/lute/fs/src/fs_impl.h
+++ b/lute/fs/src/fs_impl.h
@@ -17,4 +17,5 @@ int open_impl(lua_State* L, const char* path, int flags, int mode);
 int read_impl(lua_State* L, UVFile* handle);
 int write_impl(lua_State* L, UVFile* handle, const char* toWrite, size_t numBytes);
 int close_impl(lua_State* L, UVFile* handle);
+int remove_impl(lua_State* L, const char* path);
 } // namespace fs


### PR DESCRIPTION
Continuation of https://github.com/luau-lang/lute/pull/661 and one part of making file system APIs asynchronous (https://github.com/luau-lang/lute/issues/709)