### PR TITLE
Add `AstExprTableItem` to `AstExpr` union

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -263,6 +263,7 @@ export type AstExpr = { kind: "expr" } & (
 	| AstExprIndexExpr
 	| AstExprFunction
 	| AstExprTable
+	| AstExprTableItem
 	| AstExprUnary
 	| AstExprBinary
 	| AstExprInterpString


### PR DESCRIPTION
I found that `AstExprTableItem` is missing from the `AstExpr` type definition. This was leading to annoying type errors in a side project.