### PR TITLE
Fixes excessive spinning of the runtime when there is no work to do

### DIFF
--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -49,7 +49,8 @@ bool Runtime::hasWork()
 
 RuntimeStep Runtime::runOnce()
 {
-    uv_run(uv_default_loop(), UV_RUN_NOWAIT);
+    uv_run_mode mode = (hasContinuations() || hasThreads()) ? UV_RUN_NOWAIT : UV_RUN_ONCE;
+    uv_run(uv_default_loop(), mode);
 
     // Complete all C++ continuations
     std::vector<std::function<void()>> copy;


### PR DESCRIPTION
This PR fixes https://github.com/luau-lang/lute/issues/703, which reports high CPU consumption when the runtime should have no work to do. 

A fix was contributed here https://github.com/luau-lang/lute/pull/704/changes, but ended up running into issues and blocking the runtime thread even though there were continuations to process. The modification needed here is to check if there are threads that need to be scheduled, or any continuations, and if there are, run in NO_WAIT mode. If there aren't any of these, then block until there is work on the event loop to do.

This is only a patch - ideally, we would always run in UV_RUN_ONCE mode. Eventually, we should get rid of the continuations vector, and schedule continuations on the libuv event loop. At that point, we can delete these checks, and just pass UV_RUN_ONCE to the uv_run method.