### PR TITLE
Implements a `lute new <project>` subcommand.

### DIFF
--- a/lute/cli/commands/lib/typedefs.luau
+++ b/lute/cli/commands/lib/typedefs.luau
@@ -1,0 +1,109 @@
+local path = require("@std/path")
+local process = require("@std/process")
+
+local TYPEDEFS_VERSION = "0.1.0"
+local TYPEDEFS_BASE_DIR = `.lute/typedefs/{TYPEDEFS_VERSION}`
+local TYPEDEFS_RELATIVE_DIR = `~/{TYPEDEFS_BASE_DIR}`
+local TYPEDEFS_PATH = path.join(process.homedir(), TYPEDEFS_BASE_DIR)
+
+local TEMPLATE_RC_FILE: { [any]: any } = {
+	aliases = {
+		lint = `{TYPEDEFS_RELATIVE_DIR}/lint`,
+		lute = `{TYPEDEFS_RELATIVE_DIR}/lute`,
+		std = `{TYPEDEFS_RELATIVE_DIR}/std`,
+	},
+}
+
+local function indent(level: number)
+	return string.rep("\t", level)
+end
+
+local function nest(src, parenIndent)
+	return `\{\n{src}\n{parenIndent}\}`
+end
+
+local function kv(k, v, desc: string?)
+	local kvpair = `{k} = {v}`
+	if desc then
+		kvpair = kvpair .. `, -- {desc}`
+	end
+	return kvpair
+end
+
+local function tbl(fields: { { value: string, description: string } } | { string }, level)
+	local buf: { string } = {}
+	local fieldIndent = indent(level + 1)
+	local parenIndent = indent(level)
+	for _, f in fields do
+		if typeof(f) == "string" then
+			table.insert(buf, `{fieldIndent}{f},`)
+		else
+			table.insert(buf, `{fieldIndent}-- {f.description}`)
+			table.insert(buf, `{fieldIndent}{f.value},`)
+		end
+	end
+
+	return nest(table.concat(buf, "\n"), parenIndent)
+end
+
+local function generateLuauConfig(languageMode: "strict" | "nonstrict"): string
+	local aliases = {
+		kv("lute", `"{TYPEDEFS_RELATIVE_DIR}/lute"`),
+		kv("std", `"{TYPEDEFS_RELATIVE_DIR}/std"`),
+		kv("lint", `"{TYPEDEFS_RELATIVE_DIR}/lint"`),
+	}
+	local aliasTable = tbl(aliases, 2)
+	local luau = tbl({
+		{
+			value = kv("languagemode", `"{languageMode}"`),
+			description = "Default language mode to use for typechecking",
+		},
+		{ value = kv("aliases", aliasTable), description = "Aliases for builtin libraries" },
+	}, 1)
+	return luau
+end
+
+local function generateLuteConfig(): string
+	local ruleconfigs = tbl({
+		`-- [RuleName] : \{`,
+		`-- Array of globbed strings, representing paths exempt from this rule`,
+		`-- ignores: \{string\}?`,
+		`-- Override a rule's default severity`,
+		`-- severity: ("warn" | "error" | "info" | "hint")?`,
+		`-- Pass custom options through to a rule`,
+		`-- options: \{ [string]: unknown \}?`,
+		`-- Disable this rule`,
+		`-- off: boolean?`,
+		`-- \}`,
+	}, 3)
+	local lint = tbl({
+		{
+			value = kv("ignores", "{}"),
+			description = "Array of globbed strings, representing paths to exempt from linting",
+		},
+		{ value = kv("globals", "{}"), description = "Global values passed to each linting rule" },
+		{ value = kv("rulepaths", "{}"), description = "Array of strings from which to load local lint rules" },
+		{
+			value = kv("ruleconfigs", ruleconfigs),
+			description = "Per rule overrides, with schema [RuleName] : {...}, where the schema is described below ",
+		},
+	}, 2)
+	local lute = tbl({ kv("lint", lint) }, 1)
+	return lute
+end
+
+local typedefs = {}
+
+typedefs.TYPEDEFS_PATH = TYPEDEFS_PATH
+typedefs.TYPEDEFS_RELATIVE_DIR = TYPEDEFS_RELATIVE_DIR
+typedefs.LUAURC_TEMPLATE = TEMPLATE_RC_FILE
+
+function typedefs.generateConfigDotLuau(languageMode: "strict" | "nonstrict"): string
+	local luauConfig = generateLuauConfig(languageMode)
+	local luteConfig = generateLuteConfig()
+
+	local configDotLuau = "return " .. tbl({ kv("lute", luteConfig), kv("luau", luauConfig) }, 0)
+	return configDotLuau
+end
+
+return table.freeze(typedefs)

