### PR TITLE
Fixes a crash in listdir

### DIFF
--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -459,65 +459,15 @@ int type(lua_State* L)
 
 int listdir(lua_State* L)
 {
-    const char* path = luaL_checkstring(L, 1);
-
-    auto* req = new uv_fs_t();
-    req->data = new ResumeToken(getResumeToken(L));
-
-    int err = uv_fs_scandir(
-        uv_default_loop(),
-        req,
-        path,
-        0,
-        [](uv_fs_t* req)
-        {
-            auto* request_state = static_cast<ResumeToken*>(req->data);
-
-            request_state->get()->complete(
-                [req](lua_State* L)
-                {
-                    lua_createtable(L, 1, 0);
-
-                    uv_dirent_t dir;
-                    int i = 0;
-                    int err = 0;
-                    while ((err = uv_fs_scandir_next(req, &dir)) >= 0)
-                    {
-                        lua_pushinteger(L, ++i);
-
-                        lua_createtable(L, 0, 2);
-
-                        lua_pushstring(L, dir.name);
-                        lua_setfield(L, -2, "name");
-
-                        lua_pushstring(L, fs::UV_DIRENT_TYPES[dir.type]);
-                        lua_setfield(L, -2, "type");
-
-                        lua_settable(L, -3);
-                    }
-
-                    uv_fs_req_cleanup(req);
-
-                    delete static_cast<ResumeToken*>(req->data);
-                    delete req;
-
-                    if (err != UV_EOF)
-                        luaL_errorL(L, "%s", uv_strerror(err));
-
-                    return 1;
-                }
-            );
-        }
-    );
-
-    if (err)
+    int nArgs = lua_gettop(L);
+    if (nArgs > 1)
     {
-        delete static_cast<ResumeToken*>(req->data);
-        delete req;
-        luaL_errorL(L, "%s", uv_strerror(err));
+        luaL_errorL(L, "listdir: too many arguments supplied\n");
     }
 
-    return lua_yield(L, 0);
+    const char* path = luaL_checkstring(L, 1);
+
+    return listdir_impl(L, path);
 }
 
 } // namespace fs

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -464,6 +464,7 @@ int mkdir_impl(lua_State* L, const char* path, int mode)
     return lua_yield(L, 0);
 }
 
+
 int rmdir_impl(lua_State* L, const char* path)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);
@@ -485,6 +486,66 @@ int rmdir_impl(lua_State* L, const char* path)
                 [](lua_State* L)
                 {
                     return 0;
+                }
+            );
+        }
+    );
+
+    return lua_yield(L, 0);
+}
+
+
+int listdir_impl(lua_State* L, const char* path)
+{
+    uvutils::ScopedUVRequest<FSRequest> req(L);
+    uv_fs_scandir(
+        uv_default_loop(),
+        &req->req,
+        path,
+        0,
+        [](uv_fs_t* req)
+        {
+            auto r = uvutils::retake<FSRequest>(req);
+            auto result = req->result;
+            if (result < 0)
+            {
+                r->fail("listdir: Error listing directory %s (%s)", req->path, uv_strerror(result));
+                return;
+            }
+
+            std::vector<std::pair<std::string, uv_dirent_type_t>> entries;
+            uv_dirent_t dirent;
+            int err = 0;
+            while ((err = uv_fs_scandir_next(req, &dirent)) >= 0)
+            {
+                entries.emplace_back(dirent.name, dirent.type);
+            }
+
+            if (err != UV_EOF)
+            {
+                r->fail("listdir: Error reading directory entry (%s)", uv_strerror(err));
+                return;
+            }
+
+            r->succeed(
+                [entries = std::move(entries)](lua_State* L)
+                {
+                    lua_createtable(L, entries.size(), 0);
+                    for (size_t i = 0; i < entries.size(); ++i)
+                    {
+                        lua_pushinteger(L, i + 1);
+
+                        lua_createtable(L, 0, 2);
+
+                        lua_pushstring(L, entries[i].first.c_str());
+                        lua_setfield(L, -2, "name");
+
+                        lua_pushstring(L, UV_DIRENT_TYPES[entries[i].second]);
+                        lua_setfield(L, -2, "type");
+
+                        lua_settable(L, -3);
+                    }
+                    return 1;
                 }
             );
         }

--- a/lute/fs/src/fs_impl.h
+++ b/lute/fs/src/fs_impl.h
@@ -44,4 +44,6 @@ int type_impl(lua_State* L, const char* path);
 
 int mkdir_impl(lua_State* L, const char* path, int mode);
 int rmdir_impl(lua_State* L, const char* path);
+int listdir_impl(lua_State* L, const char* path);
+
 } // namespace fs


### PR DESCRIPTION
This PR just pulls in @checkraisefold 's fix here: https://github.com/luau-lang/lute/pull/740. The main change is to check the return error code from `uv_fs_scandir`.

Using the UVRequest abstractions a) helps make this function suitable for use cooperatively (async), and handles the additional memory management improvments that @checkraisefold added. 

Helps address one of the functions listed in https://github.com/luau-lang/lute/issues/709