### PR TITLE
Adds suggested fixes for divide by zero lint rule

### DIFF
--- a/lute/cli/commands/lint/rules/divide_by_zero.luau
+++ b/lute/cli/commands/lint/rules/divide_by_zero.luau
@@ -23,10 +23,20 @@ local function lint(ast: syntax.AstStatBlock, sourcepath: path.path?): { lintTyp
 		:maptoarray(
 			function(
 				n: syntax.AstExprBinary
-			): lintTypes.LintViolation -- LUAUFIX: Bidirectional inference of generics should let us not need this annotation
+			): lintTypes.LintViolation? -- LUAUFIX: Bidirectional inference of generics should let us not need this annotation
 				local suggestedfix = nil
-				if (n.operator.text == "/" or n.operator.text == "//") and not isZeroLiteral(n.lhsoperand) then
-					suggestedfix = table.freeze({ fix = "math.huge" })
+				if n.operator.text == "/" or n.operator.text == "//" then
+					if isZeroLiteral(n.lhsoperand) then
+						return nil
+					elseif n.lhsoperand.tag == "unary" and n.lhsoperand.operator.text == "-" then
+						if isZeroLiteral(n.lhsoperand.operand) then
+							suggestedfix = table.freeze({ fix = "0 / 0" })
+						else
+							suggestedfix = table.freeze({ fix = "-math.huge" })
+						end
+					else
+						suggestedfix = table.freeze({ fix = "math.huge" })
+					end
 				elseif n.operator.text == "%" then
 					suggestedfix = table.freeze({ fix = "0 / 0" })
 				end

--- a/lute/cli/commands/lint/rules/divide_by_zero.luau
+++ b/lute/cli/commands/lint/rules/divide_by_zero.luau
@@ -7,6 +7,10 @@ local utils = require("@std/syntax/utils")
 local name = "divide_by_zero"
 local message = "Division by zero detected."
 
+local function isZeroLiteral(expr: syntax.AstExpr): boolean
+	return expr.kind == "expr" and expr.tag == "number" and expr.value == 0
+end
+
 local function lint(ast: syntax.AstStatBlock, sourcepath: path.path?): { lintTypes.LintViolation }
 	return query
 		.findallfromroot(ast, utils.isExprBinary)
@@ -14,18 +18,26 @@ local function lint(ast: syntax.AstStatBlock, sourcepath: path.path?): { lintTyp
 			return bin.operator.text == "/" or bin.operator.text == "//" or bin.operator.text == "%"
 		end)
 		:filter(function(bin)
-			return bin.rhsoperand.kind == "expr" and bin.rhsoperand.tag == "number" and bin.rhsoperand.value == 0
+			return isZeroLiteral(bin.rhsoperand)
 		end)
 		:maptoarray(
 			function(
 				n: syntax.AstExprBinary
 			): lintTypes.LintViolation -- LUAUFIX: Bidirectional inference of generics should let us not need this annotation
+				local suggestedfix = nil
+				if (n.operator.text == "/" or n.operator.text == "//") and not isZeroLiteral(n.lhsoperand) then
+					suggestedfix = table.freeze({ fix = "math.huge" })
+				elseif n.operator.text == "%" then
+					suggestedfix = table.freeze({ fix = "0 / 0" })
+				end
+
 				return {
 					lintname = name,
 					location = n.location,
 					message = message,
 					severity = "warning",
 					sourcepath = sourcepath,
+					suggestedfix = suggestedfix,
 				}
 			end
 		)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -141,6 +141,43 @@ violator.luau:1:11-16 ──
 		fs.remove(violatorPath)
 	end)
 
+	suite:case("divide_by_zero auto-fix", function(assert)
+		-- Setup
+		-- Create a file that violates the rule
+		local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+		fs.writestringtofile(
+			violatorPath,
+			[[
+local x = 1 / 0
+local y = -3 // 0
+local z = 4 % 0
+local nan = 0 / 0
+local negnan = -0 / 0
+]]
+		)
+
+		-- Do
+		-- Run the transformer on the transformee
+		local result = process.run({ lutePath, "lint", "--auto-fix", violatorPath })
+
+		-- Check
+		print(result.stdout)
+		assert.eq(result.exitcode, 0) -- After applying the auto-fix, there are no more violations
+
+		local fixedContents = fs.readfiletostring(violatorPath)
+		local expectedFixedContents = [[
+local x = math.huge
+local y = -math.huge
+local z = 0 / 0
+local nan = 0 / 0
+local negnan = 0 / 0
+]]
+		assert.eq(fixedContents, expectedFixedContents)
+
+		-- Teardown
+		fs.remove(violatorPath)
+	end)
+
 	suite:case("almost_swapped", function(assert)
 		-- Setup
 		-- Create a file that violates the rule
@@ -997,6 +1034,19 @@ local x = 1 / 0
                             "character": 15, 
                             "line": 0
                         }
+                    }, 
+                    "suggestedfix": {
+                        "range": {
+                            "start": {
+                                "character": 10, 
+                                "line": 0
+                            }, 
+                            "end": {
+                                "character": 15, 
+                                "line": 0
+                            }
+                        }, 
+                        "fix": "math.huge"
                     }
                 }
             ], 
@@ -1225,6 +1275,19 @@ b = a
                 "character": 15, 
                 "line": 0
             }
+        }, 
+        "suggestedfix": {
+            "range": {
+                "start": {
+                    "character": 10, 
+                    "line": 0
+                }, 
+                "end": {
+                    "character": 15, 
+                    "line": 0
+                }
+            }, 
+            "fix": "math.huge"
         }
     }
 ]]=]
@@ -1431,7 +1494,7 @@ until 5 == 5
 a = b
 b = a
 
-local x = 3 / 0
+local x = t == { x = 3 }
 ]]
 		)
 
@@ -1446,11 +1509,14 @@ local x = 3 / 0
 		local expectedFixedContents = [[
 a, b = b, a
 
-local x = 3 / 0
+local x = t == { x = 3 }
 ]]
 		assert.eq(fixedContents, expectedFixedContents)
 
-		assert.strcontains(result.stdout, "warning[divide_by_zero]: Division by zero detected.")
+		assert.strcontains(
+			result.stdout,
+			"warning[constant_table_comparison]: Constant table comparison detected. Comparing a table reference to a table literal will always evaluate to false."
+		)
 
 		assert.strnotcontains(result.stdout, "warning[almost_swapped]: This looks like a failed attempt to swap.")
 


### PR DESCRIPTION
Suggests `math.huge` and `0 / 0` in lieu of a `math.nan`