--- a/lute/cli/commands/new/init.luau
+++ b/lute/cli/commands/new/init.luau
@@ -1,0 +1,88 @@
+local cli = require("@batteries/cli")
+local fs = require("@std/fs")
+local path = require("@std/path")
+local process = require("@std/process")
+local typedefs = require("./lib/typedefs")
+
+local USAGE = "Usage: lute new <project-name>"
+
+local function printHelp()
+	print(USAGE)
+	print([[
+Create a new Lute project with a standard directory layout.
+
+ARGUMENTS:
+  <project-name>    Name of the project to create
+
+OPTIONS:
+  -h, --help        Show this help message
+
+EXAMPLES:
+  lute new myproject
+]])
+end
+
+local function main(...: string)
+	local args = cli.parser()
+	args:add("help", "flag", { help = "Show this help message", aliases = { "h" } })
+	args:add("name", "positional", { help = "Name of the project to create" })
+	args:parse({ ... })
+
+	if args:has("help") then
+		printHelp()
+		return
+	end
+
+	local projectName = args:get("name")
+	if projectName == nil or projectName == "" then
+		print("Error: Missing required argument <project-name>.\n\n" .. USAGE .. "\nUse --help for more information.")
+		process.exit(1)
+	end
+
+	-- LUAUFIX - refinements aren't correctly being applied here.
+	-- At this point, we should know that ~ (projectName == nil or projectName == "") is true (which should imply that projectName ~= nil)
+	assert(projectName)
+	local projectPath = path.join(process.cwd(), projectName)
+
+	if fs.exists(projectPath) then
+		print(`Error: Directory '{projectName}' already exists.`)
+		process.exit(1)
+	end
+
+	if not fs.exists(typedefs.TYPEDEFS_PATH) then
+		print("Running lute setup first...")
+		local result = process.run({ path.format(process.execpath()), "setup" }, { stdio = "inherit" })
+		if not result.ok then
+			print("Error: lute setup failed.")
+			process.exit(1)
+		end
+	end
+
+	fs.createdirectory(projectPath)
+
+	local mainScript = path.join(projectPath, "main.luau")
+	local testScript = path.join(projectPath, "main.test.luau")
+
+	fs.writestringtofile(
+		mainScript,
+		[[print("Hello, world!")
+]]
+	)
+
+	fs.writestringtofile(
+		testScript,
+		[[local _test = require("@std/test")
+]]
+	)
+
+	fs.writestringtofile(path.join(projectPath, ".config.luau"), typedefs.generateConfigDotLuau("strict"))
+
+	print(`Created project '{projectName}'`)
+	print("")
+	print("To get started:")
+	print(`\tcd {projectName}`)
+	print("\tlute run main.luau")
+	print("\tlute test")
+end
+
+main(...)

--- a/lute/cli/commands/setup/init.luau
+++ b/lute/cli/commands/setup/init.luau
@@ -1,21 +1,31 @@
+local cli = require("@batteries/cli")
 local definitions = require("@self/generated/definitions")
 local fs = require("@std/fs")
 local path = require("@std/path")
 local process = require("@std/process")
 local json = require("@std/json")
+local typedefs = require("./lib/typedefs")
 
-local TYPEDEFS_PATH = path.parse(".lute/typedefs/0.1.0")
-local BASE_PATH = path.join(process.homedir(), TYPEDEFS_PATH)
-local BASE_PATH_PRETTY = `~/{TYPEDEFS_PATH}`
-local TEMPLATE_RC_FILE = {
-	aliases = {
-		lint = `{BASE_PATH_PRETTY}/lint`,
-		lute = `{BASE_PATH_PRETTY}/lute`,
-		std = `{BASE_PATH_PRETTY}/std`,
-	},
-}
+local BASE_PATH = typedefs.TYPEDEFS_PATH
+local BASE_PATH_PRETTY = typedefs.TYPEDEFS_RELATIVE_DIR
+local TEMPLATE = typedefs.LUAURC_TEMPLATE
 
