### PR TITLE
Refactors stringext library to match conventions

### DIFF
--- a/lute/cli/commands/lib/files.luau
+++ b/lute/cli/commands/lib/files.luau
@@ -27,7 +27,7 @@ local function traverseDirectoryRecursive(
 			tableext.extend(results, traverseDirectoryRecursive(fullPath, ignoreResolver, verbose))
 		else
 			-- TODO: allow customisation of the filter when traversing a directory. e.g., globs? file endings? ignore paths?
-			if stringext.hassuffix(entry.name, ".luau") or stringext.hassuffix(entry.name, ".lua") then
+			if stringext.hasSuffix(entry.name, ".luau") or stringext.hasSuffix(entry.name, ".lua") then
 				if ignoreResolver:isIgnoredFile(fullPath) then
 					if verbose then
 						print("Skipping", fullPath)

--- a/lute/cli/commands/lib/parseIgnores.luau
+++ b/lute/cli/commands/lib/parseIgnores.luau
@@ -117,12 +117,12 @@ function parseIgnores.parseIgnoreContents(location: string, contents: string | {
 	for _, line in lines do
 		line = stringext.trim(line)
 
-		if line == "" or stringext.hasprefix(line, "#") then
+		if line == "" or stringext.hasPrefix(line, "#") then
 			continue
 		end
 
-		if stringext.hasprefix(line, "!") then
-			local globPattern = stringext.removeprefix(line, "!")
+		if stringext.hasPrefix(line, "!") then
+			local globPattern = stringext.removePrefix(line, "!")
 			local glob = parseGlob(globPattern)
 			table.insert(ignoreData.whitelists, glob)
 		else

--- a/lute/cli/commands/test/finder.luau
+++ b/lute/cli/commands/test/finder.luau
@@ -4,11 +4,11 @@ local path = require("@std/path")
 local stringext = require("@std/stringext")
 
 local function istestfile(filename: string): boolean
-	return stringext.hassuffix(filename, ".test.luau") or stringext.hassuffix(filename, ".spec.luau")
+	return stringext.hasSuffix(filename, ".test.luau") or stringext.hasSuffix(filename, ".spec.luau")
 end
 
 local function issnapfile(filename: string): boolean
-	return stringext.hassuffix(filename, ".snap.luau")
+	return stringext.hasSuffix(filename, ".snap.luau")
 end
 
 local function findfiles(paths: { string }, predicate: (string) -> boolean): { path.Path }

--- a/lute/cli/commands/test/snap/runner.luau
+++ b/lute/cli/commands/test/snap/runner.luau
@@ -9,8 +9,8 @@ local snapty = require("./types")
 -- e.g. /foo/bar.snap.luau -> /foo/bar.snap
 local function artifactpath(filepath: path.Path): string
 	local f = path.format(filepath)
-	assert(strext.hassuffix(f, ".snap.luau"), `expected {f} to have suffix .snap.luau`)
-	return strext.removesuffix(f, ".luau") -- strips ".luau"
+	assert(strext.hasSuffix(f, ".snap.luau"), `expected {f} to have suffix .snap.luau`)
+	return strext.removeSuffix(f, ".luau") -- strips ".luau"
 end
 
 local function posixify(str)

--- a/lute/cli/commands/transform/lib/arguments.luau
+++ b/lute/cli/commands/transform/lib/arguments.luau
@@ -34,8 +34,8 @@ local function parse(arguments: { string }): Config
 	while i <= #arguments do
 		local argument = arguments[i]
 
-		if stringext.hasprefix(argument, "--") then
-			local name = stringext.removeprefix(argument, "--")
+		if stringext.hasPrefix(argument, "--") then
+			local name = stringext.removePrefix(argument, "--")
 
 			if config.migrationPath == nil then
 				-- Options before the codemod file are parsed as options for the tool itself

--- a/lute/std/libs/stringext.luau
+++ b/lute/std/libs/stringext.luau
@@ -5,7 +5,7 @@
 
 local stringext = {}
 
-function stringext.hasprefix(str: string, prefix: string): boolean
+function stringext.hasPrefix(str: string, prefix: string): boolean
 	if #prefix > #str then
 		return false
 	end
@@ -13,20 +13,20 @@ function stringext.hasprefix(str: string, prefix: string): boolean
 	return str:sub(1, #prefix) == prefix
 end
 
-function stringext.removeprefix(str: string, prefix: string): string
-	if not stringext.hasprefix(str, prefix) then
+function stringext.removePrefix(str: string, prefix: string): string
+	if not stringext.hasPrefix(str, prefix) then
 		return str
 	end
 
 	return str:sub(#prefix + 1)
 end
 
-function stringext.hassuffix(str: string, suffix: string): boolean
+function stringext.hasSuffix(str: string, suffix: string): boolean
 	return str:sub(-#suffix) == suffix
 end
 
-function stringext.removesuffix(str: string, suffix: string): string
-	if not stringext.hassuffix(str, suffix) then
+function stringext.removeSuffix(str: string, suffix: string): string
+	if not stringext.hasSuffix(str, suffix) then
 		return str
 	end
 

--- a/lute/std/libs/test/assert.luau
+++ b/lute/std/libs/test/assert.luau
@@ -170,7 +170,7 @@ local function throwsWith<T...>(with: any, func: (T...) -> ...unknown, ...: T...
 
 	if typeof(with) == "string" then
 		-- pcall appends filename and line number of the error, so we check suffix only
-		if not stringext.hassuffix(actualErrorMessage, with) then
+		if not stringext.hasSuffix(actualErrorMessage, with) then
 			return assertion(`Expected suffix of error message "{with}", but got "{actualErrorMessage}"`)
 		end
 	else

--- a/tests/std/json.test.luau
+++ b/tests/std/json.test.luau
@@ -24,7 +24,7 @@ test.suite("JSONParsingTestSuite", function(suite)
 				return json.deserialize(src)
 			end)
 
-			if stringext.hasprefix(name, "y_") then
+			if stringext.hasPrefix(name, "y_") then
 				-- valid JSON: must parse
 				assert.that(ok)
 
@@ -38,7 +38,7 @@ test.suite("JSONParsingTestSuite", function(suite)
 					json.deserialize(_ser)
 				end)
 				assert.that(_ok3)
-			elseif stringext.hasprefix(name, "n_") then
+			elseif stringext.hasPrefix(name, "n_") then
 				-- invalid JSON: must fail to parse
 				assert.eq(ok, false)
 			else

--- a/tests/std/stringext.test.luau
+++ b/tests/std/stringext.test.luau
@@ -1,38 +1,38 @@
-local stringext = require("@std/stringext")
+local stringExt = require("@std/stringext")
 local test = require("@std/test")
 
 test.suite("StringExt", function(suite)
-	suite:case("hasprefixAndHassuffix", function(assert)
-		assert.that(stringext.hasprefix("hello", "he"))
-		assert.eq(stringext.hasprefix("hi", "hello"), false)
+	suite:case("hasprefixAndHasSuffix", function(assert)
+		assert.that(stringExt.hasPrefix("hello", "he"))
+		assert.eq(stringExt.hasPrefix("hi", "hello"), false)
 
-		assert.that(stringext.hassuffix("foobar", "bar"))
-		assert.eq(stringext.hassuffix("foo", "foobar"), false)
+		assert.that(stringExt.hasSuffix("foobar", "bar"))
+		assert.eq(stringExt.hasSuffix("foo", "foobar"), false)
 	end)
 
-	suite:case("removeprefixAndRemovesuffix", function(assert)
-		assert.eq(stringext.removeprefix("hello", "he"), "llo")
-		assert.eq(stringext.removeprefix("hello", "nope"), "hello")
+	suite:case("removePrefixAndRemovesuffix", function(assert)
+		assert.eq(stringExt.removePrefix("hello", "he"), "llo")
+		assert.eq(stringExt.removePrefix("hello", "nope"), "hello")
 
-		assert.eq(stringext.removesuffix("foobar", "bar"), "foo")
-		assert.eq(stringext.removesuffix("foobar", "nope"), "foobar")
+		assert.eq(stringExt.removeSuffix("foobar", "bar"), "foo")
+		assert.eq(stringExt.removeSuffix("foobar", "nope"), "foobar")
 	end)
 
 	suite:case("trim", function(assert)
-		assert.eq(stringext.trim("  a b  "), "a b")
-		assert.eq(stringext.trim("\n\thi\n"), "hi")
-		assert.eq(stringext.trim(""), "")
-		assert.eq(stringext.trim("   "), "")
+		assert.eq(stringExt.trim("  a b  "), "a b")
+		assert.eq(stringExt.trim("\n\thi\n"), "hi")
+		assert.eq(stringExt.trim(""), "")
+		assert.eq(stringExt.trim("   "), "")
 	end)
 
 	suite:case("count", function(assert)
-		assert.eq(stringext.count("hello world", "o"), 2)
-		assert.eq(stringext.count("hello world", "l", 4), 2) -- from position 4 to end
-		assert.eq(stringext.count("hello world", "l", nil, 5), 2) -- from start to position 5
-		assert.eq(stringext.count("hello world", "l", 4, 9), 1) -- from position 4 to position 9
-		assert.eq(stringext.count("aaaaaa", "aa"), 3) -- overlapping patterns
-		assert.eq(stringext.count("no matches here", "z"), 0)
-		assert.eq(stringext.count("hello world", "%s"), 1) -- patterns supported too
-		assert.eq(stringext.count("hello world", "[hw]"), 2) -- count h and w
+		assert.eq(stringExt.count("hello world", "o"), 2)
+		assert.eq(stringExt.count("hello world", "l", 4), 2) -- from position 4 to end
+		assert.eq(stringExt.count("hello world", "l", nil, 5), 2) -- from start to position 5
+		assert.eq(stringExt.count("hello world", "l", 4, 9), 1) -- from position 4 to position 9
+		assert.eq(stringExt.count("aaaaaa", "aa"), 3) -- overlapping patterns
+		assert.eq(stringExt.count("no matches here", "z"), 0)
+		assert.eq(stringExt.count("hello world", "%s"), 1) -- patterns supported too
+		assert.eq(stringExt.count("hello world", "[hw]"), 2) -- count h and w
 	end)
 end)

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -127,7 +127,7 @@ test.suite("Parser", function(suite)
 			if entry.type ~= "file" then
 				continue
 			end
-			if not strext.hassuffix(entry.name, ".luau") then
+			if not strext.hasSuffix(entry.name, ".luau") then
 				continue
 			end
 


### PR DESCRIPTION
- camelCases the members of the stringext library.
- `local stringext = require("@std/stringext') -> local stringExt = require("@std/stringext")` - not strictly required, but I just feel like it's better.