### PR TITLE
Adds support for bare paths in .luaurc

### DIFF
--- a/lute/luau/src/resolvemodule.cpp
+++ b/lute/luau/src/resolvemodule.cpp
@@ -86,6 +86,9 @@ NC::NavigateResult FileVfsContext::resetToRequirer()
 
 NC::NavigateResult FileVfsContext::jumpToAlias(const std::string& path)
 {
+    if (isBarePath(path))
+        return convert(walkBarePath(path, vfs));
+
     return convert(vfs.resetToPath(path));
 }
 

--- a/lute/require/include/lute/modulepath.h
+++ b/lute/require/include/lute/modulepath.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <string_view>
 
 enum class NavigationStatus
 {
@@ -10,6 +11,29 @@ enum class NavigationStatus
     Ambiguous,
     NotFound
 };
+
+bool isBarePath(std::string_view path);
+
+template<typename Vfs>
+NavigationStatus walkBarePath(std::string_view path, Vfs& vfs)
+{
+    NavigationStatus status = NavigationStatus::Success;
+    while (!path.empty())
+    {
+        size_t sep = path.find('/');
+        std::string_view component = (sep == std::string_view::npos) ? path : path.substr(0, sep);
+
+        if (component == "..")
+            status = vfs.toParent();
+        else if (component != ".")
+            status = vfs.toChild(std::string(component));
+
+        if (status != NavigationStatus::Success)
+            return status;
+        path = (sep == std::string_view::npos) ? std::string_view{} : path.substr(sep + 1);
+    }
+    return status;
+}
 
 enum class ConfigStatus
 {

--- a/lute/require/src/modulepath.cpp
+++ b/lute/require/src/modulepath.cpp
@@ -209,3 +209,23 @@ NavigationStatus ModulePath::toChild(const std::string& name)
 
     return getRealPath().status;
 }
+
+bool isBarePath(std::string_view path)
+{
+    if (path.empty())
+        return false;
+    // Absolute, tilde, or alias-prefixed paths are not implicitly relative.
+    if (path[0] == '@' || path[0] == '/' || path[0] == '~')
+        return false;
+    // Windows absolute path.
+    if (path.size() >= 2 && path[1] == ':')
+        return false;
+    // Paths starting with "./" or "../" are already explicitly relative and
+    // handled correctly by Luau's navigator, so only "." and ".." without a
+    // trailing slash, and bare names like "src", need implicit treatment.
+    if (path.size() >= 2 && path[0] == '.' && path[1] == '/')
+        return false;
+    if (path.size() >= 3 && path[0] == '.' && path[1] == '.' && path[2] == '/')
+        return false;
+    return true;
+}

--- a/lute/require/src/packagerequirevfs.cpp
+++ b/lute/require/src/packagerequirevfs.cpp
@@ -53,6 +53,8 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
     switch (vfsType)
     {
     case VFSType::Userland:
+        if (isBarePath(path))
+            return walkBarePath(path, userlandVfs);
         status = userlandVfs.resetToPath(std::string(path));
         break;
     case VFSType::Std:

--- a/lute/require/src/requirevfs.cpp
+++ b/lute/require/src/requirevfs.cpp
@@ -75,6 +75,8 @@ NavigationStatus RequireVfs::jumpToAlias(lua_State* L, std::string_view path)
     switch (vfsType)
     {
     case VFSType::Disk:
+        if (isBarePath(path))
+            return walkBarePath(path, fileVfs);
         status = fileVfs.resetToPath(std::string(path));
         break;
     case VFSType::Std:

--- a/tests/src/require.test.cpp
+++ b/tests/src/require.test.cpp
@@ -148,6 +148,11 @@ TEST_CASE_FIXTURE(LuteFixture, "require_modules")
             );
         }
 
+        SUBCASE("bare_alias_is_implicitly_relative")
+        {
+            doPassingSubcase(argv, {"./config_tests/bare_alias/requirer"}, {"result from bare alias module"});
+        }
+
         SUBCASE("lute_modules")
         {
             doPassingSubcase(argv, {"./lute/lute"}, {"successfully required @lute modules"});

--- a/tests/src/require/config_tests/bare_alias/.luaurc
+++ b/tests/src/require/config_tests/bare_alias/.luaurc
@@ -1,0 +1,6 @@
+{
+  "languageMode": "strict",
+  "aliases": {
+    "root": "src"
+  }
+}

--- a/tests/src/require/config_tests/bare_alias/requirer.luau
+++ b/tests/src/require/config_tests/bare_alias/requirer.luau
@@ -1,0 +1,1 @@
+return require("@root/module")

--- a/tests/src/require/config_tests/bare_alias/src/module.luau
+++ b/tests/src/require/config_tests/bare_alias/src/module.luau
@@ -1,0 +1,1 @@
+return { "result from bare alias module" }


### PR DESCRIPTION
`jumpToAlias` implementations now detect implicitly relative paths. Bare names like `"src"` that lack the trailing slash required by Luau's classifier are processed component by component via `toChild` / `toParent` from the current navigator position. Since the navigator is already positioned at the directory containing the config file when `jumpToAlias` is called, this resolves correctly regardless of the working directory.

Resolves #853.

P.S.
If such support is needed at the language level, [here](https://github.com/luau-lang/luau/blob/b37af212cb60366043c93c5a4acd085ab29c8d7a/CLI/src/AnalyzeRequirer.cpp#L45) would be the best entry point for it. Right now `luau` rejects all non-absolute alias values, so bare paths like `"src"` fail with `NotFound`.