### PR TITLE
Enables CLI commands to use the lute version string defined in C++

### DIFF
--- a/lute/cli/commands/lib/typedefs.luau
+++ b/lute/cli/commands/lib/typedefs.luau
@@ -1,7 +1,10 @@
 local path = require("@std/path")
 local process = require("@std/process")
 
-local TYPEDEFS_VERSION = "0.1.0"
+type version = { version: string, versionSuffix: string, versionFull: string }
+local version: version = _G["version"]
+
+local TYPEDEFS_VERSION = version.version
 local TYPEDEFS_BASE_DIR = `.lute/typedefs/{TYPEDEFS_VERSION}`
 local TYPEDEFS_RELATIVE_DIR = `~/{TYPEDEFS_BASE_DIR}`
 local TYPEDEFS_PATH = path.join(process.homedir(), TYPEDEFS_BASE_DIR)

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -630,7 +630,7 @@ int handleCompileCommand(int argc, char** argv, int argOffset, LuteReporter& rep
 
 void setupVersionLibrary(lua_State* L)
 {
-    lua_checkstack(L, 3);
+    lua_checkstack(L, 2);
 
     lua_createtable(L, 0, 3);
 

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -628,10 +628,28 @@ int handleCompileCommand(int argc, char** argv, int argOffset, LuteReporter& rep
     return 0;
 }
 
+void setupVersionLibrary(lua_State* L)
+{
+    lua_checkstack(L, 3);
+
+    lua_createtable(L, 0, 3);
+
+    lua_pushstring(L, LUTE_VERSION);
+    lua_setfield(L, -2, "version");
+
+    lua_pushstring(L, LUTE_VERSION_SUFFIX);
+    lua_setfield(L, -2, "versionSuffix");
+
+    lua_pushstring(L, LUTE_VERSION_FULL);
+    lua_setfield(L, -2, "versionFull");
+
+    lua_setglobal(L, "version");
+}
+
 int handleCliCommand(CliCommandResult result, int program_argc, char** program_argv, LuteReporter& reporter)
 {
     Runtime runtime;
-    lua_State* L = setupCliCommandState(runtime);
+    lua_State* L = setupCliCommandState(runtime, setupVersionLibrary);
 
     std::string bytecode = Luau::compile(std::string(result.contents), copts());
     return runBytecode(runtime, bytecode, "@" + result.path, L, program_argc, program_argv, reporter) ? 0 : 1;


### PR DESCRIPTION
We've defined a version string in CMake, which gets turned into a header that C++ commands can consume. However, the code in lute uses a hardcoded version of this string. We need to expose this information to the cli commands so that they can use the correct version when setting up new projects or generating type definition files.

This PR sets up a global table called `version` with shape: `{version: string, versionFull : string, versionSuffix : string}` for consumption _exclusively_ by the CLI commands. User code and code loaded by various lute apis in the tests cannot use this global (as those are sandboxed environments).