### PR TITLE
Define `LUTE_ASSERT` and `LUTE_UNREACHABLE` in Lute.Common library

### DIFF
--- a/lute/cli/src/packagerun.cpp
+++ b/lute/cli/src/packagerun.cpp
@@ -1,5 +1,6 @@
 #include "lute/packagerun.h"
 
+#include "lute/common.h"
 #include "lute/userlandvfs.h"
 
 #include "Luau/FileUtils.h"
@@ -127,7 +128,7 @@ std::pair<std::vector<Package::Identifier>, std::vector<std::pair<Package::Ident
     const std::string& lockfilePath
 )
 {
-    LUAU_ASSERT(isFile(lockfilePath));
+    LUTE_ASSERT(isFile(lockfilePath));
 
     std::optional<std::string> contents = readFile(lockfilePath);
     if (!contents)

--- a/lute/common/CMakeLists.txt
+++ b/lute/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(Lute.Common STATIC)
 
 target_sources(Lute.Common PRIVATE
+    include/lute/common.h
     include/lute/fileutils.h
 
     src/fileutils.cpp
@@ -8,5 +9,5 @@ target_sources(Lute.Common PRIVATE
 
 target_compile_features(Lute.Common PUBLIC cxx_std_17)
 target_include_directories(Lute.Common PUBLIC include)
-target_link_libraries(Lute.Common PRIVATE Luau.CLI.lib)
+target_link_libraries(Lute.Common PRIVATE Luau.CLI.lib Luau.Common)
 target_compile_options(Lute.Common PRIVATE ${LUTE_OPTIONS})

--- a/lute/common/include/lute/common.h
+++ b/lute/common/include/lute/common.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "Luau/Common.h"
+
+#define LUTE_ASSERT(expr) LUAU_ASSERT(expr)
+#define LUTE_UNREACHABLE() LUAU_UNREACHABLE()

--- a/lute/common/include/lute/fileutils.h
+++ b/lute/common/include/lute/fileutils.h
@@ -24,7 +24,6 @@ bool removeFile(const std::string& path);
 // Remove a directory (must be empty)
 bool removeDirectory(const std::string& path);
 
-
 bool isDirectory(const std::string& path);
 
 // Get the name of a file without its extension

--- a/lute/luau/CMakeLists.txt
+++ b/lute/luau/CMakeLists.txt
@@ -16,5 +16,5 @@ target_sources(Lute.Luau PRIVATE
 
 target_compile_features(Lute.Luau PUBLIC cxx_std_17)
 target_include_directories(Lute.Luau PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Luau PRIVATE Lute.Require Lute.Runtime uv_a Luau.Analysis Luau.Ast Luau.Compiler Luau.CLI.lib Luau.Require Luau.VM)
+target_link_libraries(Lute.Luau PRIVATE Lute.Common Lute.Require Lute.Runtime uv_a Luau.Analysis Luau.Ast Luau.Compiler Luau.CLI.lib Luau.Require Luau.VM)
 target_compile_options(Lute.Luau PRIVATE ${LUTE_OPTIONS})

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -1,9 +1,10 @@
 #include "lute/luau.h"
 
+#include "lute/common.h"
 #include "lute/configresolver.h"
 #include "lute/moduleresolver.h"
-#include "lute/userdatas.h"
 #include "lute/type.h"
+#include "lute/userdatas.h"
 
 #include "Luau/Ast.h"
 #include "Luau/BuiltinDefinitions.h"
@@ -252,7 +253,7 @@ struct AstSerialize : public Luau::AstVisitor
     Luau::NotNull<T> lookupCstNode(Luau::AstNode* astNode)
     {
         const auto cstNode = cstNodeMap.find(astNode);
-        LUAU_ASSERT(cstNode);
+        LUTE_ASSERT(cstNode);
         return Luau::NotNull{(*cstNode)->as<T>()};
     }
 
@@ -283,9 +284,9 @@ struct AstSerialize : public Luau::AstVisitor
     {
         auto beginPosition = currentPosition;
 
-        LUAU_ASSERT(currentPosition < newPos);
-        LUAU_ASSERT(currentPosition.line < lineOffsets.size());
-        LUAU_ASSERT(newPos.line < lineOffsets.size());
+        LUTE_ASSERT(currentPosition < newPos);
+        LUTE_ASSERT(currentPosition.line < lineOffsets.size());
+        LUTE_ASSERT(newPos.line < lineOffsets.size());
         size_t startOffset = lineOffsets[currentPosition.line] + currentPosition.column;
         size_t endOffset = lineOffsets[newPos.line] + newPos.column;
 
@@ -313,14 +314,14 @@ struct AstSerialize : public Luau::AstVisitor
             if (index == std::string::npos)
                 break;
         }
-        LUAU_ASSERT(currentPosition == newPos);
+        LUTE_ASSERT(currentPosition == newPos);
 
         return result;
     }
 
     std::vector<Trivia> extractTrivia(const Luau::Position& newPos)
     {
-        LUAU_ASSERT(currentPosition <= newPos);
+        LUTE_ASSERT(currentPosition <= newPos);
         if (currentPosition == newPos)
             return {};
 
@@ -335,8 +336,8 @@ struct AstSerialize : public Luau::AstVisitor
                 result.insert(result.end(), whitespace.begin(), whitespace.end());
             }
 
-            LUAU_ASSERT(comment.location.begin.line < lineOffsets.size());
-            LUAU_ASSERT(comment.location.end.line < lineOffsets.size());
+            LUTE_ASSERT(comment.location.begin.line < lineOffsets.size());
+            LUTE_ASSERT(comment.location.end.line < lineOffsets.size());
 
             size_t startOffset = lineOffsets[comment.location.begin.line] + comment.location.begin.column;
             size_t endOffset = lineOffsets[comment.location.end.line] + comment.location.end.column;
@@ -345,10 +346,10 @@ struct AstSerialize : public Luau::AstVisitor
 
             // TODO: advancePosition is more of a debug check - we can probably just set currentPosition directly here
             advancePosition(commentText);
-            LUAU_ASSERT(currentPosition == comment.location.end);
+            LUTE_ASSERT(currentPosition == comment.location.end);
 
             // TODO: currently the text includes the `--` / `--[[` characters, should it?
-            LUAU_ASSERT(comment.type != Luau::Lexeme::BrokenComment);
+            LUTE_ASSERT(comment.type != Luau::Lexeme::BrokenComment);
             auto kind = comment.type == Luau::Lexeme::Comment ? Trivia::SingleLineComment : Trivia::MultiLineComment;
             result.emplace_back(Trivia{kind, comment.location, commentText});
         }
@@ -359,7 +360,7 @@ struct AstSerialize : public Luau::AstVisitor
             result.insert(result.end(), whitespace.begin(), whitespace.end());
         }
 
-        LUAU_ASSERT(currentPosition == newPos);
+        LUTE_ASSERT(currentPosition == newPos);
 
         return result;
     }
