### PR TITLE
Lute Lint: Ensure `suggestedfix` is included in lsp diagnostic

### DIFF
--- a/lute/cli/commands/lint/lsp/init.luau
+++ b/lute/cli/commands/lint/lsp/init.luau
@@ -1,7 +1,7 @@
-local pathLib = require("@std/path")
-local luau = require("@lute/luau")
 local lintTypes = require("./types")
 local lspTypes = require("@self/types")
+local pathLib = require("@std/path")
+local syntax = require("@std/syntax")
 local tableext = require("@std/tableext")
 
 local lsp = {}
@@ -26,7 +26,7 @@ local function tag(t: lintTypes.tag): number
 	end
 end
 
-local function getRange(location: luau.span)
+local function getRange(location: syntax.span): lspTypes.Range
 	return table.freeze({
 		start = table.freeze({
 			line = location.beginline - 1,
@@ -48,10 +48,10 @@ function lsp.diagnostic(lint: lintTypes.LintViolation): lspTypes.Diagnostic
 		message = lint.message,
 		tags = if lint.tags then table.freeze(tableext.map(lint.tags, tag)) else nil,
 		suggestedfix = if lint.suggestedfix
-			then {
+			then table.freeze({
 				fix = lint.suggestedfix.fix,
 				range = getRange(lint.suggestedfix.location or lint.location),
-			}
+			})
 			else nil,
 	})
 end

--- a/lute/cli/commands/lint/lsp/init.luau
+++ b/lute/cli/commands/lint/lsp/init.luau
@@ -1,4 +1,5 @@
 local pathLib = require("@std/path")
+local luau = require("@lute/luau")
 local lintTypes = require("./types")
 local lspTypes = require("@self/types")
 local tableext = require("@std/tableext")
@@ -25,23 +26,33 @@ local function tag(t: lintTypes.tag): number
 	end
 end
 
+local function getRange(location: luau.span)
+	return table.freeze({
+		start = table.freeze({
+			line = location.beginline - 1,
+			character = location.begincolumn - 1,
+		}),
+		["end"] = table.freeze({
+			line = location.endline - 1,
+			character = location.endcolumn - 1,
+		}),
+	})
+end
+
 function lsp.diagnostic(lint: lintTypes.LintViolation): lspTypes.Diagnostic
 	return table.freeze({
-		range = table.freeze({
-			start = table.freeze({
-				line = lint.location.beginline - 1,
-				character = lint.location.begincolumn - 1,
-			}),
-			["end"] = table.freeze({
-				line = lint.location.endline - 1,
-				character = lint.location.endcolumn - 1,
-			}),
-		}),
+		range = getRange(lint.location),
 		severity = severity(lint.severity),
 		code = lint.lintname,
 		source = "lute lint" :: "lute lint", -- LUAUFIX: Annotation needed, otherwise this errors because string isn't inferred as a singleton
 		message = lint.message,
 		tags = if lint.tags then table.freeze(tableext.map(lint.tags, tag)) else nil,
+		suggestedfix = if lint.suggestedfix
+			then {
+				fix = lint.suggestedfix.fix,
+				range = getRange(lint.suggestedfix.location or lint.location),
+			}
+			else nil,
 	})
 end
 

--- a/lute/cli/commands/lint/lsp/types.luau
+++ b/lute/cli/commands/lint/lsp/types.luau
@@ -1,13 +1,19 @@
 export type Diagnostic = {
-	read range: {
-		read start: { read line: number, read character: number },
-		read ["end"]: { read line: number, read character: number },
-	}, -- zero-based
+	read range: Range, -- zero-based
 	read severity: number, -- 1: Error, 2: Warning, 3: Information, 4: Hint
 	read code: string, -- lint name
 	read source: "lute lint",
 	read message: string,
 	read tags: { number }?, -- 1: Unnecessary, 2: Deprecated
+	read suggestedfix: {
+		read fix: string,
+		read range: Range,
+	}?,
+}
+
+export type Range = {
+	read start: { read line: number, read character: number },
+	read ["end"]: { read line: number, read character: number },
 }
 
 export type WorkspaceDocumentDiagnosticReport = {

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -1633,5 +1633,3 @@ local e = next(t) ~= nil
 		assert.strcontains(result.stdout, expected)
 	end)
 end)
-
-test.run()

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -1584,4 +1584,54 @@ local e = next(t) ~= nil
 		-- Teardown
 		fs.remove(violatorPath)
 	end)
+
+	suite:case("lute lint json output includes suggestedfix", function(assert)
+		local inputString = [[
+			a = b
+			b = a
+		]]
+
+		-- Do
+		-- Run the linter on string input with json flag
+		local result = process.run({ lutePath, "lint", "-j", "-s", inputString })
+
+		-- Check
+		assert.eq(result.exitcode, 0)
+
+		local expected = [=[
+[
+    {
+        "message": "This looks like a failed attempt to swap.", 
+        "source": "lute lint", 
+        "code": "almost_swapped", 
+        "severity": 2, 
+        "range": {
+            "start": {
+                "character": 3, 
+                "line": 0
+            }, 
+            "end": {
+                "character": 8, 
+                "line": 1
+            }
+        }, 
+        "suggestedfix": {
+            "range": {
+                "start": {
+                    "character": 3, 
+                    "line": 0
+                }, 
+                "end": {
+                    "character": 8, 
+                    "line": 1
+                }
+            }, 
+            "fix": "a, b = b, a"
+        }
+    }
+]]=]
+		assert.strcontains(result.stdout, expected)
+	end)
 end)
+
+test.run()


### PR DESCRIPTION
To support registering code actions in Mandolin, it is essential that the `suggestedfix` data is serialized as part of `lute lint`'s JSON diagnostic output.

This PR adds support for this and a sanity check test case