### PR TITLE
Brings in profiler and codecoverage from Luau

### DIFF
--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -25,9 +25,11 @@ add_library(Lute.CLI.lib STATIC)
 target_sources(Lute.CLI.lib PRIVATE
     include/lute/climain.h
     include/lute/compile.h
+    include/lute/coverage.h
     include/lute/fileutils.h
     include/lute/luauflags.h
     include/lute/packagerun.h
+    include/lute/profiler.h
     include/lute/reporter.h
     include/lute/requiresetup.h
     include/lute/staticrequires.h
@@ -36,9 +38,11 @@ target_sources(Lute.CLI.lib PRIVATE
 
     src/climain.cpp
     src/compile.cpp
+    src/coverage.cpp
     src/fileutils.cpp
     src/luauflags.cpp
     src/packagerun.cpp
+    src/profiler.cpp
     src/requiresetup.cpp
     src/staticrequires.cpp
     src/tc.cpp

--- a/lute/cli/include/lute/coverage.h
+++ b/lute/cli/include/lute/coverage.h
@@ -1,0 +1,9 @@
+#pragma once
+
+struct lua_State;
+
+void coverageInit(lua_State* L);
+bool coverageActive();
+
+void coverageTrack(lua_State* L, int funcindex);
+void coverageDump(const char* path);

--- a/lute/cli/include/lute/profiler.h
+++ b/lute/cli/include/lute/profiler.h
@@ -1,0 +1,7 @@
+#pragma once
+
+struct lua_State;
+
+void profilerStart(lua_State* L, int frequency);
+void profilerStop();
+void profilerDump(const char* path);

--- a/lute/cli/src/coverage.cpp
+++ b/lute/cli/src/coverage.cpp
@@ -1,0 +1,87 @@
+#include "lute/coverage.h"
+
+#include "lua.h"
+
+#include <string>
+#include <vector>
+
+struct Coverage
+{
+    lua_State* L = nullptr;
+    std::vector<int> functions;
+} gCoverage;
+
+void coverageInit(lua_State* L)
+{
+    gCoverage.L = lua_mainthread(L);
+}
+
+bool coverageActive()
+{
+    return gCoverage.L != nullptr;
+}
+
+void coverageTrack(lua_State* L, int funcindex)
+{
+    int ref = lua_ref(L, funcindex);
+    gCoverage.functions.push_back(ref);
+}
+
+static void coverageCallback(void* context, const char* function, int linedefined, int depth, const int* hits, size_t size)
+{
+    FILE* f = static_cast<FILE*>(context);
+
+    std::string name;
+
+    if (depth == 0)
+        name = "<main>";
+    else if (function)
+        name = std::string(function) + ":" + std::to_string(linedefined);
+    else
+        name = "<anonymous>:" + std::to_string(linedefined);
+
+    fprintf(f, "FN:%d,%s\n", linedefined, name.c_str());
+
+    for (size_t i = 0; i < size; ++i)
+        if (hits[i] != -1)
+        {
+            fprintf(f, "FNDA:%d,%s\n", hits[i], name.c_str());
+            break;
+        }
+
+    for (size_t i = 0; i < size; ++i)
+        if (hits[i] != -1)
+            fprintf(f, "DA:%d,%d\n", int(i), hits[i]);
+}
+
+void coverageDump(const char* path)
+{
+    lua_State* L = gCoverage.L;
+
+    FILE* f = fopen(path, "w");
+    if (!f)
+    {
+        fprintf(stderr, "Error opening coverage %s\n", path);
+        return;
+    }
+
+    fprintf(f, "TN:\n");
+
+    for (int fref : gCoverage.functions)
+    {
+        lua_getref(L, fref);
+
+        lua_Debug ar = {};
+        lua_getinfo(L, -1, "s", &ar);
+
+        fprintf(f, "SF:%s\n", ar.short_src);
+        lua_getcoverage(L, -1, f, coverageCallback);
+        fprintf(f, "end_of_record\n");
+
+        lua_pop(L, 1);
+    }
+
+    fclose(f);
+
+    printf("Coverage dump written to %s (%d functions)\n", path, int(gCoverage.functions.size()));
+}

--- a/lute/cli/src/profiler.cpp
+++ b/lute/cli/src/profiler.cpp
@@ -1,0 +1,163 @@
+#include "lute/profiler.h"
+
+#include "lua.h"
+
+#include "Luau/DenseHash.h"
+
+#include <thread>
+#include <atomic>
+#include <string>
+
+struct Profiler
+{
+    // static state
+    lua_Callbacks* callbacks = nullptr;
+    int frequency = 1000;
+    std::thread thread;
+
+    // variables for communication between loop and trigger
+    std::atomic<bool> exit = false;
+    std::atomic<uint64_t> ticks = 0;
+    std::atomic<uint64_t> samples = 0;
+
+    // private state for trigger
+    uint64_t currentTicks = 0;
+    std::string stackScratch;
+
+    // statistics, updated by trigger
+    Luau::DenseHashMap<std::string, uint64_t> data{""};
+    uint64_t gc[16] = {};
+} gProfiler;
+
+static void profilerTrigger(lua_State* L, int gc)
+{
+    uint64_t currentTicks = gProfiler.ticks.load();
+    uint64_t elapsedTicks = currentTicks - gProfiler.currentTicks;
+
+    if (elapsedTicks)
+    {
+        std::string& stack = gProfiler.stackScratch;
+
+        stack.clear();
+
+        if (gc > 0)
+            stack += "GC,GC,";
+
+        lua_Debug ar;
+        for (int level = 0; lua_getinfo(L, level, "sn", &ar); ++level)
+        {
+            if (!stack.empty())
+                stack += ';';
+
+            stack += ar.short_src;
+            stack += ',';
+            if (ar.name)
+                stack += ar.name;
+            stack += ',';
+            if (ar.linedefined > 0)
+                stack += std::to_string(ar.linedefined);
+        }
+
+        if (!stack.empty())
+        {
+            gProfiler.data[stack] += elapsedTicks;
+        }
+
+        if (gc > 0)
+        {
+            gProfiler.gc[gc] += elapsedTicks;
+        }
+    }
+
+    gProfiler.currentTicks = currentTicks;
+    gProfiler.callbacks->interrupt = nullptr;
+}
+
+static void profilerLoop()
+{
+    double last = lua_clock();
+
+    while (!gProfiler.exit)
+    {
+        double now = lua_clock();
+
+        if (now - last >= 1.0 / double(gProfiler.frequency))
+        {
+            int64_t ticks = int64_t((now - last) * 1e6);
+
+            gProfiler.ticks += ticks;
+            gProfiler.samples++;
+            gProfiler.callbacks->interrupt = profilerTrigger;
+
+            last += ticks * 1e-6;
+        }
+        else
+        {
+            std::this_thread::yield();
+        }
+    }
+}
+
+void profilerStart(lua_State* L, int frequency)
+{
+    gProfiler.frequency = frequency;
+    gProfiler.callbacks = lua_callbacks(L);
+
+    gProfiler.exit = false;
+    gProfiler.thread = std::thread(profilerLoop);
+}
+
+void profilerStop()
+{
+    gProfiler.exit = true;
+    gProfiler.thread.join();
+}
+
+void profilerDump(const char* path)
+{
+    FILE* f = fopen(path, "wb");
+    if (!f)
+    {
+        fprintf(stderr, "Error opening profile %s\n", path);
+        return;
+    }
+
+    uint64_t total = 0;
+
+    for (auto& p : gProfiler.data)
+    {
+        fprintf(f, "%lld %s\n", static_cast<long long>(p.second), p.first.c_str());
+        total += p.second;
+    }
+
+    fclose(f);
+
+    printf(
+        "Profiler dump written to %s (total runtime %.3f seconds, %lld samples, %lld stacks)\n",
+        path,
+        double(total) / 1e6,
+        static_cast<long long>(gProfiler.samples.load()),
+        static_cast<long long>(gProfiler.data.size())
+    );
+
+    uint64_t totalgc = 0;
+    for (uint64_t p : gProfiler.gc)
+        totalgc += p;
+
+    if (totalgc)
+    {
+        printf("GC: %.3f seconds (%.2f%%)", double(totalgc) / 1e6, double(totalgc) / double(total) * 100);
+
+        for (size_t i = 0; i < std::size(gProfiler.gc); ++i)
+        {
+            extern const char* luaC_statename(int state);
+
+            uint64_t p = gProfiler.gc[i];
+
+            if (p)
+                printf(", %s %.2f%%", luaC_statename(int(i)), double(p) / double(totalgc) * 100);
+        }
+
+        printf("\n");
+    }
+}


### PR DESCRIPTION
This PR just pulls in the Luau CLI's Profiler and Code Coverage modules into `lute`. We're doing this instead of exposing them from Luau because these features are not really products, so much as best effort attempts, so we don't necessarily want to expose them from Luau yet.

This is just copied from Luau/CLI - no changes have been made.