@@ -434,7 +435,7 @@ struct AstSerialize : public Luau::AstVisitor
 
                 if (local->annotation)
                 {
-                    LUAU_ASSERT(colonPosition);
+                    LUTE_ASSERT(colonPosition);
                     serializeToken(*colonPosition, ":");
                 }
                 else
@@ -459,7 +460,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serialize(Luau::AstExprTable::Item& item, Luau::CstExprTable::Item* cstNode)
     {
-        LUAU_ASSERT(cstNode);
+        LUTE_ASSERT(cstNode);
 
         lua_rawcheckstack(L, 2);
 
@@ -493,7 +494,7 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(item.key->location.begin, std::string(value.data, value.size).data());
             lua_setfield(L, -2, "key");
 
-            LUAU_ASSERT(cstNode->equalsPosition);
+            LUTE_ASSERT(cstNode->equalsPosition);
             serializeToken(*cstNode->equalsPosition, "=");
             lua_setfield(L, -2, "equals");
 
@@ -509,7 +510,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_pushboolean(L, 1);
             lua_setfield(L, -2, "istableitem");
 
-            LUAU_ASSERT(cstNode->indexerOpenPosition);
+            LUTE_ASSERT(cstNode->indexerOpenPosition);
             withLocation(Luau::Location{*cstNode->indexerOpenPosition, item.value->location.end});
 
             serializeToken(*cstNode->indexerOpenPosition, "[");
@@ -518,11 +519,11 @@ struct AstSerialize : public Luau::AstVisitor
             visit(item.key);
             lua_setfield(L, -2, "key");
 
-            LUAU_ASSERT(cstNode->indexerClosePosition);
+            LUTE_ASSERT(cstNode->indexerClosePosition);
             serializeToken(*cstNode->indexerClosePosition, "]");
             lua_setfield(L, -2, "indexerclose");
 
-            LUAU_ASSERT(cstNode->equalsPosition);
+            LUTE_ASSERT(cstNode->equalsPosition);
             serializeToken(*cstNode->equalsPosition, "=");
             lua_setfield(L, -2, "equals");
 
@@ -611,7 +612,7 @@ struct AstSerialize : public Luau::AstVisitor
             const auto [trailingTrivia, leadingTrivia] = splitTrivia(trivia);
 
             lua_getref(L, lastTokenRef);
-            LUAU_ASSERT(lua_istable(L, -1));
+            LUTE_ASSERT(lua_istable(L, -1));
 
             serializeTrivia(trailingTrivia);
             lua_setfield(L, -2, "trailingtrivia");
@@ -625,7 +626,7 @@ struct AstSerialize : public Luau::AstVisitor
         {
             serializeTrivia(trivia);
         }
-        LUAU_ASSERT(lua_istable(L, -2));
+        LUTE_ASSERT(lua_istable(L, -2));
         lua_setfield(L, -2, "leadingtrivia");
 
         size_t textLength = strlen(text);
@@ -848,7 +849,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         // Unlike normal tokens, string content contains quotation marks that were not included during advancement
         // For simplicity, lets set the current position manually
-        LUAU_ASSERT(currentPosition <= node->location.end);
+        LUTE_ASSERT(currentPosition <= node->location.end);
         currentPosition = node->location.end;
     }
 
