### PR TITLE
Fix `lute compile` fails to detect a luaurc when the entry point is not in the same directory as the luaurc

### DIFF
--- a/lute/cli/src/staticrequires.cpp
+++ b/lute/cli/src/staticrequires.cpp
@@ -53,17 +53,17 @@ void StaticRequireTracer::trace(const std::string& entryPoint)
         return;
     }
 
-    // Calculate the entry point directory - we should not look for .luaurc files beyond this directory
-    std::string entryPointDir = entryPoint;
-    size_t lastSlash = entryPointDir.find_last_of("/\\");
-    if (lastSlash != std::string::npos)
-    {
-        entryPointDir = entryPointDir.substr(0, lastSlash);
-    }
-    else
-    {
-        entryPointDir = "";
-    }
+    // // Calculate the entry point directory - we should not look for .luaurc files beyond this directory
+    // std::string entryPointDir = entryPoint;
+    // size_t lastSlash = entryPointDir.find_last_of("/\\");
+    // if (lastSlash != std::string::npos)
+    // {
+    //     entryPointDir = entryPointDir.substr(0, lastSlash);
+    // }
+    // else
+    // {
+    //     entryPointDir = "";
+    // }
 
     // Temporary set to collect absolute paths to .luaurc files
     Luau::DenseHashSet<std::string> luaurcAbsolutePaths{""};
@@ -108,9 +108,9 @@ void StaticRequireTracer::trace(const std::string& entryPoint)
                     break;
                 }
 
-                // Stop if we've reached the entry point directory
-                if (dir == entryPointDir)
-                    break;
+                // // Stop if we've reached the entry point directory
+                // if (dir == entryPointDir)
+                //     break;
 
                 // Move to parent directory
                 size_t parentSlash = dir.find_last_of("/\\");
@@ -153,8 +153,15 @@ void StaticRequireTracer::trace(const std::string& entryPoint)
         // Store the resolved dependencies in the graph
         requireGraph[filePath] = std::move(resolvedDeps);
     }
-
-    lowestCommonRoot = findLowestCommonRoot(discovered);
+    
+    // Include .luaurc files in the lowest common root calculation
+    std::vector<std::string> allPaths = discovered;
+    for (const auto& luaurcPath : luaurcAbsolutePaths)
+    {
+        allPaths.push_back(luaurcPath);
+    }
+    
+    lowestCommonRoot = findLowestCommonRoot(allPaths);
 
     // Convert absolute .luaurc paths to LCR-relative .luaurc paths and read their content
     size_t commonRootLen = lowestCommonRoot.empty() ? 0 : lowestCommonRoot.length() + 1; // +1 for the trailing slash

--- a/lute/cli/src/staticrequires.cpp
+++ b/lute/cli/src/staticrequires.cpp
@@ -140,10 +140,10 @@ void StaticRequireTracer::trace(const std::string& entryPoint)
     
     // Include .luaurc files in the lowest common root calculation
     std::vector<std::string> allPaths = discovered;
-    // for (const auto& luaurcPath : luaurcAbsolutePaths)
-    // {
-    //     allPaths.push_back(luaurcPath);
-    // }
+    for (const auto& luaurcPath : luaurcAbsolutePaths)
+    {
+        allPaths.push_back(luaurcPath);
+    }
     
     lowestCommonRoot = findLowestCommonRoot(allPaths);
 

--- a/lute/cli/src/staticrequires.cpp
+++ b/lute/cli/src/staticrequires.cpp
@@ -53,18 +53,6 @@ void StaticRequireTracer::trace(const std::string& entryPoint)
         return;
     }
 
-    // // Calculate the entry point directory - we should not look for .luaurc files beyond this directory
-    // std::string entryPointDir = entryPoint;
-    // size_t lastSlash = entryPointDir.find_last_of("/\\");
-    // if (lastSlash != std::string::npos)
-    // {
-    //     entryPointDir = entryPointDir.substr(0, lastSlash);
-    // }
-    // else
-    // {
-    //     entryPointDir = "";
-    // }
-
     // Temporary set to collect absolute paths to .luaurc files
     Luau::DenseHashSet<std::string> luaurcAbsolutePaths{""};
 
