### PR TITLE
`Profiler`: single source for `sampling frequency`

### DIFF
--- a/lute/cli/include/lute/climain.h
+++ b/lute/cli/include/lute/climain.h
@@ -1,4 +1,6 @@
 #pragma once
+#include "lute/profiler.h"
+
 #include <functional>
 #include <optional>
 #include <string>
@@ -6,12 +8,6 @@
 struct lua_State;
 struct Runtime;
 class LuteReporter;
-
-struct ProfileOptions
-{
-    std::string filename;
-    int frequency = 10000;
-};
 
 int cliMain(int argc, char** argv, LuteReporter& reporter);
 bool runBytecode(

--- a/lute/cli/include/lute/profiler.h
+++ b/lute/cli/include/lute/profiler.h
@@ -1,7 +1,15 @@
 #pragma once
 #include "lute/reporter.h"
 
+#include <string>
+
 struct lua_State;
+
+struct ProfileOptions
+{
+    std::string filename;
+    int frequency = 10000;
+};
 
 void profilerStart(lua_State* L, int frequency);
 void profilerStop();

--- a/lute/cli/src/profiler.cpp
+++ b/lute/cli/src/profiler.cpp
@@ -50,7 +50,7 @@ struct Profiler
 {
     // static state
     lua_Callbacks* callbacks = nullptr;
-    int frequency = 10000;
+    int frequency = ProfileOptions{}.frequency;
     std::thread thread;
 
     // variables for communication between loop and trigger


### PR DESCRIPTION
Moved the `profiler options` from the `CLI` directly into the `profiler`. Currently, the sampling `frequency` in Hz duplicates its default value in two places: [here](https://github.com/luau-lang/lute/blob/6ed3142c96d109a7ac94ec7c9a7d8dc86a56ac69/lute/cli/src/profiler.cpp#L53) and [here](https://github.com/luau-lang/lute/blob/6ed3142c96d109a7ac94ec7c9a7d8dc86a56ac69/lute/cli/include/lute/climain.h#L13).
It has no impact at the moment, but having a single source will help avoid potential bugs in the future.

Originally a minor change in PR #911, this has been moved to a separate PR for better clarity.

Besides, in PR #911 the main logic of `runBytecode` was moved from `CLI` to `Runtime`, so we don't need the `profiler` dependency in the `CLI` at all.