@@ -1382,7 +1383,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         if (node->elsebody)
         {
-            LUAU_ASSERT(node->elseLocation);
+            LUTE_ASSERT(node->elseLocation);
             serializeToken(node->elseLocation->begin, "else");
             lua_setfield(L, -2, "elsekeyword");
 
@@ -1807,12 +1808,12 @@ struct AstSerialize : public Luau::AstVisitor
 
         if (node->prefix)
         {
-            LUAU_ASSERT(node->prefixLocation);
+            LUTE_ASSERT(node->prefixLocation);
             serializeToken(node->prefixLocation->begin, node->prefix->value);
             lua_setfield(L, -2, "prefix");
 
-            LUAU_ASSERT(cstNode);
-            LUAU_ASSERT(cstNode->prefixPointPosition);
+            LUTE_ASSERT(cstNode);
+            LUTE_ASSERT(cstNode->prefixPointPosition);
             serializeToken(*cstNode->prefixPointPosition, ".");
             lua_setfield(L, -2, "prefixpoint");
         }
@@ -1822,7 +1823,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         if (node->hasParameterList)
         {
-            LUAU_ASSERT(cstNode);
+            LUTE_ASSERT(cstNode);
             serializeToken(cstNode->openParametersPosition, "<");
             lua_setfield(L, -2, "openparameters");
 
@@ -1850,7 +1851,7 @@ struct AstSerialize : public Luau::AstVisitor
 
             if (node->indexer->accessLocation)
             {
-                LUAU_ASSERT(node->indexer->access != Luau::AstTableAccess::ReadWrite);
+                LUTE_ASSERT(node->indexer->access != Luau::AstTableAccess::ReadWrite);
                 serializeToken(node->indexer->accessLocation->begin, node->indexer->access == Luau::AstTableAccess::Read ? "read" : "write");
             }
             else
@@ -1885,14 +1886,14 @@ struct AstSerialize : public Luau::AstVisitor
 
             if (item.kind == Luau::CstTypeTable::Item::Kind::Indexer)
             {
-                LUAU_ASSERT(node->indexer);
+                LUTE_ASSERT(node->indexer);
 
                 lua_pushstring(L, "indexer");
                 lua_setfield(L, -2, "kind");
 
                 if (node->indexer->accessLocation)
                 {
-                    LUAU_ASSERT(node->indexer->access != Luau::AstTableAccess::ReadWrite);
+                    LUTE_ASSERT(node->indexer->access != Luau::AstTableAccess::ReadWrite);
                     serializeToken(node->indexer->accessLocation->begin, node->indexer->access == Luau::AstTableAccess::Read ? "read" : "write");
                 }
                 else
@@ -1935,7 +1936,7 @@ struct AstSerialize : public Luau::AstVisitor
 
                 if (prop->accessLocation)
                 {
-                    LUAU_ASSERT(prop->access != Luau::AstTableAccess::ReadWrite);
+                    LUTE_ASSERT(prop->access != Luau::AstTableAccess::ReadWrite);
                     serializeToken(prop->accessLocation->begin, prop->access == Luau::AstTableAccess::Read ? "read" : "write");
                 }
                 else
@@ -1963,7 +1964,7 @@ struct AstSerialize : public Luau::AstVisitor
                             lua_pushstring(L, "double");
                             break;
                         default:
-                            LUAU_ASSERT(false);
+                            LUTE_ASSERT(false);
                         }
                         lua_setfield(L, -2, "quotestyle");
 
@@ -2216,13 +2217,13 @@ struct AstSerialize : public Luau::AstVisitor
             lua_pushstring(L, "double");
             break;
         default:
-            LUAU_ASSERT(false);
+            LUTE_ASSERT(false);
         }
         lua_setfield(L, -2, "quotestyle");
 
         // Unlike normal tokens, string content contains quotation marks that were not included during advancement
         // For simplicity, lets set the current position manually
-        LUAU_ASSERT(currentPosition <= node->location.end);
+        LUTE_ASSERT(currentPosition <= node->location.end);
         currentPosition = node->location.end;
     }
 

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -1,5 +1,7 @@
 #include "lute/type.h"
 
+#include "lute/common.h"
+
 #include "Luau/ToString.h"
 #include "Luau/Type.h"
 #include "Luau/TypeFwd.h"
@@ -592,8 +594,8 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         // NOTE: `TypeSerialize` should explicitly visit _all_ types and type packs,
         // otherwise it's prone to serializing types that should not be serialized.
-        LUAU_ASSERT(false);
-        LUAU_UNREACHABLE();
+        LUTE_ASSERT(false);
+        LUTE_UNREACHABLE();
     }
 
     bool visit(TypeId ty, const BoundType& btv) override
