### PR TITLE
Adds `luau.resolveConfig` to `@std`

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -722,6 +722,27 @@ export type ParseResult = {
 	read lineoffsets: { number },
 }
 
+export type AliasInfo = {
+	read value: string,
+	read originalCase: string,
+}
+
+export type ConfigError = {
+	read path: string,
+	read message: string,
+}
+
+export type LuauConfig = {
+	read languageMode: "strict" | "nonstrict" | "nocheck" | "definition",
+	read aliases: { [string]: AliasInfo },
+	read lintErrors: boolean,
+	read typeErrors: boolean,
+	read globals: { string },
+	read enabledLint: { [string]: boolean },
+	read fatalLint: { [string]: boolean },
+	read configErrors: { ConfigError }?,
+}
+
 function luau.parse(source: string): ParseResult
 	error("not implemented")
 end
@@ -741,6 +762,10 @@ function luau.load(bytecode: Bytecode, chunkname: string, env: { [any]: any }?):
 end
 
 function luau.resolveModule(path: string, fromchunkname: string): string
+	error("not implemented")
+end
+
+function luau.resolveConfig(path: string): LuauConfig
 	error("not implemented")
 end
 

--- a/lute/luau/CMakeLists.txt
+++ b/lute/luau/CMakeLists.txt
@@ -5,12 +5,14 @@ target_sources(Lute.Luau PRIVATE
     include/lute/luau.h
     include/lute/tcmoduleresolver.h
     include/lute/resolvemodule.h
+    include/lute/resolveconfig.h
     include/lute/type.h
 
     src/configresolver.cpp
     src/luau.cpp
     src/tcmoduleresolver.cpp
     src/resolvemodule.cpp
+    src/resolveconfig.cpp
     src/type.cpp
 )
 

--- a/lute/luau/include/lute/luau.h
+++ b/lute/luau/include/lute/luau.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "lute/resolveconfig.h"
 #include "lute/resolvemodule.h"
 
 #include "lua.h"
@@ -33,6 +34,7 @@ static const luaL_Reg lib[] = {
     {"compile", compile_luau},
     {"load", load_luau},
     {"resolveModule", resolveModule_luau},
+    {"resolveConfig", resolveConfig_luau},
     {"typeofmodule", typeofmodule_luau},
     {nullptr, nullptr},
 };

--- a/lute/luau/include/lute/resolveconfig.h
+++ b/lute/luau/include/lute/resolveconfig.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "Luau/Config.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+struct lua_State;
+
+Luau::Config resolveConfig(const std::string& filePath, std::vector<std::pair<std::string, std::string>>* configErrors);
+int resolveConfig_luau(lua_State* L);

--- a/lute/luau/src/resolveconfig.cpp
+++ b/lute/luau/src/resolveconfig.cpp
@@ -1,0 +1,133 @@
+#include "lute/resolveconfig.h"
+
+#include "lute/configresolver.h"
+
+#include "Luau/Config.h"
+#include "Luau/FileUtils.h"
+#include "Luau/LinterConfig.h"
+
+#include "lua.h"
+#include "lualib.h"
+
+#include <string>
+
+static const char* modeToString(Luau::Mode mode)
+{
+    switch (mode)
+    {
+    case Luau::Mode::NoCheck:
+        return "nocheck";
+    case Luau::Mode::Nonstrict:
+        return "nonstrict";
+    case Luau::Mode::Strict:
+        return "strict";
+    case Luau::Mode::Definition:
+        return "definition";
+    }
+    return "nonstrict";
+}
+
+static void pushLintOptions(lua_State* L, const Luau::LintOptions& lintOptions)
+{
+    lua_createtable(L, 0, 0);
+    for (int i = 1; i < static_cast<int>(Luau::LintWarning::Code__Count); i++)
+    {
+        auto code = static_cast<Luau::LintWarning::Code>(i);
+        if (lintOptions.isEnabled(code))
+        {
+            lua_pushboolean(L, 1);
+            lua_setfield(L, -2, Luau::kWarningNames[i]);
+        }
+    }
+}
+
+// Public API
+Luau::Config resolveConfig(const std::string& filePath, std::vector<std::pair<std::string, std::string>>* configErrors)
+{
+    Luau::LuteConfigResolver configResolver(Luau::Mode::Nonstrict);
+
+    std::optional<std::string> parentPath = getParentPath(filePath);
+    if (!parentPath)
+        return configResolver.defaultConfig;
+
+    Luau::Config config = configResolver.readConfigRec(*parentPath);
+
+    if (configErrors)
+        *configErrors = std::move(configResolver.configErrors);
+
+    return config;
+}
+
+int resolveConfig_luau(lua_State* L)
+{
+    std::string filePath = luaL_checkstring(L, 1);
+
+    std::vector<std::pair<std::string, std::string>> configErrors;
+    const Luau::Config config = resolveConfig(filePath, &configErrors);
+
+    // result table
+    lua_createtable(L, 0, 8);
+
+    // languageMode
+    lua_pushstring(L, modeToString(config.mode));
+    lua_setfield(L, -2, "languageMode");
+
+    // aliases: { [string]: { value: string, originalCase: string } }
+    lua_createtable(L, 0, 0);
+    for (auto it = config.aliases.begin(); it != config.aliases.end(); ++it)
+    {
+        const auto& [key, aliasInfo] = *it;
+        if (key.empty())
+            continue;
+        lua_createtable(L, 0, 2);
+        lua_pushlstring(L, aliasInfo.value.c_str(), aliasInfo.value.size());
+        lua_setfield(L, -2, "value");
+        lua_pushlstring(L, aliasInfo.originalCase.c_str(), aliasInfo.originalCase.size());
+        lua_setfield(L, -2, "originalCase");
+        lua_setfield(L, -2, key.c_str());
+    }
+    lua_setfield(L, -2, "aliases");
+
+    // lintErrors
+    lua_pushboolean(L, config.lintErrors);
+    lua_setfield(L, -2, "lintErrors");
+
+    // typeErrors
+    lua_pushboolean(L, config.typeErrors);
+    lua_setfield(L, -2, "typeErrors");
+
+    // globals
+    lua_createtable(L, static_cast<int>(config.globals.size()), 0);
+    for (size_t i = 0; i < config.globals.size(); i++)
+    {
+        lua_pushlstring(L, config.globals[i].c_str(), config.globals[i].size());
+        lua_rawseti(L, -2, static_cast<int>(i + 1));
+    }
+    lua_setfield(L, -2, "globals");
+
+    // enabledLint: { [warningName]: true }
+    pushLintOptions(L, config.enabledLint);
+    lua_setfield(L, -2, "enabledLint");
+
+    // fatalLint: { [warningName]: true }
+    pushLintOptions(L, config.fatalLint);
+    lua_setfield(L, -2, "fatalLint");
+
+    // configErrors
+    if (!configErrors.empty())
+    {
+        lua_createtable(L, static_cast<int>(configErrors.size()), 0);
+        for (size_t i = 0; i < configErrors.size(); i++)
+        {
+            lua_createtable(L, 0, 2);
+            lua_pushlstring(L, configErrors[i].first.c_str(), configErrors[i].first.size());
+            lua_setfield(L, -2, "path");
+            lua_pushlstring(L, configErrors[i].second.c_str(), configErrors[i].second.size());
+            lua_setfield(L, -2, "message");
+            lua_rawseti(L, -2, static_cast<int>(i + 1));
+        }
+        lua_setfield(L, -2, "configErrors");
+    }
+
+    return 1;
+}

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -46,4 +46,11 @@ function luau.resolveModule(modulepath: string, frompath: path.Pathlike): path.P
 	return luteLuau.resolveModule(modulepath, `@{frompathString}`)
 end
 
