### PR TITLE
Fix bug preventing `lute pkg run` from detecting files with `require-by-string` semantics

### DIFF
--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -403,7 +403,7 @@ int handleRunCommand(int argc, char** argv, int argOffset, bool packageAwareness
                 reporter.reportError("Error: Failed to get current working directory.\n");
                 return 1;
             }
-            validPath = normalizePath(joinPaths(*cwd, filePath));
+            validPath = normalizePath(joinPaths(*cwd, validPath));
         }
 
         std::optional<std::string> lockfile = getAbsolutePathToNearestLockfile(validPath);


### PR DESCRIPTION
In this code, we created `validPath` from `filePath` using require-by-string semantics, but we forgot to pass `validPath` along when converting it into an absolute path.

This manifests when doing `lute pkg run ./run/this/script`, where we're trying to run `./run/this/script.luau`.