### PR TITLE
`luthier`: change `constexpr` to `const`

### DIFF
--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -295,7 +295,7 @@ local function generateEmbeddedModulesIfNeeded(config: EmbeddedModuleConfig)
 		"",
 		`#include "{headerFile}"`,
 		"",
-		`constexpr std::pair<std::string_view, std::string_view> {config.arrayName}[] = \{`,
+		`const std::pair<std::string_view, std::string_view> {config.arrayName}[] = \{`,
 	})
 
 	local numItems = 0


### PR DESCRIPTION
The arrays generated by `luthier.luau`([line](https://github.com/luau-lang/lute/blob/93a18677dca27a989a786d88ef6b631400ff058c/tools/luthier.luau#L298)) are lookup tables for embedded source files. 
If I understand correctly, they are not used at compile time, so `constexpr` gives no practical benefit over `const`.

Using `constexpr` forces the compiler to evaluate `strlen` at compile time for every string literal when constructing `std::string_view`. With many or large embedded files, this can exceed the compiler's limits.

This has already happened in PR #863. 
Switching these arrays to `const` should resolve the issue.