### PR TITLE
Updates unused_variable lint rule to allow configuring write-only APIs

### DIFF
--- a/lute/cli/commands/lint/rules/unused_variable.luau
+++ b/lute/cli/commands/lint/rules/unused_variable.luau
@@ -8,11 +8,47 @@ local name = "unused_variable"
 local message = "Unused variable detected. Prefix this variable with '_' to indicate that it's intentionally unused."
 local target = "https://lute.luau.org/cli/lint/unused_variable.html"
 
+type leaf = { tag: "leaf", vals: { [number]: true } }
+
+type branch = { tag: "branch", entries: { [string]: leaf } }
+
+-- We assume that we only need 2 levels of depth, since there currently no APIs nested more than 2 levels.
+-- If we need more levels in the future, we can generalize, but this greatly simplifies the logic.
+type smallTrie = { tag: "root", entries: { [string]: branch | leaf } }
+
 local function isRequireCall(expr: syntax.AstExpr)
 	return expr.tag == "call" and expr.func.tag == "global" and expr.func.name.text == "require"
 end
 
-local function unusedLocals(block: syntax.AstStatBlock): { syntax.AstLocal }
+local function getWriteOnlyArgs(func: syntax.AstExpr, writeOnlyAPIs: smallTrie): { [number]: true }?
+	if func.tag == "global" then
+		local entry = writeOnlyAPIs.entries[func.name.text]
+
+		if not entry or entry.tag ~= "leaf" then
+			return nil
+		end
+
+		return entry.vals
+	elseif
+		(func.tag == "indexname" and func.expression.tag == "global")
+		or (func.tag == "index" and func.expression.tag == "global" and func.index.tag == "string") -- LUAUFIX: Refinement bug here: func should be narrowed to AstExprIndexExpr
+	then
+		func = func :: syntax.AstExprIndexName | syntax.AstExprIndexExpr
+		local branch = writeOnlyAPIs.entries[(func.expression :: syntax.AstExprGlobal).name.text]
+
+		if not branch or branch.tag ~= "branch" then
+			return nil
+		end
+
+		local entry = branch.entries[(func.index :: syntax.Token<string>).text]
+
+		return if entry then entry.vals else nil
+	else
+		return nil
+	end
+end
+
+local function unusedLocals(block: syntax.AstStatBlock, writeOnlyAPIs: smallTrie): { syntax.AstLocal }
 	local visitor: visitorLib.Visitor & {
 		unusedLocals: { syntax.AstLocal },
 		scopes: { { [syntax.AstLocal]: boolean } },
@@ -293,26 +329,110 @@ local function unusedLocals(block: syntax.AstStatBlock): { syntax.AstLocal }
 		return false
 	end
 
+	function visitor.visitExprCall(node: syntax.AstExprCall)
+		local writeOnlyIndices = getWriteOnlyArgs(node.func, writeOnlyAPIs)
+
+		if not writeOnlyIndices then
+			return true
+		end
+
+		visitorLib.visitexpression(node.func, visitor)
+
+		for i, arg in node.arguments do
+			if writeOnlyIndices[i] then
+				local prevInLValueContext = visitor.inLValueContext
+				visitor.inLValueContext = true
+				visitorLib.visitexpression(arg.node, visitor)
+				visitor.inLValueContext = prevInLValueContext
+			else
+				visitorLib.visitexpression(arg.node, visitor)
+			end
+		end
+
+		return false
+	end
+
 	visitorLib.visitblock(block, visitor)
 
 	return visitor.unusedLocals
 end
 
+local function isPositiveInt(v: unknown): boolean
+	return type(v) == "number" and v > 0 and math.floor(v) == v
+end
+
 local function lint(
 	ast: syntax.AstStatBlock,
 	sourcepath: path.path?,
-	_context: lintTypes.RuleContext
+	context: lintTypes.RuleContext
 ): { lintTypes.LintViolation }
-	return tableext.map(unusedLocals(ast), function(l): lintTypes.LintViolation
+	-- Validate context.options, which should be of form { ["api"] = { number } },
+	-- where the number keys represent argument indices which only write to their passed values.
+	for api, args in context.options do
+		local errorMessage =
+			`Expected options for API '{api}' to be an array of argument indices which only write to their passed values`
+		if type(args) ~= "table" then
+			error(errorMessage)
+		end
+
+		for k, v in args do
+			if not isPositiveInt(k) or not isPositiveInt(v) then
+				error(errorMessage)
+			end
+		end
+	end
+
+	local writeOnlyAPIs: smallTrie = {
+		tag = "root",
+		entries = {
+			table = { tag = "branch", entries = { insert = { tag = "leaf", vals = { [1] = true } } } },
+		},
+	}
+
+	for k, v in context.options do
+		local parts = k:split(".")
+		if #parts < 1 or #parts > 2 then
+			error(`Invalid API '${k}' in options. Only APIs up to 2 levels deep are supported.`)
+		end
+
+		if #parts == 1 then
+			local entry = writeOnlyAPIs.entries[parts[1]]
+
+			if entry then
+				error(
+					`API '{parts[1]}' is already defined as {if entry.tag == "branch" then "part of " else ""}a write-only API, so '{k}' cannot be added as a write-only API.`
+				)
+			end
+
+			writeOnlyAPIs.entries[parts[1]] = { tag = "leaf", vals = tableext.toset(v :: { number }) } -- We validate v above, so the cast is ok
+		else
+			if not writeOnlyAPIs.entries[parts[1]] then
+				writeOnlyAPIs.entries[parts[1]] = {
+					tag = "branch",
+					entries = { [parts[2]] = { tag = "leaf", vals = tableext.toset(v :: { number }) } },
+				}
+			else
+				local branch = writeOnlyAPIs.entries[parts[1]]
+				if branch.tag ~= "branch" then
+					error(
+						`API '{parts[1]}' is already defined as a write-only API, so '{k}' cannot be added as a write-only API.`
+					)
+				end
+				branch.entries[parts[2]] = { tag = "leaf", vals = tableext.toset(v :: { number }) } -- We validate v above, so the cast is ok
+			end
+		end
+	end
+
+	return tableext.map(unusedLocals(ast, writeOnlyAPIs), function(l): lintTypes.LintViolation
 		return {
 			lintname = name,
-			location = l.location,
+			location = l.location, -- LUAUFIX: Bidirectional inference should let us know that l : syntax.AstLocal
 			message = message,
 			severity = "warning",
 			sourcepath = sourcepath,
 			target = target,
 			tags = { "unnecessary" },
-		} -- LUAUFIX: Table literal doesn't subtype against lintTypes.LintViolation for some reason
+		}
 	end)
 end
 

--- a/lute/cli/commands/lint/rules/unused_variable.luau
+++ b/lute/cli/commands/lint/rules/unused_variable.luau
@@ -31,7 +31,7 @@ local function getWriteOnlyArgs(func: syntax.AstExpr, writeOnlyAPIs: smallTrie):
 		return entry.vals
 	elseif
 		(func.tag == "indexname" and func.expression.tag == "global")
-		or (func.tag == "index" and func.expression.tag == "global" and func.index.tag == "string") -- LUAUFIX: Refinement bug here: func should be narrowed to AstExprIndexExpr
+		or (func.tag == "index" and func.expression.tag == "global" and func.index.tag == "string") -- LUAUFIX: Refinement bug here: func should be narrowed to AstExprIndexExpr (CLI-190889)
 	then
 		func = func :: syntax.AstExprIndexName | syntax.AstExprIndexExpr
 		local branch = writeOnlyAPIs.entries[(func.expression :: syntax.AstExprGlobal).name.text]

--- a/lute/cli/commands/lint/rules/unused_variable.luau
+++ b/lute/cli/commands/lint/rules/unused_variable.luau
@@ -392,7 +392,7 @@ local function lint(
 	for k, v in context.options do
 		local parts = k:split(".")
 		if #parts < 1 or #parts > 2 then
-			error(`Invalid API '${k}' in options. Only APIs up to 2 levels deep are supported.`)
+			error(`Invalid API '{k}' in options. Only APIs up to 2 levels deep are supported.`)
 		end
 
 		if #parts == 1 then

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -2430,7 +2430,7 @@ return {
 			]],
 			outputExpectations = {
 				{
-					expectedOutput = "Error applying lint rule 'unused_variable': lute/cli/commands/lint/rules/unused_variable.luau:395: Invalid API '$deeply.nested.api' in options. Only APIs up to 2 levels deep are supported.",
+					expectedOutput = "Invalid API 'deeply.nested.api' in options. Only APIs up to 2 levels deep are supported.",
 					count = 1,
 				},
 			},
@@ -2461,7 +2461,7 @@ return {
 			]],
 			outputExpectations = {
 				{
-					expectedOutput = "Error applying lint rule 'unused_variable': lute/cli/commands/lint/rules/unused_variable.luau:402: API 'myApi' is already defined as part of a write-only API, so 'myApi' cannot be added as a write-only API.",
+					expectedOutput = "API 'myApi' is already defined as part of a write-only API, so 'myApi' cannot be added as a write-only API.",
 					count = 1,
 				},
 			},

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -2152,6 +2152,322 @@ end
 		})
 	end)
 
