### PR TITLE
Fixes bug when serializing nested `MetatableType`

### DIFF
--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -372,11 +372,8 @@ struct TypeSerialize final : public Luau::TypeVisitor
     // metatable: type?
     void serialize(TypeId ty, const MetatableType& mtv)
     {
-        checkStack(L, 2);
-        lua_createtable(L, 0, 2);
-        registerType(ty);
-
         traverse(mtv.table);
+        registerType(ty);
 
         traverse(mtv.metatable);
         lua_setfield(L, -2, "metatable");

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -539,6 +539,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_simple_type_pack_nil_tail")
     REQUIRE(lua_isnil(L, -1)); // no tail
 }
 
+
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_type_pack_with_head_and_tail")
 {
     TypeId numberTy = arena.addType(PrimitiveType{PrimitiveType::Number});

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -539,7 +539,6 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_simple_type_pack_nil_tail")
     REQUIRE(lua_isnil(L, -1)); // no tail
 }
 
-
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_type_pack_with_head_and_tail")
 {
     TypeId numberTy = arena.addType(PrimitiveType{PrimitiveType::Number});


### PR DESCRIPTION
Found a bug when serializing nested MetatableTypes when testing the `typeofmodule` API on the modules in `definitions/` and it passed the current test cases because I was only testing shallow metatables, but when we have nested metatables like that in `@lute/time` and we have things like 

```lua
export type Duration = setmetatable<Frozen, {
	read __metatable: "The metatable is locked!",
	read __index: typeof(table.freeze(duration_ops)),
	read __add: (Duration, Duration) -> Duration,
	read __sub: (Duration, Duration) -> Duration,
	read __eq: (Duration, Duration) -> boolean,
	read __lt: (Duration, Duration) -> boolean,
	read __le: (Duration, Duration) -> boolean,
}>
```

The indices were getting messed up because I was creating an extra table for the metatable, which isn't correct bc we're treating a metatable as just a table with an extra `metatable` field). We don't need to do that because when `traverse(mtv.table)` enters the `serialize(TableType)` case, that already handles creating that table. 

This fixes any issues I have with calling the Type Serializer on all of the `.luau` files in `definitions/`