### PR TITLE
Adds tests to TypeSerializer pt 1

### DIFF
--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -2913,11 +2913,6 @@ int typeofmodule_luau(lua_State* L)
 
     // Serialize and push the return type
     serializeTypePack(modulePtr->returnType, L);
-
-    // check the table was created and set it read-only
-    lua_rawcheckstack(L, 1);
-    lua_setreadonly(L, -1, 1);
-
     return 1;
 }
 

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -2913,6 +2913,7 @@ int typeofmodule_luau(lua_State* L)
 
     // Serialize and push the return type
     serializeTypePack(modulePtr->returnType, L);
+
     return 1;
 }
 

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -2914,6 +2914,10 @@ int typeofmodule_luau(lua_State* L)
     // Serialize and push the return type
     serializeTypePack(modulePtr->returnType, L);
 
+    // check the table was created and set it read-only
+    lua_rawcheckstack(L, 1);
+    lua_setreadonly(L, -1, 1);
+
     return 1;
 }
 

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -5,6 +5,7 @@
 #include "Luau/VisitType.h"
 
 #include "lua.h"
+#include "lualib.h"
 
 namespace Luau
 {
@@ -556,6 +557,84 @@ struct TypeSerialize final : public Luau::TypeVisitor
     bool visit(TypePackId tp, const GenericTypePack& gtp) override
     {
         serialize(tp, gtp);
+        return false;
+    }
+
+    // Non-Serialized Types
+
+    bool visit(TypeId ty) override
+    {
+        // NOTE: `TypeSerialize` should explicitly visit _all_ types and type packs,
+        // otherwise it's prone to serializing types that should not be serialized.
+        LUAU_ASSERT(false);
+        LUAU_UNREACHABLE();
+    }
+    bool visit(TypeId ty, const BoundType& btv) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize BoundType");
+        return false;
+    }
+    bool visit(TypeId ty, const FreeType& ftv) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize FreeType");
+        return false;
+    }
+    bool visit(TypeId ty, const ErrorType& etv) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize ErrorType");
+        return false;
+    }
+    bool visit(TypeId ty, const NoRefineType& nrt) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize NoRefineType");
+        return false;
+    }
+    bool visit(TypeId ty, const BlockedType& btv) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize BlockedType");
+        return false;
+    }
+    bool visit(TypeId ty, const PendingExpansionType& petv) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize PendingExpansionType");
+        return false;
+    }
+    bool visit(TypeId ty, const TypeFunctionInstanceType& tfit) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize TypeFunctionInstanceType");
+        return false;
+    }
+
+    bool visit(TypePackId tp) override
+    {
+        // NOTE: `TypeSerialize` should explicitly visit _all_ types and type packs,
+        // otherwise it's prone to serializing type packs that should not be serialized.
+        LUAU_ASSERT(false);
+        LUAU_UNREACHABLE();
+    }
+    bool visit(TypePackId tp, const BoundTypePack& btp) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize BoundTypePack");
+        return false;
+    }
+    bool visit(TypePackId tp, const FreeTypePack& ftp) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize FreeTypePack");
+        return false;
+    }
+    bool visit(TypePackId tp, const ErrorTypePack& etp) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize ErrorTypePack");
+        return false;
+    }
+    bool visit(TypePackId tp, const BlockedTypePack& btp) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize BlockedTypePack");
+        return false;
+    }
+    bool visit(TypePackId tp, const TypeFunctionInstanceTypePack& tfitp) override
+    {
+        luaL_error(L, "TypeSerialize: cannot serialize TypeFunctionInstanceTypePack");
         return false;
     }
 };

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -519,36 +519,43 @@ struct TypeSerialize final : public Luau::TypeVisitor
         LUAU_ASSERT(false);
         LUAU_UNREACHABLE();
     }
+
     bool visit(TypeId ty, const BoundType& btv) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize BoundType");
         return false;
     }
