### PR TITLE
Use the new `math.nan` constant instead of `0 / 0`

### DIFF
--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -160,8 +160,7 @@ local function deserialize(input: string): { [string]: unknown }
 			elseif value == "-inf" then
 				value = -math.huge
 			elseif value == "nan" then
-				--lute-lint-ignore(divide_by_zero)
-				value = 0 / 0
+				value = math.nan
 			end
 
 			currentTable[key] = value

--- a/docs/cli/lint/divide_by_zero.md
+++ b/docs/cli/lint/divide_by_zero.md
@@ -10,7 +10,7 @@ This lint rule checks for instances of divison, floor division, or taking the re
 Division and floor division by 0 will generally give `inf` or `-inf` (unless the dividend is 0).
 The direct use of `math.huge` or `-math.huge` instead is encouraged.
 Taking remainder with respect to 0 (i.e. `3 % 0`) will give `NaN`.
-We instead encourage the use of `0 / 0` until such time as a `NaN` constant is added to `math`.
+We instead encourage the use of `math.nan`.
 
 ## Example violations
 
@@ -27,5 +27,5 @@ You should instead do:
 ```luau
 local x = math.huge
 local y = -math.huge
-local z = 0 / 0
+local z = math.nan
 ```

--- a/examples/badisnan.luau
+++ b/examples/badisnan.luau
@@ -1,4 +1,0 @@
-return function(n)
-	--lute-lint-ignore(divide_by_zero)
-	return n == 0 / 0
-end

--- a/lute/cli/commands/lint/rules/divide_by_zero.luau
+++ b/lute/cli/commands/lint/rules/divide_by_zero.luau
@@ -32,10 +32,10 @@ local function lint(
 				local suggestedfix = nil
 				if n.operator.text == "/" or n.operator.text == "//" then
 					if isZeroLiteral(n.lhsoperand) then
-						return nil
+						suggestedfix = table.freeze({ fix = "math.nan" })
 					elseif n.lhsoperand.tag == "unary" and n.lhsoperand.operator.text == "-" then
 						if isZeroLiteral(n.lhsoperand.operand) then
-							suggestedfix = table.freeze({ fix = "0 / 0" })
+							suggestedfix = table.freeze({ fix = "math.nan" })
 						else
 							suggestedfix = table.freeze({ fix = "-math.huge" })
 						end
@@ -43,7 +43,7 @@ local function lint(
 						suggestedfix = table.freeze({ fix = "math.huge" })
 					end
 				elseif n.operator.text == "%" then
-					suggestedfix = table.freeze({ fix = "0 / 0" })
+					suggestedfix = table.freeze({ fix = "math.nan" })
 				end
 
 				return {

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -206,9 +206,9 @@ local _negnan = -0 / 0
 			expectedAutofixContents = [[
 local _x = math.huge
 local _y = -math.huge
-local _z = 0 / 0
-local _nan = 0 / 0
-local _negnan = 0 / 0
+local _z = math.nan
+local _nan = math.nan
+local _negnan = math.nan
 ]],
 		})
 	end)


### PR DESCRIPTION
Updates all existing uses of `0 / 0` in our codebase to `math.nan`, updates the suggested fix during linting, and adds a new lint warning for new uses of `0 / 0`.