### PR TITLE
Adds handling cyclic type references in `TypeSerializer` + tests

### DIFF
--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -1,5 +1,6 @@
 #include "lute/type.h"
 
+#include "Luau/ToString.h"
 #include "Luau/Type.h"
 #include "Luau/TypeFwd.h"
 #include "Luau/VisitType.h"
@@ -20,11 +21,63 @@ static void checkStack(lua_State* L, int n)
 struct TypeSerialize final : public Luau::TypeVisitor
 {
     lua_State* L;
+    int refsTableIndex; // Reference table for handling cyclic & shared type references. Maps TypeId/TypePackId (as lightuserdata) to the corresponding serialized table on the stack.
 
     explicit TypeSerialize(lua_State* L)
         : Luau::TypeVisitor{"TypeSerialize", /*skipBoundTypes=*/false}
         , L(L)
     {
+        // Create the refs table and store a reference to it. This table will be used to track already serialized types to handle cycles and shared references.
+        lua_createtable(L, 0, 0);
+        refsTableIndex = lua_gettop(L);
+    }
+
+    ~TypeSerialize()
+    {
+        // Pop the refs table from the stack when the serializer is destroyed
+        if (refsTableIndex > 0 && lua_gettop(L) >= refsTableIndex)
+            lua_remove(L, refsTableIndex);
+    }
+
+    void cycle(TypeId ty) override
+    {
+        lua_pushlightuserdata(L, (void*)ty);
+        lua_gettable(L, refsTableIndex);
+
+        if (lua_isnil(L, -1))
+        {
+            luaL_error(L, "TypeSerialize: cycle detected while serializing type, but TypeId %s was not found in refs table", Luau::toString(ty).data());
+        }
+    }
+
+    void cycle(TypePackId tp) override
+    {
+        lua_pushlightuserdata(L, (void*)tp);
+        lua_gettable(L, refsTableIndex);
+
+        if (lua_isnil(L, -1))
+        {
+            luaL_error(L, "TypeSerialize: cycle detected while serializing type pack, but TypePackId %s was not found in refs table", Luau::toString(tp).data());
+        }
+    }
+
+    // Register this type's serialized table in the refs table, using the TypeId as the key.
+    // Called after creating the serialized table for a type, but before traversing any child types.
+    void registerType(TypeId ty)
+    {
+        checkStack(L, 3);
+        lua_pushlightuserdata(L, (void*)ty); // TypeId pointer as key
+        lua_pushvalue(L, -2); // Copy of the serialized type table as value
+        lua_rawset(L, refsTableIndex); // refs[ty] = serializedTable
+    }
+
+    // Similar to registerType but for TypePackId
+    void registerTypePack(TypePackId tp)
+    {
+        checkStack(L, 3);
+        lua_pushlightuserdata(L, (void*)tp);
+        lua_pushvalue(L, -2);
+        lua_rawset(L, refsTableIndex);
     }
 
     // Helper to push the "tag" field that every Luau type has
@@ -77,6 +130,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2); // 1 for table + 1 for space to push/set remaining fields
         lua_createtable(L, 0, 1);
+        registerType(ty);
 
         const char* tag = nullptr;
         switch (ptv.type)
@@ -110,6 +164,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 1);
+        registerType(ty);
 
         pushTag("any");
     }
@@ -118,6 +173,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 1);
+        registerType(ty);
 
         pushTag("unknown");
     }
@@ -126,6 +182,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 1);
+        registerType(ty);
 
         pushTag("never");
     }
@@ -136,6 +193,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 2);
+        registerType(ty);
 
         pushTag("singleton");
 
@@ -154,6 +212,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 2);
+        registerType(ty);
 
         pushTag("negation");
 
@@ -167,6 +226,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 3); // 1 for table + 1 for components table + 1 for traverse
         lua_createtable(L, 0, 2);
+        registerType(ty);
 
         pushTag("union");
 
@@ -185,6 +245,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 3); // 1 for table + 1 for components table + 1 for traverse
         lua_createtable(L, 0, 2);
+        registerType(ty);
 
         pushTag("intersection");
 
@@ -204,6 +265,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 3);
+        registerType(ty);
 
         pushTag("generic");
 
@@ -226,6 +288,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 3); // max 1 for table + 1 for subtable + 1 for traverse
         lua_createtable(L, 0, 5);
+        registerType(ty);
 
         pushTag("function");
 