@@ -98,7 +86,7 @@ void StaticRequireTracer::trace(const std::string& entryPoint)
         {
             dir = dir.substr(0, lastSlash);
 
-            // Walk up the directory tree looking for .luaurc files, but stop at the entry point directory
+            // Walk up the directory tree looking for .luaurc files
             while (!dir.empty())
             {
                 std::string luaurcPath = dir + "/" + Luau::kConfigName;
@@ -107,10 +95,6 @@ void StaticRequireTracer::trace(const std::string& entryPoint)
                     luaurcAbsolutePaths.insert(luaurcPath);
                     break;
                 }
-
-                // // Stop if we've reached the entry point directory
-                // if (dir == entryPointDir)
-                //     break;
 
                 // Move to parent directory
                 size_t parentSlash = dir.find_last_of("/\\");
@@ -156,10 +140,10 @@ void StaticRequireTracer::trace(const std::string& entryPoint)
     
     // Include .luaurc files in the lowest common root calculation
     std::vector<std::string> allPaths = discovered;
-    for (const auto& luaurcPath : luaurcAbsolutePaths)
-    {
-        allPaths.push_back(luaurcPath);
-    }
+    // for (const auto& luaurcPath : luaurcAbsolutePaths)
+    // {
+    //     allPaths.push_back(luaurcPath);
+    // }
     
     lowestCommonRoot = findLowestCommonRoot(allPaths);
 

--- a/tests/src/compile.test.cpp
+++ b/tests/src/compile.test.cpp
@@ -538,3 +538,41 @@ TEST_CASE_FIXTURE(LuteFixture, "compile_command_e2e")
     // Clean up
     std::remove(outputExePath.c_str());
 }
+
+TEST_CASE_FIXTURE(LuteFixture, "compile_command_e2e_requirealias")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+
+    // Use a test file that has the entry point and dependencies that are below the .luaurc
+    std::string testFilePath = joinPaths(luteProjectRoot, "tests/src/staticrequires/dep/requirealias.luau");
+
+    // Create a temporary output path for the compiled executable
+    std::string outputExePath = joinPaths(luteProjectRoot, "tests/temp_compiled_e2e_requirealias");
+#ifdef _WIN32
+    outputExePath += ".exe";
+#endif
+
+    // Build argv for cliMain: ["lute", "compile", <testFilePath>, "--output", <outputExePath>]
+    char executablePlaceholder[] = "lute";
+    char compileCommand[] = "compile";
+    char outputFlag[] = "--output";
+
+    std::vector<char*> argv = {executablePlaceholder, compileCommand, testFilePath.data(), outputFlag, outputExePath.data()};
+
+    // Run the compile command
+    int compileResult = cliMain(argv.size(), argv.data(), getReporter());
+    REQUIRE(compileResult == 0);
+
+    // Verify the output file was created
+    std::ifstream checkFile(outputExePath, std::ios::binary);
+    REQUIRE(checkFile.is_open());
+    checkFile.close();
+
+    // Now run the compiled executable to verify it works
+    std::vector<char*> runArgv = {outputExePath.data()};
+    int runResult = cliMain(runArgv.size(), runArgv.data(), getReporter());
+    CHECK(runResult == 0);
+
+    // Clean up
+    std::remove(outputExePath.c_str());
+}

--- a/tests/src/staticrequires.test.cpp
+++ b/tests/src/staticrequires.test.cpp
@@ -126,20 +126,23 @@ TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_require_alias")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
-    std::string entryPoint = joinPaths(testDir, "lib/requirealias.luau");
+    std::string entryPoint = joinPaths(testDir, "dep/requirealias.luau");
 
     StaticRequireTracer tracer{getReporter()};
     tracer.trace(entryPoint);
 
     auto pairs = tracer.getStaticRequirePairs();
 
-    // requirealias.luau requires @example/option.luau, should resolve correctly
+    // requirealias.luau requires @otherlib/example.luau, should resolve correctly
     REQUIRE(pairs.size() == 2);
 
-    CHECK(pairs[0].first == "lib/requirealias.luau");
+    CHECK(pairs[0].first == "dep/requirealias.luau");
 
-    std::string absoluteOption = joinPaths(tracer.getLowestCommonRoot(), "dep/option.luau");
-    CHECK(tracer.containsAbsolute(absoluteOption));
+    std::string absoluteExample = joinPaths(tracer.getLowestCommonRoot(), "dep/nested/example.luau");
+    CHECK(tracer.containsAbsolute(absoluteExample));
+
+    // Verify that the lowestCommonRoot is staticrequires, NOT dep even though entry point and dependency are in dep
+    CHECK(tracer.getLowestCommonRoot() == testDir);
 
     // Verify .luaurc file was discovered (should find it in parent directory)
     auto luaurcFiles = tracer.getLuaurcFiles();

--- a/tests/src/staticrequires.test.cpp
+++ b/tests/src/staticrequires.test.cpp
@@ -133,7 +133,7 @@ TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_requirealias")
 
     auto pairs = tracer.getStaticRequirePairs();
 
