### PR TITLE
Resolves typecheck errors in `lute test`

### DIFF
--- a/lute/cli/commands/test/filter.luau
+++ b/lute/cli/commands/test/filter.luau
@@ -23,14 +23,8 @@ local function filtertests(
 		if caseEntry and caseEntry.suites[suiteName] then
 			local suite = env.suiteindex[suiteName]
 			if suite then
-				local filteredSuite = {
-					name = suite.name,
-					cases = caseEntry.suites[suiteName],
-					_beforeeach = suite._beforeeach,
-					_beforeall = suite._beforeall,
-					_aftereach = suite._aftereach,
-					_afterall = suite._afterall,
-				}
+				local filteredSuite = table.clone(suite)
+				filteredSuite.cases = caseEntry.suites[suiteName]
 				table.insert(filtered.suites, filteredSuite)
 			end
 		end
@@ -51,14 +45,8 @@ local function filtertests(
 			for sName, cases in caseEntry.suites do
 				local suite = env.suiteindex[sName]
 				if suite then
-					local filteredSuite = {
-						name = suite.name,
-						cases = cases,
-						_beforeeach = suite._beforeeach,
-						_beforeall = suite._beforeall,
-						_aftereach = suite._aftereach,
-						_afterall = suite._afterall,
-					}
+					local filteredSuite = table.clone(suite)
+					filteredSuite.cases = cases
 					table.insert(filtered.suites, filteredSuite)
 				end
 			end

--- a/tools/check-faillist.txt
+++ b/tools/check-faillist.txt
@@ -15,10 +15,6 @@ lute/cli/commands/lint/rules/almost_swapped.luau:92:5-16
 lute/cli/commands/lint/rules/parenthesized_conditions.luau:27:5-16
 lute/cli/commands/lint/rules/parenthesized_conditions.luau:42:6-17
 lute/cli/commands/lint/rules/parenthesized_conditions.luau:68:4-15
-lute/cli/commands/test/filter.luau:34:5-16
-lute/cli/commands/test/filter.luau:34:5-16
-lute/cli/commands/test/filter.luau:62:6-17
-lute/cli/commands/test/filter.luau:62:6-17
 tests/src/packages/package_aware_require/dep/module.luau:1:16-30
 tests/src/packages/pkgrun_with_lockfile/Packages/dep/src/init.luau:1:16-38
 tests/src/require/config_tests/config_ambiguity/requirer.luau:1:8-22


### PR DESCRIPTION
The typechecker was flagging an actual error in the luau code, which is that the table we were creating to represent filtered test suites was missing properties. Although the testing framework never uses these properties (as they are index metatable methods that are used to register test cases), they are in fact missing, which can cause errors if they are accesses down the road. This PR just table.clones these testsuites and updates their test cases explicitly to the list of filtered test cases.