@@ -642,8 +644,8 @@ struct TypeSerialize final : public Luau::TypeVisitor
     {
         // NOTE: `TypeSerialize` should explicitly visit _all_ types and type packs,
         // otherwise it's prone to serializing type packs that should not be serialized.
-        LUAU_ASSERT(false);
-        LUAU_UNREACHABLE();
+        LUTE_ASSERT(false);
+        LUTE_UNREACHABLE();
     }
 
     bool visit(TypePackId tp, const BoundTypePack& btp) override

--- a/lute/net/CMakeLists.txt
+++ b/lute/net/CMakeLists.txt
@@ -8,5 +8,5 @@ target_sources(Lute.Net PRIVATE
 
 target_compile_features(Lute.Net PUBLIC cxx_std_17)
 target_include_directories(Lute.Net PUBLIC "include" ${LIBUV_INCLUDE_DIR} ${UWEBSOCKETS_INCLUDE_DIR})
-target_link_libraries(Lute.Net PRIVATE Lute.Runtime Luau.VM uv_a libcurl uWS zlibstatic)
+target_link_libraries(Lute.Net PRIVATE Lute.Common Lute.Runtime Luau.VM uv_a libcurl uWS zlibstatic)
 target_compile_options(Lute.Net PRIVATE ${LUTE_OPTIONS})

--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -1,5 +1,6 @@
 #include "lute/net.h"
 
+#include "lute/common.h"
 #include "lute/runtime.h"
 
 #include "Luau/DenseHash.h"
@@ -40,6 +41,8 @@ struct CurlResponse
 static size_t writeFunction(char* ptr, size_t size, size_t nmemb, void* userdata)
 {
     std::vector<char>* target = static_cast<std::vector<char>*>(userdata);
+    LUTE_ASSERT(target);
+
     size_t fullsize = size * nmemb;
     target->insert(target->end(), ptr, ptr + fullsize);
     return fullsize;

--- a/lute/process/CMakeLists.txt
+++ b/lute/process/CMakeLists.txt
@@ -8,5 +8,5 @@ target_sources(Lute.Process PRIVATE
 
 target_compile_features(Lute.Process PUBLIC cxx_std_17)
 target_include_directories(Lute.Process PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Process PRIVATE Lute.Runtime Luau.VM uv_a)
+target_link_libraries(Lute.Process PRIVATE Lute.Common Lute.Runtime Luau.VM uv_a)
 target_compile_options(Lute.Process PRIVATE ${LUTE_OPTIONS})

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -1,5 +1,6 @@
 #include "lute/process.h"
 
+#include "lute/common.h"
 #include "lute/runtime.h"
 #include "lute/uvutils.h"
 
@@ -479,7 +480,7 @@ int exitFunc(lua_State* L)
     // Exit with the provided code
     std::exit(exitCode);
 
-    LUAU_UNREACHABLE();
+    LUTE_UNREACHABLE();
 }
 
 int cwd(lua_State* L)

--- a/lute/require/CMakeLists.txt
+++ b/lute/require/CMakeLists.txt
@@ -28,5 +28,5 @@ target_sources(Lute.Require PRIVATE
 
 target_compile_features(Lute.Require PUBLIC cxx_std_17)
 target_include_directories(Lute.Require PUBLIC include)
-target_link_libraries(Lute.Require PUBLIC Luau.Require PRIVATE Luau.CLI.lib Luau.Compiler Luau.CodeGen Lute.Std Lute.CLI.Commands Lute.Batteries Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Runtime)
+target_link_libraries(Lute.Require PUBLIC Luau.Require PRIVATE Luau.CLI.lib Luau.Compiler Luau.CodeGen Lute.Common Lute.Std Lute.CLI.Commands Lute.Batteries Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Runtime)
 target_compile_options(Lute.Require PRIVATE ${LUTE_OPTIONS})

--- a/lute/require/src/bundlevfs.cpp
+++ b/lute/require/src/bundlevfs.cpp
@@ -1,5 +1,7 @@
 #include "lute/bundlevfs.h"
 
+#include "lute/common.h"
+
 #include "Luau/Common.h"
 #include "Luau/DenseHash.h"
 
@@ -109,13 +111,13 @@ NavigationStatus BundleVfs::resetToPath(const std::string& path)
 
 NavigationStatus BundleVfs::toParent()
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     return modulePath->toParent();
 }
 
 NavigationStatus BundleVfs::toChild(const std::string& name)
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     return modulePath->toChild(name);
 }
 
@@ -126,9 +128,9 @@ bool BundleVfs::isModulePresent() const
 
 std::string BundleVfs::getIdentifier() const
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     ResolvedRealPath result = modulePath->getRealPath();
-    LUAU_ASSERT(result.status == NavigationStatus::Success);
+    LUTE_ASSERT(result.status == NavigationStatus::Success);
     return result.realPath;
 }
 
@@ -149,7 +151,7 @@ std::optional<std::string> BundleVfs::getContents(const std::string& path) const
 
 ConfigStatus BundleVfs::getConfigStatus() const
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
 
     // Get the potential config path for the current module path
     std::string configPath = modulePath->getPotentialConfigPath(".luaurc");
