### PR TITLE
Remove `lute helloworld`

### DIFF
--- a/lute/cli/commands/helloworld/helloworld.luau
+++ b/lute/cli/commands/helloworld/helloworld.luau
@@ -1,1 +1,0 @@
-return { "Hello, world!" }

--- a/lute/cli/commands/helloworld/init.luau
+++ b/lute/cli/commands/helloworld/init.luau
@@ -1,2 +1,0 @@
-local result = require("@self/helloworld")
-print(result[1])


### PR DESCRIPTION
This was added back in the early days of Lute, when I first implemented the `CliVfs` and we had no other examples of embedded CLI commands: https://github.com/luau-lang/lute/pull/314.

We have no need for `lute helloworld` anymore and can clean this up.