### PR TITLE
Add executable bit to release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
           mkdir release
           for dir in ./artifacts/*; do
             base_name=$(basename "$dir")
-            chmod +x "$dir"/* # Artifacts don't preserve permissions, so re-add them.
+            chmod 755 "$dir"/* # Artifacts don't preserve permissions, so re-add them.
             zip -rj release/"${base_name}.zip" "$dir"/*
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
           mkdir release
           for dir in ./artifacts/*; do
             base_name=$(basename "$dir")
+            chmod +x "$dir"/* # Artifacts don't preserve permissions, so re-add them.
             zip -rj release/"${base_name}.zip" "$dir"/*
           done
 


### PR DESCRIPTION
GitHub does not preserve permissions when uploading files as an artifact, causing the executable bit of the binaries within the release artifacts to be lost. This makes Lute not executable when installing it using [mise-en-place's GitHub backend](https://mise.jdx.dev/dev-tools/backends/github.html).

This PR re-adds the executable bit to the release artifacts.