@@ -167,7 +169,7 @@ ConfigStatus BundleVfs::getConfigStatus() const
 
 std::optional<std::string> BundleVfs::getConfig() const
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
 
     // Get the potential config path for the current module path
     std::string configPath = modulePath->getPotentialConfigPath(".luaurc");

--- a/lute/require/src/clivfs.cpp
+++ b/lute/require/src/clivfs.cpp
@@ -2,6 +2,7 @@
 
 #include "lute/clibatteries.h"
 #include "lute/clicommands.h"
+#include "lute/common.h"
 #include "lute/modulepath.h"
 
 #include "Luau/Common.h"
@@ -94,13 +95,13 @@ NavigationStatus CliVfs::toAliasFallback(std::string_view aliasUnprefixed)
 
 NavigationStatus CliVfs::toParent()
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     return modulePath->toParent();
 }
 
 NavigationStatus CliVfs::toChild(const std::string& name)
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     return modulePath->toChild(name);
 }
 
@@ -112,9 +113,9 @@ bool CliVfs::isModulePresent() const
 
 std::string CliVfs::getIdentifier() const
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     ResolvedRealPath result = modulePath->getRealPath();
-    LUAU_ASSERT(result.status == NavigationStatus::Success);
+    LUTE_ASSERT(result.status == NavigationStatus::Success);
     return result.realPath;
 }
 

--- a/lute/require/src/filevfs.cpp
+++ b/lute/require/src/filevfs.cpp
@@ -1,5 +1,6 @@
 #include "lute/filevfs.h"
 
+#include "lute/common.h"
 #include "lute/modulepath.h"
 #include "lute/uvutils.h"
 
@@ -21,7 +22,7 @@ NavigationStatus FileVfs::resetToStdIn()
         return NavigationStatus::NotFound;
 
     size_t firstSlash = cwd->find_first_of("\\/");
-    LUAU_ASSERT(firstSlash != std::string::npos);
+    LUTE_ASSERT(firstSlash != std::string::npos);
 
     modulePath = ModulePath::create(cwd->substr(0, firstSlash), cwd->substr(firstSlash + 1), isFile, isDirectory, "./");
     return modulePath ? NavigationStatus::Success : NavigationStatus::NotFound;
@@ -52,7 +53,7 @@ NavigationStatus FileVfs::resetToPath(const std::string& path)
     if (isAbsolutePath(normalizedPath))
     {
         size_t firstSlash = normalizedPath.find_first_of('/');
-        LUAU_ASSERT(firstSlash != std::string::npos);
+        LUTE_ASSERT(firstSlash != std::string::npos);
 
         modulePath = ModulePath::create(normalizedPath.substr(0, firstSlash), normalizedPath.substr(firstSlash + 1), isFile, isDirectory);
     }
@@ -65,7 +66,7 @@ NavigationStatus FileVfs::resetToPath(const std::string& path)
         std::string joinedPath = normalizePath(*cwd + "/" + normalizedPath);
 
         size_t firstSlash = joinedPath.find_first_of("\\/");
-        LUAU_ASSERT(firstSlash != std::string::npos);
+        LUTE_ASSERT(firstSlash != std::string::npos);
 
         modulePath = ModulePath::create(joinedPath.substr(0, firstSlash), joinedPath.substr(firstSlash + 1), isFile, isDirectory, normalizedPath);
     }
@@ -75,13 +76,13 @@ NavigationStatus FileVfs::resetToPath(const std::string& path)
 
 NavigationStatus FileVfs::toParent()
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     return modulePath->toParent();
 }
 
 NavigationStatus FileVfs::toChild(const std::string& name)
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     return modulePath->toChild(name);
 }
 
@@ -92,17 +93,17 @@ bool FileVfs::isModulePresent() const
 
 std::string FileVfs::getFilePath() const
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     ResolvedRealPath result = modulePath->getRealPath();
-    LUAU_ASSERT(result.status == NavigationStatus::Success);
+    LUTE_ASSERT(result.status == NavigationStatus::Success);
     return result.relativePath ? *result.relativePath : result.realPath;
 }
 
 std::string FileVfs::getAbsoluteFilePath() const
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     ResolvedRealPath result = modulePath->getRealPath();
-    LUAU_ASSERT(result.status == NavigationStatus::Success);
+    LUTE_ASSERT(result.status == NavigationStatus::Success);
     return result.realPath;
 }
 
@@ -113,7 +114,7 @@ std::optional<std::string> FileVfs::getContents(const std::string& path) const
 
 ConfigStatus FileVfs::getConfigStatus() const
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
 
     bool luaurcExists = isFile(modulePath->getPotentialConfigPath(Luau::kConfigName));
     bool luauConfigExists = isFile(modulePath->getPotentialConfigPath(Luau::kLuauConfigName));
@@ -130,15 +131,15 @@ ConfigStatus FileVfs::getConfigStatus() const
 
 std::optional<std::string> FileVfs::getConfig() const
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
 
     ConfigStatus status = getConfigStatus();
