### PR TITLE
Cleans up `TypeSerialize`

### DIFF
--- a/lute/luau/include/lute/type.h
+++ b/lute/luau/include/lute/type.h
@@ -7,7 +7,7 @@
 namespace Luau
 {
 
-void serializeType(TypeId ty, lua_State* L);
-void serializeTypePack(TypePackId tp, lua_State* L);
+int serializeType(lua_State* L, TypeId ty);
+int serializeTypePack(lua_State* L, TypePackId tp);
 
 } // namespace Luau

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -2912,7 +2912,7 @@ int typeofmodule_luau(lua_State* L)
     }
 
     // Serialize and push the return type
-    serializeTypePack(modulePtr->returnType, L);
+    serializeTypePack(L, modulePtr->returnType);
 
     return 1;
 }

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -5,9 +5,16 @@
 #include "Luau/VisitType.h"
 
 #include "lua.h"
+#include "lualib.h"
 
 namespace Luau
 {
+
+static void checkStack(lua_State* L, int n)
+{
+    if (!lua_checkstack(L, n))
+        luaL_error(L, "stack overflow while serializing type");
+}
 
 // Serializer for runtime types, modeled after AstSerialize but for TypeId/TypePackId
 struct TypeSerialize final : public Luau::TypeVisitor
@@ -30,7 +37,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // Helper to push a Name, Property pair into the properties table
     void pushProperty(const std::string& name, const Property& prop)
     {
-        lua_checkstack(L, 3); // 1 for key + 1 for value table + 1 for traverse/nil
+        checkStack(L, 3); // 1 for key + 1 for value table + 1 for traverse/nil
 
         // push the Name string as the key for the property
         lua_pushstring(L, name.c_str());
@@ -55,7 +62,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // Helper to set the "properties" field for table and extern types
     void setPropertiesFields(const std::map<Name, Property>& props)
     {
-        lua_checkstack(L, 1); // 1 for properties table
+        checkStack(L, 1); // 1 for properties table
         lua_createtable(L, 0, props.size());
 
         for (const auto& [name, prop] : props)
@@ -68,7 +75,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // tag: "nil" | "unknown" | "never" | "any" | "boolean" | "number" | "string" | "buffer" | "thread" | "singleton" | "negation" | "union" | "intersection" | "table" | "function" | "extern" | "generic"
     void serialize(TypeId ty, const PrimitiveType& ptv)
     {
-        lua_checkstack(L, 2); // 1 for table + 1 for space to push/set remaining fields
+        checkStack(L, 2); // 1 for table + 1 for space to push/set remaining fields
         lua_createtable(L, 0, 1);
 
         const char* tag = nullptr;
@@ -93,7 +100,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
             tag = "buffer";
             break;
         default:
-            lua_error(L);
+            luaL_error(L, "unexpected primitive type");
         }
 
         pushTag(tag);
@@ -101,7 +108,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     void serialize(TypeId ty, const AnyType& atv)
     {
-        lua_checkstack(L, 2);
+        checkStack(L, 2);
         lua_createtable(L, 0, 1);
 
         pushTag("any");
@@ -109,7 +116,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     void serialize(TypeId ty, const UnknownType& utv)
     {
-        lua_checkstack(L, 2);
+        checkStack(L, 2);
         lua_createtable(L, 0, 1);
 
         pushTag("unknown");
@@ -117,7 +124,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     void serialize(TypeId ty, const NeverType& ntv)
     {
-        lua_checkstack(L, 2);
+        checkStack(L, 2);
         lua_createtable(L, 0, 1);
 
         pushTag("never");
@@ -127,7 +134,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // value: string | boolean | nil
     void serialize(TypeId ty, const SingletonType& stv)
     {
-        lua_checkstack(L, 2);
+        checkStack(L, 2);
         lua_createtable(L, 0, 2);
 
         pushTag("singleton");
@@ -145,7 +152,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // inner: type
     void serialize(TypeId ty, const NegationType& ntv)
     {
-        lua_checkstack(L, 2);
+        checkStack(L, 2);
         lua_createtable(L, 0, 2);
 
         pushTag("negation");
@@ -158,7 +165,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // components: { type }
     void serialize(TypeId ty, const UnionType& utv)
     {
-        lua_checkstack(L, 3); // 1 for table + 1 for components table + 1 for traverse
+        checkStack(L, 3); // 1 for table + 1 for components table + 1 for traverse
         lua_createtable(L, 0, 2);
 
         pushTag("union");
@@ -176,7 +183,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // components: { type }
     void serialize(TypeId ty, const IntersectionType& itv)
     {
-        lua_checkstack(L, 3); // 1 for table + 1 for components table + 1 for traverse
+        checkStack(L, 3); // 1 for table + 1 for components table + 1 for traverse
         lua_createtable(L, 0, 2);
 
         pushTag("intersection");
@@ -195,7 +202,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // ispack: boolean
     void serialize(TypeId ty, const GenericType& gtv)
     {
-        lua_checkstack(L, 2);
+        checkStack(L, 2);
         lua_createtable(L, 0, 3);
 
         pushTag("generic");
@@ -217,7 +224,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // genericpacks: {typepack}
     void serialize(TypeId ty, const FunctionType& ftv)
     {
-        lua_checkstack(L, 3); // max 1 for table + 1 for subtable + 1 for traverse
+        checkStack(L, 3); // max 1 for table + 1 for subtable + 1 for traverse
         lua_createtable(L, 0, 5);
 
         pushTag("function");
@@ -256,7 +263,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // [TODO] writeindexer: { index: type, result: type } }?,
     void serialize(TypeId ty, const TableType& ttv)
     {
-        lua_checkstack(L, 2);
+        checkStack(L, 2);
         lua_createtable(L, 0, 3);
 
         pushTag("table");
@@ -293,7 +300,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // metatable: type?
     void serialize(TypeId ty, const MetatableType& mtv)
     {
-        lua_checkstack(L, 2);
+        checkStack(L, 2);
         lua_createtable(L, 0, 3);
 
         pushTag("metatable");
@@ -310,7 +317,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // parent: type?
     void serialize(TypeId ty, const ExternType& etv)
     {
-        lua_checkstack(L, 2);
+        checkStack(L, 2);
         lua_createtable(L, 0, 4);
 
         pushTag("extern");
@@ -344,7 +351,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // Luau TypePack is { head: {type}?, tail: type? }
     void serialize(TypePackId tp, const TypePack& pack)
     {
-        lua_checkstack(L, 3); // 1 for root table + 1 for subtable + 1 for traverse
+        checkStack(L, 3); // 1 for root table + 1 for subtable + 1 for traverse
         lua_createtable(L, 0, 2);
 
         // Head
@@ -374,7 +381,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // Luau VariadicTypePack is { head: nil, tail: type }
     void serialize(TypePackId tp, const VariadicTypePack& vtp)
     {
-        lua_checkstack(L, 2);
+        checkStack(L, 2);
         lua_createtable(L, 0, 2);
 
         // Head is nil
@@ -391,7 +398,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // ispack: boolean
     void serialize(TypePackId tp, const GenericTypePack& gtp)
     {
-        lua_checkstack(L, 2);
+        checkStack(L, 2);
         lua_createtable(L, 0, 3);
         pushTag("generic");
 

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -30,7 +30,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // Helper to push a Name, Property pair into the properties table
     void pushProperty(const std::string& name, const Property& prop)
     {
-        lua_checkstack(L, 3);
+        lua_checkstack(L, 2); // 1 for key + 1 for value table
 
         // push the Name string as the key for the property
         lua_pushstring(L, name.c_str());
@@ -65,6 +65,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // Helper to set the "properties" field for table and extern types
     void setPropertiesFields(const std::map<Name, Property>& props)
     {
+        lua_checkstack(L, 1); // 1 for properties table
         lua_createtable(L, 0, props.size());
 
         for (const auto& [name, prop] : props)
@@ -77,7 +78,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // tag: "nil" | "unknown" | "never" | "any" | "boolean" | "number" | "string" | "buffer" | "thread" | "singleton" | "negation" | "union" | "intersection" | "table" | "function" | "extern" | "generic"
     void serialize(TypeId ty, const PrimitiveType& ptv)
     {
-        lua_checkstack(L, 1);
+        lua_checkstack(L, 2); // 1 for table + 1 for space to push/set remaining fields
         lua_createtable(L, 0, 1);
 
         const char* tag = nullptr;
@@ -110,7 +111,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     void serialize(TypeId ty, const AnyType& atv)
     {
-        lua_checkstack(L, 1);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 1);
 
         pushTag("any");
@@ -118,7 +119,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     void serialize(TypeId ty, const UnknownType& utv)
     {
-        lua_checkstack(L, 1);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 1);
 
         pushTag("unknown");
@@ -126,7 +127,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     void serialize(TypeId ty, const NeverType& ntv)
     {
-        lua_checkstack(L, 1);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 1);
 
         pushTag("never");
@@ -212,7 +213,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // ispack: boolean
     void serialize(TypeId ty, const GenericType& gtv)
     {
-        lua_checkstack(L, 3);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 3);
 
         pushTag("generic");
@@ -239,7 +240,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // genericpacks: {typepack}
     void serialize(TypeId ty, const FunctionType& ftv)
     {
-        lua_checkstack(L, 5);
+        lua_checkstack(L, 2); // 1 for table + 1 for space to push/set remaining fields
         lua_createtable(L, 0, 5);
 
         pushTag("function");
@@ -278,7 +279,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // [TODO] writeindexer: { index: type, result: type } }?,
     void serialize(TypeId ty, const TableType& ttv)
     {
-        lua_checkstack(L, 3);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 3);
 
         pushTag("table");
@@ -315,7 +316,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // metatable: type?
     void serialize(TypeId ty, const MetatableType& mtv)
     {
-        lua_checkstack(L, 3);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 3);
 
         pushTag("metatable");
@@ -332,7 +333,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // parent: type?
     void serialize(TypeId ty, const ExternType& etv)
     {
-        lua_checkstack(L, 4);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 4);
 
         pushTag("extern");
@@ -429,7 +430,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // ispack: boolean
     void serialize(TypePackId tp, const GenericTypePack& gtp)
     {
-        lua_checkstack(L, 3);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 3);
         pushTag("generic");
 

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -38,26 +38,16 @@ struct TypeSerialize final : public Luau::TypeVisitor
         // Create property value table with read/write types
         lua_createtable(L, 0, 2);
         if (prop.readTy)
-        {
             traverse(*prop.readTy);
-            lua_setfield(L, -2, "read");
-        }
         else
-        {
             lua_pushnil(L);
-            lua_setfield(L, -2, "read");
-        }
+        lua_setfield(L, -2, "read");
 
         if (prop.writeTy)
-        {
             traverse(*prop.writeTy);
-            lua_setfield(L, -2, "write");
-        }
         else
-        {
             lua_pushnil(L);
-            lua_setfield(L, -2, "write");
-        }
+        lua_setfield(L, -2, "write");
 
         lua_settable(L, -3);
     }
@@ -143,20 +133,12 @@ struct TypeSerialize final : public Luau::TypeVisitor
         pushTag("singleton");
 
         if (auto boolSingleton = get<BooleanSingleton>(&stv))
-        {
             lua_pushboolean(L, boolSingleton->value);
-            lua_setfield(L, -2, "value");
-        }
         else if (auto strSingleton = get<StringSingleton>(&stv))
-        {
             lua_pushstring(L, strSingleton->value.c_str());
-            lua_setfield(L, -2, "value");
-        }
         else
-        {
             lua_pushnil(L);
-            lua_setfield(L, -2, "value");
-        }     
+        lua_setfield(L, -2, "value");
     }
 
     // Luau negation type:
@@ -219,15 +201,10 @@ struct TypeSerialize final : public Luau::TypeVisitor
         pushTag("generic");
 
         if (!gtv.name.empty())
-        {
             lua_pushstring(L, gtv.name.c_str());
-            lua_setfield(L, -2, "name");
-        }
         else
-        {
             lua_pushnil(L);
-            lua_setfield(L, -2, "name");
-        }
+        lua_setfield(L, -2, "name");
 
         lua_pushboolean(L, false); // GenericType is not a pack
         lua_setfield(L, -2, "ispack");
@@ -351,27 +328,17 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
         // Parent
         if (etv.parent)
-        {
             traverse(*etv.parent);
-            lua_setfield(L, -2, "parent");
-        }
         else
-        {
             lua_pushnil(L);
-            lua_setfield(L, -2, "parent");
-        }
+        lua_setfield(L, -2, "parent");
 
         // Metatable
         if (etv.metatable)
-        {
             traverse(*etv.metatable);
-            lua_setfield(L, -2, "metatable"); 
-        }
         else
-        {
             lua_pushnil(L);
-            lua_setfield(L, -2, "metatable");
-        }
+        lua_setfield(L, -2, "metatable"); 
     }
 
     // Luau TypePack is { head: {type}?, tail: type? }
@@ -389,25 +356,19 @@ struct TypeSerialize final : public Luau::TypeVisitor
                 traverse(pack.head[i]);
                 lua_rawseti(L, -2, int(i + 1));
             }
-            lua_setfield(L, -2, "head");
         }
         else
         {
             lua_pushnil(L);
-            lua_setfield(L, -2, "head");
         }
+        lua_setfield(L, -2, "head");
 
         // Tail
         if (pack.tail)
-        {
             traverse(*pack.tail);
-            lua_setfield(L, -2, "tail");
-        }
         else
-        {
             lua_pushnil(L);
-            lua_setfield(L, -2, "tail");
-        }
+        lua_setfield(L, -2, "tail");
     }
 
     // Luau VariadicTypePack is { head: nil, tail: type }
@@ -435,15 +396,10 @@ struct TypeSerialize final : public Luau::TypeVisitor
         pushTag("generic");
 
         if (!gtp.name.empty())
-        {
             lua_pushstring(L, gtp.name.c_str());
-            lua_setfield(L, -2, "name");
-        }
         else
-        {
             lua_pushnil(L);
-            lua_setfield(L, -2, "name");
-        }
+        lua_setfield(L, -2, "name");
 
         lua_pushboolean(L, true); // GenericTypePack is a pack
         lua_setfield(L, -2, "ispack");

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -20,7 +20,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
     }
 
-    // Helper to push the "tag" field
+    // Helper to push the "tag" field that every Luau type has
     void pushTag(const char* tag)
     {
         lua_pushstring(L, tag);
@@ -30,6 +30,8 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // Helper to push a Name, Property pair into the properties table
     void pushProperty(const std::string& name, const Property& prop)
     {
+        lua_checkstack(L, 3);
+
         // push the Name string as the key for the property
         lua_pushstring(L, name.c_str());
 
@@ -38,7 +40,6 @@ struct TypeSerialize final : public Luau::TypeVisitor
         if (prop.readTy)
         {
             traverse(*prop.readTy);
-            lua_rawcheckstack(L, 2);
             lua_setfield(L, -2, "read");
         }
         else
@@ -50,7 +51,6 @@ struct TypeSerialize final : public Luau::TypeVisitor
         if (prop.writeTy)
         {
             traverse(*prop.writeTy);
-            lua_rawcheckstack(L, 2);
             lua_setfield(L, -2, "write");
         }
         else
@@ -73,11 +73,11 @@ struct TypeSerialize final : public Luau::TypeVisitor
         lua_setfield(L, -2, "properties");
     }
 
-    // Luau type
+    // Luau primitive type
     // tag: "nil" | "unknown" | "never" | "any" | "boolean" | "number" | "string" | "buffer" | "thread" | "singleton" | "negation" | "union" | "intersection" | "table" | "function" | "extern" | "generic"
     void serialize(TypeId ty, const PrimitiveType& ptv)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 1);
         lua_createtable(L, 0, 1);
 
         const char* tag = nullptr;
@@ -110,7 +110,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     void serialize(TypeId ty, const AnyType& atv)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 1);
         lua_createtable(L, 0, 1);
 
         pushTag("any");
@@ -118,7 +118,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     void serialize(TypeId ty, const UnknownType& utv)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 1);
         lua_createtable(L, 0, 1);
 
         pushTag("unknown");
@@ -126,7 +126,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     void serialize(TypeId ty, const NeverType& ntv)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 1);
         lua_createtable(L, 0, 1);
 
         pushTag("never");
@@ -136,7 +136,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // value: string | boolean | nil
     void serialize(TypeId ty, const SingletonType& stv)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 2);
 
         pushTag("singleton");
@@ -162,13 +162,12 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // inner: type
     void serialize(TypeId ty, const NegationType& ntv)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 2);
 
         pushTag("negation");
 
         traverse(ntv.ty);
-        lua_rawcheckstack(L, 2);
         lua_setfield(L, -2, "inner");
     }
 
@@ -176,7 +175,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // components: { type }
     void serialize(TypeId ty, const UnionType& utv)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 2);
 
         pushTag("union");
@@ -185,7 +184,6 @@ struct TypeSerialize final : public Luau::TypeVisitor
         for (size_t i = 0; i < utv.options.size(); i++)
         {
             traverse(utv.options[i]);
-            lua_rawcheckstack(L, 2);
             lua_rawseti(L, -2, i + 1);
         }
         lua_setfield(L, -2, "components");
@@ -195,7 +193,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // components: { type }
     void serialize(TypeId ty, const IntersectionType& itv)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 2);
 
         pushTag("intersection");
@@ -204,7 +202,6 @@ struct TypeSerialize final : public Luau::TypeVisitor
         for (size_t i = 0; i < itv.parts.size(); i++)
         {
             traverse(itv.parts[i]);
-            lua_rawcheckstack(L, 2);
             lua_rawseti(L, -2, i + 1);
         }
         lua_setfield(L, -2, "components");
@@ -215,7 +212,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // ispack: boolean
     void serialize(TypeId ty, const GenericType& gtv)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 3);
         lua_createtable(L, 0, 3);
 
         pushTag("generic");
@@ -239,21 +236,20 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // parameters: { head: {type}?, tail: type? },
     // returns: { head: {type}?, tail: type? },
     // generics: {type},
+    // genericpacks: {typepack}
     void serialize(TypeId ty, const FunctionType& ftv)
     {
-        lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, 4);
+        lua_checkstack(L, 5);
+        lua_createtable(L, 0, 5);
 
         pushTag("function");
 
         // Parameters
         traverse(ftv.argTypes);
-        lua_rawcheckstack(L, 2);
         lua_setfield(L, -2, "parameters");
 
         // Returns
         traverse(ftv.retTypes);
-        lua_rawcheckstack(L, 2);
         lua_setfield(L, -2, "returns");
 
         // Generics
@@ -261,7 +257,6 @@ struct TypeSerialize final : public Luau::TypeVisitor
         for (size_t i = 0; i < ftv.generics.size(); i++)
         {
             traverse(ftv.generics[i]);
-            lua_rawcheckstack(L, 2);
             lua_rawseti(L, -2, i + 1);
         }
         lua_setfield(L, -2, "generics");
@@ -271,7 +266,6 @@ struct TypeSerialize final : public Luau::TypeVisitor
         for (size_t i = 0; i < ftv.genericPacks.size(); i++)
         {
             traverse(ftv.genericPacks[i]);
-            lua_rawcheckstack(L, 2);
             lua_rawseti(L, -2, i + 1);
         }
         lua_setfield(L, -2, "genericpacks");
@@ -284,8 +278,8 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // [TODO] writeindexer: { index: type, result: type } }?,
     void serialize(TypeId ty, const TableType& ttv)
     {
-        lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, 4);
+        lua_checkstack(L, 3);
+        lua_createtable(L, 0, 3);
 
         pushTag("table");
 
@@ -305,8 +299,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
         {
             lua_createtable(L, 0, 3);
             traverse(ttv.indexer->indexType);
-            lua_rawcheckstack(L, 2);
-            lua_setfield(L, -2, "index");
+            lua_setfield(L, -2, "indexer");
 
             // TODO: implement readindexer and writeindexer from ttv.indexer->indexResultType
         }
@@ -318,20 +311,19 @@ struct TypeSerialize final : public Luau::TypeVisitor
     }
 
     // Luau metatable type:
+    // table: type,
     // metatable: type?
     void serialize(TypeId ty, const MetatableType& mtv)
     {
-        lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, 2);
+        lua_checkstack(L, 3);
+        lua_createtable(L, 0, 3);
 
         pushTag("metatable");
 
         traverse(mtv.table);
-        lua_rawcheckstack(L, 2);
         lua_setfield(L, -2, "table");
 
         traverse(mtv.metatable);
-        lua_rawcheckstack(L, 2);
         lua_setfield(L, -2, "metatable");
     }
 
@@ -340,8 +332,8 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // parent: type?
     void serialize(TypeId ty, const ExternType& etv)
     {
-        lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, 3);
+        lua_checkstack(L, 4);
+        lua_createtable(L, 0, 4);
 
         pushTag("extern");
 
@@ -360,7 +352,6 @@ struct TypeSerialize final : public Luau::TypeVisitor
         if (etv.parent)
         {
             traverse(*etv.parent);
-            lua_rawcheckstack(L, 2);
             lua_setfield(L, -2, "parent");
         }
         else
@@ -373,7 +364,6 @@ struct TypeSerialize final : public Luau::TypeVisitor
         if (etv.metatable)
         {
             traverse(*etv.metatable);
-            lua_rawcheckstack(L, 2);
             lua_setfield(L, -2, "metatable"); 
         }
         else
@@ -386,7 +376,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // Luau TypePack is { head: {type}?, tail: type? }
     void serialize(TypePackId tp, const TypePack& pack)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 2);
 
         // Head
@@ -396,7 +386,6 @@ struct TypeSerialize final : public Luau::TypeVisitor
             for (size_t i = 0; i < pack.head.size(); i++)
             {
                 traverse(pack.head[i]);
-                lua_rawcheckstack(L, 2);
                 lua_rawseti(L, -2, int(i + 1));
             }
             lua_setfield(L, -2, "head");
@@ -411,7 +400,6 @@ struct TypeSerialize final : public Luau::TypeVisitor
         if (pack.tail)
         {
             traverse(*pack.tail);
-            lua_rawcheckstack(L, 2);
             lua_setfield(L, -2, "tail");
         }
         else
@@ -424,7 +412,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // Luau VariadicTypePack is { head: nil, tail: type }
     void serialize(TypePackId tp, const VariadicTypePack& vtp)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 2);
         lua_createtable(L, 0, 2);
 
         // Head is nil
@@ -433,32 +421,31 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
         // Tail is the type
         traverse(vtp.ty);
-        lua_rawcheckstack(L, 2);
         lua_setfield(L, -2, "tail");
     }
 
-    // Luau GenericTypePack is { head: nil, tail: generic type with ispack=true }
+    // Luau GenericTypePack is
+    // name: string?
+    // ispack: boolean
     void serialize(TypePackId tp, const GenericTypePack& gtp)
     {
-        lua_rawcheckstack(L, 2);
+        lua_checkstack(L, 3);
         lua_createtable(L, 0, 3);
+        pushTag("generic");
 
-        // Head is nil
-        lua_pushnil(L);
-        lua_setfield(L, -2, "head");
-
-        // Tail is generic type
-        lua_createtable(L, 0, 3);
-        lua_pushstring(L, "generic");
-        lua_setfield(L, -2, "tag");
         if (!gtp.name.empty())
         {
             lua_pushstring(L, gtp.name.c_str());
             lua_setfield(L, -2, "name");
         }
-        lua_pushboolean(L, true); // ispack = true for generic type packs
+        else
+        {
+            lua_pushnil(L);
+            lua_setfield(L, -2, "name");
+        }
+
+        lua_pushboolean(L, true); // GenericTypePack is a pack
         lua_setfield(L, -2, "ispack");
-        lua_setfield(L, -2, "tail");
     }
 
     // Luau Type visitors
@@ -560,16 +547,20 @@ struct TypeSerialize final : public Luau::TypeVisitor
     }
 };
 
