### PR TITLE
Fixes the task.spawn, task.defer, and task.resume methods

### DIFF
--- a/definitions/task.luau
+++ b/definitions/task.luau
@@ -3,19 +3,23 @@ local time = require("./time")
 
 local task = {}
 
-function task.defer()
-	error("unimplemented")
-end
-
-function task.wait(dur: (number | time.Duration)?): number
-	error("unimplemented")
-end
-
 function task.spawn<T..., U...>(routine: ((T...) -> U...) | thread, ...: T...): thread
 	error("unimplemented")
 end
 
+function task.defer<T..., U...>(routine: ((T...) -> U...) | thread, ...: T...): thread
+	error("unimplemented")
+end
+
 function task.resume(thread: thread): thread
+	error("unimplemented")
+end
+
+function task.deferSelf()
+	error("unimplemented")
+end
+
+function task.wait(dur: (number | time.Duration)?): number
 	error("unimplemented")
 end
 

--- a/examples/coroutine_error_isolation.luau
+++ b/examples/coroutine_error_isolation.luau
@@ -2,7 +2,7 @@ local task = require("@lute/task")
 
 local function loop()
 	while true do
-		task.defer()
+		task.deferSelf()
 
 		-- It may be useful to remove this print because it gets spammed, or implement another way
 		-- in which you can determinatively tell whether or not the thread is still active despite
@@ -13,7 +13,7 @@ end
 
 local function otherloop()
 	while true do
-		task.defer()
+		task.deferSelf()
 
 		if math.random(1, 2) == 1 then
 			error("oops")

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -93,6 +93,27 @@ RuntimeStep Runtime::runOnce()
 
     int status = LUA_OK;
 
+    int co_status = lua_costatus(GL, L);
+
+    // It's possible for a spawned task to be killed by a coroutine.close()
+    // before it gets processed in the runningThreads queue. This leads to situations where a thread was scheduled to resume
+    // but has already been killed.
+
+    // One example:
+    // 1) Main thread executes task.defer on a coroutine.create thread
+    // 2) Code is queued up on the thread
+    // 3) coroutine.cancel is invoked
+    // 4) runtime evaluates callbacks
+    // 5) runtime evaluates running threads <- UH OH, found a thread that was scheduled to resume but has already been killed
+    // 6) We can just step over it, because
+    // a) if it scheduled a resume, the corresponding pending token will have been cleared
+    // b) the corresponding ref for the lua state will be freed at the end of Runtime::runOnce()
+
+    if (co_status == LUA_COFIN)
+    {
+        return StepSuccess{L};
+    }
+
     if (!next.success)
         status = lua_resumeerror(L, nullptr);
     else