@@ -265,6 +328,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 3);
+        registerType(ty);
 
         pushTag("table");
 
@@ -284,6 +348,8 @@ struct TypeSerialize final : public Luau::TypeVisitor
         {
             lua_createtable(L, 0, 3);
             traverse(ttv.indexer->indexType);
+            lua_setfield(L, -2, "index");
+
             lua_setfield(L, -2, "indexer");
 
             // TODO: implement readindexer and writeindexer from ttv.indexer->indexResultType
@@ -302,6 +368,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 3);
+        registerType(ty);
 
         pushTag("metatable");
 
@@ -319,6 +386,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 4);
+        registerType(ty);
 
         pushTag("extern");
 
@@ -353,6 +421,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 3); // 1 for root table + 1 for subtable + 1 for traverse
         lua_createtable(L, 0, 2);
+        registerTypePack(tp);
 
         // Head
         if (!pack.head.empty())
@@ -383,6 +452,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 2);
+        registerTypePack(tp);
 
         // Head is nil
         lua_pushnil(L);
@@ -400,6 +470,8 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 3);
+        registerTypePack(tp);
+
         pushTag("generic");
 
         if (!gtp.name.empty())

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -37,6 +37,8 @@ struct TypeSerialize final : public Luau::TypeVisitor
         // Pop the refs table from the stack when the serializer is destroyed
         if (refsTableIndex > 0 && lua_gettop(L) >= refsTableIndex)
             lua_remove(L, refsTableIndex);
+        else
+            luaL_error(L, "TypeSerialize: reference table index corrupted during serialization");
     }
 
     void cycle(TypeId ty) override

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -43,6 +43,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     void cycle(TypeId ty) override
     {
+        checkStack(L, 1);
         lua_pushlightuserdata(L, (void*)ty);
         lua_gettable(L, refsTableIndex);
 
@@ -54,6 +55,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     void cycle(TypePackId tp) override
     {
+        checkStack(L, 1);
         lua_pushlightuserdata(L, (void*)tp);
         lua_gettable(L, refsTableIndex);
 

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -69,7 +69,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         checkStack(L, 3);
         lua_pushlightuserdata(L, (void*)ty); // TypeId pointer as key
-        lua_pushvalue(L, -2); // Copy of the serialized type table as value
+        lua_pushvalue(L, -2); // Reference to the serialized type table as value
         lua_rawset(L, refsTableIndex); // refs[ty] = serializedTable
     }
 

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -34,6 +34,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_nil_type")
     // We need to first ensure we have enough stack space to serialize.
     // The stack size corresponds to the max depth needed (see lute/type.cpp).
     lua_checkstack(L, 2);
+
+    // { tag: "nil" }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -45,6 +47,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_boolean_type")
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Boolean});
 
     lua_checkstack(L, 2);
+
+    // { tag: "boolean" }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -56,6 +60,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_number_type")
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Number});
 
     lua_checkstack(L, 2);
+
+    // { tag: "number" }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -67,6 +73,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_string_type")
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::String});
 
     lua_checkstack(L, 2);
+
+    // { tag: "string" }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -78,6 +86,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_thread_type")
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Thread});
 
     lua_checkstack(L, 2);
+
+    // { tag: "thread" }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -89,6 +99,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_primitive_buffer_type")
     TypeId ty = arena.addType(PrimitiveType{PrimitiveType::Buffer});
 
     lua_checkstack(L, 2);
+
+    // { tag: "buffer" }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -100,6 +112,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_any_type")
     TypeId ty = arena.addType(AnyType{});
 
     lua_checkstack(L, 2);
+
+    // { tag: "any" }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -111,6 +125,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_unknown_type")
     TypeId ty = arena.addType(UnknownType{});
 
     lua_checkstack(L, 2);
+
+    // { tag: "unknown" }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -122,6 +138,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_never_type")
     TypeId ty = arena.addType(NeverType{});
 
     lua_checkstack(L, 2);
+
+    // { tag: "never" }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -135,6 +153,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_string_singleton")
     TypeId ty = arena.addType(SingletonType{StringSingleton{"hello"}});
 
     lua_checkstack(L, 2);
+
+    // { tag: "singleton", value: "hello" }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -147,6 +167,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_boolean_singleton")
     TypeId ty = arena.addType(SingletonType{BooleanSingleton{true}});
 
     lua_checkstack(L, 2);