-    LUAU_ASSERT(status == ConfigStatus::PresentJson || status == ConfigStatus::PresentLuau);
+    LUTE_ASSERT(status == ConfigStatus::PresentJson || status == ConfigStatus::PresentLuau);
 
     if (status == ConfigStatus::PresentJson)
         return readFile(modulePath->getPotentialConfigPath(Luau::kConfigName));
     else if (status == ConfigStatus::PresentLuau)
         return readFile(modulePath->getPotentialConfigPath(Luau::kLuauConfigName));
 
-    LUAU_UNREACHABLE();
+    LUTE_UNREACHABLE();
 }

--- a/lute/require/src/lutevfs.cpp
+++ b/lute/require/src/lutevfs.cpp
@@ -1,5 +1,6 @@
 #include "lute/lutevfs.h"
 
+#include "lute/common.h"
 #include "lute/crypto.h"
 #include "lute/fs.h"
 #include "lute/io.h"
@@ -61,29 +62,29 @@ NavigationStatus LuteVfs::resetToPath(const std::string& path)
 
 NavigationStatus LuteVfs::toParent()
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     return modulePath->toParent();
 }
 
 NavigationStatus LuteVfs::toChild(const std::string& name)
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     return modulePath->toChild(name);
 }
 
 bool LuteVfs::isModulePresent() const
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     ResolvedRealPath result = modulePath->getRealPath();
-    LUAU_ASSERT(result.status == NavigationStatus::Success);
+    LUTE_ASSERT(result.status == NavigationStatus::Success);
     return result.type == ResolvedRealPath::PathType::File;
 }
 
 std::string LuteVfs::getIdentifier() const
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     ResolvedRealPath result = modulePath->getRealPath();
-    LUAU_ASSERT(result.status == NavigationStatus::Success);
+    LUTE_ASSERT(result.status == NavigationStatus::Success);
     return result.realPath;
 }
 

--- a/lute/require/src/require.cpp
+++ b/lute/require/src/require.cpp
@@ -1,5 +1,6 @@
 #include "lute/require.h"
 
+#include "lute/common.h"
 #include "lute/lutevfs.h"
 #include "lute/modulepath.h"
 #include "lute/options.h"
@@ -154,7 +155,7 @@ static int load(lua_State* L, void* ctx, const char* path, const char* chunkname
     if (strncmp(loadname, "@lute/", 6) == 0)
     {
         const lua_CFunction* func = kLuteModules.find(loadname);
-        LUAU_ASSERT(func);
+        LUTE_ASSERT(func);
         lua_pushcfunction(L, *func, nullptr);
         lua_call(L, 0, 1);
         return 1;

--- a/lute/require/src/requirevfs.cpp
+++ b/lute/require/src/requirevfs.cpp
@@ -1,6 +1,7 @@
 #include "lute/requirevfs.h"
 
 #include "lute/bundlevfs.h"
+#include "lute/common.h"
 #include "lute/modulepath.h"
 #include "lute/stdlibvfs.h"
 
@@ -39,14 +40,14 @@ NavigationStatus RequireVfs::reset(lua_State* L, std::string_view requirerChunkn
     if ((requirerChunkname.size() >= 6 && requirerChunkname.substr(0, 6) == "@@cli/"))
     {
         vfsType = VFSType::Cli;
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         return cliVfs->resetToPath(std::string(requirerChunkname.substr(1)));
     }
 
     if ((requirerChunkname.size() >= 9 && requirerChunkname.substr(0, 9) == "@@bundle/"))
     {
         vfsType = VFSType::Bundle;
-        LUAU_ASSERT(bundleVfs);
+        LUTE_ASSERT(bundleVfs);
         return bundleVfs->resetToPath(std::string(requirerChunkname.substr(1)));
     }
 
@@ -75,11 +76,11 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
         status = luteVfs.resetToPath(std::string(path));
         break;
     case VFSType::Cli:
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         status = cliVfs->resetToPath(std::string(path));
         break;
     case VFSType::Bundle:
-        LUAU_ASSERT(bundleVfs);
+        LUTE_ASSERT(bundleVfs);
         status = bundleVfs->resetToPath(std::string(path));
         break;
     }
@@ -106,7 +107,7 @@ NavigationStatus RequireVfs::toAliasFallback(lua_State* L, std::string_view alia
 {
     if (vfsType == VFSType::Cli)
     {
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         return cliVfs->toAliasFallback(aliasUnprefixed);
     }
     return NavigationStatus::NotFound;
@@ -127,11 +128,11 @@ NavigationStatus RequireVfs::toParent(lua_State* L)
         status = luteVfs.toParent();
         break;
     case VFSType::Cli:
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         status = cliVfs->toParent();
         break;
     case VFSType::Bundle:
-        LUAU_ASSERT(bundleVfs);
+        LUTE_ASSERT(bundleVfs);
         status = bundleVfs->toParent();
         break;
     }
@@ -149,10 +150,10 @@ NavigationStatus RequireVfs::toChild(lua_State* L, std::string_view name)
     case VFSType::Lute:
         return luteVfs.toChild(std::string(name));
     case VFSType::Cli:
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         return cliVfs->toChild(std::string(name));
     case VFSType::Bundle:
-        LUAU_ASSERT(bundleVfs);
+        LUTE_ASSERT(bundleVfs);
         return bundleVfs->toChild(std::string(name));
     }
     return NavigationStatus::NotFound;
@@ -170,10 +171,10 @@ bool RequireVfs::isModulePresent(lua_State* L) const
         return luteVfs.isModulePresent();
         break;
     case VFSType::Cli:
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         return cliVfs->isModulePresent();
     case VFSType::Bundle:
-        LUAU_ASSERT(bundleVfs);
+        LUTE_ASSERT(bundleVfs);
         return bundleVfs->isModulePresent();
     }
 
@@ -196,11 +197,11 @@ std::string RequireVfs::getContents(lua_State* L, const std::string& loadname) c
         contents = luteVfs.getContents(loadname);
         break;
     case VFSType::Cli:
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         contents = cliVfs->getContents(loadname);
         break;
     case VFSType::Bundle:
-        LUAU_ASSERT(bundleVfs);
+        LUTE_ASSERT(bundleVfs);
         contents = bundleVfs->getContents(loadname);
         break;
     }