+	suite:case("unused_variable with table.insert default write-only API", function(assert)
+		lintTestHelper(assert, {
+			content = [[
+local t = {}
+table.insert(t, 1)
+]],
+			expectedExitCode = 1,
+			rulePath = defaultRulesPaths.unused_variable,
+			disableDefaultLints = true,
+			outputExpectations = {
+				{
+					expectedOutput = LINT_RULE_MESSAGES.unused_variable,
+					count = 1,
+				},
+				{
+					expectedOutput = [[
+violator.luau:1:7-8 ──
+   │
+ 1 │ local t = {}
+   │       ^
+   │
+]],
+					count = 1,
+				},
+			},
+		})
+	end)
+
+	suite:case("unused_variable with custom write-only API (single level)", function(assert)
+		lintTestHelper(assert, {
+			content = [[
+local output = {}
+myWrite(output, "data")
+]],
+			expectedExitCode = 1,
+			rulePath = defaultRulesPaths.unused_variable,
+			disableDefaultLints = true,
+			configContents = [[
+return {
+	lute = {
+		lint = {
+			rules = {
+				["unused_variable"] = {
+					options = {
+						myWrite = { 1 }
+					}
+				}
+			}
+		}
+	}
+}
+			]],
+			outputExpectations = {
+				{
+					expectedOutput = LINT_RULE_MESSAGES.unused_variable,
+					count = 1,
+				},
+				{
+					expectedOutput = [[
+violator.luau:1:7-13 ──
+   │
+ 1 │ local output = {}
+   │       ^^^^^^
+   │
+]],
+					count = 1,
+				},
+			},
+		})
+	end)
+
+	suite:case("unused_variable with custom write-only API (nested)", function(assert)
+		lintTestHelper(assert, {
+			content = [[
+local buffer = {}
+fs.write(buffer, "content")
+]],
+			expectedExitCode = 1,
+			rulePath = defaultRulesPaths.unused_variable,
+			disableDefaultLints = true,
+			configContents = [[
+return {
+	lute = {
+		lint = {
+			rules = {
+				["unused_variable"] = {
+					options = {
+						["fs.write"] = { 1 }
+					}
+				}
+			}
+		}
+	}
+}
+			]],
+			outputExpectations = {
+				{
+					expectedOutput = LINT_RULE_MESSAGES.unused_variable,
+					count = 1,
+				},
+				{
+					expectedOutput = [[
+violator.luau:1:7-13 ──
+   │
+ 1 │ local buffer = {}
+   │       ^^^^^^
+   │
+]],
+					count = 1,
+				},
+			},
+		})
+	end)
+
+	suite:case("unused_variable with custom write-only API (nested, index expr access)", function(assert)
+		lintTestHelper(assert, {
+			content = [[
+local buffer = {}
+fs["write"](buffer, "content")
+]],
+			expectedExitCode = 1,
+			rulePath = defaultRulesPaths.unused_variable,
+			disableDefaultLints = true,
+			configContents = [[
+return {
+	lute = {
+		lint = {
+			rules = {
+				["unused_variable"] = {
+					options = {
+						["fs.write"] = { 1 }
+					}
+				}
+			}
+		}
+	}
+}
+			]],
+			outputExpectations = {
+				{
+					expectedOutput = LINT_RULE_MESSAGES.unused_variable,
+					count = 1,
+				},
+				{
+					expectedOutput = [[
+violator.luau:1:7-13 ──
+   │
+ 1 │ local buffer = {}
+   │       ^^^^^^
+   │
+]],
+					count = 1,
+				},
+			},
+		})
+	end)
+
+	suite:case("unused_variable with multiple write-only args", function(assert)
+		lintTestHelper(assert, {
+			content = [[
+local a = {}
+local b = {}
+myMultiWrite(a, b, "data")
+]],
+			expectedExitCode = 1,
+			rulePath = defaultRulesPaths.unused_variable,
+			disableDefaultLints = true,
+			configContents = [[
+return {
+	lute = {
+		lint = {
+			rules = {
+				["unused_variable"] = {
+					options = {
+						myMultiWrite = { 1, 2 }
+					}
+				}
+			}
+		}
+	}
+}
+			]],
+			outputExpectations = {
+				{
+					expectedOutput = LINT_RULE_MESSAGES.unused_variable,
+					count = 2,
+				},
+				{
+					expectedOutput = [[
+violator.luau:1:7-8 ──
+   │
+ 1 │ local a = {}
+   │       ^
+   │
+]],
+					count = 1,
+				},
+				{
+					expectedOutput = [[
+violator.luau:2:7-8 ──
+   │
+ 2 │ local b = {}
+   │       ^
+   │
+]],
+					count = 1,
+				},
+			},
+		})
+	end)
+
+	suite:case("unused_variable with write-only arg at position 2", function(assert)
+		lintTestHelper(assert, {
+			content = [[
+local config = "read"
+local output = {}
+myFunc(config, output)
+]],
+			expectedExitCode = 1,
+			rulePath = defaultRulesPaths.unused_variable,
+			disableDefaultLints = true,
+			configContents = [[
+return {
+	lute = {
+		lint = {
+			rules = {
+				["unused_variable"] = {
+					options = {
+						myFunc = { 2 }
+					}
+				}
+			}
+		}
+	}
+}
+			]],
+			outputExpectations = {
+				{
+					expectedOutput = LINT_RULE_MESSAGES.unused_variable,
+					count = 1,
+				},
+				{
+					expectedOutput = [[
+violator.luau:2:7-13 ──
+   │
+ 2 │ local output = {}
+   │       ^^^^^^
+   │
+]],
+					count = 1,
+				},
+			},
+		})
+	end)
+
+	suite:case("unused_variable with deep nesting errors", function(assert)
+		lintTestHelper(assert, {
+			content = "local x = 1",
+			expectedExitCode = 0,
+			rulePath = defaultRulesPaths.unused_variable,
+			disableDefaultLints = true,
+			configContents = [[
+return {
+	lute = {
+		lint = {
+			rules = {
+				["unused_variable"] = {
+					options = {
+						["deeply.nested.api"] = { 1 }
+					}
+				}
+			}
+		}
+	}
+}
+			]],
+			outputExpectations = {
+				{
+					expectedOutput = "Error applying lint rule 'unused_variable': lute/cli/commands/lint/rules/unused_variable.luau:395: Invalid API '$deeply.nested.api' in options. Only APIs up to 2 levels deep are supported.",
+					count = 1,
+				},
+			},
+		})
+	end)
+
+	suite:case("unused_variable with conflicting API definitions errors", function(assert)
+		lintTestHelper(assert, {
+			content = "local x = 1",
+			expectedExitCode = 0,
+			rulePath = defaultRulesPaths.unused_variable,
+			disableDefaultLints = true,
+			configContents = [[
+return {
+	lute = {
+		lint = {
+			rules = {
+				["unused_variable"] = {
+					options = {
+						myApi = { 1 },
+						["myApi.nested"] = { 1 }
+					}
+				}
+			}
+		}
+	}
+}
+			]],
+			outputExpectations = {
+				{
+					expectedOutput = "Error applying lint rule 'unused_variable': lute/cli/commands/lint/rules/unused_variable.luau:402: API 'myApi' is already defined as part of a write-only API, so 'myApi' cannot be added as a write-only API.",
+					count = 1,
+				},
+			},
+		})
+	end)
+
 	suite:case("throws error when config has invalid structure", function(assert)
 		-- local invalidGlobalConfig = [[
 		-- 	return {

--- a/tools/check-faillist.txt
+++ b/tools/check-faillist.txt
@@ -64,7 +64,10 @@ lute/cli/commands/lint/rules/almost_swapped.luau:92:5-16
 lute/cli/commands/lint/rules/parenthesized_conditions.luau:27:5-16
 lute/cli/commands/lint/rules/parenthesized_conditions.luau:42:6-17
 lute/cli/commands/lint/rules/parenthesized_conditions.luau:68:4-15
-lute/cli/commands/lint/rules/unused_variable.luau:309:15-24
+lute/cli/commands/lint/rules/unused_variable.luau:34:31-49
+lute/cli/commands/lint/rules/unused_variable.luau:34:67-76
+lute/cli/commands/lint/rules/unused_variable.luau:34:67-80
+lute/cli/commands/lint/rules/unused_variable.luau:429:15-24
 lute/cli/commands/pkg/loom-core/extern/pp.luau:97:3-14
 lute/cli/commands/pkg/loom-core/extern/pp.luau:97:3-14
 lute/cli/commands/pkg/loom-core/extern/unzip/crc.luau:25:42-59


### PR DESCRIPTION
This supports reporting patterns like the following, where `t` is unused because it's only inserted into:
```luau
local t = {}
table.insert(t, 2)
```