+
+    // { tag: "singleton", value: true }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -159,6 +181,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_negation_type")
     TypeId ty = arena.addType(NegationType{arena.addType(PrimitiveType{PrimitiveType::Number})});
 
     lua_checkstack(L, 2);
+
+    // { tag: "negation", inner: { tag: "number" } }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -177,6 +201,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_union_type")
     TypeId unionTy = arena.addType(UnionType{{numberTy, stringTy}});
 
     lua_checkstack(L, 3);
+
+    // { tag: "union", components: { { tag: "number" }, { tag: "string" } } }
     REQUIRE_EQ(Luau::serializeType(L, unionTy), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -201,6 +227,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_intersection_type")
     TypeId intersectionTy = arena.addType(IntersectionType{{numberTy, stringTy}});
 
     lua_checkstack(L, 3); // Ensure enough stack for serialization. This would be size 3 
+
+    // { tag: "intersection", components: { { tag: "number" }, { tag: "string" } } }
     REQUIRE_EQ(Luau::serializeType(L, intersectionTy), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -225,6 +253,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type")
     TypeId ty = arena.addType(gtp);
 
     lua_checkstack(L, 2);
+
+    // { tag: "generic", name: "T", ispack: false }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -247,6 +277,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_function_type")
     TypeId ty = arena.addType(ftv);
 
     lua_checkstack(L, 3);
+
+    // { tag: "function", parameters: { head: { { tag: "number" } }, tail: nil }, returns: { head: nil, tail: nil }, generics: { { tag: "generic", name: "T", ispack: false } }, genericpacks: {} }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -292,6 +324,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_table_type_with_properties")
     TypeId ty = arena.addType(ttv);
 
     lua_checkstack(L, 3);
+
+    // { tag: "table", properties: { x: { read: { tag: "number" }, write: { tag: "string" } } } }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -326,6 +360,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_table_type_with_nil_property"
     TypeId ty = arena.addType(ttv);
 
     lua_checkstack(L, 3);
+
+    // { tag: "table", properties: { x: { read: { tag: "number" }, write: nil } } }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -360,6 +396,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_cyclic_table_type")
     table->props["next"] = Property::readonly(nodeType);
 
     lua_checkstack(L, 3);
+
+    // { tag: "table", properties: { value: { read: { tag: "number" } }, next: { read: <cycle> } } }
     REQUIRE_EQ(Luau::serializeType(L, nodeType), 1);
     
     REQUIRE(lua_istable(L, -1));
@@ -390,6 +428,65 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_cyclic_table_type")
     REQUIRE(lua_istable(L, -1));
     
     // Verify it has both 'value' and 'next' properties (proving it's the same cycle)
+    lua_getfield(L, -1, "value");
+    REQUIRE(lua_istable(L, -1));
+    lua_pop(L, 1);
+    
+    lua_getfield(L, -1, "next");
+    REQUIRE(lua_istable(L, -1));
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_cyclic_table_deep_reference")
+{
+    // Create a cyclic type: type Node = { value: number, next: Node }
+    TypeId nodeType = arena.addType(TableType{});
+    TableType* table = getMutable<TableType>(nodeType);
+    
+    // Add the 'value' property
+    TypeId numberType = arena.addType(PrimitiveType{PrimitiveType::Number});
+    table->props["value"] = Property::readonly(numberType);
+    
+    // Add the 'next' property that references itself (creating the cycle)
+    table->props["next"] = Property::readonly(nodeType);
+
+    lua_checkstack(L, 3);
+
+    REQUIRE_EQ(Luau::serializeType(L, nodeType), 1);
+    
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "table");
+    
+    // Node.next.read
+    lua_getfield(L, -1, "properties");
+    REQUIRE(lua_istable(L, -1));
+    lua_getfield(L, -1, "next");
+    REQUIRE(lua_istable(L, -1));
+    lua_getfield(L, -1, "read");
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "table");
+    
+    // Node.next.next.read (should be same table)
+    lua_getfield(L, -1, "properties");
+    REQUIRE(lua_istable(L, -1));
+    lua_getfield(L, -1, "next");
+    REQUIRE(lua_istable(L, -1));
+    lua_getfield(L, -1, "read");
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "table");
+    
+    // Node.next.next.next.read (should still be same table)
+    lua_getfield(L, -1, "properties");
+    REQUIRE(lua_istable(L, -1));
+    lua_getfield(L, -1, "next");
+    REQUIRE(lua_istable(L, -1));
+    lua_getfield(L, -1, "read");
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "table");
+    
+    // Verify it still has both properties (proving the cycle is maintained)
+    lua_getfield(L, -1, "properties");
+    REQUIRE(lua_istable(L, -1));
+    
     lua_getfield(L, -1, "value");
     REQUIRE(lua_istable(L, -1));
     lua_pop(L, 1);

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -434,7 +434,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_cyclic_table_type")
     lua_getfield(L, -1, "read");
     REQUIRE(lua_istable(L, -1));
     
