### PR TITLE
Testing: break bootstrap builds on `primary`

### DIFF
--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+exit 1 # intentionally break bootstrap builds
 set -e
 install_requested=false
 


### PR DESCRIPTION
Plan to revert after confirming that our notification system is working as intended.