### PR TITLE
Write `.luaurc` to generated typedefs folder

### DIFF
--- a/lute/cli/commands/setup/init.luau
+++ b/lute/cli/commands/setup/init.luau
@@ -30,6 +30,9 @@ for key, value in definitions :: { [string]: string } do
 	fs.writestringtofile(filePath, value)
 end
 
+local typedefsLuauRcPath = path.join(BASE_PATH, ".luaurc")
+fs.writestringtofile(typedefsLuauRcPath, json.serialize(TEMPLATE_RC_FILE, true))
+
 print(`Successfully wrote type definition files to {BASE_PATH_PRETTY}`)
 
 if not table.find(args, "--with-luaurc") then


### PR DESCRIPTION
There is no `.luaurc` file included in the generated type definitions folder. Files within the folder using any lute-reserved alias, like the syntax types, will yield errors when consumed.

This PR ensures `lute setup` generates a `.luaurc` file in the type definitions