-local args = { ... }
+local args = cli.parser()
+args:add("help", "flag", { help = "Show this help message", aliases = { "h" } })
+args:add("with-luaurc", "flag", { help = "Also write a .luaurc file in the current directory" })
+args:parse({ ... })
+
+if args:has("help") then
+	print("Usage: lute setup [options]")
+	print([[
+Install Lute type definitions to ~/.lute/typedefs/{version}.
+
+OPTIONS:
+  --with-luaurc     Also write a .luaurc file in the current directory
+  -h, --help        Show this help message
+]])
+	return
+end
 
 -- TODO we're assuming the files are completely unmodified, but we really shouldn't do that.
 print(`Writing definitions at {BASE_PATH_PRETTY}`)
@@ -31,11 +41,14 @@ for key, value in definitions :: { [string]: string } do
 end
 
 local typedefsLuauRcPath = path.join(BASE_PATH, ".luaurc")
-fs.writestringtofile(typedefsLuauRcPath, json.serialize(TEMPLATE_RC_FILE, true))
+
+-- LUAUFIX. Without an annotation on typedefs.LUAURC_TEMPLATE, we arent able to figure out the type of TEMPLATE
+-- If that table was declared in this file, this typechecks, but if it's in a different one, we'll get a type error here
+fs.writestringtofile(typedefsLuauRcPath, json.serialize(TEMPLATE, true))
 
 print(`Successfully wrote type definition files to {BASE_PATH_PRETTY}`)
 
-if not table.find(args, "--with-luaurc") then
+if not args:has("with-luaurc") then
 	return
 end
 
@@ -48,11 +61,11 @@ if fs.exists(luauRcPath) then
 	rcFile = json.deserialize(contents) :: any
 
 	rcFile.aliases = rcFile.aliases or {}
-	for key, value in TEMPLATE_RC_FILE.aliases :: { [string]: string } do
+	for key, value in TEMPLATE.aliases :: { [string]: string } do
 		rcFile.aliases[key] = value
 	end
 else
-	rcFile = TEMPLATE_RC_FILE
+	rcFile = TEMPLATE
 end
 fs.writestringtofile(luauRcPath, json.serialize(rcFile, true))
 

--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -94,7 +94,7 @@ local function main(...: string)
 		end
 	end
 
-	local searchpath = if forwarded and #forwarded > 0 then forwarded else { "./tests" }
+	local searchpath = if forwarded and #forwarded > 0 then forwarded else { "./" }
 	loadtests(finder.findtestfiles(searchpath))
 
 	if args:has("list") then

