### PR TITLE
Changes the standard library implementation of `@std/time` to be backed by `@lute/time`

### DIFF
--- a/definitions/time.luau
+++ b/definitions/time.luau
@@ -14,6 +14,10 @@ end
 
 time.duration = {}
 
+function time.duration.create(seconds: number, subsecnanos: number): Duration
+	error("not implemented")
+end
+
 function time.duration.nanoseconds(nanoseconds: number): Duration
 	error("not implemented")
 end
@@ -100,6 +104,8 @@ export type Duration = setmetatable<Frozen, {
 	read __index: typeof(table.freeze(duration_ops)),
 	read __add: (Duration, Duration) -> Duration,
 	read __sub: (Duration, Duration) -> Duration,
+	read __mul: (Duration, number) -> Duration,
+	read __div: (Duration, number) -> Duration,
 	read __eq: (Duration, Duration) -> boolean,
 	read __lt: (Duration, Duration) -> boolean,
 	read __le: (Duration, Duration) -> boolean,

--- a/lute/std/libs/time/duration.luau
+++ b/lute/std/libs/time/duration.luau
@@ -7,6 +7,10 @@ export type Duration = time.Duration
 
 local duration = {}
 
+function duration.create(seconds: number, subsecnanos: number): Duration
+	return time.duration.create(seconds, subsecnanos)
+end
+
 function duration.nanoseconds(nanoseconds: number): Duration
 	return time.duration.nanoseconds(nanoseconds)
 end

--- a/lute/std/libs/time/duration.luau
+++ b/lute/std/libs/time/duration.luau
@@ -1,170 +1,42 @@
 --!strict
 -- Submodule of @std/time that provides utility functions for time durations
 
-local NANOS_PER_SEC = 1_000_000_000
-local NANOS_PER_MILLI = 1_000_000
-local NANOS_PER_MICRO = 1_000
-local MILLIS_PER_SEC = 1_000
-local MICROS_PER_SEC = 1_000_000
-local SECS_PER_MINUTE = 60
-local MINS_PER_HOUR = 60
-local HOURS_PER_DAY = 24
-local DAYS_PER_WEEK = 7
+local time = require("@lute/time")
 
-type DurationData = {
-	_seconds: number,
-	_nanoseconds: number,
-}
+export type Duration = time.Duration
 
 local duration = {}
-duration.__index = duration
 
-type DurationInterface = typeof(duration)
-export type Duration = setmetatable<DurationData, DurationInterface>
-
-function duration.create(seconds: number, nanoseconds: number): Duration
-	local self = {
-		_seconds = seconds,
-		_nanoseconds = nanoseconds,
-	}
-
-	return setmetatable(self, duration)
-end
-
-function duration.seconds(seconds: number): Duration
-	return duration.create(seconds, 0)
-end
-
-function duration.milliseconds(milliseconds: number): Duration
-	local seconds = math.floor(milliseconds / MILLIS_PER_SEC)
-	local nanoseconds = (milliseconds % MILLIS_PER_SEC) * NANOS_PER_MILLI
-
-	return duration.create(seconds, nanoseconds)
+function duration.nanoseconds(nanoseconds: number): Duration
+	return time.duration.nanoseconds(nanoseconds)
 end
 
 function duration.microseconds(microseconds: number): Duration
-	local seconds = math.floor(microseconds / MICROS_PER_SEC)
-	local nanoseconds = (microseconds % MICROS_PER_SEC) * NANOS_PER_MICRO
-
-	return duration.create(seconds, nanoseconds)
+	return time.duration.microseconds(microseconds)
 end
 
-function duration.nanoseconds(nanoseconds: number): Duration
-	local seconds = math.floor(nanoseconds / NANOS_PER_SEC)
-	local nanosecondsRemaining = nanoseconds % NANOS_PER_SEC
+function duration.milliseconds(milliseconds: number): Duration
+	return time.duration.milliseconds(milliseconds)
+end
 
-	return duration.create(seconds, nanosecondsRemaining)
+function duration.seconds(seconds: number): Duration
+	return time.duration.seconds(seconds)
 end
 
 function duration.minutes(minutes: number): Duration
-	return duration.create(minutes * SECS_PER_MINUTE, 0)
+	return time.duration.minutes(minutes)
 end
 
 function duration.hours(hours: number): Duration
-	return duration.create(hours * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
+	return time.duration.hours(hours)
 end
 
 function duration.days(days: number): Duration
-	return duration.create(days * HOURS_PER_DAY * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
+	return time.duration.days(days)
 end
 
 function duration.weeks(weeks: number): Duration
-	return duration.create(weeks * DAYS_PER_WEEK * HOURS_PER_DAY * MINS_PER_HOUR * SECS_PER_MINUTE, 0)
-end
-
-function duration.subsecmillis(self: Duration): number
-	return math.floor(self._nanoseconds / NANOS_PER_MILLI)
-end
-
-function duration.subsecmicros(self: Duration): number
-	return math.floor(self._nanoseconds / NANOS_PER_MICRO)
-end
-
-function duration.subsecnanos(self: Duration): number
-	return self._nanoseconds
-end
-
-function duration.toseconds(self: Duration): number
-	return self._seconds + self._nanoseconds / NANOS_PER_SEC
-end
-
-function duration.tomilliseconds(self: Duration): number
-	return self._seconds * MILLIS_PER_SEC + self:subsecmillis()
-end
-
-function duration.tomicroseconds(self: Duration): number
-	return self._seconds * MICROS_PER_SEC + self:subsecmicros()
-end
-
-function duration.tonanoseconds(self: Duration): number
-	return self._seconds * NANOS_PER_SEC + self:subsecnanos()
-end
-
-function duration.__add(a: Duration, b: Duration): Duration
-	local seconds = a._seconds + b._seconds
-	local nanoseconds = a._nanoseconds + b._nanoseconds
-
-	if nanoseconds >= NANOS_PER_SEC then
-		seconds += 1
-		nanoseconds -= NANOS_PER_SEC
-	end
-
-	return duration.create(seconds, nanoseconds)
-end
-
-function duration.__sub(a: Duration, b: Duration): Duration
-	local seconds = a._seconds - b._seconds
-	local nanoseconds = a._nanoseconds - b._nanoseconds
-
-	if nanoseconds < 0 then
-		seconds -= 1
-		nanoseconds += NANOS_PER_SEC
-	end
-
-	return duration.create(seconds, nanoseconds)
-end
-
-function duration.__mul(a: Duration, b: number): Duration
-	local seconds = a._seconds * b
-	local nanoseconds = a._nanoseconds * b
-
-	seconds += math.floor(nanoseconds / NANOS_PER_SEC)
-	nanoseconds %= NANOS_PER_SEC
-
-	return duration.create(seconds, nanoseconds)
-end
-
-function duration.__div(a: Duration, b: number): Duration
-	local seconds, extraSeconds = a._seconds / b, a._seconds % b
-	local nanoseconds, extraNanos = a._nanoseconds / b, a._nanoseconds % b
-
-	nanoseconds += (extraSeconds * NANOS_PER_SEC + extraNanos) / b
-
-	return duration.create(seconds, nanoseconds)
-end
-
-function duration.__eq(a: Duration, b: Duration): boolean
-	return a._seconds == b._seconds and a._nanoseconds == b._nanoseconds
-end
-
-function duration.__lt(a: Duration, b: Duration): boolean
-	if a._seconds == b._seconds then
-		return a._nanoseconds < b._nanoseconds
-	end
-
-	return a._seconds < b._seconds
-end
-
-function duration.__le(a: Duration, b: Duration): boolean
-	if a._seconds == b._seconds then
-		return a._nanoseconds <= b._nanoseconds
-	end
-
-	return a._seconds <= b._seconds
-end
-
-function duration.__tostring(self: Duration): string
-	return string.format("%d.%09d", self._seconds, self._nanoseconds)
+	return time.duration.weeks(weeks)
 end
 
 return table.freeze(duration)

--- a/lute/std/libs/time/init.luau
+++ b/lute/std/libs/time/init.luau
@@ -2,11 +2,22 @@
 -- @std/time
 -- Provides utility functions for time
 
+local luteTime = require("@lute/time")
 local duration = require("@self/duration")
+
 local time = {}
 
 export type Duration = duration.Duration
+export type Instant = luteTime.Instant
 
 time.duration = duration
+
+function time.now(): Instant
+	return luteTime.now()
+end
+
+function time.since(instant: Instant): number
+	return luteTime.since(instant)
+end
 
 return table.freeze(time)

--- a/lute/time/include/lute/time.h
+++ b/lute/time/include/lute/time.h
@@ -24,6 +24,7 @@ int createDurationFromSeconds(lua_State* L, double seconds);
 
 namespace duration
 {
+int lua_createduration(lua_State* L);
 int lua_nanoseconds(lua_State* L);
 int lua_microseconds(lua_State* L);
 int lua_milliseconds(lua_State* L);
@@ -34,6 +35,7 @@ int lua_days(lua_State* L);
 int lua_weeks(lua_State* L);
 
 static const luaL_Reg lib[] = {
+    {"create", lua_createduration},
     {"nanoseconds", lua_nanoseconds},
     {"microseconds", lua_microseconds},
     {"milliseconds", lua_milliseconds},

--- a/lute/time/src/time.cpp
+++ b/lute/time/src/time.cpp
@@ -98,7 +98,7 @@ int createDurationFromSeconds(lua_State* L, double seconds)
 static int duration_tonanoseconds(lua_State* L)
 {
     uv_timespec64_t timespec = getTimespecFromDuration(L, 1);
-    lua_pushnumber(L, static_cast<double>(timespec.tv_sec) * NANOSECONDS_PER_SECOND + timespec.tv_nsec);
+    lua_pushnumber(L, static_cast<double>(timespec.tv_sec * NANOSECONDS_PER_SECOND) + timespec.tv_nsec);
     return 1;
 }
 

--- a/lute/time/src/time.cpp
+++ b/lute/time/src/time.cpp
@@ -12,15 +12,15 @@
 #include <cstdint>
 #include <iterator>
 
-const int64_t NANOSECONDS_PER_SECOND = 1000000000;
-const int64_t MICROSECONDS_PER_SECOND = 1000000;
+const int64_t NANOSECONDS_PER_SECOND = 1'000'000'000;
+const int64_t MICROSECONDS_PER_SECOND = 1'000'000;
 const int64_t MILLISECONDS_PER_SECOND = 1000;
 const int64_t SECONDS_PER_MINUTE = 60;
 const int64_t SECONDS_PER_HOUR = 3600;
-const int64_t SECONDS_PER_DAY = 86400;
-const int64_t SECONDS_PER_WEEK = 604800;
+const int64_t SECONDS_PER_DAY = 86'400;
+const int64_t SECONDS_PER_WEEK = 604'800;
 const int64_t NANOSECONDS_PER_MICROSECOND = 1000;
-const int64_t NANOSECONDS_PER_MILLISECOND = 1000000;
+const int64_t NANOSECONDS_PER_MILLISECOND = 1'000'000;
 
 // Timespec helpers
 static float_t diffTimespecs(uv_timespec64_t left, uv_timespec64_t right)

--- a/lute/time/src/time.cpp
+++ b/lute/time/src/time.cpp
@@ -50,6 +50,25 @@ double getSecondsFromTimespec(uv_timespec64_t timespec)
     return static_cast<double>(timespec.tv_sec) + static_cast<double>(timespec.tv_nsec) / NANOSECONDS_PER_SECOND;
 }
 
+uv_timespec64_t getTimespecFromSeconds(double seconds)
+{
+	int64_t sec = static_cast<int64_t>(seconds);
+	int32_t nsec = static_cast<int32_t>(fmod(seconds, 1) * NANOSECONDS_PER_SECOND);
+	return {sec, nsec};
+}
+
+uint64_t getNanosecondsFromTimespec(uv_timespec64_t timespec)
+{
+	return timespec.tv_sec * NANOSECONDS_PER_SECOND + timespec.tv_nsec;
+}
+
+uv_timespec64_t getTimespecFromNanoseconds(int64_t nanoseconds)
+{
+	int64_t sec = nanoseconds / NANOSECONDS_PER_SECOND ;
+	int32_t nsec = static_cast<int32_t>(fmod(nanoseconds, NANOSECONDS_PER_SECOND));
+	return {sec, nsec};
+}
+
 // Durations
 
 // returns the address of the timespec from the duration on the stack
@@ -72,28 +91,28 @@ int createDurationFromTimespec(lua_State* L, uv_timespec64_t timespec)
 
 int createDurationFromSeconds(lua_State* L, double seconds)
 {
-    return createDurationFromTimespec(L, {static_cast<int64_t>(seconds), static_cast<int32_t>(fmod(seconds, 1) * NANOSECONDS_PER_SECOND)});
+    return createDurationFromTimespec(L, getTimespecFromSeconds(seconds));
 }
 
 // Duration methods
 static int duration_tonanoseconds(lua_State* L)
 {
     uv_timespec64_t timespec = getTimespecFromDuration(L, 1);
-    lua_pushnumber(L, static_cast<double>(timespec.tv_sec * NANOSECONDS_PER_SECOND) + timespec.tv_nsec);
+    lua_pushnumber(L, static_cast<double>(timespec.tv_sec) * NANOSECONDS_PER_SECOND + timespec.tv_nsec);
     return 1;
 }
 
 static int duration_tomicroseconds(lua_State* L)
 {
     uv_timespec64_t timespec = getTimespecFromDuration(L, 1);
-    lua_pushnumber(L, getSecondsFromTimespec(timespec) * MICROSECONDS_PER_SECOND);
+    lua_pushnumber(L, static_cast<double>(timespec.tv_sec) * MICROSECONDS_PER_SECOND + timespec.tv_nsec / NANOSECONDS_PER_MICROSECOND);
     return 1;
 }
 
 static int duration_tomilliseconds(lua_State* L)
 {
     uv_timespec64_t timespec = getTimespecFromDuration(L, 1);
-    lua_pushnumber(L, getSecondsFromTimespec(timespec) * MILLISECONDS_PER_SECOND);
+    lua_pushnumber(L, static_cast<double>(timespec.tv_sec) * MILLISECONDS_PER_SECOND + timespec.tv_nsec / NANOSECONDS_PER_MILLISECOND);
     return 1;
 }
 
@@ -121,35 +140,35 @@ static int duration_tohours(lua_State* L)
 static int duration_todays(lua_State* L)
 {
     uv_timespec64_t timespec = getTimespecFromDuration(L, 1);
-    lua_pushnumber(L, getSecondsFromTimespec(timespec) / SECONDS_PER_DAY);
+    lua_pushinteger(L, getSecondsFromTimespec(timespec) / SECONDS_PER_DAY);
     return 1;
 }
 
 static int duration_toweeks(lua_State* L)
 {
     uv_timespec64_t timespec = getTimespecFromDuration(L, 1);
-    lua_pushnumber(L, getSecondsFromTimespec(timespec) / SECONDS_PER_WEEK);
+    lua_pushinteger(L, getSecondsFromTimespec(timespec) / SECONDS_PER_WEEK);
     return 1;
 }
 
 static int duration_subsecnanos(lua_State* L)
 {
     uv_timespec64_t timespec = getTimespecFromDuration(L, 1);
-    lua_pushnumber(L, timespec.tv_nsec);
+    lua_pushinteger(L, timespec.tv_nsec);
     return 1;
 }
 
 static int duration_subsecmicros(lua_State* L)
 {
     uv_timespec64_t timespec = getTimespecFromDuration(L, 1);
-    lua_pushnumber(L, static_cast<double>(timespec.tv_nsec) / NANOSECONDS_PER_MICROSECOND);
+    lua_pushinteger(L, timespec.tv_nsec / NANOSECONDS_PER_MICROSECOND);
     return 1;
 }
 
 static int duration_subsecmillis(lua_State* L)
 {
     uv_timespec64_t timespec = getTimespecFromDuration(L, 1);
-    lua_pushnumber(L, static_cast<double>(timespec.tv_nsec) / NANOSECONDS_PER_MILLISECOND);
+    lua_pushinteger(L, timespec.tv_nsec / NANOSECONDS_PER_MILLISECOND);
     return 1;
 }
 
@@ -169,7 +188,7 @@ static int duration__add(lua_State* L)
     uv_timespec64_t right = getTimespecFromDuration(L, 2);
 
     uv_timespec64_t result = {left.tv_sec + right.tv_sec, left.tv_nsec + right.tv_nsec};
-    if (result.tv_nsec > NANOSECONDS_PER_SECOND)
+    if (result.tv_nsec >= NANOSECONDS_PER_SECOND)
     {
         result.tv_sec += 1;
         result.tv_nsec -= NANOSECONDS_PER_SECOND;
@@ -190,6 +209,24 @@ static int duration__sub(lua_State* L)
         result.tv_nsec += NANOSECONDS_PER_SECOND;
     }
 
+    return createDurationFromTimespec(L, {result.tv_sec >= 0 ? result.tv_sec : 0, result.tv_nsec >= 0 ? result.tv_nsec : 0});
+}
+
+static int duration__mul(lua_State* L)
+{
+    uv_timespec64_t left = getTimespecFromDuration(L, 1);
+    double factor = luaL_checknumber(L, 2);
+
+    uv_timespec64_t result = getTimespecFromNanoseconds(getNanosecondsFromTimespec(left) * factor);
+    return createDurationFromTimespec(L, {result.tv_sec >= 0 ? result.tv_sec : 0, result.tv_nsec >= 0 ? result.tv_nsec : 0});
+}
+
+static int duration__div(lua_State* L)
+{
+    uv_timespec64_t left = getTimespecFromDuration(L, 1);
+    double factor = luaL_checknumber(L, 2);
+
+    uv_timespec64_t result = getTimespecFromNanoseconds(getNanosecondsFromTimespec(left) / factor);
     return createDurationFromTimespec(L, {result.tv_sec >= 0 ? result.tv_sec : 0, result.tv_nsec >= 0 ? result.tv_nsec : 0});
 }
 
@@ -271,15 +308,32 @@ static int instant__le(lua_State* L)
 
 namespace duration
 {
+
+int lua_createduration(lua_State* L)
+{
+    int64_t seconds = luaL_checkinteger(L, 1);
+    int64_t nanoseconds = static_cast<int64_t>(luaL_checkinteger(L, 2));
+    if (seconds < 0 || nanoseconds < 0)
+        luaL_error(L, "duration components cannot be negative");
+
+    if (nanoseconds >= NANOSECONDS_PER_SECOND)
+    {
+        seconds += nanoseconds / NANOSECONDS_PER_SECOND;
+        nanoseconds = fmod(nanoseconds, NANOSECONDS_PER_SECOND);
+    }
+
+    return createDurationFromTimespec(L, {seconds, static_cast<int32_t>(nanoseconds)});
+}
+
 int lua_nanoseconds(lua_State* L)
 {
     // int32_t doesn't have enough precision for nanoseconds
-    int64_t nanoseconds = static_cast<int64_t>(luaL_checknumber(L, 1));
+    int64_t nanoseconds = static_cast<int64_t>(luaL_checkinteger(L, 1));
     if (nanoseconds < 0)
         luaL_error(L, "duration cannot be negative");
 
     int64_t seconds = 0;
-    if (nanoseconds > NANOSECONDS_PER_SECOND)
+    if (nanoseconds >= NANOSECONDS_PER_SECOND)
     {
         seconds = static_cast<int64_t>(nanoseconds / NANOSECONDS_PER_SECOND);
         nanoseconds = static_cast<int64_t>(fmod(nanoseconds, NANOSECONDS_PER_SECOND));
@@ -310,14 +364,9 @@ int lua_milliseconds(lua_State* L)
     if (milliseconds < 0)
         luaL_error(L, "duration cannot be negative");
 
-    int64_t seconds = 0;
-    if (milliseconds > MILLISECONDS_PER_SECOND)
-    {
-        seconds = static_cast<int64_t>(milliseconds / MILLISECONDS_PER_SECOND);
-        milliseconds = fmod(milliseconds, MILLISECONDS_PER_SECOND);
-    }
+    uint64_t nanoseconds = milliseconds * NANOSECONDS_PER_MILLISECOND;
 
-    return createDurationFromTimespec(L, {seconds, static_cast<int32_t>(milliseconds * NANOSECONDS_PER_MILLISECOND)});
+    return createDurationFromTimespec(L, getTimespecFromNanoseconds(nanoseconds));
 }
 
 int lua_seconds(lua_State* L)
@@ -431,6 +480,12 @@ static void init_duration_lib(lua_State* L)
 
     lua_pushcfunction(L, duration__sub, "Duration__sub");
     lua_setfield(L, -2, "__sub");
+
+    lua_pushcfunction(L, duration__mul, "Duration__mul");
+    lua_setfield(L, -2, "__mul");
+
+    lua_pushcfunction(L, duration__div, "Duration__div");
+    lua_setfield(L, -2, "__div");
 
     lua_pushcfunction(L, duration__eq, "Duration__eq");
     lua_setfield(L, -2, "__eq");

--- a/tests/std/time.test.luau
+++ b/tests/std/time.test.luau
@@ -51,18 +51,15 @@ test.suite("TimeSuite", function(suite)
 	end)
 
 	suite:case("createRawValuesAndNormalizationViaOps", function(assert)
-		-- create keeps raw values without normalization
 		local d = duration.create(1, 500_000_000)
 		assert.eq(d:toseconds(), 1.5)
 		assert.eq(d:subsecnanos(), 500_000_000)
 		assert.eq(d:tomilliseconds(), 1500)
 
-		-- if nanoseconds exceed a second, create still allows it
 		local d2 = duration.create(1, 1_500_000_000)
 		assert.eq(d2:toseconds(), 2.5)
-		assert.eq(d2:subsecnanos(), 1_500_000_000)
+		assert.eq(d2:subsecnanos(), 500_000_000)
 
-		-- operations like addition normalize nanoseconds
 		local normalized = d2 + duration.seconds(0)
 		assert.eq(normalized:toseconds(), 2.5)
 		assert.eq(normalized:subsecnanos(), 500_000_000)


### PR DESCRIPTION
We've had a long-standing split between `@std/time` and `@lute/time` where the former provided an entirely userland implementation of duration, but the latter provided both durations and instants from C++. In the interest of getting the standard library generally into shape and avoiding these confusing duplications (with differences!) between the runtime and the standard library, this PR eliminates the `@std/time` that already exists, and replaces it with one that re-exports the runtime functionality. Making this a proper replacement required both implementing `__mul` and `__div`, as well as fixing a number of smaller bugs that were scattered throughout the runtime implementation of duration.