### PR TITLE
Restricts codemod replacements to just strings

### DIFF
--- a/lute/std/libs/syntax/printer.luau
+++ b/lute/std/libs/syntax/printer.luau
@@ -17,7 +17,7 @@ type PrintVisitor = visitor.Visitor & {
 	printToken: (self: PrintVisitor, token: types.Token) -> (),
 	printString: (self: PrintVisitor, expr: types.AstExprConstantString | types.AstTypeSingletonString) -> (),
 	printInterpolatedString: (self: PrintVisitor, expr: types.AstExprInterpString) -> (),
-	printReplacement: (self: PrintVisitor, node: types.AstNode, replacement: types.replacement) -> (),
+	printReplacement: (self: PrintVisitor, node: types.AstNode, replacement: string) -> (),
 }
 local function exhaustiveMatch(value: never): never
 	error(`Unknown value in exhaustive match: {value}`)
@@ -98,19 +98,14 @@ local function printInterpolatedString(self: PrintVisitor, expr: types.AstExprIn
 	end
 end
 
-local function printReplacement(self: PrintVisitor, node: types.AstNode, replacement: types.replacement)
+local function printReplacement(self: PrintVisitor, node: types.AstNode, replacement: string)
 	local leftmostTrivia = triviaUtils.leftmosttrivia(node)
 	if leftmostTrivia ~= nil then
 		self:printTriviaList(leftmostTrivia)
 	end
 
-	if typeof(replacement) == "string" then
-		self:write(replacement)
-	elseif replacement.kind ~= nil then
-		visitor.visit(replacement :: any, self) -- LUAUFIX: Code too complex emitted in absence of cast because AstNode is very large
-	else
-		error("Unsupported replacement type")
-	end
+	assert(typeof(replacement) == "string", "Unsupported replacement type")
+	self:write(replacement)
 
 	local rightmostTrivia = triviaUtils.rightmosttrivia(node)
 	if rightmostTrivia ~= nil then
@@ -147,11 +142,11 @@ local function printVisitor(replacements: types.replacements?)
 		if replacements == nil then
 			return true
 		end
-		local replacement = replacements[node]
+		local replacement: string? = replacements[node]
 		if replacement == nil then
 			return true
 		end
-		printer:printReplacement(node, replacement :: any) -- remove any cast once code to complex no longer emitted
+		printer:printReplacement(node, replacement)
 		return false
 	end
 

--- a/lute/std/libs/syntax/query.luau
+++ b/lute/std/libs/syntax/query.luau
@@ -11,7 +11,7 @@ type node = types.AstNode
 export type query<T = node> = {
 	nodes: { T },
 	filter: (self: query<T>, pred: (T) -> boolean) -> query<T>,
-	replace: (self: query<T>, repl: (T) -> types.replacement?) -> types.replacements,
+	replace: (self: query<T>, repl: (T) -> string?) -> types.replacements,
 	map: <U>(self: query<T>, fn: (T) -> U?) -> query<U>, -- recursion violation reported
 	foreach: (self: query<T>, callback: (T) -> ()) -> query<T>,
 	findall: <U>(self: query<T>, fn: (node) -> U?) -> query<U>,
@@ -32,12 +32,12 @@ function queryLib.filter<T>(self: query<T>, pred: (T) -> boolean): query<T>
 	return self
 end
 
-function queryLib.replace<T>(self: query<T>, repl: (T) -> types.replacement?): types.replacements
+function queryLib.replace<T>(self: query<T>, repl: (T) -> string?): types.replacements
 	local replacements = {}
 	for _, node in self.nodes do
 		local r = repl(node)
 		if r ~= nil then
-			replacements[node] = r :: any -- LUAUFIX: remove any cast once code too complex no longer emitted
+			replacements[node] = r
 		end
 	end
 	return replacements
@@ -131,7 +131,7 @@ function queryLib.findallfromroot<T>(ast: types.ParseResult | node, fn: (node) -
 	return {
 		nodes = nodes,
 		filter = queryLib.filter,
-		replace = queryLib.replace :: any, -- LUAUFIX: Remove any cast once code too complex no longer emitted
+		replace = queryLib.replace,
 		map = queryLib.map :: any, -- LUAUFIX: Remove any cast once recursion restriction is loosened
 		foreach = queryLib.foreach,
 		findall = queryLib.findall :: any, -- LUAUFIX: Remove any cast once recursion restriction is loosened

--- a/lute/std/libs/syntax/types.luau
+++ b/lute/std/libs/syntax/types.luau
@@ -159,8 +159,7 @@ export type AstNode = luau.AstNode
 
 export type ParseResult = luau.ParseResult
 
-export type replacement = string | AstNode
-export type replacements = { [AstNode]: replacement }
+export type replacements = { [AstNode]: string }
 
 export type Type = luau.Type
 

--- a/tests/std/syntax/printer.test.luau
+++ b/tests/std/syntax/printer.test.luau
@@ -29,11 +29,9 @@ test.suite("SyntaxPrinter", function(suite)
 		local expected = "            local name = 1 + 2\n"
 
 		checkReplacement(source, expected, function(ast)
-			return query
-				.findallfromroot(ast :: any, syntaxUtils.isExprConstantString)
-				:replace(function(s) -- LUAUFIX: Remove any cast once code too complex no longer emitted
-					return if s.token.text == "World" then "1 + 2" else nil
-				end)
+			return query.findallfromroot(ast :: any, syntaxUtils.isExprConstantString):replace(function(s)
+				return if s.token.text == "World" then "1 + 2" else nil
+			end)
 		end, assert)
 	end)
 
@@ -45,11 +43,9 @@ test.suite("SyntaxPrinter", function(suite)
 		local expected = "            local name = 1 + 2\n"
 
 		checkReplacement(source, expected, function(ast)
-			return query
-				.findallfromroot(ast :: any, syntaxUtils.isExprConstantString)
-				:replace(function(s) -- LUAUFIX: Remove any cast once code too complex no longer emitted
-					return if s.token.text == "World" then syntax.parseexpr("1 + 2") else nil
-				end)
+			return query.findallfromroot(ast :: any, syntaxUtils.isExprConstantString):replace(function(s)
+				return if s.token.text == "World" then "1 + 2" else nil
+			end)
 		end, assert)
 	end)
 
@@ -64,7 +60,7 @@ test.suite("SyntaxPrinter", function(suite)
 			return query
 				.findallfromroot(ast :: any, syntaxUtils.isStatLocal) -- LUAUFIX: Remove any cast once code too complex no longer emitted
 				:replace(function(_)
-					return syntax.parseblock("local name = 1 + 2")
+					return "local name = 1 + 2"
 				end)
 		end, assert)
 	end)
@@ -83,7 +79,7 @@ test.suite("SyntaxPrinter", function(suite)
 					return assign.variables[1].node.annotation
 				end)
 				:replace(function(_)
-					return ann
+					return printer.printnode(ann :: any) -- LUAUFIX: Remove any cast once code too complex no longer emitted
 				end)
 		end, assert)
 	end)
@@ -102,7 +98,7 @@ test.suite("SyntaxPrinter", function(suite)
 					return if ta.type.tag == "function" then ta.type.returntypes else nil
 				end)
 				:replace(function(_)
-					return tp
+					return printer.printnode(tp)
 				end)
 		end, assert)
 	end)


### PR DESCRIPTION
Consulted with @wmccrthy and existing ones already only use strings. Now that AST nodes are frozen, constructing them is a bit more of a pain, and this simplifies the codemod story.