### PR TITLE
Exposes @std/task as a wrapper around functions defined in @lute/task

### DIFF
--- a/examples/net_example.luau
+++ b/examples/net_example.luau
@@ -22,7 +22,7 @@ local together = true
 local start = os.clock()
 
 if together then
-	task.awaitall(t1, t2, t3)
+	task.awaitAll(t1, t2, t3)
 else
 	task.await(t1)
 	task.await(t2)

--- a/examples/parallel_sort.luau
+++ b/examples/parallel_sort.luau
@@ -55,7 +55,7 @@ local function parallelMergeSort<T>(t: { T }, comp: (T, T) -> lt<T>): { T }
 		table.insert(slices, task.create(threads[i].sort, getslice(t, i, threadCount)))
 	end
 
-	local tomerge = table.pack(task.awaitall(table.unpack(slices)))
+	local tomerge = table.pack(task.awaitAll(table.unpack(slices)))
 	tomerge.n = nil :: any
 
 	while #tomerge > 1 do

--- a/examples/process.luau
+++ b/examples/process.luau
@@ -12,7 +12,7 @@ local t1 = task.create(process.run, { "echo", "-n", "One" })
 local t2 = task.create(process.run, { "echo", "-n", "Two" })
 local t3 = task.create(process.run, { "echo", "-n", "Three" })
 
-local r1, r2, r3 = task.awaitall(t1, t2, t3)
+local r1, r2, r3 = task.awaitAll(t1, t2, t3)
 
 print(r1.stdout)
 print(r2.stdout)

--- a/examples/spawn_example.luau
+++ b/examples/spawn_example.luau
@@ -45,7 +45,7 @@ do
 
 	local s1, s2, s3 = task.create(vm1.fib, 33), task.create(vm1.fib, 33), task.create(vm1.fib, 33)
 
-	print("fib(33):", task.awaitall(s1, s2, s3))
+	print("fib(33):", task.awaitAll(s1, s2, s3))
 
 	print("3 serial fibs in", os.clock() - start)
 end
@@ -55,7 +55,7 @@ do
 
 	local p1, p2, p3 = task.create(vm1.fib, 33), task.create(vm2.fib, 33), task.create(vm3.fib, 33)
 
-	print("fib(33):", task.awaitall(p1, p2, p3))
+	print("fib(33):", task.awaitAll(p1, p2, p3))
 
 	print("3 parallel fibs in", os.clock() - start)
 end

--- a/lute/std/libs/task.luau
+++ b/lute/std/libs/task.luau
@@ -3,7 +3,7 @@
 -- stdlib for `@lute/task`
 -- Provides utilities for creating and managing asynchronous tasks
 
-local task = require("@lute/task")
+local lutetask = require("@lute/task")
 
 local tasklib = {}
 
@@ -12,6 +12,26 @@ export type Task = {
 	result: any,
 	co: thread,
 }
+
+function tasklib.spawn<T..., U...>(routine: ((T...) -> U...) | thread, ...: T...): thread
+	return lutetask.spawn(routine, ...)
+end
+
+function tasklib.defer<T..., U...>(routine: ((T...) -> U...) | thread, ...: T...): thread
+	return lutetask.defer(routine, ...)
+end
+
+function tasklib.delay<T..., U...>(dur: number, routine: ((T...) -> U...) | thread, ...: T...): thread
+	return lutetask.delay(dur, routine, ...)
+end
+
+function tasklib.wait(dur: number?): number
+	return lutetask.wait(dur)
+end
+
+function tasklib.cancel(thread: thread)
+	coroutine.close(thread)
+end
 
 function tasklib.create(f, ...): Task
 	local data = {}
@@ -33,7 +53,7 @@ function tasklib.await(t: Task): any
 	end
 
 	while t.success == nil do
-		task.deferSelf()
+		lutetask.deferSelf()
 	end
 
 	if t.success then
@@ -43,7 +63,7 @@ function tasklib.await(t: Task): any
 	end
 end
 
-function tasklib.awaitall(...: Task): ...unknown
+function tasklib.awaitAll(...: Task): ...unknown
 	local tasks = table.pack(...)
 
 	for i, v in ipairs(tasks) do
@@ -59,7 +79,7 @@ function tasklib.awaitall(...: Task): ...unknown
 		for _, v in ipairs(tasks) do
 			if v.success == nil then
 				done = false
-				task.deferSelf()
+				lutetask.deferSelf()
 			end
 		end
 	end


### PR DESCRIPTION
This PR exposes the `task` library methods in `@std` as wrappers around the task methods in `@lute`. I've left in the previous implementations of `task.await/awaitAll/create` for now, because we're still exposing the superset that users would expect of the roblox api.