-    // requirealias.luau requires @otherlib/example.luau, should resolve correctly
+    // requirealias.luau requires @nested/example, should resolve correctly
     REQUIRE(pairs.size() == 2);
 
     CHECK(pairs[0].first == "dep/requirealias.luau");

--- a/tests/src/staticrequires.test.cpp
+++ b/tests/src/staticrequires.test.cpp
@@ -122,7 +122,7 @@ TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_relative_paths")
     CHECK(luaurcFiles.find(".luaurc") != nullptr);
 }
 
-TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_require_alias")
+TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_requirealias")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();
     std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");

--- a/tests/src/staticrequires.test.cpp
+++ b/tests/src/staticrequires.test.cpp
@@ -122,6 +122,31 @@ TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_relative_paths")
     CHECK(luaurcFiles.find(".luaurc") != nullptr);
 }
 
+TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_require_alias")
+{
+    std::string luteProjectRoot = getLuteProjectRootAbsolute();
+    std::string testDir = joinPaths(luteProjectRoot, "tests/src/staticrequires");
+    std::string entryPoint = joinPaths(testDir, "lib/requirealias.luau");
+
+    StaticRequireTracer tracer{getReporter()};
+    tracer.trace(entryPoint);
+
+    auto pairs = tracer.getStaticRequirePairs();
+
+    // requirealias.luau requires @example/option.luau, should resolve correctly
+    REQUIRE(pairs.size() == 2);
+
+    CHECK(pairs[0].first == "lib/requirealias.luau");
+
+    std::string absoluteOption = joinPaths(tracer.getLowestCommonRoot(), "dep/option.luau");
+    CHECK(tracer.containsAbsolute(absoluteOption));
+
+    // Verify .luaurc file was discovered (should find it in parent directory)
+    auto luaurcFiles = tracer.getLuaurcFiles();
+    REQUIRE(luaurcFiles.size() == 1);
+    CHECK(luaurcFiles.find(".luaurc") != nullptr);
+}
+
 TEST_CASE_FIXTURE(LuteFixture, "staticrequiretracer_require_graph")
 {
     std::string luteProjectRoot = getLuteProjectRootAbsolute();

--- a/tests/src/staticrequires/.luaurc
+++ b/tests/src/staticrequires/.luaurc
@@ -1,5 +1,6 @@
 {
     "aliases": {
-        "example": "./dep"
+        "example": "./dep",
+        "nested": "./dep/nested"
     }
 }

--- a/tests/src/staticrequires/dep/nested/example.luau
+++ b/tests/src/staticrequires/dep/nested/example.luau
@@ -1,0 +1,3 @@
+local v = { file = "example.luau" }
+
+return v

--- a/tests/src/staticrequires/dep/requirealias.luau
+++ b/tests/src/staticrequires/dep/requirealias.luau
@@ -1,10 +1,10 @@
 -- Helper module that also requires using an alias
-local option = require("@example/option")
+local example = require("@nested/example")
 
 -- print("Helper module")
 return {
 	help = function()
 		return "helper"
 	end,
-	option = option,
+	example = example,
 }

--- a/tests/src/staticrequires/lib/requirealias.luau
+++ b/tests/src/staticrequires/lib/requirealias.luau
@@ -1,0 +1,10 @@
+-- Helper module that also requires using an alias
+local option = require("@example/option")
+
+-- print("Helper module")
+return {
+	help = function()
+		return "helper"
+	end,
+	option = option,
+}


### PR DESCRIPTION
Addresses https://github.com/luau-lang/lute/issues/708

In the linked issue, removing the entry point limit to the `.luaurc` discovery doesn't fix the issue. When doing so, `src` doesn't exist as a path in the bundle VFS and it crashes at runtime when trying to `require("@ext/bat")`

The LCR calculation calculates `LCR("repo/src/entry.luau", "repo/src/batteries/bat.luau") = src`, and the final bundle VFS gets laid out as:
```
@bundle
  entry.luau
  batteries
    bat.luau
```

The `.luaurc` has this, which doesn't actually match with the bundle VFS.
```
    "aliases": {
        "ext": "./src/batteries/"
    }
```

So when trying to `require("@ext/bat")`, lute tries to navigate to `@bundle/src/batteries`. `"@bundle/src"` doesn't exist and crashes [here](https://github.com/luau-lang/lute/blob/e11f8b0c0d933e7bbd0463c9213a364fb966f920/lute/require/src/modulepath.cpp#L119).

This fix adds any discovered `.luaurc` to the LCR calculation, which makes the paths between the bundle VFS and the `.luaurc` at the repo root symmetric.

Alternatively, could have used the LCR to strip prefixes in the bundled `.luaurc`.