+export type LuauConfig = luteLuau.LuauConfig
+
+function luau.resolveConfig(filepath: path.Pathlike): LuauConfig
+	local filepathString = if typeof(filepath) == "string" then filepath else path.format(filepath)
+	return luteLuau.resolveConfig(filepathString)
+end
+
 return table.freeze(luau)

--- a/tests/std/luau.test.luau
+++ b/tests/std/luau.test.luau
@@ -160,4 +160,48 @@ test.suite("LuauTypeOfModuleSuite", function(suite)
 		local expected = path.format(testPath):gsub("\\", "/")
 		assert.eq(resolvedPath, expected)
 	end)
+
+	suite:case("resolveConfigWithConfig", function(assert)
+		local testDir = path.join(tmpDir, "resolveconfig_test")
+		fs.createdirectory(testDir, { makeparents = true })
+
+		-- .luaurc with known config values
+		local configPath = path.join(testDir, ".luaurc")
+		local configFile = fs.open(configPath, "w+")
+		fs.write(configFile, '{"languageMode": "strict", "aliases": {"root": "./src"}}')
+		fs.close(configFile)
+
+		local testPath = path.join(testDir, "test.luau")
+		local testFile = fs.open(testPath, "w+")
+		fs.write(testFile, "content")
+		fs.close(testFile)
+
+		local config = luau.resolveConfig(testPath)
+		assert.neq(config, nil)
+		assert.eq(config.languageMode, "strict")
+		assert.neq(config.aliases, nil)
+		assert.neq(config.aliases.root, nil)
+		assert.eq(config.aliases.root.value, "./src")
+		assert.eq(config.aliases.root.originalCase, "root")
+		assert.eq(config.typeErrors, true)
+		assert.eq(config.lintErrors, false)
+	end)
+
+	suite:case("resolveConfigWithoutConfig", function(assert)
+		-- Subdirectory without a .luaurc
+		local testDir = path.join(tmpDir, "resolveconfig_default_test")
+		fs.createdirectory(testDir, { makeparents = true })
+
+		local testPath = path.join(testDir, "test.luau")
+		local testFile = fs.open(testPath, "w+")
+		fs.write(testFile, "content")
+		fs.close(testFile)
+
+		-- Fallback behavior when no .luaurc is found in the directory hierarchy
+		local config = luau.resolveConfig(testPath)
+		assert.neq(config, nil)
+		assert.eq(config.languageMode, "nonstrict")
+		assert.eq(config.typeErrors, true)
+		assert.eq(config.lintErrors, false)
+	end)
 end)


### PR DESCRIPTION
Adds `luau.resolveConfig(filepath: path.Pathlike): LuauConfig` to `@std`, which resolves the Luau configuration for a given file path by walking up the directory tree and merging `.luaurc` / `.config.luau` files.

Resolves #322.
Followed the official [RFCs for .luaurc](https://rfcs.luau.org/config-luaurc) and the [RFCs for .config.luau](https://rfcs.luau.org/config-luauconfig.html).

The `dogfooding test` suite passed, but it was excluded from the test file to avoid creating an unnecessary dependency:
```luau
suite:case("resolveConfigDogfooding", function(assert)
  local config = luau.resolveConfig(debug.info(1, "s"))
  assert.eq(config.languageMode, "strict")
  assert.neq(config.aliases, nil)
  assert.eq(config.aliases.batteries.value, "./batteries")
  assert.eq(config.aliases.std.value, "./lute/std/libs")
  assert.eq(config.aliases.lute.value, "./definitions")
  assert.eq(config.aliases.commands.value, "./lute/cli/commands")
end)
  ```