### PR TITLE
fix lint severity mapping

### DIFF
--- a/lute/cli/commands/lint/lsp/init.luau
+++ b/lute/cli/commands/lint/lsp/init.luau
@@ -8,13 +8,13 @@ local lsp = {}
 
 local function severity(sev: lintTypes.severity): number
 	if sev == "error" then
-		return 1
+		return 0
 	elseif sev == "warning" then
-		return 2
+		return 1
 	elseif sev == "info" then
-		return 3
+		return 2
 	else
-		return 4
+		return 3
 	end
 end
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -936,7 +936,7 @@ local x = 1 / 0
                     "codeDescription": "https://lute.luau.org/cli/lint/unused_variable.html", 
                     "source": "lute lint", 
                     "code": "unused_variable", 
-                    "severity": 2, 
+                    "severity": 1, 
                     "range": {
                         "start": {
                             "character": 6, 
@@ -953,7 +953,7 @@ local x = 1 / 0
                     "codeDescription": "https://lute.luau.org/cli/lint/divide_by_zero.html", 
                     "source": "lute lint", 
                     "code": "divide_by_zero", 
-                    "severity": 2, 
+                    "severity": 1, 
                     "range": {
                         "start": {
                             "character": 10, 
@@ -1176,7 +1176,7 @@ b = a
         "codeDescription": "https://lute.luau.org/cli/lint/unused_variable.html", 
         "source": "lute lint", 
         "code": "unused_variable", 
-        "severity": 2, 
+        "severity": 1, 
         "range": {
             "start": {
                 "character": 6, 
@@ -1193,7 +1193,7 @@ b = a
         "codeDescription": "https://lute.luau.org/cli/lint/divide_by_zero.html", 
         "source": "lute lint", 
         "code": "divide_by_zero", 
-        "severity": 2, 
+        "severity": 1, 
         "range": {
             "start": {
                 "character": 10, 
@@ -1512,7 +1512,7 @@ local e = next(t) ~= nil
         "codeDescription": "https://lute.luau.org/cli/lint/almost_swapped.html", 
         "source": "lute lint", 
         "code": "almost_swapped", 
-        "severity": 2, 
+        "severity": 1, 
         "range": {
             "start": {
                 "character": 3, 


### PR DESCRIPTION
I found it odd that my lint "warning" violations kept showing up with blue squiggles instead of the red I'm more used to; did a little digging and it looks like we our severity mapping was off by one, see [VS Code API def here:](https://code.visualstudio.com/api/references/vscode-api#DiagnosticSeverity)

<img width="345" height="427" alt="Screenshot 2026-02-12 at 2 51 21 PM" src="https://github.com/user-attachments/assets/b8ed4f25-66dc-4d58-b210-362fdb3adc97" />

This fixes mapping.