+
     bool visit(TypeId ty, const FreeType& ftv) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize FreeType");
         return false;
     }
+
     bool visit(TypeId ty, const ErrorType& etv) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize ErrorType");
         return false;
     }
+
     bool visit(TypeId ty, const NoRefineType& nrt) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize NoRefineType");
         return false;
     }
+
     bool visit(TypeId ty, const BlockedType& btv) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize BlockedType");
         return false;
     }
+
     bool visit(TypeId ty, const PendingExpansionType& petv) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize PendingExpansionType");
         return false;
     }
+
     bool visit(TypeId ty, const TypeFunctionInstanceType& tfit) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize TypeFunctionInstanceType");
@@ -562,26 +569,31 @@ struct TypeSerialize final : public Luau::TypeVisitor
         LUAU_ASSERT(false);
         LUAU_UNREACHABLE();
     }
+
     bool visit(TypePackId tp, const BoundTypePack& btp) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize BoundTypePack");
         return false;
     }
+
     bool visit(TypePackId tp, const FreeTypePack& ftp) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize FreeTypePack");
         return false;
     }
+
     bool visit(TypePackId tp, const ErrorTypePack& etp) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize ErrorTypePack");
         return false;
     }
+
     bool visit(TypePackId tp, const BlockedTypePack& btp) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize BlockedTypePack");
         return false;
     }
+
     bool visit(TypePackId tp, const TypeFunctionInstanceTypePack& tfitp) override
     {
         luaL_error(L, "TypeSerialize: cannot serialize TypeFunctionInstanceTypePack");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,9 @@ target_sources(Lute.Test PRIVATE
     src/luteprojectroot.cpp
     src/testreporter.cpp
 
+    src/typeserializefixture.h
+    src/typeserializefixture.cpp
+
     # Test files
     src/compile.test.cpp
     src/configresolver.test.cpp
@@ -23,6 +26,7 @@ target_sources(Lute.Test PRIVATE
     src/moduleresolver.test.cpp
     src/packagerequire.test.cpp
     src/require.test.cpp
+    src/typeserializer.test.cpp
     src/staticrequires.test.cpp
     src/stdsystem.test.cpp
     src/typecheck.test.cpp)

--- a/tests/src/typeserializefixture.cpp
+++ b/tests/src/typeserializefixture.cpp
@@ -1,0 +1,15 @@
+#include "typeserializefixture.h"
+
+#include "lua.h"
+#include "lualib.h"
+
+TypeSerializeFixture::TypeSerializeFixture()
+{
+    L = luaL_newstate();
+    luaL_openlibs(L);
+}
+
+TypeSerializeFixture::~TypeSerializeFixture()
+{
+    lua_close(L);
+}

--- a/tests/src/typeserializefixture.h
+++ b/tests/src/typeserializefixture.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "lutefixture.h"
+#include "lua.h"
+#include "Luau/TypeArena.h"
+
+class TypeSerializeFixture : public LuteFixture
+{
+public:
+    TypeSerializeFixture();
+    ~TypeSerializeFixture();
+
+    lua_State* L = nullptr;
+    Luau::TypeArena arena;
+};

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -31,7 +31,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_nil_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::NilType});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "nil");
@@ -41,7 +41,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_boolean_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Boolean});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "boolean");
@@ -51,7 +51,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_number_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Number});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "number");
@@ -61,7 +61,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_string_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::String});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "string");
@@ -71,7 +71,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_thread_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Thread});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "thread");
@@ -81,7 +81,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_buffer_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Buffer});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "buffer");
@@ -91,7 +91,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_any_type")
 {
     TypeId ty = arena.addType(AnyType{});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "any");
@@ -101,7 +101,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_unknown_type")
 {
     TypeId ty = arena.addType(UnknownType{});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "unknown");
@@ -111,7 +111,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_never_type")
 {
     TypeId ty = arena.addType(NeverType{});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "never");
