### PR TITLE
Uses batteries argparsing in lute test

### DIFF
--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -1,3 +1,4 @@
+local cli = require("@batteries/cli")
 local finder = require("@self/finder")
 local filter = require("@self/filter")
 local luau = require("@std/luau")
@@ -7,30 +8,6 @@ local testtypes = require("@std/test/types")
 local runner = require("@std/test/runner")
 local reporter = require("@self/reporter")
 local test = require("@std/test")
-
-local function printHelp()
-	print([[
-Usage: lute test [OPTIONS] [PATHS...]
-
-Run tests discovered in .test.luau and .spec.luau files.
-
-OPTIONS:
-  -h, --help              Show this help message
-  --list                  List all discovered test cases without running them
-  -s, --suite=SUITE       Run only tests in the specified suite
-  -c, --case=CASE         Run only test cases matching the specified name
-
-PATHS:
-  Directories or files to search for tests (default: ./tests)
-
-EXAMPLES:
-  lute test                                    Run all tests in ./tests
-  lute test --list                             List all test cases
-  lute test -s MyTestSuite                     Run all tests in MyTestSuite
-  lute test --suite MyTestSuite --case mytest  Run specific test in suite
-  lute test --case "some case"                 Run all test cases named "some case"
-]])
-end
 
 local function loadtests(testfiles: { path.path })
 	-- Load all test files first
@@ -71,54 +48,29 @@ local function runtests(env: testtypes.testenvironment, runner: testtypes.testru
 end
 
 local function main(...: string)
-	local args = { ... }
-	local testPaths = {}
-	local isListMode = false
-	local suiteName: string? = nil
-	local caseName: string? = nil
+	local args = cli.parser()
 
-	local i = 1
-	while i <= #args do
-		local arg = args[i]
+	args:add("help", "flag", { help = "Show this help message", aliases = { "h" } })
+	args:add("list", "flag", { help = "List all discovered test cases without running them" })
+	args:add("suite", "option", { help = "Run only tests in the specified suite", aliases = { "s" } })
+	args:add("case", "option", { help = "Run only test cases matching the specified name", aliases = { "c" } })
 
-		if arg == "-h" or arg == "--help" then
-			printHelp()
-			return
-		elseif arg == "--list" then
-			isListMode = true
-			i += 1
-		elseif arg == "-s" or arg == "--suite" then
-			i += 1
-			if i <= #args then
-				suiteName = args[i]
-				i += 1
-			else
-				print(`Error: {arg} requires a value`)
-				ps.exit(1)
-			end
-		elseif arg == "-c" or arg == "--case" then
-			i += 1
-			if i <= #args then
-				caseName = args[i]
-				i += 1
-			else
-				print(`Error: {arg} requires a value`)
-				ps.exit(1)
-			end
-		else
-			table.insert(testPaths, arg)
-			i += 1
-		end
+	args:parse({ ... })
+
+	if args:has("help") then
+		print(args:help())
+		return
 	end
 
-	local searchpath = if #testPaths > 0 then testPaths else { "./tests" }
+	local testPaths = args:forwarded()
+	local searchpath = if testPaths and #testPaths > 0 then testPaths else { "./tests" }
 	loadtests(finder.findtestfiles(searchpath))
 
-	if isListMode then
+	if args:has("list") then
 		listtests()
 	else
-		local env = test._registered()
-		local filteredEnv = filter.filtertests(env, suiteName, caseName)
+		local env = test._registered() :: testtypes.testenvironment
+		local filteredEnv = filter.filtertests(env, args:get("suite"), args:get("case"))
 		runtests(filteredEnv, runner.run, reporter.color)
 	end
 end

--- a/tools/check-faillist.txt
+++ b/tools/check-faillist.txt
@@ -89,7 +89,6 @@ lute/cli/commands/test/filter.luau:34:5-16
 lute/cli/commands/test/filter.luau:34:5-16
 lute/cli/commands/test/filter.luau:62:6-17
 lute/cli/commands/test/filter.luau:62:6-17
-lute/cli/commands/test/init.luau:121:42-44
 lute/cli/commands/transform/init.luau:16:26-30
 lute/cli/commands/transform/lib/arguments.luau:47:26-37
 lute/cli/commands/transform/lib/arguments.luau:47:26-37


### PR DESCRIPTION
Just a small refactor PR - gets rid of the manual(and kind of buggy) arg parsing lute test was doing and replaces it with the `@batteries/cli` arg parser.