### PR TITLE
Adds color reporting to `lute test`

### DIFF
--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -5,7 +5,7 @@ local path = require("@std/path")
 local ps = require("@std/process")
 local testtypes = require("@std/test/types")
 local runner = require("@std/test/runner")
-local reporter = require("@std/test/reporter")
+local reporter = require("@self/reporter")
 local test = require("@std/test")
 
 local function printHelp()
@@ -119,7 +119,7 @@ local function main(...: string)
 	else
 		local env = test._registered()
 		local filteredEnv = filter.filtertests(env, suiteName, caseName)
-		runtests(filteredEnv, runner.run, reporter.simple)
+		runtests(filteredEnv, runner.run, reporter.color)
 	end
 end
 

--- a/lute/cli/commands/test/reporter.luau
+++ b/lute/cli/commands/test/reporter.luau
@@ -1,0 +1,65 @@
+local rt = require("@batteries/richterm")
+local tys = require("@std/test/types")
+
+local function splitStacktrace(stacktrace: string): { string }
+	local lines = {}
+	for line in stacktrace:gmatch("[^\n]+") do
+		table.insert(lines, line)
+	end
+	return lines
+end
+
+-- Styles
+local pass = rt.combine(rt.green, rt.bold)
+local fail = rt.combine(rt.red, rt.bold)
+local testname = rt.combine(rt.bold, rt.white)
+local errlabel = rt.yellow
+local errmsg = rt.red
+local stkframe = rt.red
+local location = rt.cyan
+local dim = rt.dim
+local separator = dim
+
+local function printFailure(failed: tys.failedtest)
+	print(fail("  FAIL ") .. testname(failed.test))
+	if failed.failure.__tag == "assertion" then
+		print(location(`\t{failed.failure.filename}:{failed.failure.linenumber}`))
+		print(errmsg(`\t{failed.failure.assertion}: {failed.failure.msg}`))
+	elseif failed.failure.__tag == "lifecycle" then
+		print(location(`\t{failed.failure.filename}:{failed.failure.linenumber}`))
+		print(errmsg(`\t{failed.failure.hook}: {failed.failure.msg}`))
+	else
+		print(errlabel("\tRuntime error: ") .. errmsg(failed.failure.msg))
+		print(stkframe("\tStacktrace:"))
+		for _, line in splitStacktrace(failed.failure.stacktrace) do
+			print(stkframe(`\t  {line}`))
+		end
+	end
+end
+
+local function printSummary(result: tys.testrunresult)
+	print(separator(string.rep("─", 50)))
+	print(
+		rt.bold("Results: ")
+			.. pass(`{result.passed} passed`)
+			.. dim(", ")
+			.. fail(`{result.failed} failed`)
+			.. dim(` of {result.total}`)
+	)
+end
+
+local function colorReporter(result: tys.testrunresult)
+	if #result.failures > 0 then
+		print("")
+		print(fail("Failures:"))
+		print("")
+		for _, failed in result.failures do
+			printFailure(failed)
+			print("")
+		end
+	end
+
+	printSummary(result)
+end
+
+return { color = colorReporter }

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -46,8 +46,8 @@ test.suite("LuteTestCommand", function(suite)
 
 		-- Check that it runs only tests in SmokeSuite
 		assert.eq(result.exitcode, 0)
-		assert.neq(result.stdout:find("Total:  2", 1, true), nil)
-		assert.neq(result.stdout:find("Passed: 2", 1, true), nil)
+		assert.neq(result.stdout:find("of 2", 1, true), nil)
+		assert.neq(result.stdout:find("2 passed", 1, true), nil)
 	end)
 
 	suite:case("lute test filters by case name", function(assert)
@@ -56,8 +56,8 @@ test.suite("LuteTestCommand", function(suite)
 
 		-- Check that it runs only tests named make_pass
 		assert.eq(result.exitcode, 0)
-		assert.neq(result.stdout:find("Total:  1", 1, true), nil)
-		assert.neq(result.stdout:find("Passed: 1", 1, true), nil)
+		assert.neq(result.stdout:find("of 1", 1, true), nil)
+		assert.neq(result.stdout:find("1 passed", 1, true), nil)
 	end)
 
 	suite:case("lute test filters by suite and case name", function(assert)
@@ -66,7 +66,7 @@ test.suite("LuteTestCommand", function(suite)
 
 		-- Check that it runs only make_fail in SmokeSuite
 		assert.eq(result.exitcode, 0)
-		assert.neq(result.stdout:find("Total:  1", 1, true), nil)
-		assert.neq(result.stdout:find("Passed: 1", 1, true), nil)
+		assert.neq(result.stdout:find("of 1", 1, true), nil)
+		assert.neq(result.stdout:find("1 passed", 1, true), nil)
 	end)
 end)


### PR DESCRIPTION
This PR uses the richterm battery to implement a simple test reporter that produces color output.

Here are some examples of the output on both dark mode and light mode terminals:
<img width="1013" height="628" alt="Failing tests" src="https://github.com/user-attachments/assets/cb3bf76b-a932-4b35-a561-1c0d04d0950f" />

<img width="1053" height="530" alt="Some failing Light mode" src="https://github.com/user-attachments/assets/5f442298-dcc2-47b0-8285-78702cd59999" />