@@ -123,7 +123,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_string_singleton")
 {
     TypeId ty = arena.addType(SingletonType{StringSingleton{"hello"}});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "singleton");
@@ -138,7 +138,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_boolean_singleton")
 {
     TypeId ty = arena.addType(SingletonType{BooleanSingleton{true}});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "singleton");
@@ -151,7 +151,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_negation_type")
 {
     TypeId ty = arena.addType(NegationType{arena.addType(PrimitiveType{PrimitiveType::Number})});
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "negation");
@@ -169,7 +169,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
 
     TypeId unionTy = arena.addType(UnionType{{numberTy, stringTy}});
 
-    Luau::serializeType(unionTy, L);
+    Luau::serializeType(L, unionTy);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "union");
@@ -195,7 +195,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
 
     TypeId intersectionTy = arena.addType(IntersectionType{{numberTy, stringTy}});
 
-    Luau::serializeType(intersectionTy, L);
+    Luau::serializeType(L, intersectionTy);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "intersection");
@@ -221,7 +221,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type")
 
     TypeId ty = arena.addType(gtp);
 
-    Luau::serializeType(ty, L);
+    Luau::serializeType(L, ty);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "generic");
@@ -238,28 +238,28 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_free_type_should_error")
 {
     TypeId ty = arena.addType(FreeType{TypeLevel{1}, nullptr, nullptr});
 
-    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize FreeType", std::exception);
+    CHECK_THROWS_WITH_AS(Luau::serializeType(L, ty), "TypeSerialize: cannot serialize FreeType", std::exception);
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_error_type_should_error")
 {
     TypeId ty = arena.addType(ErrorType{});
 
-    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize ErrorType", std::exception);
+    CHECK_THROWS_WITH_AS(Luau::serializeType(L, ty), "TypeSerialize: cannot serialize ErrorType", std::exception);
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_norefine_type_should_error")
 {
     TypeId ty = arena.addType(NoRefineType{});
 
-    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize NoRefineType", std::exception);
+    CHECK_THROWS_WITH_AS(Luau::serializeType(L, ty), "TypeSerialize: cannot serialize NoRefineType", std::exception);
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_blocked_type_should_error")
 {
     TypeId ty = arena.addType(BlockedType{});
 
-    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize BlockedType", std::exception);
+    CHECK_THROWS_WITH_AS(Luau::serializeType(L, ty), "TypeSerialize: cannot serialize BlockedType", std::exception);
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_pending_expansion_type_should_error")
@@ -267,7 +267,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_pending_expansion_type_should
 
     TypeId ty = arena.addType(PendingExpansionType{std::nullopt, AstName("fakename"), {}, {}});
 
-    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize PendingExpansionType", std::exception);
+    CHECK_THROWS_WITH_AS(Luau::serializeType(L, ty), "TypeSerialize: cannot serialize PendingExpansionType", std::exception);
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_typefunctioninstance_type_should_error")
@@ -282,7 +282,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_typefunctioninstance_type_sho
     };
     TypeId ty = arena.addType(tftt);
 
-    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize TypeFunctionInstanceType", std::exception);
+    CHECK_THROWS_WITH_AS(Luau::serializeType(L, ty), "TypeSerialize: cannot serialize TypeFunctionInstanceType", std::exception);
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_free_typepack_should_error")
@@ -290,19 +290,19 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_free_typepack_should_error")
     TypeLevel level = TypeLevel{1};
     TypePackId tp = arena.addTypePack(FreeTypePack{level});
 
-    CHECK_THROWS_WITH_AS(Luau::serializeTypePack(tp, L), "TypeSerialize: cannot serialize FreeTypePack", std::exception);
+    CHECK_THROWS_WITH_AS(Luau::serializeTypePack(L, tp), "TypeSerialize: cannot serialize FreeTypePack", std::exception);
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_error_typepack_should_error")
 {
     TypePackId tp = arena.addTypePack(ErrorTypePack{});
 
-    CHECK_THROWS_WITH_AS(Luau::serializeTypePack(tp, L), "TypeSerialize: cannot serialize ErrorTypePack", std::exception);
+    CHECK_THROWS_WITH_AS(Luau::serializeTypePack(L, tp), "TypeSerialize: cannot serialize ErrorTypePack", std::exception);
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_blocked_typepack_should_error")
 {
     TypePackId tp = arena.addTypePack(BlockedTypePack{});
 
-    CHECK_THROWS_WITH_AS(Luau::serializeTypePack(tp, L), "TypeSerialize: cannot serialize BlockedTypePack", std::exception);
+    CHECK_THROWS_WITH_AS(Luau::serializeTypePack(L, tp), "TypeSerialize: cannot serialize BlockedTypePack", std::exception);
 }

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -164,7 +164,6 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_negation_type")
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "negation");
 
-    lua_checkstack(L, 1);
     lua_getfield(L, -1, "inner");
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "number");
@@ -183,7 +182,6 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "union");
 
-    lua_checkstack(L, 1);
     lua_getfield(L, -1, "components");
     REQUIRE(lua_istable(L, -1));
 
@@ -208,7 +206,6 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "intersection");
 
