### PR TITLE
Fixes std/path metatable type errors

### DIFF
--- a/lute/std/libs/path/pathinterface.luau
+++ b/lute/std/libs/path/pathinterface.luau
@@ -1,5 +1,5 @@
 export type pathinterface = {
-	__tostring: () -> string,
+	__tostring: (self: pathinterface) -> string,
 }
 
 return table.freeze({})

--- a/lute/std/libs/path/pathinterface.luau
+++ b/lute/std/libs/path/pathinterface.luau
@@ -1,5 +1,5 @@
 export type pathinterface = {
-	__tostring: (self: pathinterface) -> string,
+	__tostring: () -> string,
 }
 
 return table.freeze({})

--- a/lute/std/libs/path/posix/init.luau
+++ b/lute/std/libs/path/posix/init.luau
@@ -1,11 +1,12 @@
 local process = require("@lute/process")
 local posixtypes = require("@self/types")
+local pathinterface = require("./pathinterface")
 
 export type path = posixtypes.path
 export type pathlike = posixtypes.pathlike
 
 local posix = {}
-posix.pathmt = {} :: posixtypes.pathMT
+posix.pathmt = {} :: pathinterface.pathinterface
 
 function posix.basename(path: pathlike): string?
 	path = if typeof(path) == "string" then posix.parse(path) else path

--- a/lute/std/libs/path/win32/init.luau
+++ b/lute/std/libs/path/win32/init.luau
@@ -1,12 +1,13 @@
 local process = require("@lute/process")
 local win32types = require("@self/types")
+local pathinterface = require("./pathinterface")
 
 export type pathkind = win32types.pathkind
 export type path = win32types.path
 export type pathlike = win32types.pathlike
 
 local win32 = {}
-win32.pathmt = {} :: win32types.pathMT
+win32.pathmt = {} :: pathinterface.pathinterface
 
 function win32.basename(path: pathlike): string?
 	path = if typeof(path) == "string" then win32.parse(path) else path

--- a/tools/check-faillist.txt
+++ b/tools/check-faillist.txt
@@ -64,11 +64,11 @@ examples/task-delay.luau:3:15-37
 examples/task-resume.luau:12:7-7
 examples/transformee.luau:3:7-7
 examples/transformer.luau:33:38-100
-lute/cli/commands/doc/init.luau:210:2-11
-lute/cli/commands/doc/init.luau:211:10-24
-lute/cli/commands/doc/init.luau:321:5-16
-lute/cli/commands/doc/init.luau:326:5-16
-lute/cli/commands/doc/init.luau:332:10-24
+lute/cli/commands/doc/init.luau:203:2-11
+lute/cli/commands/doc/init.luau:204:10-24
+lute/cli/commands/doc/init.luau:310:5-16
+lute/cli/commands/doc/init.luau:315:5-16
+lute/cli/commands/doc/init.luau:321:10-24
 lute/cli/commands/lib/cli.luau:50:2-13
 lute/cli/commands/lib/cli.luau:50:2-13
 lute/cli/commands/lib/cli.luau:52:3-14

--- a/tools/check-faillist.txt
+++ b/tools/check-faillist.txt
@@ -64,11 +64,11 @@ examples/task-delay.luau:3:15-37
 examples/task-resume.luau:12:7-7
 examples/transformee.luau:3:7-7
 examples/transformer.luau:33:38-100
-lute/cli/commands/doc/init.luau:203:2-11
-lute/cli/commands/doc/init.luau:204:10-24
-lute/cli/commands/doc/init.luau:310:5-16
-lute/cli/commands/doc/init.luau:315:5-16
-lute/cli/commands/doc/init.luau:321:10-24
+lute/cli/commands/doc/init.luau:210:2-11
+lute/cli/commands/doc/init.luau:211:10-24
+lute/cli/commands/doc/init.luau:321:5-16
+lute/cli/commands/doc/init.luau:326:5-16
+lute/cli/commands/doc/init.luau:332:10-24
 lute/cli/commands/lib/cli.luau:50:2-13
 lute/cli/commands/lib/cli.luau:50:2-13
 lute/cli/commands/lib/cli.luau:52:3-14
@@ -127,10 +127,6 @@ lute/std/libs/fs.luau:184:52-68
 lute/std/libs/fs.luau:184:52-68
 lute/std/libs/fs.luau:192:11-17
 lute/std/libs/fs.luau:192:11-17
-lute/std/libs/path/posix/init.luau:8:22-38
-lute/std/libs/path/posix/init.luau:8:22-38
-lute/std/libs/path/win32/init.luau:9:22-38
-lute/std/libs/path/win32/init.luau:9:22-38
 lute/std/libs/syntax/printer.luau:41:23-27
 lute/std/libs/syntax/printer.luau:41:23-27
 lute/std/libs/syntax/printer.luau:42:25-29


### PR DESCRIPTION
Fixes a type error in path lib's `posix` and `win32` files (came up when I was trying to serialize the type of these modules), thx for helping fix @skanosue !