### PR TITLE
Adds `mode` option to `fs.createdirectory`

### DIFF
--- a/definitions/fs.luau
+++ b/definitions/fs.luau
@@ -59,7 +59,9 @@ function fs.type(path: string): FileType
 	error("not implemented")
 end
 
-function fs.mkdir(path: string): ()
+--- Creates a directory at the specified path.
+--- @param mode, if specified, should be a hexadecimal literal that corresponds to a valid octal permission mode (e.g., 0x1FF for octal 0777 permissions). Default read, write, execute for everyone permissions (0777) will be used if mode not specified.
+function fs.mkdir(path: string, mode: number?): ()
 	error("not implemented")
 end
 

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -260,7 +260,17 @@ int mkdir(lua_State* L)
         luaL_errorL(L, "Error: too many arguments supplied\n");
     }
     const char* path = luaL_checkstring(L, 1);
-    int mode = luaL_optinteger(L, 2, 0777);
+
+    int mode = 0777;
+    if (nArgs == 2)
+    {
+        mode = luaL_checkinteger(L, 2);
+        // check mode is valid octal permission
+        if (mode < 0 || mode > 0777)
+        {
+            luaL_errorL(L, "Error: invalid mode supplied\n");
+        }
+    }
 
     return mkdir_impl(L, path, mode);
 }

--- a/lute/std/libs/fs.luau
+++ b/lute/std/libs/fs.luau
@@ -22,6 +22,7 @@ type path = pathlib.path
 
 export type createdirectoryoptions = {
 	makeparents: boolean?,
+	mode: number?, -- pass in a hexadecimal literal that corresponds to a valid octal permission mode (e.g., 0x1FF for octal 0777 permissions)
 }
 
 export type removedirectoryoptions = {
@@ -142,11 +143,19 @@ function fslib.createdirectory(path: pathlike, options: createdirectoryoptions?)
 		for _, part in parts do
 			subdir = pathlib.join(subdir, part)
 			if not fslib.exists(subdir) then
-				fs.mkdir(pathlib.format(subdir))
+				if options.mode then
+					fs.mkdir(pathlib.format(subdir), options.mode)
+				else
+					fs.mkdir(pathlib.format(subdir))
+				end
 			end
 		end
 	else
-		fs.mkdir(pathlib.format(path))
+		if options and options.mode then
+			fs.mkdir(pathlib.format(path), options.mode)
+		else
+			fs.mkdir(pathlib.format(path))
+		end
 	end
 end
 

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -260,4 +260,37 @@ test.suite("FsSuite", function(suite)
 
 		fs.removedirectory(baseDir, { recursive = true })
 	end)
+
+	suite:case("mkdir_with_valid_mode", function(assert)
+		local dir = path.join(tmpdir, "mode_test_dir")
+		local mode = 0x124 -- octal 0444 (read-only for everyone)
+
+		if fs.exists(dir) then
+			fs.removedirectory(dir)
+		end
+
+		fs.createdirectory(dir, { makeparents = true, mode = mode })
+		assert.eq(fs.exists(dir), true)
+
+		local metadata = fs.metadata(dir)
+		assert.eq(metadata.permissions.readonly, true)
+
+		fs.removedirectory(dir)
+	end)
+
+	suite:case("mkdir_fails_with_invalid_mode", function(assert)
+		local dir = path.join(tmpdir, "mode_test_dir_that_should_not_exist")
+		local mode = -1
+
+		if fs.exists(dir) then
+			fs.removedirectory(dir)
+		end
+
+		local success, err = pcall(function()
+			fs.createdirectory(dir, { makeparents = true, mode = mode })
+		end)
+		assert.neq(success, true)
+		assert.neq(err, nil)
+		assert.eq(fs.exists(dir), false)
+	end)
 end)


### PR DESCRIPTION
Previously, `fs.createdirectory` and `fs.mkdir` did not provide an option to change the permissions when creating a directory - we always defaulted to octal 0777 which is read/write/execute for everyone (owner, group and others). 

This PR adds `mode: number?` to the `fs.mkdir` signature and the `fs.createdirectory` `createdirectoryoptions` type so users can pass in a hexadecimal literal that corresponds to the octal permission.

I do realize that having the user pass in a hex isn't super great user experience and it would be better if we had some equivalent of how the `fs.open`'s `mode` works with `"r" | "w" | ...`, but discussed with @Vighnesh-V and having an optional param that exposes `mode` in the first place is better than nothing for now!

now if we want to specify read-only permissions for a directory, we can write:

```lua
local dir = path.join(tmpdir, "read_only_dir")
local mode = 0x124 -- octal 0444 (read-only for everyone)

fs.createdirectory(dir, { makeparents = true, mode = mode })
```