-    // lua_checkstack(L, 1);
     lua_getfield(L, -1, "components");
     REQUIRE(lua_istable(L, -1));
 

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -1,0 +1,308 @@
+#include "typeserializefixture.h"
+
+#include "doctest.h"
+
+#include "lute/type.h"
+
+#include "Luau/TypeArena.h"
+#include "Luau/TypeFunction.h"
+
+using namespace Luau;
+
+static void requireStringField(lua_State* L, const char* field, const char* expected)
+{
+    lua_getfield(L, -1, field);
+    REQUIRE(lua_isstring(L, -1));
+    CHECK(std::string(lua_tostring(L, -1)) == expected);
+    lua_pop(L, 1);
+}
+
+static void requireBoolField(lua_State* L, const char* field, bool expected)
+{
+    lua_getfield(L, -1, field);
+    REQUIRE(lua_isboolean(L, -1));
+    CHECK(lua_toboolean(L, -1) == expected);
+    lua_pop(L, 1);
+}
+
+// Primitive Types
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_nil_type")
+{
+    TypeId ty = arena.addType(PrimitiveType{PrimitiveType::NilType});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "nil");
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_boolean_type")
+{
+    TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Boolean});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "boolean");
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_number_type")
+{
+    TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Number});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "number");
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_string_type")
+{
+    TypeId ty = arena.addType(PrimitiveType{PrimitiveType::String});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "string");
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_thread_type")
+{
+    TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Thread});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "thread");
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_buffer_type")
+{
+    TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Buffer});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "buffer");
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_any_type")
+{
+    TypeId ty = arena.addType(AnyType{});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "any");
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_unknown_type")
+{
+    TypeId ty = arena.addType(UnknownType{});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "unknown");
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_never_type")
+{
+    TypeId ty = arena.addType(NeverType{});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "never");
+}
+
+// Singleton Types
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_string_singleton")
+{
+    TypeId ty = arena.addType(SingletonType{StringSingleton{"hello"}});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "singleton");
+
+    lua_getfield(L, -1, "value");
+    REQUIRE(lua_isstring(L, -1));
+    CHECK(std::string(lua_tostring(L, -1)) == "hello");
+    lua_pop(L, 1);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_boolean_singleton")
+{
+    TypeId ty = arena.addType(SingletonType{BooleanSingleton{true}});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "singleton");
+
+    requireBoolField(L, "value", true);
+    lua_pop(L, 1);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_negation_type")
+{
+    TypeId ty = arena.addType(NegationType{arena.addType(PrimitiveType{PrimitiveType::Number})});
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "negation");
+
+    lua_getfield(L, -1, "inner");
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "number");
+    lua_pop(L, 1);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
+{
+    TypeId numberTy = arena.addType(PrimitiveType{PrimitiveType::Number});
+    TypeId stringTy = arena.addType(PrimitiveType{PrimitiveType::String});
+
+    TypeId unionTy = arena.addType(UnionType{{numberTy, stringTy}});
+
+    Luau::serializeType(unionTy, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "union");
+
+    lua_getfield(L, -1, "components");
+    REQUIRE(lua_istable(L, -1));
+
+    lua_rawgeti(L, -1, 1);
+    requireStringField(L, "tag", "number");
+    lua_pop(L, 1);
+
+    lua_rawgeti(L, -1, 2);
+    requireStringField(L, "tag", "string");
+    lua_pop(L, 1);
+
+    lua_pop(L, 1); // components
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
+{
+    TypeId numberTy = arena.addType(PrimitiveType{PrimitiveType::Number});
+    TypeId stringTy = arena.addType(PrimitiveType{PrimitiveType::String});
+
+    TypeId intersectionTy = arena.addType(IntersectionType{{numberTy, stringTy}});
+
+    Luau::serializeType(intersectionTy, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "intersection");
+
+    lua_getfield(L, -1, "components");
+    REQUIRE(lua_istable(L, -1));
+
+    lua_rawgeti(L, -1, 1);
+    requireStringField(L, "tag", "number");
+    lua_pop(L, 1);
+
+    lua_rawgeti(L, -1, 2);
+    requireStringField(L, "tag", "string");
+    lua_pop(L, 1);
+
+    lua_pop(L, 1); // components
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type")
+{
+    GenericType gtp;
+    gtp.name = "T";
+
+    TypeId ty = arena.addType(gtp);
+
+    Luau::serializeType(ty, L);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "generic");
+    requireStringField(L, "name", "T");
+    requireBoolField(L, "ispack", false);
+    lua_pop(L, 1);
+}
+
+// TODO: FunctionType, TableType, MetatableType, ExternType, TypePack, VariadicTypePack, GenericTypePack tests
+
+// Non-Serialized Types
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_free_type_should_error")
+{
+    TypeId ty = arena.addType(FreeType{TypeLevel{1}, nullptr, nullptr});
+
+    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize FreeType", std::exception);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_error_type_should_error")
+{
+    TypeId ty = arena.addType(ErrorType{});
+
+    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize ErrorType", std::exception);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_norefine_type_should_error")
+{
+    TypeId ty = arena.addType(NoRefineType{});
+
+    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize NoRefineType", std::exception);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_blocked_type_should_error")
+{
+    TypeId ty = arena.addType(BlockedType{});
+
+    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize BlockedType", std::exception);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_pending_expansion_type_should_error")
+{
+
+    TypeId ty = arena.addType(PendingExpansionType{std::nullopt, AstName("fakename"), {}, {}});
+
+    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize PendingExpansionType", std::exception);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_typefunctioninstance_type_should_error")
+{
+    TypeFunction user{"tf", nullptr};
+    TypeFunctionInstanceType tftt{
+        NotNull{&user},
+        std::vector<TypeId>{}, // Type Function Arguments
+        {},
+        {AstName{"fakename"}}, // Type Function Name
+        {},
+    };
+    TypeId ty = arena.addType(tftt);
+
+    CHECK_THROWS_WITH_AS(Luau::serializeType(ty, L), "TypeSerialize: cannot serialize TypeFunctionInstanceType", std::exception);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_free_typepack_should_error")
+{
+    TypeLevel level = TypeLevel{1};
+    TypePackId tp = arena.addTypePack(FreeTypePack{level});
+
+    CHECK_THROWS_WITH_AS(Luau::serializeTypePack(tp, L), "TypeSerialize: cannot serialize FreeTypePack", std::exception);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_error_typepack_should_error")
+{
+    TypePackId tp = arena.addTypePack(ErrorTypePack{});
+
+    CHECK_THROWS_WITH_AS(Luau::serializeTypePack(tp, L), "TypeSerialize: cannot serialize ErrorTypePack", std::exception);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_blocked_typepack_should_error")
+{
+    TypePackId tp = arena.addTypePack(BlockedTypePack{});
+
+    CHECK_THROWS_WITH_AS(Luau::serializeTypePack(tp, L), "TypeSerialize: cannot serialize BlockedTypePack", std::exception);
+}

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -11,6 +11,7 @@ using namespace Luau;
 
 static void requireStringField(lua_State* L, const char* field, const char* expected)
 {
+    lua_checkstack(L, 1);
     lua_getfield(L, -1, field);
     REQUIRE(lua_isstring(L, -1));
     CHECK(std::string(lua_tostring(L, -1)) == expected);
@@ -19,6 +20,7 @@ static void requireStringField(lua_State* L, const char* field, const char* expe
 
 static void requireBoolField(lua_State* L, const char* field, bool expected)
 {
+    lua_checkstack(L, 1);
     lua_getfield(L, -1, field);
     REQUIRE(lua_isboolean(L, -1));
     CHECK(lua_toboolean(L, -1) == expected);
@@ -31,7 +33,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_nil_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::NilType});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "nil");
@@ -41,7 +43,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_boolean_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Boolean});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "boolean");
@@ -51,7 +53,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_number_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Number});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "number");
@@ -61,7 +63,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_string_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::String});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "string");
@@ -71,7 +73,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_thread_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Thread});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "thread");
@@ -81,7 +83,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_buffer_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Buffer});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "buffer");
@@ -91,7 +93,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_any_type")
 {
     TypeId ty = arena.addType(AnyType{});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "any");
