### PR TITLE
Fix crash and improve cleanup semantics on fs.listdir

### DIFF
--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -616,8 +616,22 @@ int listdir(lua_State* L)
         [](uv_fs_t* req)
         {
             auto* request_state = static_cast<ResumeToken*>(req->data);
+            auto token = std::move(*request_state);
+            delete request_state;
 
-            request_state->get()->complete(
+            auto result = req->result;
+
+            if (result < 0)
+            {
+                if (result != UV_EOF)
+                    token->fail(uv_strerror(result));
+
+                uv_fs_req_cleanup(req);
+                delete req;
+                return;
+            }
+
+            token->complete(
                 [req](lua_State* L)
                 {
                     lua_createtable(L, 1, 0);
@@ -641,12 +655,7 @@ int listdir(lua_State* L)
                     }
 
                     uv_fs_req_cleanup(req);
-
-                    delete static_cast<ResumeToken*>(req->data);
                     delete req;
-
-                    if (err != UV_EOF)
-                        luaL_errorL(L, "%s", uv_strerror(err));
 
                     return 1;
                 }


### PR DESCRIPTION
Because of a very poorly thought usage of `luaL_errorL` inside of a resumption completion callback, the Lua error was instead emitting an immediate crash because the C++ `lua_exception` thrown goes unhandled. For example, if you called `listdir` and the path was non-existent or you don't have permissions, your program would immediately hard crash and throw out a crash dump file, with the output to the user just being nothing/no suggestion of why the failure happened.

This changes to the proper semantics with resumption tokens - it fails the token before offering a completion instead of throwing an error inside the completion.

The only possible issue—which is probably obvious—is that `err` is modified in the loop with `uv_fs_scandir_next`. Fortunately, after reading the implementation, it will only ever return `UV_EOF` because this function literally just loops over an array from the result. The only situation it doesn't return `UV_EOF` is when the request result itself is already an error, or it succeeds and returns 0.

We also now run `uv_fs_req_cleanup` and delete the request before returning early, since that cleanup is normally performed in the completion callback. I also changed to use `std::move` on the `request_state` and then delete the old pointer; I'm not sure why this is done, but it seems better semantically and is what is done in the `defaultCallback`. If someone could tell me why it's done that way it'd be nice (why not just leave it in req->data there and delete it later? does this way avoid a ref counting memory leak or something with `shared_ptr`?)