-void serializeType(TypeId ty, lua_State* L)
+int serializeType(lua_State* L, TypeId ty)
 {
     TypeSerialize serializer(L);
     serializer.traverse(ty);
+    lua_setreadonly(L, -1, 1);
+    return 1;
 }
 
-void serializeTypePack(TypePackId tp, lua_State* L)
+int serializeTypePack(lua_State* L, TypePackId tp)
 {
     TypeSerialize serializer(L);
     serializer.traverse(tp);
+    lua_setreadonly(L, -1, 1);
+    return 1;
 }
 
 } // namespace Luau

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -30,7 +30,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // Helper to push a Name, Property pair into the properties table
     void pushProperty(const std::string& name, const Property& prop)
     {
-        lua_checkstack(L, 2); // 1 for key + 1 for value table
+        lua_checkstack(L, 3); // 1 for key + 1 for value table + 1 for traverse/nil
 
         // push the Name string as the key for the property
         lua_pushstring(L, name.c_str());
@@ -158,7 +158,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // components: { type }
     void serialize(TypeId ty, const UnionType& utv)
     {
-        lua_checkstack(L, 2);
+        lua_checkstack(L, 3); // 1 for table + 1 for components table + 1 for traverse
         lua_createtable(L, 0, 2);
 
         pushTag("union");
@@ -176,7 +176,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // components: { type }
     void serialize(TypeId ty, const IntersectionType& itv)
     {
-        lua_checkstack(L, 2);
+        lua_checkstack(L, 3); // 1 for table + 1 for components table + 1 for traverse
         lua_createtable(L, 0, 2);
 
         pushTag("intersection");
@@ -217,7 +217,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // genericpacks: {typepack}
     void serialize(TypeId ty, const FunctionType& ftv)
     {
-        lua_checkstack(L, 2); // 1 for table + 1 for space to push/set remaining fields
+        lua_checkstack(L, 3); // max 1 for table + 1 for subtable + 1 for traverse
         lua_createtable(L, 0, 5);
 
         pushTag("function");
@@ -344,7 +344,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // Luau TypePack is { head: {type}?, tail: type? }
     void serialize(TypePackId tp, const TypePack& pack)
     {
-        lua_checkstack(L, 2);
+        lua_checkstack(L, 3); // 1 for root table + 1 for subtable + 1 for traverse
         lua_createtable(L, 0, 2);
 
         // Head


### PR DESCRIPTION
Some cleaning up of `TypeSerialize` after talking with @Vighnesh-V and @vrn-sn 
Changes: 
* update API of public `serializeType` and `serializeTypePack` funcs to match luau definitions & sets the table to be read only
* removing check stacks that come after internal `serialize` traverse functions bc upon further discussion and implementation of all of the traverse functions in https://github.com/luau-lang/lute/pull/778, we don't need to add the extra checks, we will just error if we reach a type or typepack that we aren't serializing
* renaming raw checkstacks to be regular `lua_checkstack` and making sure the size is just enough (each `lua_pushxxx` followed by a `lua_setfield` removes space on the top of the `lua_state` so we only need to allocate a spot for non-temporary pushes (i.e., `lua_createtable`) and a slot to do the temporary pushes)
* updating setPropertiesFields to also check its stack before pushing