@@ -101,7 +103,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_unknown_type")
 {
     TypeId ty = arena.addType(UnknownType{});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "unknown");
@@ -111,7 +113,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_never_type")
 {
     TypeId ty = arena.addType(NeverType{});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "never");
@@ -123,35 +125,29 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_string_singleton")
 {
     TypeId ty = arena.addType(SingletonType{StringSingleton{"hello"}});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "singleton");
-
-    lua_getfield(L, -1, "value");
-    REQUIRE(lua_isstring(L, -1));
-    CHECK(std::string(lua_tostring(L, -1)) == "hello");
-    lua_pop(L, 1);
+    requireStringField(L, "value", "hello");
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_boolean_singleton")
 {
     TypeId ty = arena.addType(SingletonType{BooleanSingleton{true}});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "singleton");
-
     requireBoolField(L, "value", true);
-    lua_pop(L, 1);
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_negation_type")
 {
     TypeId ty = arena.addType(NegationType{arena.addType(PrimitiveType{PrimitiveType::Number})});
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "negation");
@@ -159,7 +155,6 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_negation_type")
     lua_getfield(L, -1, "inner");
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "number");
-    lua_pop(L, 1);
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
@@ -169,7 +164,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
 
     TypeId unionTy = arena.addType(UnionType{{numberTy, stringTy}});
 