-    REQUIRE(lua_rawequal(L, root, -1)); // The 'next' property's read type should be the same table as the root (cycle)
+    REQUIRE(lua_equal(L, root, -1)); // The 'next' property's read type should be the same table as the root (cycle)
 }
 
 // TODO: MetatableType, ExternType, TypePack, VariadicTypePack, GenericTypePack tests

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -278,6 +278,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_function_type")
 
     lua_checkstack(L, 3);
 
+    // <T>(number) -> ()
     // { tag: "function", parameters: { head: { { tag: "number" } }, tail: nil }, returns: { head: nil, tail: nil }, generics: { { tag: "generic", name: "T", ispack: false } }, genericpacks: {} }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
@@ -286,23 +287,32 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_function_type")
 
     lua_getfield(L, -1, "parameters");
     REQUIRE(lua_istable(L, -1));
+
     lua_getfield(L, -1, "head");
     REQUIRE(lua_istable(L, -1));
     lua_rawgeti(L, -1, 1);
     requireStringField(L, "tag", "number");
-    lua_pop(L, 3); // head, parameters, function
+    lua_pop(L, 2); // head[0], head
+
+    lua_getfield(L, -1, "tail");
+    REQUIRE(lua_isnil(L, -1));
+    lua_pop(L, 2); // tail, parameters
 
     lua_getfield(L, -1, "returns");
     REQUIRE(lua_istable(L, -1));
     lua_getfield(L, -1, "head");
     REQUIRE(lua_isnil(L, -1)); // no return types
-    lua_pop(L, 2); // returns, function
+    lua_pop(L, 1); // head
+    lua_getfield(L, -1, "tail");
+    REQUIRE(lua_isnil(L, -1)); // no return types
+    lua_pop(L, 2); // tail, returns
 
     lua_getfield(L, -1, "generics");
     REQUIRE(lua_istable(L, -1));
     lua_rawgeti(L, -1, 1);
     requireStringField(L, "tag", "generic");
     requireStringField(L, "name", "T");
+    requireBoolField(L, "ispack", false);
     lua_pop(L, 2); // generics, function
 
     lua_getfield(L, -1, "genericpacks");
@@ -325,6 +335,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_table_type_with_properties")
 
     lua_checkstack(L, 3);
 
+    // { read x: number, write x: string }
     // { tag: "table", properties: { x: { read: { tag: "number" }, write: { tag: "string" } } } }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
@@ -401,6 +412,8 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_cyclic_table_type")
     REQUIRE_EQ(Luau::serializeType(L, nodeType), 1);
     
     REQUIRE(lua_istable(L, -1));
+    int root = lua_absindex(L, -1);
+
     requireStringField(L, "tag", "table");
     
     // Check properties field exists
@@ -421,78 +434,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_cyclic_table_type")
     lua_getfield(L, -1, "read");
     REQUIRE(lua_istable(L, -1));
     