@@ -311,10 +332,8 @@ void ResumeTokenData::complete(std::function<int(lua_State*)> cont)
 ResumeToken getResumeToken(lua_State* L)
 {
     ResumeToken token = std::make_shared<ResumeTokenData>();
-
     token->runtime = getRuntime(L);
     token->ref = getRefForThread(L);
-
     token->runtime->addPendingToken();
 
     return token;

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -93,8 +93,6 @@ RuntimeStep Runtime::runOnce()
 
     int status = LUA_OK;
 
-    int co_status = lua_costatus(GL, L);
-
     // It's possible for a spawned task to be killed by a coroutine.close()
     // before it gets processed in the runningThreads queue. This leads to situations where a thread was scheduled to resume
     // but has already been killed.
@@ -108,7 +106,7 @@ RuntimeStep Runtime::runOnce()
     // 6) We can just step over it, because
     // a) if it scheduled a resume, the corresponding pending token will have been cleared
     // b) the corresponding ref for the lua state will be freed at the end of Runtime::runOnce()
-
+    int co_status = lua_costatus(GL, L);
     if (co_status == LUA_COFIN)
     {
         return StepSuccess{L};

--- a/lute/std/libs/task.luau
+++ b/lute/std/libs/task.luau
@@ -33,7 +33,7 @@ function tasklib.await(t: task): any
 	end
 
 	while t.success == nil do
-		task.defer()
+		task.deferSelf()
 	end
 
 	if t.success then
@@ -59,7 +59,7 @@ function tasklib.awaitall(...: task): ...unknown
 		for _, v in tasks do
 			if v.success == nil then
 				done = false
-				task.defer()
+				task.deferSelf()
 			end
 		end
 	end

--- a/lute/task/CMakeLists.txt
+++ b/lute/task/CMakeLists.txt
@@ -8,5 +8,5 @@ target_sources(Lute.Task PRIVATE
 
 target_compile_features(Lute.Task PUBLIC cxx_std_17)
 target_include_directories(Lute.Task PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Task PRIVATE Lute.Runtime Lute.Time Luau.VM uv_a)
+target_link_libraries(Lute.Task PRIVATE Lute.Runtime Lute.Common Lute.Time Luau.VM uv_a)
 target_compile_options(Lute.Task PRIVATE ${LUTE_OPTIONS})

--- a/lute/task/include/lute/task.h
+++ b/lute/task/include/lute/task.h
@@ -12,19 +12,19 @@ namespace task
 {
 
 int lua_defer(lua_State* L);
+int lua_deferSelf(lua_State* L);
 int lua_wait(lua_State* L);
 int lua_spawn(lua_State* L);
 int lute_resume(lua_State* L);
 int lua_delay(lua_State* L);
 
 static const luaL_Reg lib[] = {
-    {"defer", lua_defer},
-    {"wait", lua_wait},
     {"spawn", lua_spawn},
-    {"delay", lua_delay},
-
+    {"defer", lua_defer},
     {"resume", lute_resume},
-
+    {"deferSelf", lua_deferSelf},
+    {"wait", lua_wait},
+    {"delay", lua_delay},
     {nullptr, nullptr},
 };
 

--- a/lute/task/src/task.cpp
+++ b/lute/task/src/task.cpp
@@ -108,7 +108,7 @@ struct LuaThread
         int toPush = lua_gettop(parent);
         // We only want to resume with the actual number of arguments here, regardless of if the first argument is a thread or a function
         int numResumeArgs = toPush > 1 ? toPush - 1 : 0;
-        if (!lua_checkstack(L, 1))
+        if (!lua_checkstack(parent, 1))
             luaL_error(L, "Not enough stack space to create a new thread");
         if (lua_isfunction(parent, 1))
         {
@@ -163,7 +163,7 @@ struct LuaThread
         if (!ok)
         {
             runtime->reportError(child);
-            return 1;
+	    return 1;
         }
 
         return 1;

--- a/lute/task/src/task.cpp
+++ b/lute/task/src/task.cpp
@@ -94,7 +94,7 @@ namespace task
 
 struct LuaThread
 {
-    LuaThread(lua_State* L)
+    LuaThread(lua_State* L, std::string_view caller = "")
         : parent(L)
         , runtime(getRuntime(parent))
     {
@@ -123,7 +123,7 @@ struct LuaThread
         }
         else
         {
-            luaL_error(parent, "Expected a thread or function as the first argument.");
+            luaL_error(parent, "%s: Expected a thread or function as the first argument.", caller.data());
         }
         this->resumeArgs = numResumeArgs;
 
@@ -163,7 +163,7 @@ struct LuaThread
         if (!ok)
         {
             runtime->reportError(child);
-	    return 1;
+            return 1;
         }
 
         return 1;
@@ -184,7 +184,7 @@ private:
 
 int lua_spawn(lua_State* L)
 {
-    LuaThread newThread{L};
+    LuaThread newThread{L, "task.spawn"};
     return newThread.resume();
 }
 
@@ -196,7 +196,7 @@ int lua_deferSelf(lua_State* L)
         return 0;
     }
     lua_pushthread(L);
-    LuaThread newThread{L};
+    LuaThread newThread{L, "task.deferSelf"};
     newThread.defer();
     return lua_yield(L, 0);
 }
@@ -204,7 +204,7 @@ int lua_deferSelf(lua_State* L)
 int lua_defer(lua_State* L)
 {
 
-    LuaThread newThread{L};
+    LuaThread newThread{L, "task.defer"};
     return newThread.defer();
 }
 
@@ -215,7 +215,7 @@ int lute_resume(lua_State* L)
         luaL_error(L, "Expected a thread as the first argument.");
         return 0;
     }
-    LuaThread newThread{L};
+    LuaThread newThread{L, "task.resume"};
     return newThread.resume();
 }
 

--- a/lute/task/src/task.cpp
+++ b/lute/task/src/task.cpp
@@ -1,8 +1,11 @@
 #include "lute/task.h"
 
+#include "lute/common.h"
 #include "lute/ref.h"
 #include "lute/runtime.h"
 #include "lute/time.h"
+
+#include "Luau/Common.h"
 
 #include "lua.h"
 #include "lualib.h"
@@ -88,13 +91,114 @@ static void yieldLuaStateFor(lua_State* L, uint64_t milliseconds, bool putDeltaT
 
 namespace task
 {
+
+struct LuaThread
+{
+    LuaThread(lua_State* L)
+        : parent(L)
+        , runtime(getRuntime(parent))
+    {
+        // At this point, the lua stack should look like:
+        // [function, (args...]
+        // or
+        // [thread, args...]
+
+        // If passed a thread, we push the 0 or more arguments onto that threads stack and resume it.
+        // If passed a function, we push the function and the 0 or more arguments onto a newly created thread's stack
+        int toPush = lua_gettop(parent);
+        // We only want to resume with the actual number of arguments here, regardless of if the first argument is a thread or a function
+        int numResumeArgs = numResumeArgs = toPush > 1 ? toPush - 1 : 0;
+        if (!lua_checkstack(L, 1))
+            luaL_error(L, "Not enough stack space to create a new thread");
+        if (lua_isfunction(parent, 1))
+        {
+            child = lua_newthread(parent);
+        }
+        else if (lua_isthread(parent, 1))
+        {
+            child = lua_tothread(parent, 1);
+            lua_pushvalue(parent, 1);
+            lua_remove(parent, 1);
+            toPush--;
+        }
+        else
+        {
+            luaL_error(parent, "Expected a thread or function as the first argument.");
+        }
+        this->resumeArgs = numResumeArgs;
+
+        // At this point the invariant here is that the caller stack should look like:
+        // If the first argument was a function
+        // [function, 0 or more args to resume, thread to return ]
+        // If the first argument was a thread
+        // [ 0 or more args to resume the thread with, thread to return ]
+        if (!lua_checkstack(child, toPush))
+            luaL_error(L, "Not enough stack space to push arguments to child thread");
+        for (int i = 1; i <= toPush; i++)
+            lua_xpush(parent, child, i);
+
+        // The top of the stack must be the thread that we will return
+        LUTE_ASSERT(lua_isthread(parent, -1));
+    }
+
+    int defer()
+    {
+        runtime->runningThreads.push_back({true, getRefForThread(child), resumeArgs});
+        return 1;
+    }
+
+    int resume()
+    {
+        auto st = getChildThreadStatus();
+        bool suspended = st.first == LUA_COSUS;
+        if (!suspended)
+        {
+            luaL_error(parent, "cannot resume thread with status %s", st.second);
+            return 1;
+        }
+
+        int resumeStatus = lua_resume(child, parent, resumeArgs);
+        bool ok = resumeStatus == LUA_OK || resumeStatus == LUA_YIELD || resumeStatus == LUA_BREAK;
+
+        if (!ok)
+        {
+            runtime->reportError(child);
+            return 1;
+        }
+
+        return 1;
+    }
+
+private:
+    std::pair<int, const char*> getChildThreadStatus()
+    {
+        int st = lua_costatus(parent, child);
+        return {st, statnames[st]};
+    }
+
+    lua_State* parent = nullptr;
+    Runtime* runtime = nullptr;
+    lua_State* child = nullptr;
+    int resumeArgs = 0;
+};
+
+int lua_spawn(lua_State* L)
+{
+    LuaThread newThread{L};
+    return newThread.resume();
+}
+
 int lua_defer(lua_State* L)
 {
-    Runtime* runtime = getRuntime(L);
+    LuaThread newThread{L};
+    return newThread.defer();
+}
 
-    runtime->runningThreads.push_back({true, getRefForThread(L), 0});
-    return lua_yield(L, 0);
-};
+int lute_resume(lua_State* L)
+{
+    LuaThread newThread{L};
+    return newThread.resume();
+}
 
 
 int lua_delay(lua_State* L)
@@ -157,32 +261,6 @@ int lua_delay(lua_State* L)
     return 1;
 }
 
-int lua_spawn(lua_State* L)
-{
-    if (lua_isfunction(L, 1))
-    {
-        lua_State* NL = lua_newthread(L);
-
-        // transfer arguments from other lua_State to the called lua_State
-        lua_xpush(L, NL, 1);
-
-        // remove the function arg
-        lua_remove(L, 1);
-
-        // insert the thread
-        lua_insert(L, 1);
-    }
-    else if (!lua_isthread(L, 1))
-    {
-        luaL_error(L, "can only pass threads or functions to task.spawn");
-    }
-
-    lute_resume(L);
-
-    // return the thread
-    return 1;
-}
-
 int lua_wait(lua_State* L)
 {
     int type = lua_type(L, 1);
@@ -210,35 +288,6 @@ int lua_wait(lua_State* L)
     yieldLuaStateFor(L, milliseconds, true, 0);
 
     return lua_yield(L, 0);
-}
-
-int lute_resume(lua_State* L)
-{
-    Runtime* runtime = getRuntime(L);
-
-    lua_State* thread = lua_tothread(L, 1);
-    luaL_argexpected(L, thread, 1, "thread");
-
-    int currentThreadStatus = lua_costatus(L, thread);
-    if (currentThreadStatus != LUA_COSUS)
-    {
-        luaL_errorL(L, "cannot resume %s coroutine", statnames[currentThreadStatus]);
-
-        return 1;
-    };
-
-    lua_remove(L, 1);
-
-    int args = lua_gettop(L);
-    lua_xmove(L, thread, args);
-
-    int resumptionStatus = lua_resume(thread, L, args);
-    if (resumptionStatus != LUA_OK && resumptionStatus != LUA_YIELD && resumptionStatus != LUA_BREAK)
-    {
-        runtime->reportError(thread);
-    }
-
-    return 0;
 }
 
 } // namespace task

--- a/lute/task/src/task.cpp
+++ b/lute/task/src/task.cpp
@@ -99,7 +99,7 @@ struct LuaThread
         , runtime(getRuntime(parent))
     {
         // At this point, the lua stack should look like:
-        // [function, (args...]
+        // [function, args...]
         // or
         // [thread, args...]
 
@@ -107,7 +107,7 @@ struct LuaThread
         // If passed a function, we push the function and the 0 or more arguments onto a newly created thread's stack
         int toPush = lua_gettop(parent);
         // We only want to resume with the actual number of arguments here, regardless of if the first argument is a thread or a function
-        int numResumeArgs = numResumeArgs = toPush > 1 ? toPush - 1 : 0;
+        int numResumeArgs = toPush > 1 ? toPush - 1 : 0;
         if (!lua_checkstack(L, 1))
             luaL_error(L, "Not enough stack space to create a new thread");
         if (lua_isfunction(parent, 1))
@@ -188,14 +188,33 @@ int lua_spawn(lua_State* L)
     return newThread.resume();
 }
 
+int lua_deferSelf(lua_State* L)
+{
+    if (lua_gettop(L) != 0)
+    {
+        luaL_error(L, "task.deferSelf does not take any arguments");
+        return 0;
+    }
+    lua_pushthread(L);
+    LuaThread newThread{L};
+    newThread.defer();
+    return lua_yield(L, 0);
+}
+
 int lua_defer(lua_State* L)
 {
+
     LuaThread newThread{L};
     return newThread.defer();
 }
 
 int lute_resume(lua_State* L)
 {
+    if (!lua_isthread(L, 1))
+    {
+        luaL_error(L, "Expected a thread as the first argument.");
+        return 0;
+    }
     LuaThread newThread{L};
     return newThread.resume();
 }

--- a/tests/lute/task.test.luau
+++ b/tests/lute/task.test.luau
@@ -23,6 +23,18 @@ test.suite("LuteTaskSuite", function(suite)
 		assert.eq(endTime - startTime >= 0.5, true)
 	end)
 
+	suite:case("taskSpawn0ArgsErrors", function(assert)
+		assert.errors(function()
+			(task.spawn :: any)()
+		end)
+	end)
+
+	suite:case("taskDefer0ArgsErrors", function(assert)
+		assert.errors(function()
+			(task.defer :: any)()
+		end)
+	end)
+
 	suite:case("taskSpawnFunctionNoArgsCoroutineStatus", function(assert)
 		local thread = task.spawn(function()
 			task.wait(2)

--- a/tests/lute/task.test.luau
+++ b/tests/lute/task.test.luau
@@ -47,7 +47,7 @@ test.suite("LuteTaskSuite", function(suite)
 
 	-- task.spawn with function, >0 args
 	suite:case("taskSpawnFunctionWithArgsCoroutineStatus", function(assert)
-		local thread = task.spawn(function(a, b, c)
+		local thread = task.spawn(function(_a, _b, _c)
 			task.wait(2)
 		end, "hello", "world", "boom")
 
@@ -58,7 +58,7 @@ test.suite("LuteTaskSuite", function(suite)
 
 	-- task.spawn with thread, >0 args
 	suite:case("taskSpawnThreadWithArgsCoroutineStatus", function(assert)
-		local co = coroutine.create(function(a, b, c)
+		local co = coroutine.create(function(_a, _b, _c)
 			task.wait(2)
 		end)
 		local thread = task.spawn(co, "hello", "world", "boom")
@@ -93,7 +93,7 @@ test.suite("LuteTaskSuite", function(suite)
 
 	-- task.defer with function, >0 args
 	suite:case("taskDeferFunctionWithArgsCoroutineStatus", function(assert)
-		local thread = task.defer(function(a, b, c)
+		local thread = task.defer(function(_a, _b, _c)
 			task.wait(2)
 		end, "hello", "world", "boom")
 
@@ -104,7 +104,7 @@ test.suite("LuteTaskSuite", function(suite)
 
 	-- task.defer with thread, >0 args
 	suite:case("taskDeferThreadWithArgsCoroutineStatus", function(assert)
-		local co = coroutine.create(function(a, b, c)
+		local co = coroutine.create(function(_a, _b, _c)
 			task.wait(2)
 		end)
 		local thread = task.defer(co, "hello", "world", "boom")
@@ -128,7 +128,7 @@ test.suite("LuteTaskSuite", function(suite)
 
 	-- task.resume with thread, >0 args
 	suite:case("taskResumeThreadWithArgsCoroutineStatus", function(assert)
-		local co = coroutine.create(function(a, b, c)
+		local co = coroutine.create(function(_a, _b, _c)
 			task.wait(2)
 		end)
 		local thread = task.resume(co, "hello", "world", "boom")

--- a/tests/lute/task.test.luau
+++ b/tests/lute/task.test.luau
@@ -22,4 +22,119 @@ test.suite("LuteTaskSuite", function(suite)
 
 		assert.eq(endTime - startTime >= 0.5, true)
 	end)
+
+	suite:case("taskSpawnFunctionNoArgsCoroutineStatus", function(assert)
+		local thread = task.spawn(function()
+			task.wait(2)
+		end)
+
+		local status = coroutine.status(thread)
+		assert.eq(status, "suspended")
+		coroutine.close(thread)
+	end)
+
+	-- task.spawn with thread, 0 args
+	suite:case("taskSpawnThreadNoArgsCoroutineStatus", function(assert)
+		local co = coroutine.create(function()
+			task.wait(2)
+		end)
+		local thread = task.spawn(co)
+
+		local status = coroutine.status(thread)
+		assert.eq(status, "suspended")
+		coroutine.close(thread)
+	end)
+
+	-- task.spawn with function, >0 args
+	suite:case("taskSpawnFunctionWithArgsCoroutineStatus", function(assert)
+		local thread = task.spawn(function(a, b, c)
+			task.wait(2)
+		end, "hello", "world", "boom")
+
+		local status = coroutine.status(thread)
+		assert.eq(status, "suspended")
+		coroutine.close(thread)
+	end)
+
+	-- task.spawn with thread, >0 args
+	suite:case("taskSpawnThreadWithArgsCoroutineStatus", function(assert)
+		local co = coroutine.create(function(a, b, c)
+			task.wait(2)
+		end)
+		local thread = task.spawn(co, "hello", "world", "boom")
+
+		local status = coroutine.status(thread)
+		assert.eq(status, "suspended")
+		coroutine.close(thread)
+	end)
+
+	-- task.defer with function, 0 args
+	suite:case("taskDeferFunctionNoArgsCoroutineStatus", function(assert)
+		local thread = task.defer(function()
+			task.wait(2)
+		end)
+
+		local status = coroutine.status(thread)
+		assert.eq(status, "suspended")
+		coroutine.close(thread)
+	end)
+
+	-- task.defer with thread, 0 args
+	suite:case("taskDeferThreadNoArgsCoroutineStatus", function(assert)
+		local co = coroutine.create(function()
+			task.wait(2)
+		end)
+		local thread = task.defer(co)
+
+		local status = coroutine.status(thread)
+		assert.eq(status, "suspended")
+		coroutine.close(thread)
+	end)
+
+	-- task.defer with function, >0 args
+	suite:case("taskDeferFunctionWithArgsCoroutineStatus", function(assert)
+		local thread = task.defer(function(a, b, c)
+			task.wait(2)
+		end, "hello", "world", "boom")
+
+		local status = coroutine.status(thread)
+		assert.eq(status, "suspended")
+		coroutine.close(thread)
+	end)
+
+	-- task.defer with thread, >0 args
+	suite:case("taskDeferThreadWithArgsCoroutineStatus", function(assert)
+		local co = coroutine.create(function(a, b, c)
+			task.wait(2)
+		end)
+		local thread = task.defer(co, "hello", "world", "boom")
+
+		local status = coroutine.status(thread)
+		assert.eq(status, "suspended")
+		coroutine.close(thread)
+	end)
+
+	-- task.resume with thread, 0 args
+	suite:case("taskResumeThreadNoArgsCoroutineStatus", function(assert)
+		local co = coroutine.create(function()
+			task.wait(2)
+		end)
+		local thread = task.resume(co)
+
+		local status = coroutine.status(thread)
+		assert.eq(status, "suspended")
+		coroutine.close(thread)
+	end)
+
+	-- task.resume with thread, >0 args
+	suite:case("taskResumeThreadWithArgsCoroutineStatus", function(assert)
+		local co = coroutine.create(function(a, b, c)
+			task.wait(2)
+		end)
+		local thread = task.resume(co, "hello", "world", "boom")
+
+		local status = coroutine.status(thread)
+		assert.eq(status, "suspended")
+		coroutine.close(thread)
+	end)
 end)


### PR DESCRIPTION
Resolves #522 

This PR refactors `task.spawn, defer, resume` to share most of their logic for creating the stack and handing control off to newly created threads. The cause of the bug in #522 was that the stack didn't get set up correctly in the parent stack due to `lua_xmove` popping from the top, so the value that got returned was not callable with `coroutine.status` (because it wasn't a thread). The code I've added documents the invariant that I wanted to maintain along with helpers for correctly setting up the stack.

I've added tests for the following cases:
{task.defer, task.spawn, task.resume } called with { thread | function (except for task.resume, which only takes a thread passed { 0 arguments to resume with, > 0 arguments to resume with }.

I also introduced 'deferSelf' for the argumentless version of task.defer that says to immediately yield the current thread.