@@ -223,11 +224,11 @@ std::string RequireVfs::getChunkname(lua_State* L) const
         chunkname = "@" + luteVfs.getIdentifier();
         break;
     case VFSType::Cli:
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         chunkname = "@" + cliVfs->getIdentifier();
         break;
     case VFSType::Bundle:
-        LUAU_ASSERT(bundleVfs);
+        LUTE_ASSERT(bundleVfs);
         chunkname = "@" + bundleVfs->getIdentifier();
         break;
     }
@@ -249,11 +250,11 @@ std::string RequireVfs::getLoadname(lua_State* L) const
         loadname = luteVfs.getIdentifier();
         break;
     case VFSType::Cli:
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         loadname = cliVfs->getIdentifier();
         break;
     case VFSType::Bundle:
-        LUAU_ASSERT(bundleVfs);
+        LUTE_ASSERT(bundleVfs);
         loadname = bundleVfs->getIdentifier();
         break;
     }
@@ -275,11 +276,11 @@ std::string RequireVfs::getCacheKey(lua_State* L) const
         cacheKey = luteVfs.getIdentifier();
         break;
     case VFSType::Cli:
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         cacheKey = cliVfs->getIdentifier();
         break;
     case VFSType::Bundle:
-        LUAU_ASSERT(bundleVfs);
+        LUTE_ASSERT(bundleVfs);
         cacheKey = bundleVfs->getIdentifier();
         break;
     }
@@ -301,11 +302,11 @@ ConfigStatus RequireVfs::getConfigStatus(lua_State* L) const
         status = luteVfs.getConfigStatus();
         break;
     case VFSType::Cli:
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         status = cliVfs->getConfigStatus();
         break;
     case VFSType::Bundle:
-        LUAU_ASSERT(bundleVfs);
+        LUTE_ASSERT(bundleVfs);
         status = bundleVfs->getConfigStatus();
         break;
     }
@@ -327,11 +328,11 @@ std::string RequireVfs::getConfig(lua_State* L) const
         configContents = luteVfs.getConfig();
         break;
     case VFSType::Cli:
-        LUAU_ASSERT(cliVfs);
+        LUTE_ASSERT(cliVfs);
         configContents = cliVfs->getConfig();
         break;
     case VFSType::Bundle:
-        LUAU_ASSERT(bundleVfs);
+        LUTE_ASSERT(bundleVfs);
         configContents = bundleVfs->getConfig();
         break;
     }

--- a/lute/require/src/stdlibvfs.cpp
+++ b/lute/require/src/stdlibvfs.cpp
@@ -1,5 +1,6 @@
 #include "lute/stdlibvfs.h"
 
+#include "lute/common.h"
 #include "lute/modulepath.h"
 #include "lute/stdlib.h"
 
@@ -49,13 +50,13 @@ NavigationStatus StdLibVfs::resetToPath(const std::string& path)
 
 NavigationStatus StdLibVfs::toParent()
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     return modulePath->toParent();
 }
 
 NavigationStatus StdLibVfs::toChild(const std::string& name)
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     return modulePath->toChild(name);
 }
 
@@ -66,9 +67,9 @@ bool StdLibVfs::isModulePresent() const
 
 std::string StdLibVfs::getIdentifier() const
 {
-    LUAU_ASSERT(modulePath);
+    LUTE_ASSERT(modulePath);
     ResolvedRealPath result = modulePath->getRealPath();
-    LUAU_ASSERT(result.status == NavigationStatus::Success);
+    LUTE_ASSERT(result.status == NavigationStatus::Success);
     return result.realPath;
 }
 

--- a/lute/require/src/userlandvfs.cpp
+++ b/lute/require/src/userlandvfs.cpp
@@ -1,5 +1,6 @@
 #include "lute/userlandvfs.h"
 
