### PR TITLE
Refactors @std/process and @lute/process to be more consistent

### DIFF
--- a/definitions/process.luau
+++ b/definitions/process.luau
@@ -50,7 +50,7 @@ function process.exit(exitcode: number): never
 	error("not implemented")
 end
 
-function process.execpath(): string
+function process.execPath(): string
 	error("not implemented")
 end
 

--- a/lute/cli/commands/new/init.luau
+++ b/lute/cli/commands/new/init.luau
@@ -51,7 +51,7 @@ local function main(...: string)
 
 	if not fs.exists(typedefs.TYPEDEFS_PATH) then
 		print("Running lute setup first...")
-		local result = process.run({ path.format(process.execpath()), "setup" }, { stdio = "inherit" })
+		local result = process.run({ path.format(process.execPath()), "setup" }, { stdio = "inherit" })
 		if not result.ok then
 			print("Error: lute setup failed.")
 			process.exit(1)

--- a/lute/cli/commands/test/snap/runner.luau
+++ b/lute/cli/commands/test/snap/runner.luau
@@ -33,7 +33,7 @@ function runner.runsnapshots(files: { path.Path }): snapty.snapresult
 		new = {},
 	}
 
-	local execpath = path.format(process.execpath())
+	local execpath = path.format(process.execPath())
 
 	-- Compute the normalized current working directory exactly once
 	--[[

--- a/lute/process/include/lute/process.h
+++ b/lute/process/include/lute/process.h
@@ -23,7 +23,7 @@ int cwd(lua_State* L);
 int exitFunc(lua_State* L);
 
 std::optional<std::string> getExecPath(std::string* error);
-int execpath(lua_State* L);
+int execPath(lua_State* L);
 
 static const luaL_Reg lib[] = {
     {"run", run},
@@ -31,7 +31,7 @@ static const luaL_Reg lib[] = {
     {"homedir", homedir},
     {"cwd", cwd},
     {"exit", exitFunc},
-    {"execpath", execpath},
+    {"execPath", execPath},
 
     {nullptr, nullptr}
 };

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -516,7 +516,7 @@ std::optional<std::string> getExecPath(std::string* error)
     return *cachedPath;
 }
 
-int execpath(lua_State* L)
+int execPath(lua_State* L)
 {
     std::string error;
     std::optional<std::string> execPath = getExecPath(&error);

--- a/lute/std/libs/process.luau
+++ b/lute/std/libs/process.luau
@@ -35,8 +35,8 @@ function processlib.exit(exitcode: number): never
 	return process.exit(exitcode)
 end
 
-function processlib.execpath(): Path
-	return pathlib.parse(process.execpath())
+function processlib.execPath(): Path
+	return pathlib.parse(process.execPath())
 end
 
 -- re-exports

--- a/tests/cli/check.test.luau
+++ b/tests/cli/check.test.luau
@@ -2,7 +2,7 @@ local path = require("@std/path")
 local process = require("@std/process")
 local test = require("@std/test")
 
-local lutePath = path.format(process.execpath())
+local lutePath = path.format(process.execPath())
 
 test.suite("LuteTypeCheck", function(suite)
 	suite:case("usesNewSolver", function(assert)

--- a/tests/cli/compile.test.luau
+++ b/tests/cli/compile.test.luau
@@ -20,7 +20,7 @@ print(`SUCCESS`)
 
 local COMPILEE_CONTENTS = [[return "Hello world"]]
 
-local lutePath = process.execpath()
+local lutePath = process.execPath()
 local tmpDir = system.tmpdir()
 
 test.suite("LuteCliCompile", function(suite)

--- a/tests/cli/doc.test.luau
+++ b/tests/cli/doc.test.luau
@@ -6,7 +6,7 @@ local test = require("@std/test")
 
 local tmpDir = system.tmpdir()
 local tmpOutputDir = path.join(tmpDir, "lute-doc-output")
-local lutePath = path.format(process.execpath())
+local lutePath = path.format(process.execPath())
 
 local USAGE = "Usage: lute doc [OPTIONS]"
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -6,7 +6,7 @@ local tableext = require("@std/tableext")
 local test = require("@std/test")
 local testTypes = require("@std/test/types")
 
-local lutePath = path.format(process.execpath())
+local lutePath = path.format(process.execPath())
 local tmpDir = system.tmpdir()
 local rulesDir = path.format(path.join(".", "lints"))
 local defaultRulesFolder = path.format(path.join("lute", "cli", "commands", "lint", "rules"))

--- a/tests/cli/loadmodule.test.luau
+++ b/tests/cli/loadmodule.test.luau
@@ -15,7 +15,7 @@ print(result)
 
 local REQUIREE_CONTENTS = [[return "Success"]]
 
-local lutePath = process.execpath()
+local lutePath = process.execPath()
 
 local tmpDirStr = system.tmpdir()
 local testDir = path.join(tmpDirStr, "lute_require_test")

--- a/tests/cli/new.test.luau
+++ b/tests/cli/new.test.luau
@@ -6,7 +6,7 @@ local test = require("@std/test")
 
 local tmpdir = system.tmpdir()
 local workdir = pathlib.join(tmpdir, "lute-new")
-local lutePath = pathlib.format(process.execpath())
+local lutePath = pathlib.format(process.execPath())
 local projectName = "myproject"
 local projectDir = pathlib.join(workdir, projectName)
 

--- a/tests/cli/run.test.luau
+++ b/tests/cli/run.test.luau
@@ -8,7 +8,7 @@ local tmpdir = system.tmpdir()
 
 local rundir = pathlib.join(tmpdir, "lute-run")
 
-local lutePath = pathlib.format(process.execpath())
+local lutePath = pathlib.format(process.execPath())
 
 test.suite("LuteRun", function(suite)
 	suite:beforeeach(function()

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -2,7 +2,7 @@ local path = require("@std/path")
 local process = require("@std/process")
 local test = require("@std/test")
 
-local lutePath = path.format(process.execpath())
+local lutePath = path.format(process.execPath())
 
 local expected = [[Anonymous:
 	passing

--- a/tests/cli/transform.test.luau
+++ b/tests/cli/transform.test.luau
@@ -1,6 +1,6 @@
 local fs = require("@std/fs")
 local path = require("@std/path")
-local process = require("@lute/process")
+local process = require("@std/process")
 local system = require("@std/system")
 local test = require("@std/test")
 
@@ -9,7 +9,7 @@ local x = math.sqrt(-1)
 local b = x ~= x
 ]]
 
-local lutePath = process.execpath()
+local lutePath = path.format(process.execPath())
 local tmpDir = system.tmpdir()
 local transformeePath = path.format(path.join(tmpDir, "transformee.luau"))
 local outputPath = path.format(path.join(tmpDir, "transformee_output.luau"))

--- a/tests/lute/vm.test.luau
+++ b/tests/lute/vm.test.luau
@@ -59,7 +59,7 @@ test.suite("LuteVmSuite", function(suite)
 			fs.close(handle)
 		end
 
-		local result = process.run({ path.format(process.execpath()), path.format(parent_vm) })
+		local result = process.run({ path.format(process.execPath()), path.format(parent_vm) })
 		assert.eq(result.exitcode, 0)
 
 		fs.remove(child_vm)

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -16,7 +16,7 @@ test.suite("ProcessSuite", function(suite)
 		local cwd = process.cwd()
 		assert.neq(pathlib.format(cwd), "")
 
-		local ex = process.execpath()
+		local ex = process.execPath()
 		assert.neq(pathlib.format(ex), "")
 	end)
 

--- a/tests/std/test.test.luau
+++ b/tests/std/test.test.luau
@@ -5,7 +5,7 @@ local process = require("@std/process")
 local system = require("@std/system")
 local test = require("@std/test")
 
-local lutePath = path.format(process.execpath())
+local lutePath = path.format(process.execPath())
 local tmpDir = system.tmpdir()
 
 local function assertErrorsWithMsg(


### PR DESCRIPTION
All instances of `execpath` have become `execPath`.
