### PR TITLE
Fix `task.awaitall`

### DIFF
--- a/lute/std/libs/task.luau
+++ b/lute/std/libs/task.luau
@@ -45,6 +45,7 @@ end
 
 function tasklib.awaitall(...: Task): ...unknown
 	local tasks = table.pack(...)
+	tasks.n = nil :: never
 
 	for i, v in ipairs(tasks) do
 		if not v.co then

--- a/lute/std/libs/task.luau
+++ b/lute/std/libs/task.luau
@@ -45,7 +45,6 @@ end
 
 function tasklib.awaitall(...: Task): ...unknown
 	local tasks = table.pack(...)
-	tasks.n = nil :: never
 
 	for i, v in ipairs(tasks) do
 		if not v.co then
@@ -57,7 +56,7 @@ function tasklib.awaitall(...: Task): ...unknown
 
 	while not done do
 		done = true
-		for _, v in tasks do
+		for _, v in ipairs(tasks) do
 			if v.success == nil then
 				done = false
 				task.deferSelf()
@@ -67,7 +66,7 @@ function tasklib.awaitall(...: Task): ...unknown
 
 	local results = {}
 
-	for _, v in tasks do
+	for _, v in ipairs(tasks) do
 		if v.success then
 			table.insert(results, v.result)
 		else


### PR DESCRIPTION
If you try to run the `process` example, an error throws:
```
0
Hello, lute!

@std/task.luau:60: attempt to index number with 'success'
stacktrace:
@std/task.luau:60 function awaitall
./examples/process.luau:15
```

This occurs as we iterate over `tasks`, which is equal to a `table.pack` return value. This means `tasks` has an `n` property and is not entirely array-like. We can use `ipairs` when iterating over `tasks` to avoid the bug