-    Luau::serializeType(L, unionTy);
+    REQUIRE_EQ(Luau::serializeType(L, unionTy), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "union");
@@ -183,9 +178,6 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
 
     lua_rawgeti(L, -1, 2);
     requireStringField(L, "tag", "string");
-    lua_pop(L, 1);
-
-    lua_pop(L, 1); // components
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
@@ -195,7 +187,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
 
     TypeId intersectionTy = arena.addType(IntersectionType{{numberTy, stringTy}});
 
-    Luau::serializeType(L, intersectionTy);
+    REQUIRE_EQ(Luau::serializeType(L, intersectionTy), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "intersection");
@@ -209,9 +201,6 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
 
     lua_rawgeti(L, -1, 2);
     requireStringField(L, "tag", "string");
-    lua_pop(L, 1);
-
-    lua_pop(L, 1); // components
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type")
@@ -221,13 +210,12 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type")
 
     TypeId ty = arena.addType(gtp);
 
-    Luau::serializeType(L, ty);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "generic");
     requireStringField(L, "name", "T");
     requireBoolField(L, "ispack", false);
-    lua_pop(L, 1);
 }
 
 // TODO: FunctionType, TableType, MetatableType, ExternType, TypePack, VariadicTypePack, GenericTypePack tests

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -15,7 +15,7 @@ static void requireStringField(lua_State* L, const char* field, const char* expe
     lua_getfield(L, -1, field);
     REQUIRE(lua_isstring(L, -1));
     CHECK(std::string(lua_tostring(L, -1)) == expected);
-    lua_pop(L, 1);
+    lua_pop(L, 1); // string field
 }
 
 static void requireBoolField(lua_State* L, const char* field, bool expected)
