### PR TITLE
Try to fix `ubuntu-22.04-arm` release by bootstrapping builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
           - os: ubuntu-22.04-arm
             artifact_name: lute-linux-aarch64
             options: --c-compiler clang --cxx-compiler clang++
+            use-bootstrap: true
           - os: macos-latest
             artifact_name: lute-macos-aarch64
           - os: windows-latest
@@ -114,6 +115,7 @@ jobs:
           config: release
           options: ${{ matrix.options }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          use-bootstrap: ${{ matrix.use-bootstrap || 'false' }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Resolves https://github.com/luau-lang/lute/issues/790.

In a fresh Docker container with GCC-11 (installed with `build-essentials`), we cannot run any release binaries going back several months. We believe that GitHub was silently supporting GCC-13 (more relevant: `GLIBCXX_3.4.31` and `GLIBCXX_3.4.32`) until a few days ago.

They seem to have removed support recently, so our `ubuntu-22.04-arm` runner can't run binaries that we released in the past. To fix this, we'll bootstrap this build.