### PR TITLE
Add basic docs on lute lint's configuration system

### DIFF
--- a/docs/cli/lint/index.md
+++ b/docs/cli/lint/index.md
@@ -45,7 +45,7 @@ type Config = {
             -- Array of paths from which to load local lint rules (similar to -r CLI option)
             rulepaths: { [string] }?,
             -- Specify per-rule options and overrides
-            rules: {
+            ruleconfigs: {
                 [RuleName]: {
                     -- Array of globs (.gitignore style) that are EXEMPT from this rule
                     ignores: { string }?,

--- a/docs/cli/lint/index.md
+++ b/docs/cli/lint/index.md
@@ -29,7 +29,7 @@ Path to a single lint rule or a folder containing lint rules. If a folder is pro
 
 ### `-c, --config [CONFIG]`
 
-Path to a single file containing lute lint configuration table. If unspecified, lute lint will look for a `.config.luau` file in the working directory from which it is invoked.
+Path to file containing lute lint configuration table. If unspecified, lute lint will look for a `.config.luau` file in the working directory from which it is invoked.
 
 Configuration expects the following structure:
 ```luau

--- a/docs/cli/lint/index.md
+++ b/docs/cli/lint/index.md
@@ -33,6 +33,8 @@ Path to a single file containing lute lint configuration table. If unspecified, 
 
 Configuration expects the following structure:
 ```luau
+type RuleName = string
+
 type Config = {
     lute: {
         lint: {
@@ -44,7 +46,7 @@ type Config = {
             rulepaths: { [string] }?,
             -- Specify per-rule options and overrides
             rules: {
-                [string]: {
+                [RuleName]: {
                     -- Array of globs (.gitignore style) that are EXEMPT from this rule
                     ignores: { string }?,
                     -- Override a rule's default severity

--- a/docs/cli/lint/index.md
+++ b/docs/cli/lint/index.md
@@ -27,6 +27,40 @@ Enable verbose output
 
 Path to a single lint rule or a folder containing lint rules. If a folder is provided, any subfolders containing init.luau files will be treated as modules exporting lint rules, while all other .luau files will be treated as individual lint rules. If unspecified, the default lint rules are used.
 
+### `-c, --config [CONFIG]`
+
+Path to a single file containing lute lint configuration table. If unspecified, lute lint will look for a `.config.luau` file in the working directory from which it is invoked.
+
+Configuration expects the following structure:
+```luau
+type Config = {
+    lute: {
+        lint: {
+            -- Array of globs (.gitignore style) to EXEMPT from linting
+            ignores: { string }?,
+            -- Table of string:unknown pairs; globals are passed down to each rule
+            globals: { [string]: unknown }?,
+            -- Array of paths from which to load local lint rules (similar to -r CLI option)
+            rulepaths: { [string] }?,
+            -- Specify per-rule options and overrides
+            rules: {
+                [string]: {
+                    -- Array of globs (.gitignore style) that are EXEMPT from this rule
+                    ignores: { string }?,
+                    -- Override a rule's default severity
+                    severity: ("warn" | "error" | "info" | "hint")?,
+                    -- Pass custom options through to a rule;
+                    -- see specific rule's implementation / docs for expected options structure
+                    options: { [string]: unknown }?,
+                    -- Disable a rule
+                    off: boolean?,
+                },
+            }?,
+        }?,
+    }?,
+}
+```
+
 ### `-j, --json`
 
 Output lint violations in JSON format matching the LSP diagnostic spec.


### PR DESCRIPTION
This PR adds a section about configuring lute lint to it's docs page. We should hold off on merging until https://github.com/luau-lang/lute/pull/822 is merged, which completes the baseline functionality for lute lint's configurability.