@@ -24,7 +24,7 @@ static void requireBoolField(lua_State* L, const char* field, bool expected)
     lua_getfield(L, -1, field);
     REQUIRE(lua_isboolean(L, -1));
     CHECK(lua_toboolean(L, -1) == expected);
-    lua_pop(L, 1);
+    lua_pop(L, 1); // bool field
 }
 
 // Primitive Types
@@ -37,6 +37,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_nil_type")
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "nil");
+    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_boolean_type")
@@ -47,6 +48,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_boolean_type")
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "boolean");
+    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_number_type")
@@ -57,6 +59,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_number_type")
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "number");
+    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_string_type")
@@ -67,6 +70,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_string_type")
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "string");
+    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_thread_type")
@@ -77,6 +81,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_thread_type")
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "thread");
+    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_buffer_type")
@@ -87,6 +92,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_buffer_type")
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "buffer");
+    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_any_type")
@@ -97,6 +103,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_any_type")
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "any");
+    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_unknown_type")
@@ -107,6 +114,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_unknown_type")
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "unknown");
+    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_never_type")
@@ -117,6 +125,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_never_type")
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "never");
+    lua_pop(L, 1); // type table
 }
 
 // Singleton Types
@@ -130,6 +139,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_string_singleton")
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "singleton");
     requireStringField(L, "value", "hello");
+    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_boolean_singleton")
@@ -141,6 +151,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_boolean_singleton")
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "singleton");
     requireBoolField(L, "value", true);
+    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_negation_type")
@@ -155,6 +166,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_negation_type")
     lua_getfield(L, -1, "inner");
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "number");
+    
+    lua_pop(L, 2); // 'inner' table + type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
@@ -178,6 +191,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
 
     lua_rawgeti(L, -1, 2);
     requireStringField(L, "tag", "string");
+
+    lua_pop(L, 2); // 'components' table + type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
@@ -201,6 +216,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
 
     lua_rawgeti(L, -1, 2);
     requireStringField(L, "tag", "string");
+
+    lua_pop(L, 2); // 'components' table + type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type")
@@ -216,6 +233,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type")
     requireStringField(L, "tag", "generic");
     requireStringField(L, "name", "T");
     requireBoolField(L, "ispack", false);
+
+    lua_pop(L, 1); // type table
 }
 
 // TODO: FunctionType, TableType, MetatableType, ExternType, TypePack, VariadicTypePack, GenericTypePack tests

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -163,6 +163,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_negation_type")
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "negation");
 
+    lua_checkstack(L, 1);
     lua_getfield(L, -1, "inner");
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "number");
@@ -182,6 +183,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "union");
 
+    lua_checkstack(L, 1);
     lua_getfield(L, -1, "components");
     REQUIRE(lua_istable(L, -1));
 
@@ -207,6 +209,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "intersection");
 
