### PR TITLE
Adds unnecessary tag to unused variable lint rule violations

### DIFF
--- a/lute/cli/commands/lint/rules/unused_variable.luau
+++ b/lute/cli/commands/lint/rules/unused_variable.luau
@@ -307,6 +307,7 @@ local function lint(ast: syntax.AstStatBlock, sourcepath: path.path?): { lintTyp
 			severity = "warning",
 			sourcepath = sourcepath,
 			target = target,
+			tags = { "unnecessary" },
 		}) -- LUAUFIX: Table literal doesn't subtype against lintTypes.LintViolation for some reason
 	end)
 end

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -939,6 +939,9 @@ local x = 1 / 0
                     "source": "lute lint", 
                     "code": "unused_variable", 
                     "severity": 2, 
+                    "tags": [
+                        1
+                    ], 
                     "range": {
                         "start": {
                             "character": 6, 
@@ -1179,6 +1182,9 @@ b = a
         "source": "lute lint", 
         "code": "unused_variable", 
         "severity": 2, 
+        "tags": [
+            1
+        ], 
         "range": {
             "start": {
                 "character": 6, 


### PR DESCRIPTION
Once the necessary change makes it into Mandolin, this allows us to grey out unused variables