### PR TITLE
Adds `argnames` field in serialization of function Type

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -781,6 +781,7 @@ export type Type = {
 
 	-- for function type
 	parameters: TypePack,
+	argnames: { string? },
 	returns: TypePack,
 	generics: { Type },
 	genericpacks: { TypePack },

--- a/lute/luau/src/type.cpp
+++ b/lute/luau/src/type.cpp
@@ -287,13 +287,14 @@ struct TypeSerialize final : public Luau::TypeVisitor
 
     // Luau function type:
     // parameters: { head: {type}?, tail: type? },
+    // argnames: { string? },
     // returns: { head: {type}?, tail: type? },
     // generics: {type},
     // genericpacks: {typepack}
     void serialize(TypeId ty, const FunctionType& ftv)
     {
         checkStack(L, 3); // max 1 for table + 1 for subtable + 1 for traverse
-        lua_createtable(L, 0, 5);
+        lua_createtable(L, 0, 6);
         registerType(ty);
 
         pushTag("function");
@@ -301,6 +302,18 @@ struct TypeSerialize final : public Luau::TypeVisitor
         // Parameters
         traverse(ftv.argTypes);
         lua_setfield(L, -2, "parameters");
+
+        // ArgNames
+        lua_createtable(L, ftv.argNames.size(), 0);
+        for (size_t i = 0; i < ftv.argNames.size(); i++)
+        {
+            if (!ftv.argNames[i].has_value())
+                lua_pushnil(L);
+            else
+                lua_pushstring(L, ftv.argNames[i]->name.c_str());
+            lua_rawseti(L, -2, i + 1);
+        }
+        lua_setfield(L, -2, "argnames");
 
         // Returns
         traverse(ftv.retTypes);

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -33,6 +33,7 @@ function luau.loadModule(requirePath: path.Pathlike, env: { [any]: any }?): any
 end
 
 export type TypePack = luteLuau.TypePack
+export type Type = luteLuau.Type
 
 function luau.typeofmodule(modulepath: path.Pathlike): TypePack?
 	local modulePathStr = if typeof(modulepath) == "string" then modulepath else path.format(modulepath)

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -274,12 +274,17 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_function_type")
     TypePackId retTypes = arena.addTypePack(TypePack{{}, std::nullopt});
 
     FunctionType ftv{{genericTy}, {}, argTypes, retTypes};
+
+    FunctionArgument arg;
+    arg.name = "x";
+    ftv.argNames.push_back(arg);
+
     TypeId ty = arena.addType(ftv);
 
     lua_checkstack(L, 3);
 
-    // <T>(number) -> ()
-    // { tag: "function", parameters: { head: { { tag: "number" } }, tail: nil }, returns: { head: nil, tail: nil }, generics: { { tag: "generic", name: "T", ispack: false } }, genericpacks: {} }
+    // <T>(x: number) -> ()
+    // { tag: "function", parameters: { head: { { tag: "number" } }, tail: nil }, argnames: { "x" }, returns: { head: nil, tail: nil }, generics: { { tag: "generic", name: "T", ispack: false } }, genericpacks: {} }
     REQUIRE_EQ(Luau::serializeType(L, ty), 1);
 
     REQUIRE(lua_istable(L, -1));
@@ -297,6 +302,13 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_function_type")
     lua_getfield(L, -1, "tail");
     REQUIRE(lua_isnil(L, -1));
     lua_pop(L, 2); // tail, parameters
+
+    lua_getfield(L, -1, "argnames");
+    REQUIRE(lua_istable(L, -1));
+    lua_rawgeti(L, -1, 1);
+    REQUIRE(lua_isstring(L, -1));
+    CHECK(std::string(lua_tostring(L, -1)) == "x");
+    lua_pop(L, 2); // argnames[0], argnames
 
     lua_getfield(L, -1, "returns");
     REQUIRE(lua_istable(L, -1));

--- a/tests/src/typeserializer.test.cpp
+++ b/tests/src/typeserializer.test.cpp
@@ -275,9 +275,7 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_function_type")
 
     FunctionType ftv{{genericTy}, {}, argTypes, retTypes};
 
-    FunctionArgument arg;
-    arg.name = "x";
-    ftv.argNames.push_back(arg);
+    ftv.argNames.push_back(FunctionArgument{Name{"x"}});
 
     TypeId ty = arena.addType(ftv);
 
@@ -330,6 +328,71 @@ TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_function_type")
     lua_getfield(L, -1, "genericpacks");
     REQUIRE(lua_istable(L, -1));
     REQUIRE(lua_objlen(L, -1) == 0); // no generic packs
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "check_argnames_in_function_with_multiple_named_args")
+{
+    TypeId numTy = arena.addType(PrimitiveType{PrimitiveType::Number});
+    TypeId strTy = arena.addType(PrimitiveType{PrimitiveType::String});
+
+    TypePackId argTypes = arena.addTypePack(TypePack{{numTy, strTy}, std::nullopt});
+    TypePackId retTypes = arena.addTypePack(TypePack{{}, std::nullopt});
+
+    FunctionType ftv{{}, {}, argTypes, retTypes};
+    // (x: number, y: string)
+    ftv.argNames.push_back(FunctionArgument{Name{"x"}});
+    ftv.argNames.push_back(FunctionArgument{Name{"y"}});
+
+    TypeId ty = arena.addType(ftv);
+
+    lua_checkstack(L, 2);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
+
+    lua_getfield(L, -1, "argnames");
+    REQUIRE(lua_istable(L, -1));
+    REQUIRE(lua_objlen(L, -1) == 2);
+
+    lua_rawgeti(L, -1, 1);
+    CHECK(std::string(lua_tostring(L, -1)) == "x");
+    lua_pop(L, 1);
+
+    lua_rawgeti(L, -1, 2);
+    CHECK(std::string(lua_tostring(L, -1)) == "y");
+    lua_pop(L, 2); // y, argnames
+}
+
+TEST_CASE_FIXTURE(TypeSerializeFixture, "check_argnames_in_function_with_first_arg_unnamed_second_named")
+{
+    TypeId strTy = arena.addType(PrimitiveType{PrimitiveType::String});
+    TypeId numTy = arena.addType(PrimitiveType{PrimitiveType::Number});
+
+    TypePackId argTypes = arena.addTypePack(TypePack{{strTy, numTy}, std::nullopt});
+    TypePackId retTypes = arena.addTypePack(TypePack{{}, std::nullopt});
+
+    FunctionType ftv{{}, {}, argTypes, retTypes};
+    
+    // First arg is unnamed, second is named "path"
+    ftv.argNames.push_back(std::nullopt);
+    ftv.argNames.push_back(FunctionArgument{Name{"path"}});
+
+    TypeId ty = arena.addType(ftv);
+
+    lua_checkstack(L, 2);
+    REQUIRE_EQ(Luau::serializeType(L, ty), 1);
+
+    lua_getfield(L, -1, "argnames");
+    REQUIRE(lua_istable(L, -1));
+    REQUIRE(lua_objlen(L, -1) == 2); // Two arguments, one named and one unnamed
+
+    // Index 1 should be nil
+    lua_rawgeti(L, -1, 1);
+    CHECK(lua_isnil(L, -1));
+    lua_pop(L, 1);
+
+    // Index 2 should be "path" 
+    lua_rawgeti(L, -1, 2);
+    CHECK(std::string(lua_tostring(L, -1)) == "path");
+    lua_pop(L, 2); // path, argnames
 }
 
 TEST_CASE_FIXTURE(TypeSerializeFixture, "serialize_table_type_with_properties")


### PR DESCRIPTION
When working on cleaning up `lute doc` with `typeofmodule` API integration, I noticed that function type serialization was missing the `argNames` fields, so we weren't preserving the argument names of the parameters in function types. This makes it hard for users (aka the `lute doc` command) to use the type serialization on function types because our output would be missing the argument names and only have the types, which isn't very useful to understand the function signature.

Before this change, using the type serializer to generate docs would result in (the wip) `fs.link` serialization appearing as:

```luau
fs.link

(string, string) -> ()
```

But after this change, we have:

```luau
fs.link

(src: string, dest: string) -> ()
```

which better matches the actual function signature of of fs.link, which is 

```luau
function fs.link(src: string, dest: string): ()
```

Pls see more examples of this specific change's additions (in my [WIP branch](https://github.com/luau-lang/lute/compare/annietang/lute_doc_integration_with_typeofmodule) of `lute doc`) if curious: https://github.com/luau-lang/lute/commit/94880094b613962d4aa24d566ff6953fc4318110