-    // The 'read' type of 'next' should be the same table as the root
-    // We verify by checking that it has the same properties
-    requireStringField(L, "tag", "table");
-    lua_getfield(L, -1, "properties");
-    REQUIRE(lua_istable(L, -1));
-    
-    // Verify it has both 'value' and 'next' properties (proving it's the same cycle)
-    lua_getfield(L, -1, "value");
-    REQUIRE(lua_istable(L, -1));
-    lua_pop(L, 1);
-    
-    lua_getfield(L, -1, "next");
-    REQUIRE(lua_istable(L, -1));
-}
-
-TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_cyclic_table_deep_reference")
-{
-    // Create a cyclic type: type Node = { value: number, next: Node }
-    TypeId nodeType = arena.addType(TableType{});
-    TableType* table = getMutable<TableType>(nodeType);
-    
-    // Add the 'value' property
-    TypeId numberType = arena.addType(PrimitiveType{PrimitiveType::Number});
-    table->props["value"] = Property::readonly(numberType);
-    
-    // Add the 'next' property that references itself (creating the cycle)
-    table->props["next"] = Property::readonly(nodeType);
-
-    lua_checkstack(L, 3);
-
-    REQUIRE_EQ(Luau::serializeType(L, nodeType), 1);
-    
-    REQUIRE(lua_istable(L, -1));
-    requireStringField(L, "tag", "table");
-    
-    // Node.next.read
-    lua_getfield(L, -1, "properties");
-    REQUIRE(lua_istable(L, -1));
-    lua_getfield(L, -1, "next");
-    REQUIRE(lua_istable(L, -1));
-    lua_getfield(L, -1, "read");
-    REQUIRE(lua_istable(L, -1));
-    requireStringField(L, "tag", "table");
-    
-    // Node.next.next.read (should be same table)
-    lua_getfield(L, -1, "properties");
-    REQUIRE(lua_istable(L, -1));
-    lua_getfield(L, -1, "next");
-    REQUIRE(lua_istable(L, -1));
-    lua_getfield(L, -1, "read");
-    REQUIRE(lua_istable(L, -1));
-    requireStringField(L, "tag", "table");
-    
-    // Node.next.next.next.read (should still be same table)
-    lua_getfield(L, -1, "properties");
-    REQUIRE(lua_istable(L, -1));
-    lua_getfield(L, -1, "next");
-    REQUIRE(lua_istable(L, -1));
-    lua_getfield(L, -1, "read");
-    REQUIRE(lua_istable(L, -1));
-    requireStringField(L, "tag", "table");
-    
-    // Verify it still has both properties (proving the cycle is maintained)
-    lua_getfield(L, -1, "properties");
-    REQUIRE(lua_istable(L, -1));
-    
-    lua_getfield(L, -1, "value");
-    REQUIRE(lua_istable(L, -1));
-    lua_pop(L, 1);
-    
-    lua_getfield(L, -1, "next");
-    REQUIRE(lua_istable(L, -1));
+    REQUIRE(lua_rawequal(L, root, -1)); // The 'next' property's read type should be the same table as the root (cycle)
 }
 
 // TODO: MetatableType, ExternType, TypePack, VariadicTypePack, GenericTypePack tests

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -233,7 +233,172 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type")
     requireBoolField(L, "ispack", false);
 }
 