--- a/tests/cli/new.test.luau
+++ b/tests/cli/new.test.luau
@@ -1,0 +1,102 @@
+local fs = require("@std/fs")
+local pathlib = require("@std/path")
+local process = require("@std/process")
+local system = require("@std/system")
+local test = require("@std/test")
+
+local tmpdir = system.tmpdir()
+local workdir = pathlib.join(tmpdir, "lute-new")
+local lutePath = pathlib.format(process.execpath())
+local projectName = "myproject"
+local projectDir = pathlib.join(workdir, projectName)
+
+test.suite("LuteNew", function(suite)
+	suite:beforeeach(function()
+		if fs.exists(workdir) then
+			fs.removedirectory(workdir, { recursive = true })
+		end
+		fs.createdirectory(workdir)
+	end)
+
+	suite:case("createsProjectDirectory", function(assert)
+		local result = process.run({ lutePath, "new", projectName }, { cwd = pathlib.format(workdir) })
+
+		assert.eq(result.exitcode, 0)
+		assert.eq(true, fs.exists(pathlib.join(workdir, projectName)))
+	end)
+
+	suite:case("createsMainScript", function(assert)
+		process.run({ lutePath, "new", projectName }, { cwd = pathlib.format(workdir) })
+
+		local mainPath = pathlib.join(workdir, projectName, "main.luau")
+		assert.eq(fs.exists(mainPath), true)
+		local contents = fs.readfiletostring(mainPath)
+		assert.strcontains(contents, "Hello, world!")
+	end)
+
+	suite:case("createsTestScript", function(assert)
+		process.run({ lutePath, "new", projectName }, { cwd = pathlib.format(workdir) })
+
+		local testPath = pathlib.join(workdir, projectName, "main.test.luau")
+		assert.eq(fs.exists(testPath), true)
+		local contents = fs.readfiletostring(testPath)
+		assert.strcontains(contents, "@std/test")
+	end)
+
+	suite:case("createsConfigFile", function(assert)
+		process.run({ lutePath, "new", projectName }, { cwd = pathlib.format(workdir) })
+
+		local configPath = pathlib.join(workdir, projectName, ".config.luau")
+		assert.eq(fs.exists(configPath), true)
+		local contents = fs.readfiletostring(configPath)
+		assert.strcontains(contents, "strict")
+	end)
+
+	suite:case("printSuccessMessage", function(assert)
+		local result = process.run({ lutePath, "new", projectName }, { cwd = pathlib.format(workdir) })
+
+		assert.eq(result.exitcode, 0)
+		assert.strcontains(result.stdout, "Created project 'myproject'")
+	end)
+
+	suite:case("failsWhenNoProjectNameGiven", function(assert)
+		local result = process.run({ lutePath, "new" }, { cwd = pathlib.format(workdir) })
+
+		assert.eq(result.exitcode, 1)
+		assert.strcontains(result.stdout, "Missing required argument <project-name>")
+	end)
+
+	suite:case("failsWhenDirectoryAlreadyExists", function(assert)
+		fs.createdirectory(pathlib.join(workdir, projectName))
+
+		local result = process.run({ lutePath, "new", projectName }, { cwd = pathlib.format(workdir) })
+
+		assert.eq(result.exitcode, 1)
+		assert.strcontains(result.stdout, "already exists")
+	end)
+
+	suite:case("showsHelpWithFlag", function(assert)
+		local result = process.run({ lutePath, "new", "--help" }, { cwd = pathlib.format(workdir) })
+
+		assert.eq(result.exitcode, 0)
+		assert.strcontains(result.stdout, "Usage: lute new <project-name>")
+	end)
+
+	suite:case("typechecksOutOfTheBox", function(assert)
+		local result = process.run({ lutePath, "new", projectName }, { cwd = pathlib.format(workdir) })
+		assert.eq(result.exitcode, 0)
+
+		-- Now, let's try typechecking this project
+		local r2 = process.run({ lutePath, "check", "main.luau" }, { cwd = pathlib.format(projectDir) })
+		assert.eq(r2.exitcode, 0)
+	end)
+
+	suite:case("passesTestsOutOfTheBox", function(assert)
+		local result = process.run({ lutePath, "new", projectName }, { cwd = pathlib.format(workdir) })
+		assert.eq(result.exitcode, 0)
+
+		-- Now, let's run all of the tests as well (this should pass because there are no tests in empty projects)
+		local r2 = process.run({ lutePath, "test" }, { cwd = pathlib.format(projectDir) })
+		assert.eq(r2.exitcode, 0)
+	end)
+end)


### PR DESCRIPTION
I've added a subcommand to `lute` to make it easier to start new projects, similar to `zig init` or `cargo new`. This command is invoked with:
```
lute new <project-name>
``` 
and sets up a project with the following structure:
```
project-name/
    main.luau
    main.test.luau
    .config.luau
```
This command sets up the following default project configuration using the `.config.luau` format, with comments included for convenience.
```luau
return {
	lute = {
		lint = {
			-- Array of globbed strings, representing paths to exempt from linting,
			ignores = {},
			-- Global values passed to each linting rule,
			globals = {},
			-- Array of strings from which to load local lint rules,
			rulepaths = {},
			-- Per rule overrides,
			ruleconfigs = {
				-- Array of globbed strings, representing paths exempt from this rule,
				-- ignores: {string}?,
				-- Override a rule's default severity,
				-- severity: ("warn" | "error" | "info" | "hint")?,
				-- Pass custom options through to a rule,
				-- options: { [string]: unknown }?,
				-- Disable this rule,
				-- off: boolean?,
			},
		},
	},
	luau = {
		-- Default language mode to use for typechecking,
		languagemode = "strict",
		-- Aliases for builtin libraries and lint rules
		aliases = {
			lute = "~/.lute/typedefs/0.1.0/lute",
			std = "~/.lute/typedefs/0.1.0/std",
			lint = "~/.lute/typedefs/0.1.0/lint",
		},
	},
}
```

I think this is a good starting point, but I'm happy to take any suggestions for improvements to this command. I think this is a pretty sane set of defaults. I'd love to hear if folks have opinions on file names - `main.luau` isn't a common entry point, so we could do something like `projectName.luau` and `projectName.test.luau` instead of `main.luau` and `main.test.luau`.

Changes I've made:
1. Extract some of the common logic between `lute setup` and `lute new` into a common file.
2. Update `lute test` to search for tests from the current directory, instead of a dedicated tests/ directory, This is informed by a discussion I had with @Nicell about Luau engineers colocating tests with source files.