### PR TITLE
Ensures that the lute runtime initializes it's own event loop

### DIFF
--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -9,12 +9,11 @@
 #include "uv.h"
 
 #include <cstring>
-
-#include "fs_impl.h"
-
 #include <memory>
 #include <optional>
 #include <string>
+
+#include "fs_impl.h"
 
 namespace fs
 {
@@ -264,7 +263,6 @@ static int closeWatchHandle(lua_State* L)
 {
     luaL_checktype(L, 1, LUA_TUSERDATA);
     auto* handle = static_cast<WatchHandle*>(lua_touserdatatagged(L, 1, kWatchHandleTag));
-
     if (!handle)
     {
         luaL_errorL(L, "Invalid fs event handle");
@@ -287,7 +285,7 @@ int fs_watch(lua_State* L)
     event->callbackReference = std::make_shared<Ref>(L, 2);
     event->handle.data = event;
 
-    int init_err = uv_fs_event_init(uv_default_loop(), &event->handle);
+    int init_err = uv_fs_event_init(getRuntimeLoop(L), &event->handle);
 
     if (init_err)
     {

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -114,7 +114,7 @@ int open_impl(lua_State* L, const char* path, int flags, int mode)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);
     uv_fs_open(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         path,
         flags,
@@ -175,7 +175,7 @@ void FSRead::readCallback(uv_fs_t* req)
     std::fill(r->chunk.begin(), r->chunk.end(), 0);
 
     uvutils::ScopedUVRequest<FSRead> scopedReq{std::move(r)};
-    uv_fs_read(uv_default_loop(), &scopedReq->req, scopedReq->file->fd.value(), &scopedReq->iov, 1, -1, FSRead::readCallback);
+    uv_fs_read(scopedReq->getLoop(), &scopedReq->req, scopedReq->file->fd.value(), &scopedReq->iov, 1, -1, FSRead::readCallback);
 }
 
 void FSWrite::writeCallback(uv_fs_t* req)
@@ -208,7 +208,7 @@ void FSWrite::writeCallback(uv_fs_t* req)
     w->iov = uv_buf_init(w->chunk.data(), chunkSize);
 
     uvutils::ScopedUVRequest<FSWrite> scopedReq{std::move(w)};
-    uv_fs_write(uv_default_loop(), &scopedReq->req, scopedReq->file->fd.value(), &scopedReq->iov, 1, -1, FSWrite::writeCallback);
+    uv_fs_write(scopedReq->getLoop(), &scopedReq->req, scopedReq->file->fd.value(), &scopedReq->iov, 1, -1, FSWrite::writeCallback);
 }
 
 int read_impl(lua_State* L, UVFile* handle)
@@ -219,7 +219,7 @@ int read_impl(lua_State* L, UVFile* handle)
     }
 
     uvutils::ScopedUVRequest<FSRead> req{L, handle};
-    uv_fs_read(uv_default_loop(), &req->req, handle->fd.value(), &req->iov, 1, -1, FSRead::readCallback);
+    uv_fs_read(req->getLoop(), &req->req, handle->fd.value(), &req->iov, 1, -1, FSRead::readCallback);
     // Automatically releases when req goes out of scope
     return lua_yield(L, 0);
 }
@@ -238,7 +238,7 @@ int write_impl(lua_State* L, UVFile* handle, const char* toWrite, size_t numByte
     std::copy(req->toWrite.begin(), req->toWrite.begin() + chunkSize, req->chunk.begin());
     req->iov = uv_buf_init(req->chunk.data(), chunkSize);
 
-    uv_fs_write(uv_default_loop(), &req->req, handle->fd.value(), &req->iov, 1, -1, FSWrite::writeCallback);
+    uv_fs_write(req->getLoop(), &req->req, handle->fd.value(), &req->iov, 1, -1, FSWrite::writeCallback);
 
     return lua_yield(L, 0);
 }