-// TODO: FunctionType, TableType, MetatableType, ExternType, TypePack, VariadicTypePack, GenericTypePack tests
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_function_type")
+{
+    GenericType gtp;
+    gtp.name = "T";
+    TypeId genericTy = arena.addType(gtp);
+    TypeId numberTy = arena.addType(PrimitiveType{PrimitiveType::Number});
+
+    TypePackId argTypes = arena.addTypePack(TypePack{{numberTy}, std::nullopt});
+    TypePackId retTypes = arena.addTypePack(TypePack{{}, std::nullopt});
+
+    FunctionType ftv{{genericTy}, {}, argTypes, retTypes};
+    TypeId ty = arena.addType(ftv);
+
+    lua_checkstack(L, 3);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "function");
+
+    lua_getfield(L, -1, "parameters");
+    REQUIRE(lua_istable(L, -1));
+    lua_getfield(L, -1, "head");
+    REQUIRE(lua_istable(L, -1));
+    lua_rawgeti(L, -1, 1);
+    requireStringField(L, "tag", "number");
+    lua_pop(L, 3); // head, parameters, function
+
+    lua_getfield(L, -1, "returns");
+    REQUIRE(lua_istable(L, -1));
+    lua_getfield(L, -1, "head");
+    REQUIRE(lua_isnil(L, -1)); // no return types
+    lua_pop(L, 2); // returns, function
+
+    lua_getfield(L, -1, "generics");
+    REQUIRE(lua_istable(L, -1));
+    lua_rawgeti(L, -1, 1);
+    requireStringField(L, "tag", "generic");
+    requireStringField(L, "name", "T");
+    lua_pop(L, 2); // generics, function
+
+    lua_getfield(L, -1, "genericpacks");
+    REQUIRE(lua_istable(L, -1));
+    REQUIRE(lua_objlen(L, -1) == 0); // no generic packs
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_table_type_with_properties")
+{
+    TypeId numberTy = arena.addType(PrimitiveType{PrimitiveType::Number});
+    TypeId stringTy = arena.addType(PrimitiveType{PrimitiveType::String});
+
+    TableType ttv;
+    Property prop;
+    prop.readTy = numberTy;
+    prop.writeTy = stringTy;
+    ttv.props["x"] = prop;
+
+    TypeId ty = arena.addType(ttv);
+
+    lua_checkstack(L, 3);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "table");
+
+    lua_getfield(L, -1, "properties");
+    REQUIRE(lua_istable(L, -1));
+
+    lua_getfield(L, -1, "x");
+    REQUIRE(lua_istable(L, -1));
+
+    lua_getfield(L, -1, "read");
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "number");
+    lua_pop(L, 1); // read
+
+    lua_getfield(L, -1, "write");
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "string");
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_table_type_with_nil_property")
+{
+    TypeId numberTy = arena.addType(PrimitiveType{PrimitiveType::Number});
+
+    TableType ttv;
+    Property prop;
+    prop.readTy = numberTy;
+    prop.writeTy = std::nullopt; // write type is nil
+    ttv.props["x"] = prop;
+
+    TypeId ty = arena.addType(ttv);
+
+    lua_checkstack(L, 3);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "table");
+
+    lua_getfield(L, -1, "properties");
+    REQUIRE(lua_istable(L, -1));
+
+    lua_getfield(L, -1, "x");
+    REQUIRE(lua_istable(L, -1));
+
+    lua_getfield(L, -1, "read");
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "number");
+    lua_pop(L, 1); // read
+
+    lua_getfield(L, -1, "write");
+    REQUIRE(lua_isnil(L, -1)); // write type is nil
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_cyclic_table_type")
+{
+    // Create a cyclic type: type Node = { value: number, next: Node }
+    TypeId nodeType = arena.addType(TableType{});
+    TableType* table = getMutable<TableType>(nodeType);
+    
+    // Add the 'value' property
+    TypeId numberType = arena.addType(PrimitiveType{PrimitiveType::Number});
+    table->props["value"] = Property::readonly(numberType);
+    
+    // Add the 'next' property that references itself (creating the cycle)
+    table->props["next"] = Property::readonly(nodeType);
+
+    lua_checkstack(L, 3);
+    REQUIRE_EQ(Luau::serializeType(L, nodeType), 1);
+    
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "table");
+    
+    // Check properties field exists
+    lua_getfield(L, -1, "properties");
+    REQUIRE(lua_istable(L, -1));
+    
+    // Check 'value' property
+    lua_getfield(L, -1, "value");
+    REQUIRE(lua_istable(L, -1));
+    lua_getfield(L, -1, "read");
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "number");
+    lua_pop(L, 2); // pop read type and value property
+    
+    // Check 'next' property - this should be a cyclic reference
+    lua_getfield(L, -1, "next");
+    REQUIRE(lua_istable(L, -1));
+    lua_getfield(L, -1, "read");
+    REQUIRE(lua_istable(L, -1));
+    
+    // The 'read' type of 'next' should be the same table as the root
+    // We verify by checking that it has the same properties
+    requireStringField(L, "tag", "table");
+    lua_getfield(L, -1, "properties");
+    REQUIRE(lua_istable(L, -1));
+    
+    // Verify it has both 'value' and 'next' properties (proving it's the same cycle)
+    lua_getfield(L, -1, "value");
+    REQUIRE(lua_istable(L, -1));
+    lua_pop(L, 1);
+    
+    lua_getfield(L, -1, "next");
+    REQUIRE(lua_istable(L, -1));
+}
+
+// TODO: MetatableType, ExternType, TypePack, VariadicTypePack, GenericTypePack tests
 
 // Non-Serialized Types
 


### PR DESCRIPTION
More follow up on `TypeSerializer` improvements. This PR creates a reference table in `TypeSerializer` to handle cyclic & shared type references, since Luau types can contain cycles (e.g., `type Node = { value: number, next: Node }` )

When we're serializing the types to luau tables, we need to detect and handle these cycles to avoid infinite recursion or missing serializations. To do this, I think we can maintain a mapping of each `TypeId`/`TypePackId` to its serialized table. So when we encounter a type we've already serialized, detected by the `cycle` functions provided by the `Luau::TypeVisitor`, we retrieve and reuse the existing table instead of creating a new one, preserving the cyclic structure in the serialization.

Also adds test case for this cycle, as well as `FunctionType`, and `TableType` tests