### PR TITLE
Adds `getAllRequires` to `@std/luau`

### DIFF
--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -7,6 +7,9 @@ local luteLuau = require("@lute/luau")
 
 local fs = require("@lute/fs")
 local path = require("@std/path")
+local syntax = require("@std/syntax")
+local utils = require("@std/syntax/utils")
+local query = require("@std/syntax/query")
 
 local luau = {}
 
@@ -43,6 +46,28 @@ end
 function luau.resolveModule(modulepath: string, frompath: path.pathlike): path.pathlike
 	local frompathString = if typeof(frompath) == "string" then frompath else path.format(frompath)
 	return luteLuau.resolveModule(modulepath, `@{frompathString}`)
+end
+
+function luau.getAllRequires(src: string): { string }
+	local ast = luteLuau.parse(src)
+
+	local requireCalls = query.findallfromroot(ast, utils.isExprCall):filter(function(call)
+		return call.func.tag == "global" and (call.func :: syntax.AstExprGlobal).name.text == "require"
+	end)
+
+	return requireCalls:maptoarray(function(call: syntax.AstExprCall): string?
+		local firstArg = call.arguments[1]
+		if firstArg == nil then
+			return nil
+		end
+
+		local argNode = firstArg.node
+		if argNode.tag ~= "string" then
+			return nil
+		end
+
+		return (argNode :: syntax.AstExprConstantString).text
+	end)
 end
 
 return table.freeze(luau)

--- a/tests/std/luau.test.luau
+++ b/tests/std/luau.test.luau
@@ -161,3 +161,54 @@ test.suite("LuauTypeOfModuleSuite", function(suite)
 		assert.eq(resolvedPath, expected)
 	end)
 end)
+
+test.suite("LuauGetAllRequiresSuite", function(suite)
+	suite:case("getAllRequiresBasic", function(assert)
+		local requires = luau.getAllRequires([[
+			local crypto = require("@lute/crypto")
+			local base64 = require("@batteries/base64")
+			print("hello")
+		]])
+		assert.eq(#requires, 2)
+		assert.eq(requires[1], "@lute/crypto")
+		assert.eq(requires[2], "@batteries/base64")
+	end)
+
+	suite:case("getAllRequiresEmpty", function(assert)
+		local requires = luau.getAllRequires([[
+			local hello = 1
+			print("world")
+		]])
+		assert.eq(#requires, 0)
+	end)
+
+	suite:case("getAllRequiresNonStringArg", function(assert)
+		local requires = luau.getAllRequires([[
+			local mod = require(someVariable)
+			local other = require("@std/test")
+		]])
+		assert.eq(#requires, 1)
+		assert.eq(requires[1], "@std/test")
+	end)
+
+	suite:case("getAllRequiresNoArgs", function(assert)
+		local requires = luau.getAllRequires([[
+			require()
+			local fs = require("@std/fs")
+		]])
+		assert.eq(#requires, 1)
+		assert.eq(requires[1], "@std/fs")
+	end)
+
+	suite:case("getAllRequiresRelativePaths", function(assert)
+		local requires = luau.getAllRequires([[
+			local a = require("./libs/dependency")
+			local b = require("../utils/helper")
+			local c = require("@std/test")
+		]])
+		assert.eq(#requires, 3)
+		assert.eq(requires[1], "./libs/dependency")
+		assert.eq(requires[2], "../utils/helper")
+		assert.eq(requires[3], "@std/test")
+	end)
+end)


### PR DESCRIPTION
Adds `getAllRequires(src: string): { string }` to `@std/luau`, which parses Luau source code and returns all of its required modules.
Resolves #776.

Now we can run this code:
```luau
local pp = require("@batteries/pp")
local luau = require("@std/luau")

local code = [=[
  local crypto = require("@lute/crypto")
  local base64 = require("@batteries/base64")

  local message = "Hello, world!"
  local digest = crypto.digest(crypto.hash.sha256, message)

  function hexify(digest)
    local hex = {}
    for i = 1, buffer.len(digest) do
      hex[i] = string.format("%02x", buffer.readu8(digest, i - 1))
    end
    return table.concat(hex)
  end

  function pretty(digest)
    return buffer.tostring(base64.encode(digest))
  end

  print(hexify(digest))
  print(pretty(digest))
]=]

local requires = luau.getAllRequires(code)

print(pp(requires))
```

and get:
```console
{
  "@lute/crypto",
  "@batteries/base64",
}
```