@@ -252,7 +252,7 @@ int close_impl(lua_State* L, UVFile* handle)
 
     uvutils::ScopedUVRequest<FSClose> req{L, handle};
     uv_fs_close(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         handle->fd.value(),
         [](uv_fs_t* req)
@@ -282,7 +282,7 @@ int remove_impl(lua_State* L, const char* path)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);
     uv_fs_unlink(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         path,
         [](uv_fs_t* req)
@@ -359,7 +359,7 @@ int stat_impl(lua_State* L, const char* path)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);
     uv_fs_stat(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         path,
         [](uv_fs_t* req)
@@ -418,7 +418,7 @@ int exists_impl(lua_State* L, const char* path)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);
     uv_fs_access(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         path,
         F_OK,
@@ -450,7 +450,7 @@ int type_impl(lua_State* L, const char* path)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);
     uv_fs_stat(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         path,
         [](uv_fs_t* req)
@@ -482,7 +482,7 @@ int link_impl(lua_State* L, const char* path, const char* dest)
 {
     uvutils::ScopedUVRequest<FSPathPairRequest> req{L, path, dest};
     uv_fs_link(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         path,
         dest,
@@ -518,7 +518,7 @@ int symlink_impl(lua_State* L, const char* path, const char* dest)
 #endif
 
     uv_fs_symlink(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         path,
         dest,
@@ -550,7 +550,7 @@ int copy_impl(lua_State* L, const char* path, const char* dest)
 {
     uvutils::ScopedUVRequest<FSPathPairRequest> req{L, path, dest};
     uv_fs_copyfile(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         path,
         dest,
@@ -582,7 +582,7 @@ int mkdir_impl(lua_State* L, const char* path, int mode)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);
     uv_fs_mkdir(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         path,
         mode,
@@ -613,7 +613,7 @@ int rmdir_impl(lua_State* L, const char* path)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);
     uv_fs_rmdir(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         path,
         [](uv_fs_t* req)
@@ -643,7 +643,7 @@ int listdir_impl(lua_State* L, const char* path)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);
     uv_fs_scandir(
-        uv_default_loop(),
+        req->getLoop(),
         &req->req,
         path,
         0,

--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -82,7 +82,7 @@ static void onTtyRead(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
 int read(lua_State* L)
 {
     auto handle = std::make_shared<IOHandle>();
-    handle->loop = uv_default_loop();
+    handle->loop = getRuntimeLoop(L);
     handle->resumeToken = getResumeToken(L);
     handle->self = handle;
 

--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -530,7 +530,7 @@ bool closeServer(int serverId)
 
 int lua_serve(lua_State* L)
 {
-    uWS::Loop::get(uv_default_loop());
+    uWS::Loop::get(getRuntimeLoop(L));
 
     std::string hostname = "127.0.0.1";
     int port = 3000;

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -157,7 +157,7 @@ struct ProcessOptions
     std::string cwd;
     std::string stdioKind;
     std::map<std::string, std::string> env;
-    std::string customShell;  // only used by system()
+    std::string customShell; // only used by system()
 };
 
 static void onProcessExit(uv_process_t* process, int64_t exitStatus, int termSignal)
@@ -225,7 +225,7 @@ const std::string kStdioKindNone = "none";
 int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions opts)
 {
     auto handle = std::make_shared<ProcessHandle>();
-    handle->loop = uv_default_loop();
+    handle->loop = getRuntimeLoop(L);
     handle->self = handle;
 
     uv_process_options_t options = {};
@@ -363,7 +363,7 @@ ProcessOptions parseOptions(lua_State* L, int index)
     lua_getfield(L, index, "cwd");
     if (!lua_isnil(L, -1))
     {
-        opts.cwd = luaL_checkstring(L,-1);
+        opts.cwd = luaL_checkstring(L, -1);
     }
     lua_pop(L, 1);
 
@@ -436,13 +436,13 @@ int system(lua_State* L)
     ProcessOptions opts = parseOptions(L, 2);
 
 #ifdef _WIN32
-        const char* shellVar = "COMSPEC";
-        const char* shellFallback = "cmd.exe";
-        const char* shellArg = "/c";
+    const char* shellVar = "COMSPEC";
+    const char* shellFallback = "cmd.exe";
+    const char* shellArg = "/c";
 #else
-        const char* shellVar = "SHELL";
-        const char* shellFallback = "/bin/sh";
-        const char* shellArg = "-c";
+    const char* shellVar = "SHELL";
+    const char* shellFallback = "/bin/sh";
+    const char* shellArg = "-c";
 #endif
 
     std::string resolvedShell;
@@ -458,7 +458,7 @@ int system(lua_State* L)
         resolvedShell = opts.customShell;
     }
 
-    return executionHelper(L, { resolvedShell, shellArg, command }, opts);
+    return executionHelper(L, {resolvedShell, shellArg, command}, opts);
 }
 
 int homedir(lua_State* L)

--- a/lute/runtime/include/lute/UVRequest.h
+++ b/lute/runtime/include/lute/UVRequest.h
@@ -30,6 +30,7 @@ struct UVRequest
 {
     UVRequest(lua_State* L)
         : token(getResumeToken(L))
+        , loop(getRuntimeLoop(L))
     {
         req.data = this;
     }
@@ -68,8 +69,14 @@ struct UVRequest
         cleanup_uv_req(&req);
     }
 
+    uv_loop_t* getLoop()
+    {
+        return loop;
+    }
+
     ResumeToken token;
     ReqT req;
+    uv_loop_t* loop;
 };
 
 

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -5,6 +5,8 @@
 #include "Luau/Variant.h"
 #include "Luau/VecDeque.h"
 
+#include "uv.h"
+
 #include <atomic>
 #include <condition_variable>
 #include <functional>
@@ -72,6 +74,8 @@ struct Runtime
     void addPendingToken();
     void releasePendingToken();
 
+    uv_loop_t* getEventLoop();
+
     // VM for this runtime
     std::unique_ptr<lua_State, void (*)(lua_State*)> globalState;
 
@@ -93,9 +97,11 @@ private:
     std::thread runLoopThread;
 
     std::atomic<int> activeTokens;
+    uv_loop_t eventLoop;
 };
 
 Runtime* getRuntime(lua_State* L);
+uv_loop_t* getRuntimeLoop(lua_State* L);
 
 struct ResumeTokenData;
 using ResumeToken = std::shared_ptr<ResumeTokenData>;

--- a/lute/runtime/include/lute/uvutils.h
+++ b/lute/runtime/include/lute/uvutils.h
@@ -5,6 +5,8 @@
 #include <cstddef>
 #include <string>
 
+#define LUTE_ASSERT(expr) LUAU_ASSERT(expr)
+
 namespace uvutils
 {
 

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -1,5 +1,8 @@
 #include "lute/runtime.h"
 
+#include "lute/uvutils.h"
+
+#include "Luau/Common.h"
 #include "Luau/Require.h"
 
 #include "lua.h"
@@ -20,8 +23,14 @@ Runtime::Runtime()
     : globalState(nullptr, lua_close_checked)
     , dataCopy(nullptr, lua_close_checked)
 {
+
     stop.store(false);
     activeTokens.store(0);
+
+    if (uv_loop_init(&eventLoop) < 0)
+    {
+        LUTE_ASSERT("Couldn't initialize runtime event loop");
+    }
 }
 
 Runtime::~Runtime()
@@ -36,6 +45,9 @@ Runtime::~Runtime()
 
     if (runLoopThread.joinable())
         runLoopThread.join();
+    // At this point, Runtime::hasWork will have returned false (i.e uv_loop_alive is false)
+    // This means there are no outstanding handles, or file descriptors or work, to do, and we can exit
+    uv_loop_close(&eventLoop);
 }
 
 bool Runtime::hasWork()
@@ -44,13 +56,13 @@ bool Runtime::hasWork()
     // Unfortunately, we do currently have some places where we add/release
     // tokens that don't correspond to libuv activity, so for now we keep both.
     // uv_ref/unref could be used to patch tokens into the libuv loop itself.
-    return hasContinuations() || hasThreads() || activeTokens.load() != 0 || uv_loop_alive(uv_default_loop());
+    return hasContinuations() || hasThreads() || activeTokens.load() != 0 || uv_loop_alive(getEventLoop());
 }
 
 RuntimeStep Runtime::runOnce()
 {
     uv_run_mode mode = (hasContinuations() || hasThreads()) ? UV_RUN_NOWAIT : UV_RUN_ONCE;
-    uv_run(uv_default_loop(), mode);
+    uv_run(getEventLoop(), mode);
 
     // Complete all C++ continuations
     std::vector<std::function<void()>> copy;
@@ -234,8 +246,7 @@ void Runtime::scheduleLuauResume(std::shared_ptr<Ref> ref, std::function<int(lua
 
 void Runtime::runInWorkQueue(std::function<void()> f)
 {
-    auto loop = uv_default_loop();
-
+    auto loop = getEventLoop();
     uv_work_t* work = new uv_work_t();
     work->data = new decltype(f)(std::move(f));
 
@@ -267,9 +278,19 @@ void Runtime::releasePendingToken()
     assert(before > 0);
 }
 
+uv_loop_t* Runtime::getEventLoop()
+{
+    return &eventLoop;
+}
+
 Runtime* getRuntime(lua_State* L)
 {
     return static_cast<Runtime*>(lua_getthreaddata(lua_mainthread(L)));
+}
+
+uv_loop_t* getRuntimeLoop(lua_State* L)
+{
+    return getRuntime(L)->getEventLoop();
 }
 
 void ResumeTokenData::fail(std::string error)

--- a/lute/task/src/task.cpp
+++ b/lute/task/src/task.cpp
@@ -47,10 +47,10 @@ struct WaitData
 static void yieldLuaStateFor(lua_State* L, uint64_t milliseconds, bool putDeltaTimeOnStack, int nargs)
 {
     WaitData* yield = new WaitData();
-    uv_timer_init(uv_default_loop(), &yield->uvTimer);
+    uv_timer_init(getRuntimeLoop(L), &yield->uvTimer);
 
     yield->resumptionToken = getResumeToken(L);
-    yield->startedAtMs = uv_now(uv_default_loop());
+    yield->startedAtMs = uv_now(getRuntimeLoop(L));
     yield->uvTimer.data = yield;
     yield->putDeltaTimeOnStack = putDeltaTimeOnStack;
     yield->nargs = nargs;
@@ -67,12 +67,16 @@ static void yieldLuaStateFor(lua_State* L, uint64_t milliseconds, bool putDeltaT
                     int stackReturnAmount = yield->putDeltaTimeOnStack ? yield->nargs + 1 : yield->nargs;
 
                     if (yield->putDeltaTimeOnStack)
-                        lua_pushnumber(L, static_cast<double>(uv_now(uv_default_loop()) - yield->startedAtMs) / 1000.0);
+                        lua_pushnumber(L, static_cast<double>(uv_now(getRuntimeLoop(L)) - yield->startedAtMs) / 1000.0);
 
-                    uv_close(reinterpret_cast<uv_handle_t*>(&yield->uvTimer), [](uv_handle_t* handle) { 
-                        WaitData* yield = static_cast<WaitData*>(handle->data);
-                        delete yield; 
-                    });
+                    uv_close(
+                        reinterpret_cast<uv_handle_t*>(&yield->uvTimer),
+                        [](uv_handle_t* handle)
+                        {
+                            WaitData* yield = static_cast<WaitData*>(handle->data);
+                            delete yield;
+                        }
+                    );
                     return stackReturnAmount;
                 }
             );


### PR DESCRIPTION
We need to support parallelism in Lute, and to do that each spawned runtime must have it's own event loop. This is because the uv_loop_t is not safe to share between threads.