### PR TITLE
Modifies ParseResult's line offsets to be 1-indexed

### DIFF
--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -2844,7 +2844,7 @@ int luau_parse(lua_State* L)
     for (size_t i = 0; i < serializer.lineOffsets.size(); i++)
     {
         lua_pushinteger(L, i + 1);
-        lua_pushnumber(L, serializer.lineOffsets[i]);
+        lua_pushnumber(L, serializer.lineOffsets[i] + 1);
         lua_settable(L, -3);
     }
     lua_setfield(L, -2, "lineoffsets");

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -150,25 +150,25 @@ test.suite("Parser", function(suite)
 
 		assert.eq(type(result.lineoffsets), "table")
 		assert.eq(#result.lineoffsets, 1)
-		assert.eq(result.lineoffsets[1], 0)
+		assert.eq(result.lineoffsets[1], 1)
 
 		local multiLineCode = "local x = 1\nlocal y = 2\nlocal z = 3"
 		local multiResult = parser.parse(multiLineCode)
 
 		assert.eq(type(multiResult.lineoffsets), "table")
 		assert.eq(#multiResult.lineoffsets, 3)
-		assert.eq(multiResult.lineoffsets[1], 0)
-		assert.eq(multiResult.lineoffsets[2], 12)
-		assert.eq(multiResult.lineoffsets[3], 24)
+		assert.eq(multiResult.lineoffsets[1], 1)
+		assert.eq(multiResult.lineoffsets[2], 13)
+		assert.eq(multiResult.lineoffsets[3], 25)
 
 		local emptyLineCode = "local x = 1\n\nlocal y = 2"
 		local emptyResult = parser.parse(emptyLineCode)
 
 		assert.eq(type(emptyResult.lineoffsets), "table")
 		assert.eq(#emptyResult.lineoffsets, 3)
-		assert.eq(emptyResult.lineoffsets[1], 0)
-		assert.eq(emptyResult.lineoffsets[2], 12)
-		assert.eq(emptyResult.lineoffsets[3], 13)
+		assert.eq(emptyResult.lineoffsets[1], 1)
+		assert.eq(emptyResult.lineoffsets[2], 13)
+		assert.eq(emptyResult.lineoffsets[3], 14)
 	end)
 
 	suite:case("canParseAttributes", function(assert)


### PR DESCRIPTION
It was weird that they were previously 0-indexed since they were used to index into a Luau array.