### PR TITLE
Adds documentation for default lint rules

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .vitepress/cache
 dist
 reference
+docs/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -25,7 +25,6 @@ export default withSidebar(
     useTitleFromFileHeading: true,
     useTitleFromFrontmatter: true,
     hyphenToSpace: true,
-    underscoreToSpace: true,
     sortMenusByFrontmatterOrder: true,
     frontmatterOrderDefaultValue: 100,
     excludeByGlobPattern: ['**/test/**', 'README.md'],

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -20,7 +20,7 @@ If no command is specified, `run` is used by default.
 | ------- | ----------- |
 | [check](./check) | Type check Luau files. |
 | [compile](./compile) | Compile a Luau script into a standalone executable. |
-| [lint](./lint) | Lint the specified Luau file using the specified lint rule(s) or using the default rules. |
+| [lint](./lint/index.md) | Lint the specified Luau file using the specified lint rule(s) or using the default rules. |
 | [run](./run) | Run a Luau script. |
 | [setup](./setup) | Generate type definition files for the language server. |
 | [test](./test) | Run tests discovered in .test.luau and .spec.luau files. |

--- a/docs/cli/lint/almost_swapped.md
+++ b/docs/cli/lint/almost_swapped.md
@@ -1,0 +1,25 @@
+# almost_swapped
+
+This lint rule checks for instances of attempted swaps (i.e. `a = b; b = a`).
+
+## Why this is discouraged
+
+This will never result in the expected behavior.
+In the example above, the value of `b` will be assigned to `a`.
+Then, this same value gets assigned back to `b` (a no-op), resulting in both identifiers being bound the original value of `b`.
+You should instead use Luau's multiple assigment syntax, which will swap as expected (i.e. `a, b = b, a`).
+
+## Example violations
+
+`almost_swapped` will warn on the following:
+
+```luau
+a = b
+b = a
+```
+
+You should instead do:
+
+```luau
+a, b = b, a
+```

--- a/docs/cli/lint/constant_table_comparison.md
+++ b/docs/cli/lint/constant_table_comparison.md
@@ -1,0 +1,36 @@
+---
+title: constant_table_comparison
+---
+# constant_table_comparison
+
+This lint rule checks for instances of attempting to compare to table literals.
+
+## Why this is discouraged
+
+This will never result in the expected behavior.
+In Luau, tables are stored and compared by *reference*, rather than by value.
+This means that when you compare two variables containing tables, Luau will compare whether the two variables point to the same table in memory, rather than recursively comparing their keys and values.
+When you compare to a table literal (i.e. `if x == { a = 3 } then ... end`), Luau will create a new table with a single entry (`a = 3`) in memory and check whether `x` references that table.
+Since the table is newly created (and there wasn't even the chance to reassign `x` to that table) this comparison will always evaluate to `false`.
+
+## Example violations
+
+`constant_table_comparison` will warn on the following:
+
+```luau
+if x == {} then
+    ...
+elseif x ~= {} then
+    ...
+end
+```
+
+You should instead do:
+
+```luau
+if next(x) == nil then
+    ...
+elseif next(x) ~= nil then
+    ...
+end
+```

--- a/docs/cli/lint/divide_by_zero.md
+++ b/docs/cli/lint/divide_by_zero.md
@@ -1,0 +1,31 @@
+---
+title: divide_by_zero
+---
+# divide_by_zero
+
+This lint rule checks for instances of divison, floor division, or taking the remainder with respect to the literal value 0.
+
+## Why this is discouraged
+
+Division and floor division by 0 will generally give `inf` or `-inf` (unless the dividend is 0).
+The direct use of `math.huge` or `-math.huge` instead is encouraged.
+Taking remainder with respect to 0 (i.e. `3 % 0`) will give `NaN`.
+We instead encourage the use of `0 / 0` until such time as a `NaN` constant is added to `math`.
+
+## Example violations
+
+`divide_by_zero` will warn on the following:
+
+```luau
+local x = 3 / 0
+local y = -4 // 0
+local z = 24 % 0
+```
+
+You should instead do:
+
+```luau
+local x = math.huge
+local y = -math.huge
+local z = 0 / 0
+```

--- a/docs/cli/lint/index.md
+++ b/docs/cli/lint/index.md
@@ -4,7 +4,8 @@
 As a linter, it works to statically analyze the user's code to warn them about common pitfalls they may be falling into, or to nudge them away from discouraged coding practices.
 It is _programmable_ meaning that you can write a new lint rule for your Luau code _in Luau_.
 It's also built on top of the official Luau language stack, allowing it to leverage the same parser used by Luau and Roblox, unlike third-party linters that rely on separate, custom parser implementations.
-The examples folder contains two instances of sample lint rules, and you can find the full suite of `lute lint`'s default rules [here](https://github.com/luau-lang/lute/tree/primary/lute/cli/commands/lint/rules).
+The examples folder contains two instances of sample lint rules.
+You can find the full suite of `lute lint`'s default rules documented as sub-pages of this page and their source code [here](https://github.com/luau-lang/lute/tree/primary/lute/cli/commands/lint/rules).
 
 ## Usage
 

--- a/docs/cli/lint/parenthesized_conditions.md
+++ b/docs/cli/lint/parenthesized_conditions.md
@@ -1,0 +1,25 @@
+# parenthesized_conditions
+
+This lint rule checks for instances where the conditions of syntactic structures like if statements, while loops, and repeat loops have parenthesized conditions.
+
+## Why this is discouraged
+
+Although there is no semantic difference, the parentheses are unidiomatic and may detract from readability.
+
+## Example violations
+
+`parenthesized_conditions` will warn on the following:
+
+```luau
+if (x > 5) then
+    ...
+end
+```
+
+You should instead do:
+
+```luau
+if x > 5 then
+    ...
+end
+```

--- a/lute/cli/commands/lint/rules/README.md
+++ b/lute/cli/commands/lint/rules/README.md
@@ -1,1 +1,3 @@
-To add a new default lint rule to `lute lint`, create a module or luau file defining the rule in this folder. Then, add the name of the rule to the DEFAULT_RULES constant in `lint/init.luau`, and add a test for the rule in `tests/cli/lint.test.luau`. The expected type of a lint rule is specified in `lint/types.luau`. 
+To add a new default lint rule to `lute lint`, create a module or luau file defining the rule in this folder. 
+Then, add the name of the rule to the DEFAULT_RULES constant in `lint/init.luau`, add a test for the rule in `tests/cli/lint.test.luau`, and add documentation for it in `docs/cli/lint`.
+The expected type of a lint rule is specified in `lint/types.luau`. 


### PR DESCRIPTION
I had to change a side bar setting so that underscores are preserved in the page titles (and also specify titles in the front matter of some rules because underscores were being deleted for some reason).