+    lua_checkstack(L, 1);
     lua_getfield(L, -1, "components");
     REQUIRE(lua_istable(L, -1));
 

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -11,7 +11,6 @@ using namespace Luau;
 
 static void requireStringField(lua_State* L, const char* field, const char* expected)
 {
-    lua_checkstack(L, 1);
     lua_getfield(L, -1, field);
     REQUIRE(lua_isstring(L, -1));
     CHECK(std::string(lua_tostring(L, -1)) == expected);
@@ -20,7 +19,6 @@ static void requireStringField(lua_State* L, const char* field, const char* expe
 
 static void requireBoolField(lua_State* L, const char* field, bool expected)
 {
-    lua_checkstack(L, 1);
     lua_getfield(L, -1, field);
     REQUIRE(lua_isboolean(L, -1));
     CHECK(lua_toboolean(L, -1) == expected);
@@ -33,99 +31,101 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_nil_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::NilType});
 
+    // We need to first ensure we have enough stack space to serialize.
+    // The stack size corresponds to the max depth needed (see lute/type.cpp).
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "nil");
-    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_boolean_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Boolean});
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "boolean");
-    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_number_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Number});
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "number");
-    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_string_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::String});
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "string");
-    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_thread_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Thread});
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "thread");
-    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_buffer_type")
 {
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Buffer});
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "buffer");
-    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_any_type")
 {
     TypeId ty = arena.addType(AnyType{});
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "any");
-    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_unknown_type")
 {
     TypeId ty = arena.addType(UnknownType{});
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "unknown");
-    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_never_type")
 {
     TypeId ty = arena.addType(NeverType{});
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "never");
-    lua_pop(L, 1); // type table
 }
 
 // Singleton Types
@@ -134,30 +134,31 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_string_singleton")
 {
     TypeId ty = arena.addType(SingletonType{StringSingleton{"hello"}});
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "singleton");
     requireStringField(L, "value", "hello");
-    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_boolean_singleton")
 {
     TypeId ty = arena.addType(SingletonType{BooleanSingleton{true}});
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "singleton");
     requireBoolField(L, "value", true);
-    lua_pop(L, 1); // type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_negation_type")
 {
     TypeId ty = arena.addType(NegationType{arena.addType(PrimitiveType{PrimitiveType::Number})});
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -167,8 +168,6 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_negation_type")
     lua_getfield(L, -1, "inner");
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "number");
-    
-    lua_pop(L, 2); // 'inner' table + type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
@@ -178,6 +177,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
 
     TypeId unionTy = arena.addType(UnionType{{numberTy, stringTy}});
 
+    lua_checkstack(L, 3);
     REQUIRE_EQ(Luau::serializeType(L, unionTy), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -193,8 +193,6 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
 
     lua_rawgeti(L, -1, 2);
     requireStringField(L, "tag", "string");
-
-    lua_pop(L, 2); // 'components' table + type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
@@ -204,12 +202,13 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
 
     TypeId intersectionTy = arena.addType(IntersectionType{{numberTy, stringTy}});
 
+    lua_checkstack(L, 3); // Ensure enough stack for serialization. This would be size 3 
     REQUIRE_EQ(Luau::serializeType(L, intersectionTy), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "intersection");
 
-    lua_checkstack(L, 1);
+    // lua_checkstack(L, 1);
     lua_getfield(L, -1, "components");
     REQUIRE(lua_istable(L, -1));
 
@@ -219,8 +218,6 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
 
     lua_rawgeti(L, -1, 2);
     requireStringField(L, "tag", "string");
-
-    lua_pop(L, 2); // 'components' table + type table
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type")
@@ -230,14 +227,13 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type")
 
     TypeId ty = arena.addType(gtp);
 
+    lua_checkstack(L, 2);
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
     requireStringField(L, "tag", "generic");
     requireStringField(L, "name", "T");
     requireBoolField(L, "ispack", false);
-
-    lua_pop(L, 1); // type table
 }
 
 // TODO: FunctionType, TableType, MetatableType, ExternType, TypePack, VariadicTypePack, GenericTypePack tests


### PR DESCRIPTION
(following up from https://github.com/luau-lang/lute/pull/769)
tests tests tests for `TypeSerializer`

and adds error handling for types that we shouldn't serialize, so all overrides are implemented now

there will be a pt 2 for: FunctionType, TableType, MetatableType, ExternType, TypePack, VariadicTypePack, GenericTypePack tests