### PR TITLE
Net library: fix undefined behavior from calling `writeFunction` with wrong expected parameter type

### DIFF
--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -41,9 +41,7 @@ static size_t writeFunction(char* ptr, size_t size, size_t nmemb, void* userdata
 {
     std::vector<char>* target = static_cast<std::vector<char>*>(userdata);
     size_t fullsize = size * nmemb;
-
     target->insert(target->end(), ptr, ptr + fullsize);
-
     return fullsize;
 }
 

--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -37,7 +37,7 @@ struct CurlResponse
     }
 };
 
-static size_t writeFunction(void* contents, size_t size, size_t nmemb, void* context)
+static size_t writeFunction(char* contents, size_t size, size_t nmemb, void* context)
 {
     std::vector<char>& target = *(std::vector<char>*)context;
     size_t fullsize = size * nmemb;

--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -37,12 +37,12 @@ struct CurlResponse
     }
 };
 
-static size_t writeFunction(char* contents, size_t size, size_t nmemb, void* context)
+static size_t writeFunction(char* ptr, size_t size, size_t nmemb, void* userdata)
 {
-    std::vector<char>& target = *(std::vector<char>*)context;
+    std::vector<char>* target = static_cast<std::vector<char>*>(userdata);
     size_t fullsize = size * nmemb;
 
-    target.insert(target.end(), (char*)contents, (char*)contents + fullsize);
+    target->insert(target->end(), ptr, ptr + fullsize);
 
     return fullsize;
 }


### PR DESCRIPTION
Attempted fix for #799's failing CI run ([link](https://github.com/luau-lang/lute/actions/runs/21885285925/job/63179451762)).