+#include "lute/common.h"
 #include "lute/modulepath.h"
 
 #include "Luau/Common.h"
@@ -68,14 +69,14 @@ ConfigStatus Subtree::getConfigStatus() const
 std::optional<std::string> Subtree::getConfig() const
 {
     ConfigStatus status = getConfigStatus();
-    LUAU_ASSERT(status == ConfigStatus::PresentJson || status == ConfigStatus::PresentLuau);
+    LUTE_ASSERT(status == ConfigStatus::PresentJson || status == ConfigStatus::PresentLuau);
 
     if (status == ConfigStatus::PresentJson)
         return readFile(currentModulePath.getPotentialConfigPath(Luau::kConfigName));
     else if (status == ConfigStatus::PresentLuau)
         return readFile(currentModulePath.getPotentialConfigPath(Luau::kLuauConfigName));
 
-    LUAU_UNREACHABLE();
+    LUTE_UNREACHABLE();
 }
 
 bool Subtree::isModulePresent() const
@@ -141,7 +142,7 @@ NavigationStatus UserlandVfs::toAliasFallback(std::string_view aliasUnprefixed)
         availableDependencies = directDependencies;
         break;
     case VFSType::Subtree:
-        LUAU_ASSERT(currentSubtree);
+        LUTE_ASSERT(currentSubtree);
         availableDependencies = currentSubtree->getInfo().dependencies;
     }
 
@@ -179,7 +180,7 @@ NavigationStatus UserlandVfs::toParent()
         status = fileVfs.toParent();
         break;
     case VFSType::Subtree:
-        LUAU_ASSERT(currentSubtree);
+        LUTE_ASSERT(currentSubtree);
         status = currentSubtree->toParent();
         break;
     }
@@ -196,7 +197,7 @@ NavigationStatus UserlandVfs::toChild(const std::string& name)
         status = fileVfs.toChild(name);
         break;
     case VFSType::Subtree:
-        LUAU_ASSERT(currentSubtree);
+        LUTE_ASSERT(currentSubtree);
         status = currentSubtree->toChild(name);
         break;
     }
@@ -212,7 +213,7 @@ ConfigStatus UserlandVfs::getConfigStatus() const
         status = fileVfs.getConfigStatus();
         break;
     case VFSType::Subtree:
-        LUAU_ASSERT(currentSubtree);
+        LUTE_ASSERT(currentSubtree);
         status = currentSubtree->getConfigStatus();
         break;
     }
@@ -228,7 +229,7 @@ std::optional<std::string> UserlandVfs::getConfig() const
         config = fileVfs.getConfig();
         break;
     case VFSType::Subtree:
-        LUAU_ASSERT(currentSubtree);
+        LUTE_ASSERT(currentSubtree);
         config = currentSubtree->getConfig();
         break;
     }
@@ -244,7 +245,7 @@ bool UserlandVfs::isModulePresent() const
         isPresent = fileVfs.isModulePresent();
         break;
     case VFSType::Subtree:
-        LUAU_ASSERT(currentSubtree);
+        LUTE_ASSERT(currentSubtree);
         isPresent = currentSubtree->isModulePresent();
         break;
     }
@@ -265,7 +266,7 @@ std::string UserlandVfs::getCurrentPath() const
         path = fileVfs.getAbsoluteFilePath();
         break;
     case VFSType::Subtree:
-        LUAU_ASSERT(currentSubtree);
+        LUTE_ASSERT(currentSubtree);
         path = currentSubtree->getCurrentPath();
         break;
     }

--- a/lute/runtime/CMakeLists.txt
+++ b/lute/runtime/CMakeLists.txt
@@ -15,5 +15,5 @@ target_sources(Lute.Runtime PRIVATE
 
 target_compile_features(Lute.Runtime PUBLIC cxx_std_17)
 target_include_directories(Lute.Runtime PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Runtime PRIVATE Luau.Common Luau.Require Luau.VM uv_a)
+target_link_libraries(Lute.Runtime PRIVATE Luau.Require Luau.VM Lute.Common uv_a)
 target_compile_options(Lute.Runtime PRIVATE ${LUTE_OPTIONS})

--- a/lute/runtime/include/lute/uvutils.h
+++ b/lute/runtime/include/lute/uvutils.h
@@ -5,8 +5,6 @@
 #include <cstddef>
 #include <string>
 
-#define LUTE_ASSERT(expr) LUAU_ASSERT(expr)
-
 namespace uvutils
 {
 

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -1,9 +1,6 @@
 #include "lute/runtime.h"
 
-#include "lute/uvutils.h"
-
-#include "Luau/Common.h"
-#include "Luau/Require.h"
+#include "lute/common.h"
 
 #include "lua.h"
 #include "lualib.h"


### PR DESCRIPTION
Defines `LUTE_ASSERT` and `LUTE_UNREACHABLE` in a new `common.h` file in Lute.Common, and mass replaces all instances of the `LUAU_*` versions to the `LUTE_*` versions.