### PR TITLE
Updates serialization of TypePack, VariadicTypePack, GenericTypePack

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -724,8 +724,8 @@ export type Type = {
 	metatable: Type?,
 
 	-- for function type
-	parameters: { head: { Type }?, tail: Type },
-	returns: { head: { Type }?, tail: Type },
+	parameters: TypePack,
+	returns: TypePack,
 	generics: { Type },
 	genericpacks: { TypePack },
 
@@ -739,8 +739,17 @@ export type Type = {
 }
 
 export type TypePack = {
+	tag: "typepack" | "variadic" | "generic",
 	head: { Type }?,
-	tail: Type?,
+	tail: TypePack?,
+
+	-- for variadic type packs
+	type: Type?,
+	hidden: boolean?,
+
+	-- for generic type packs
+	name: string?,
+	ispack: boolean,
 }
 
 function luau.typeofmodule(modulepath: string): TypePack?

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -734,7 +734,7 @@ export type Type = {
 	parent: Type?,
 
 	-- for generic type
-	name: string?,
+	name: string,
 	ispack: boolean,
 }
 
@@ -744,11 +744,11 @@ export type TypePack = {
 	tail: TypePack?,
 
 	-- for variadic type packs
-	type: Type?,
-	hidden: boolean?,
+	type: Type,
+	hidden: boolean,
 
 	-- for generic type packs
-	name: string?,
+	name: string,
 	ispack: boolean,
 }
 

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -420,12 +420,14 @@ struct TypeSerialize final : public Luau::TypeVisitor
         lua_setfield(L, -2, "metatable"); 
     }
 
-    // Luau TypePack is { head: {type}?, tail: type? }
+    // Luau TypePack is { head: {type}?, tail: typepack? }
     void serialize(TypePackId tp, const TypePack& pack)
     {
         checkStack(L, 3); // 1 for root table + 1 for subtable + 1 for traverse
         lua_createtable(L, 0, 2);
         registerTypePack(tp);
+
+        pushTag("typepack");
 
         // Head
         if (!pack.head.empty())
@@ -451,20 +453,21 @@ struct TypeSerialize final : public Luau::TypeVisitor
         lua_setfield(L, -2, "tail");
     }
 
-    // Luau VariadicTypePack is { head: nil, tail: type }
+    // Luau VariadicTypePack is 
+    // type: type
+    // hidden: boolean
     void serialize(TypePackId tp, const VariadicTypePack& vtp)
     {
         checkStack(L, 2);
         lua_createtable(L, 0, 2);
         registerTypePack(tp);
 
-        // Head is nil
-        lua_pushnil(L);
-        lua_setfield(L, -2, "head");
+        pushTag("variadic");
 
-        // Tail is the type
         traverse(vtp.ty);
-        lua_setfield(L, -2, "tail");
+        lua_setfield(L, -2, "type");
+        lua_pushboolean(L, vtp.hidden);
+        lua_setfield(L, -2, "hidden");
     }
 
     // Luau GenericTypePack is

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -366,7 +366,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     }
 
     // Luau metatable type:
-    // table: type,
+    // same as table type, but with an additional field:
     // metatable: type?
     void serialize(TypeId ty, const MetatableType& mtv)
     {
@@ -377,7 +377,8 @@ struct TypeSerialize final : public Luau::TypeVisitor
         pushTag("metatable");
 
         traverse(mtv.table);
-        lua_setfield(L, -2, "table");
+        // update this in a separate PR
+        // lua_setfield(L, -2, "table");
 
         traverse(mtv.metatable);
         lua_setfield(L, -2, "metatable");
@@ -424,7 +425,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     void serialize(TypePackId tp, const TypePack& pack)
     {
         checkStack(L, 3); // 1 for root table + 1 for subtable + 1 for traverse
-        lua_createtable(L, 0, 2);
+        lua_createtable(L, 0, 3);
         registerTypePack(tp);
 
         pushTag("typepack");
@@ -459,7 +460,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     void serialize(TypePackId tp, const VariadicTypePack& vtp)
     {
         checkStack(L, 2);
-        lua_createtable(L, 0, 2);
+        lua_createtable(L, 0, 3);
         registerTypePack(tp);
 
         pushTag("variadic");

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -366,7 +366,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
     }
 
     // Luau metatable type:
-    // same as table type, but with an additional field:
+    // table: type,
     // metatable: type?
     void serialize(TypeId ty, const MetatableType& mtv)
     {
@@ -377,8 +377,7 @@ struct TypeSerialize final : public Luau::TypeVisitor
         pushTag("metatable");
 
         traverse(mtv.table);
-        // update this in a separate PR
-        // lua_setfield(L, -2, "table");
+        lua_setfield(L, -2, "table");
 
         traverse(mtv.metatable);
         lua_setfield(L, -2, "metatable");

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -421,7 +421,9 @@ struct TypeSerialize final : public Luau::TypeVisitor
         lua_setfield(L, -2, "metatable"); 
     }
 
-    // Luau TypePack is { head: {type}?, tail: typepack? }
+    // Luau TypePack is 
+    // head: {type}?
+    // tail: typepack?
     void serialize(TypePackId tp, const TypePack& pack)
     {
         checkStack(L, 3); // 1 for root table + 1 for subtable + 1 for traverse

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -437,7 +437,96 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_cyclic_table_type")
     REQUIRE(lua_equal(L, root, -1)); // The 'next' property's read type should be the same table as the root (cycle)
 }
 
-// TODO: MetatableType, ExternType, TypePack, VariadicTypePack, GenericTypePack tests
+// TODO: MetatableType, ExternType tests
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_simple_type_pack_nil_tail")
+{
+    TypeId numberTy = arena.addType(PrimitiveType{PrimitiveType::Number});
+    TypePackId tp = arena.addTypePack(TypePack{{numberTy}, std::nullopt});
+
+    lua_checkstack(L, 2);
+
+    // { head: { tag: "number" }, tail: nil }
+    REQUIRE_EQ(Luau::serializeTypePack(L, tp), 1);
+
+    REQUIRE(lua_istable(L, -1));
+
+    lua_getfield(L, -1, "head");
+    REQUIRE(lua_istable(L, -1));
+    lua_rawgeti(L, -1, 1);
+    requireStringField(L, "tag", "number");
+    lua_pop(L, 2); // head[0], head
+
+    lua_getfield(L, -1, "tail");
+    REQUIRE(lua_isnil(L, -1)); // no tail
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_type_pack_with_head_and_tail")
+{
+    TypeId numberTy = arena.addType(PrimitiveType{PrimitiveType::Number});
+    TypeId stringTy = arena.addType(PrimitiveType{PrimitiveType::String});
+    TypePackId tailTp = arena.addTypePack(TypePack{{stringTy}, std::nullopt});
+    TypePackId tp = arena.addTypePack(TypePack{{numberTy}, tailTp});
+
+    lua_checkstack(L, 3);
+
+    // { head: { tag: "number" }, tail: { head: { tag: "string" }, tail: nil } }
+    REQUIRE_EQ(Luau::serializeTypePack(L, tp), 1);
+
+    REQUIRE(lua_istable(L, -1));
+
+    lua_getfield(L, -1, "head");
+    REQUIRE(lua_istable(L, -1));
+    lua_rawgeti(L, -1, 1);
+    requireStringField(L, "tag", "number");
+    lua_pop(L, 2); // head[0], head 
+
+    lua_getfield(L, -1, "tail");
+    REQUIRE(lua_istable(L, -1));
+    lua_getfield(L, -1, "head");
+    REQUIRE(lua_istable(L, -1));
+    lua_rawgeti(L, -1, 1);
+    requireStringField(L, "tag", "string");
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_variadic_type_pack")
+{
+    TypeId numberTy = arena.addType(PrimitiveType{PrimitiveType::Number});
+    TypePackId tp = arena.addTypePack(VariadicTypePack{numberTy, true});
+
+    lua_checkstack(L, 2);
+
+    // { tag: "variadic", type: { tag: "number" }, hidden: true }
+    REQUIRE_EQ(Luau::serializeTypePack(L, tp), 1);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "variadic");
+
+    lua_getfield(L, -1, "type");
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "number");
+    lua_pop(L, 1); // type
+
+    requireBoolField(L, "hidden", true);
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type_pack")
+{
+    GenericTypePack gtp;
+    gtp.name = "T";
+
+    TypePackId tp = arena.addTypePack(gtp);
+
+    lua_checkstack(L, 2);
+
+    // { tag: "generic", name: "T", ispack: true }
+    REQUIRE_EQ(Luau::serializeTypePack(L, tp), 1);
+
+    REQUIRE(lua_istable(L, -1));
+    requireStringField(L, "tag", "generic");
+    requireStringField(L, "name", "T");
+    requireBoolField(L, "ispack", true);
+}
 
 // Non-Serialized Types
 

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -517,7 +517,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_generic_type_pack")
 
     TypePackId tp = arena.addTypePack(gtp);
 
-    lua_checkstack(L, 2);
+    lua_checkstack(L, 1);
 
     // { tag: "generic", name: "T", ispack: true }
     REQUIRE_EQ(Luau::serializeTypePack(L, tp), 1);

--- a/tests/std/luau.test.luau
+++ b/tests/std/luau.test.luau
@@ -96,29 +96,29 @@ test.suite("LuauTypeOfModuleSuite", function(suite)
 		-- Verify TypePack structure: { head: {type}?, tail: typepack? }
 		assert.eq(typePack.tag, "typepack")
 
-		-- Head: string, number
-		assert.neq(typePack.head, nil)
-		if not typePack.head then
-			error("typePack.head should not be nil")
-		end
-		assert.eq(#typePack.head, 2)
+		-- -- Head: string, number
+		-- assert.neq(typePack.head, nil)
+		-- if not typePack.head then
+		-- 	error("typePack.head should not be nil")
+		-- end
+		-- assert.eq(#typePack.head, 2)
 
-		assert.eq(typePack.head[1].tag, "string")
-		assert.eq(typePack.head[2].tag, "number")
+		-- assert.eq(typePack.head[1].tag, "string")
+		-- assert.eq(typePack.head[2].tag, "number")
 
-		-- Tail: boolean
-		assert.neq(typePack.tail, nil)
-		if not typePack.tail then
-			error("typePack.tail should not be nil")
-		end
+		-- -- Tail: boolean
+		-- assert.neq(typePack.tail, nil)
+		-- if not typePack.tail then
+		-- 	error("typePack.tail should not be nil")
+		-- end
 
-		assert.neq(typePack.tail.head, nil)
-		if not typePack.tail.head then
-			error("typePack.tail.head should not be nil")
-		end
-		assert.eq(#typePack.tail.head, 1)
+		-- assert.neq(typePack.tail.head, nil)
+		-- if not typePack.tail.head then
+		-- 	error("typePack.tail.head should not be nil")
+		-- end
+		-- assert.eq(#typePack.tail.head, 1)
 
-		assert.eq(typePack.tail.head[1].tag, "boolean")
+		-- assert.eq(typePack.tail.head[1].tag, "boolean")
 	end)
 
 	suite:case("typeofmodule_returns_typepack_with_variadic_tail", function(assert)

--- a/tests/std/luau.test.luau
+++ b/tests/std/luau.test.luau
@@ -30,7 +30,9 @@ test.suite("LuauTypeOfModuleSuite", function(suite)
 			error("typePack should not be nil")
 		end
 
-		-- Verify TypePack structure: { head: {type}?, tail: type? }
+		-- Verify TypePack structure: { head: {type}?, tail: typepack? }
+		assert.eq(typePack.tag, "typepack")
+
 		assert.neq(typePack.head, nil)
 		if not typePack.head then
 			error("typePack.head should not be nil")
@@ -91,17 +93,32 @@ test.suite("LuauTypeOfModuleSuite", function(suite)
 			error("typePack should not be nil")
 		end
 
+		-- Verify TypePack structure: { head: {type}?, tail: typepack? }
+		assert.eq(typePack.tag, "typepack")
+
+		-- Head: string, number
 		assert.neq(typePack.head, nil)
 		if not typePack.head then
 			error("typePack.head should not be nil")
 		end
-		assert.eq(#typePack.head, 3)
+		assert.eq(#typePack.head, 2)
 
-		-- Verify types: string, number, boolean
 		assert.eq(typePack.head[1].tag, "string")
 		assert.eq(typePack.head[2].tag, "number")
-		assert.eq(typePack.head[3].tag, "boolean")
-		assert.eq(typePack.tail, nil)
+
+		-- Tail: boolean
+		assert.neq(typePack.tail, nil)
+		if not typePack.tail then
+			error("typePack.tail should not be nil")
+		end
+
+		assert.neq(typePack.tail.head, nil)
+		if not typePack.tail.head then
+			error("typePack.tail.head should not be nil")
+		end
+		assert.eq(#typePack.tail.head, 1)
+
+		assert.eq(typePack.tail.head[1].tag, "boolean")
 	end)
 
 	suite:case("typeofmodule_returns_typepack_with_variadic_tail", function(assert)
@@ -110,10 +127,10 @@ test.suite("LuauTypeOfModuleSuite", function(suite)
 		fs.write(
 			testFile,
 			[[
-			local function variadic(...: string): ...string
+			local function variadic_func(...: string): ...string
 				return ...
 			end
-			return variadic
+			return variadic_func
 		]]
 		)
 		fs.close(testFile)
@@ -124,6 +141,8 @@ test.suite("LuauTypeOfModuleSuite", function(suite)
 			error("typePack should not be nil")
 		end
 
+		assert.eq(typePack.tag, "typepack")
+
 		assert.neq(typePack.head, nil)
 		if not typePack.head then
 			error("typePack.head should not be nil")
@@ -133,9 +152,14 @@ test.suite("LuauTypeOfModuleSuite", function(suite)
 		local funcType = typePack.head[1]
 		assert.eq(funcType.tag, "function")
 		assert.neq(funcType.returns, nil)
-		-- Variadic return should have tail set to the variadic type
-		assert.neq(funcType.returns.tail, nil)
-		assert.eq(funcType.returns.tail.tag, "string")
+
+		assert.eq(funcType.returns.tag, "variadic")
+
+		assert.neq(funcType.returns.type, nil)
+		if not funcType.returns.type then
+			error("Function.returns.type should not be nil")
+		end
+		assert.eq(funcType.returns.type.tag, "string")
 	end)
 
 	suite:case("resolverequire", function(assert)

--- a/tests/std/luau.test.luau
+++ b/tests/std/luau.test.luau
@@ -96,29 +96,16 @@ test.suite("LuauTypeOfModuleSuite", function(suite)
 		-- Verify TypePack structure: { head: {type}?, tail: typepack? }
 		assert.eq(typePack.tag, "typepack")
 
-		-- -- Head: string, number
-		-- assert.neq(typePack.head, nil)
-		-- if not typePack.head then
-		-- 	error("typePack.head should not be nil")
-		-- end
-		-- assert.eq(#typePack.head, 2)
+		-- Head: string, number
+		assert.neq(typePack.head, nil)
+		if not typePack.head then
+			error("typePack.head should not be nil")
+		end
+		assert.eq(#typePack.head, 3)
 
-		-- assert.eq(typePack.head[1].tag, "string")
-		-- assert.eq(typePack.head[2].tag, "number")
-
-		-- -- Tail: boolean
-		-- assert.neq(typePack.tail, nil)
-		-- if not typePack.tail then
-		-- 	error("typePack.tail should not be nil")
-		-- end
-
-		-- assert.neq(typePack.tail.head, nil)
-		-- if not typePack.tail.head then
-		-- 	error("typePack.tail.head should not be nil")
-		-- end
-		-- assert.eq(#typePack.tail.head, 1)
-
-		-- assert.eq(typePack.tail.head[1].tag, "boolean")
+		assert.eq(typePack.head[1].tag, "string")
+		assert.eq(typePack.head[2].tag, "number")
+		assert.eq(typePack.head[3].tag, "boolean")
 	end)
 
 	suite:case("typeofmodule_returns_typepack_with_variadic_tail", function(assert)


### PR DESCRIPTION
And adds tests for these!
Adding `tag` for a pack, variadic pack, and generic pack, as well as updating the luau definition to include specific fields for each, like we have for `Type`. And various fixes to the serialization after adding tests and realizing that some of the initial implementation wasn't exactly correct