### PR TITLE
Moves test.run() into @std/test/runner

### DIFF
--- a/examples/testing.luau
+++ b/examples/testing.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("foo", function(assert)
 	assert.eq(3, 3)
@@ -67,4 +68,4 @@ test.suite("MySuite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/examples/testing.luau
+++ b/examples/testing.luau
@@ -67,4 +67,4 @@ test.suite("MySuite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/lute/std/libs/test/env.luau
+++ b/lute/std/libs/test/env.luau
@@ -1,0 +1,11 @@
+--!strict
+--@std/test/types
+-- Environment to store discovered tests
+
+local types = require("./types")
+type TestEnvironment = types.TestEnvironment
+
+local env: TestEnvironment = { anonymous = {}, suites = {}, suiteindex = {}, caseindex = {} }
+
+-- not frozen, the internal test library needs to mutate this during test discovery
+return env

--- a/lute/std/libs/test/init.luau
+++ b/lute/std/libs/test/init.luau
@@ -3,6 +3,7 @@
 -- Standard test library for Luau
 
 local types = require("@self/types")
+local env = require("@self/env")
 
 type Test = types.Test
 type TestCase = types.TestCase
@@ -43,8 +44,6 @@ end
 function TestSuite:afterAll(hook: () -> ())
 	self._afterAll = hook
 end
-
-local env = require("@self/env")
 
 -- Test library export surface
 local test = {}

--- a/lute/std/libs/test/init.luau
+++ b/lute/std/libs/test/init.luau
@@ -4,14 +4,9 @@
 
 local types = require("@self/types")
 
-local reporter = require("@self/reporter")
-local runner = require("@self/runner")
-local ps = require("@std/process")
-
 type Test = types.Test
 type TestCase = types.TestCase
 type TestSuite = types.TestSuite
-type TestEnvironment = types.TestEnvironment
 type TestReporter = types.TestReporter
 
 local TestSuite = {}
@@ -49,7 +44,7 @@ function TestSuite:afterAll(hook: () -> ())
 	self._afterAll = hook
 end
 
-local env: TestEnvironment = { anonymous = {}, suites = {}, suiteindex = {}, caseindex = {} }
+local env = require("@self/env")
 
 -- Test library export surface
 local test = {}
@@ -96,16 +91,6 @@ function test._registered()
 		suiteindex = env.suiteindex,
 		caseindex = env.caseindex,
 	})
-end
-
--- run all the tests
-function test.run()
-	local failed = runner.run(env)
-	reporter.simple(failed)
-	if failed.failed ~= 0 then
-		ps.exit(1)
-	end
-	ps.exit(0)
 end
 
 return table.freeze(test)

--- a/lute/std/libs/test/runner.luau
+++ b/lute/std/libs/test/runner.luau
@@ -7,6 +7,7 @@ local asserts = require("./assert")
 local failure = require("./failure")
 local reporter = require("./reporter")
 local types = require("./types")
+local env = require("./env")
 
 type Test = types.Test
 type TestCase = types.TestCase
@@ -162,7 +163,6 @@ end
 
 -- run all the tests
 function runner.runRegisteredTests()
-	local env = require("./env")
 	local result = runner.run(env)
 	reporter.simple(result)
 	if result.failed ~= 0 then

--- a/lute/std/libs/test/runner.luau
+++ b/lute/std/libs/test/runner.luau
@@ -1,9 +1,11 @@
 --!strict
 -- @std/test/runner
 -- Standard test runner library for Luau
+local ps = require("@std/process")
 
 local asserts = require("./assert")
 local failure = require("./failure")
+local reporter = require("./reporter")
 local types = require("./types")
 
 type Test = types.Test
@@ -156,6 +158,17 @@ function runner.run(env: TestEnvironment): TestRunResult
 		failed = failed,
 		passed = passed,
 	}
+end
+
+-- run all the tests
+function runner.runRegisteredTests()
+	local env = require("./env")
+	local result = runner.run(env)
+	reporter.simple(result)
+	if result.failed ~= 0 then
+		ps.exit(1)
+	end
+	ps.exit(0)
 end
 
 return table.freeze(runner)

--- a/lute/std/libs/test/types.luau
+++ b/lute/std/libs/test/types.luau
@@ -2,8 +2,6 @@
 -- @std/test/types
 -- Standard test types library for Luau
 
--- Test Reporting
-
 export type Hook = "beforeEach" | "beforeAll" | "afterEach" | "afterAll"
 export type Failure =
 	{

--- a/tests/std/snapshots/assert_buffereq_unequal_length.snap
+++ b/tests/std/snapshots/assert_buffereq_unequal_length.snap
@@ -6,7 +6,7 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ buffereq_error
-	<ROOT>/tests/std/snapshots/assert_buffereq_unequal_length.snap.luau:6
+	<ROOT>/tests/std/snapshots/assert_buffereq_unequal_length.snap.luau:7
 		buffereq: buffers are of unequal length
 
 --------------------------------------------------

--- a/tests/std/snapshots/assert_buffereq_unequal_length.snap.luau
+++ b/tests/std/snapshots/assert_buffereq_unequal_length.snap.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("buffereq_error", function(assert)
 	local buf1 = buffer.create(1)
@@ -6,4 +7,4 @@ test.case("buffereq_error", function(assert)
 	assert.eq(buf1, buf2)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assert_buffereq_unequal_length.snap.luau
+++ b/tests/std/snapshots/assert_buffereq_unequal_length.snap.luau
@@ -6,4 +6,4 @@ test.case("buffereq_error", function(assert)
 	assert.eq(buf1, buf2)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/assert_eq_error_msg_in_case.snap
+++ b/tests/std/snapshots/assert_eq_error_msg_in_case.snap
@@ -6,7 +6,7 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ eq_error
-	<ROOT>/tests/std/snapshots/assert_eq_error_msg_in_case.snap.luau:4
+	<ROOT>/tests/std/snapshots/assert_eq_error_msg_in_case.snap.luau:5
 		eq: 1 ~= 2
 
 --------------------------------------------------

--- a/tests/std/snapshots/assert_eq_error_msg_in_case.snap.luau
+++ b/tests/std/snapshots/assert_eq_error_msg_in_case.snap.luau
@@ -4,4 +4,4 @@ test.case("eq_error", function(assert)
 	assert.eq(1, 2)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/assert_eq_error_msg_in_case.snap.luau
+++ b/tests/std/snapshots/assert_eq_error_msg_in_case.snap.luau
@@ -1,7 +1,8 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("eq_error", function(assert)
 	assert.eq(1, 2)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assert_eq_error_msg_in_suite.snap
+++ b/tests/std/snapshots/assert_eq_error_msg_in_suite.snap
@@ -6,7 +6,7 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ eq_failure_suite.eq_error
-	<ROOT>/tests/std/snapshots/assert_eq_error_msg_in_suite.snap.luau:5
+	<ROOT>/tests/std/snapshots/assert_eq_error_msg_in_suite.snap.luau:6
 		eq: 1 ~= 2
 
 --------------------------------------------------

--- a/tests/std/snapshots/assert_eq_error_msg_in_suite.snap.luau
+++ b/tests/std/snapshots/assert_eq_error_msg_in_suite.snap.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("eq_failure_suite", function(suite)
 	suite:case("eq_error", function(assert)
@@ -6,4 +7,4 @@ test.suite("eq_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assert_eq_error_msg_in_suite.snap.luau
+++ b/tests/std/snapshots/assert_eq_error_msg_in_suite.snap.luau
@@ -6,4 +6,4 @@ test.suite("eq_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/assert_error_eq_no_error.snap
+++ b/tests/std/snapshots/assert_error_eq_no_error.snap
@@ -6,7 +6,7 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ throwsWithError
-	<ROOT>/tests/std/snapshots/assert_error_eq_no_error.snap.luau:4
+	<ROOT>/tests/std/snapshots/assert_error_eq_no_error.snap.luau:5
 		throwsWith: Expected function to throw/raise error.
 
 --------------------------------------------------

--- a/tests/std/snapshots/assert_error_eq_no_error.snap.luau
+++ b/tests/std/snapshots/assert_error_eq_no_error.snap.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("throwsWithError", function(assert)
 	assert.throwsWith("expected message", function()
@@ -6,4 +7,4 @@ test.case("throwsWithError", function(assert)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assert_error_eq_no_error.snap.luau
+++ b/tests/std/snapshots/assert_error_eq_no_error.snap.luau
@@ -6,4 +6,4 @@ test.case("throwsWithError", function(assert)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/assert_erroreq_error_message.snap
+++ b/tests/std/snapshots/assert_erroreq_error_message.snap
@@ -6,8 +6,8 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ throwsWith_failure_suite.throwsWith_error
-	<ROOT>/tests/std/snapshots/assert_erroreq_error_message.snap.luau:5
-		throwsWith: Expected suffix of error message "expected message", but got "<ROOT>/tests/std/snapshots/assert_erroreq_error_message.snap.luau:6: wrong message"
+	<ROOT>/tests/std/snapshots/assert_erroreq_error_message.snap.luau:6
+		throwsWith: Expected suffix of error message "expected message", but got "<ROOT>/tests/std/snapshots/assert_erroreq_error_message.snap.luau:7: wrong message"
 
 --------------------------------------------------
 Total:  1

--- a/tests/std/snapshots/assert_erroreq_error_message.snap.luau
+++ b/tests/std/snapshots/assert_erroreq_error_message.snap.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("throwsWith_failure_suite", function(suite)
 	suite:case("throwsWith_error", function(assert)
@@ -8,4 +9,4 @@ test.suite("throwsWith_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assert_erroreq_error_message.snap.luau
+++ b/tests/std/snapshots/assert_erroreq_error_message.snap.luau
@@ -8,4 +8,4 @@ test.suite("throwsWith_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/assert_neq_error_message_in_case.snap
+++ b/tests/std/snapshots/assert_neq_error_message_in_case.snap
@@ -6,7 +6,7 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ neq_error
-	<ROOT>/tests/std/snapshots/assert_neq_error_message_in_case.snap.luau:4
+	<ROOT>/tests/std/snapshots/assert_neq_error_message_in_case.snap.luau:5
 		neq: 1 == 1
 
 --------------------------------------------------

--- a/tests/std/snapshots/assert_neq_error_message_in_case.snap.luau
+++ b/tests/std/snapshots/assert_neq_error_message_in_case.snap.luau
@@ -4,4 +4,4 @@ test.case("neq_error", function(assert)
 	assert.neq(1, 1)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/assert_neq_error_message_in_case.snap.luau
+++ b/tests/std/snapshots/assert_neq_error_message_in_case.snap.luau
@@ -1,7 +1,8 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("neq_error", function(assert)
 	assert.neq(1, 1)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assert_strcontains_instances_negative.snap
+++ b/tests/std/snapshots/assert_strcontains_instances_negative.snap
@@ -6,8 +6,8 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ strcontains_error
-	<ROOT>/tests/std/snapshots/assert_strcontains_instances_negative.snap.luau:4
-		strcontains: instances must be greater than 0
+	<ROOT>/tests/std/snapshots/assert_strcontains_instances_negative.snap.luau:5
+		strContains: instances must be greater than 0
 
 --------------------------------------------------
 Total:  1

--- a/tests/std/snapshots/assert_strcontains_instances_negative.snap.luau
+++ b/tests/std/snapshots/assert_strcontains_instances_negative.snap.luau
@@ -4,4 +4,4 @@ test.case("strcontains_error", function(assert)
 	assert.strContains("hello world", "goodbye", -1)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/assert_strcontains_instances_negative.snap.luau
+++ b/tests/std/snapshots/assert_strcontains_instances_negative.snap.luau
@@ -1,7 +1,8 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("strcontains_error", function(assert)
 	assert.strContains("hello world", "goodbye", -1)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assert_strcontains_multiple_instance_fails.snap
+++ b/tests/std/snapshots/assert_strcontains_multiple_instance_fails.snap
@@ -6,8 +6,8 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ strcontains_failure_suite.strcontains_error
-	<ROOT>/tests/std/snapshots/assert_strcontains_multiple_instance_fails.snap.luau:5
-		strcontains: Expected "hello world" to contain "goodbye".
+	<ROOT>/tests/std/snapshots/assert_strcontains_multiple_instance_fails.snap.luau:6
+		strContains: Expected "hello world" to contain "goodbye".
 
 --------------------------------------------------
 Total:  1

--- a/tests/std/snapshots/assert_strcontains_multiple_instance_fails.snap.luau
+++ b/tests/std/snapshots/assert_strcontains_multiple_instance_fails.snap.luau
@@ -6,4 +6,4 @@ test.suite("strcontains_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/assert_strcontains_multiple_instance_fails.snap.luau
+++ b/tests/std/snapshots/assert_strcontains_multiple_instance_fails.snap.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("strcontains_failure_suite", function(suite)
 	suite:case("strcontains_error", function(assert)
@@ -6,4 +7,4 @@ test.suite("strcontains_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assert_strcontains_single_instance_fails.snap
+++ b/tests/std/snapshots/assert_strcontains_single_instance_fails.snap
@@ -6,8 +6,8 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ strcontains_failure_suite.strcontains_error
-	<ROOT>/tests/std/snapshots/assert_strcontains_single_instance_fails.snap.luau:5
-		strcontains: Expected "hello world" to contain "goodbye".
+	<ROOT>/tests/std/snapshots/assert_strcontains_single_instance_fails.snap.luau:6
+		strContains: Expected "hello world" to contain "goodbye".
 
 --------------------------------------------------
 Total:  1

--- a/tests/std/snapshots/assert_strcontains_single_instance_fails.snap.luau
+++ b/tests/std/snapshots/assert_strcontains_single_instance_fails.snap.luau
@@ -6,4 +6,4 @@ test.suite("strcontains_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/assert_strcontains_single_instance_fails.snap.luau
+++ b/tests/std/snapshots/assert_strcontains_single_instance_fails.snap.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("strcontains_failure_suite", function(suite)
 	suite:case("strcontains_error", function(assert)
@@ -6,4 +7,4 @@ test.suite("strcontains_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assert_tableeq_error_message_in_case.snap
+++ b/tests/std/snapshots/assert_tableeq_error_message_in_case.snap
@@ -6,7 +6,7 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ tableeq_error
-	<ROOT>/tests/std/snapshots/assert_tableeq_error_message_in_case.snap.luau:4
+	<ROOT>/tests/std/snapshots/assert_tableeq_error_message_in_case.snap.luau:5
 		tableeq: lhs[a] = 1 but rhs[a] = 2
 
 --------------------------------------------------

--- a/tests/std/snapshots/assert_tableeq_error_message_in_case.snap.luau
+++ b/tests/std/snapshots/assert_tableeq_error_message_in_case.snap.luau
@@ -4,4 +4,4 @@ test.case("tableeq_error", function(assert)
 	assert.eq({ a = 1 }, { a = 2 })
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/assert_tableeq_error_message_in_case.snap.luau
+++ b/tests/std/snapshots/assert_tableeq_error_message_in_case.snap.luau
@@ -1,7 +1,8 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("tableeq_error", function(assert)
 	assert.eq({ a = 1 }, { a = 2 })
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assert_tableeq_error_message_in_suite.snap
+++ b/tests/std/snapshots/assert_tableeq_error_message_in_suite.snap
@@ -6,7 +6,7 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ tableeq_failure_suite.tableeq_error
-	<ROOT>/tests/std/snapshots/assert_tableeq_error_message_in_suite.snap.luau:5
+	<ROOT>/tests/std/snapshots/assert_tableeq_error_message_in_suite.snap.luau:6
 		tableeq: lhs[a] = 1 but rhs[a] = 2
 
 --------------------------------------------------

--- a/tests/std/snapshots/assert_tableeq_error_message_in_suite.snap.luau
+++ b/tests/std/snapshots/assert_tableeq_error_message_in_suite.snap.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("tableeq_failure_suite", function(suite)
 	suite:case("tableeq_error", function(assert)
@@ -6,4 +7,4 @@ test.suite("tableeq_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assert_tableeq_error_message_in_suite.snap.luau
+++ b/tests/std/snapshots/assert_tableeq_error_message_in_suite.snap.luau
@@ -6,4 +6,4 @@ test.suite("tableeq_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/assertneq_error_message_in_suite.snap
+++ b/tests/std/snapshots/assertneq_error_message_in_suite.snap
@@ -6,7 +6,7 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ neq_failure_suite.neq_error
-	<ROOT>/tests/std/snapshots/assertneq_error_message_in_suite.snap.luau:5
+	<ROOT>/tests/std/snapshots/assertneq_error_message_in_suite.snap.luau:6
 		neq: 1 == 1
 
 --------------------------------------------------

--- a/tests/std/snapshots/assertneq_error_message_in_suite.snap.luau
+++ b/tests/std/snapshots/assertneq_error_message_in_suite.snap.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("neq_failure_suite", function(suite)
 	suite:case("neq_error", function(assert)
@@ -6,4 +7,4 @@ test.suite("neq_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/assertneq_error_message_in_suite.snap.luau
+++ b/tests/std/snapshots/assertneq_error_message_in_suite.snap.luau
@@ -6,4 +6,4 @@ test.suite("neq_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/buffereq_failure_suite.snap
+++ b/tests/std/snapshots/buffereq_failure_suite.snap
@@ -6,7 +6,7 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ buffereq_failure_suite.buffereq_error
-	<ROOT>/tests/std/snapshots/buffereq_failure_suite.snap.luau:9
+	<ROOT>/tests/std/snapshots/buffereq_failure_suite.snap.luau:10
 		buffereq: lhs[0] = 54, but rhs[0] = 55
 
 --------------------------------------------------

--- a/tests/std/snapshots/buffereq_failure_suite.snap.luau
+++ b/tests/std/snapshots/buffereq_failure_suite.snap.luau
@@ -10,4 +10,4 @@ test.suite("buffereq_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/buffereq_failure_suite.snap.luau
+++ b/tests/std/snapshots/buffereq_failure_suite.snap.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("buffereq_failure_suite", function(suite)
 	suite:case("buffereq_error", function(assert)
@@ -10,4 +11,4 @@ test.suite("buffereq_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap
+++ b/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap
@@ -6,15 +6,15 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ nil_field_suite.access_field_of_nil
-	Runtime error: <ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau:6: attempt to index nil with 'field'
+	Runtime error: <ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau:7: attempt to index nil with 'field'
 Stacktrace:
-<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau:6: attempt to index nil with 'field'
+<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau:7: attempt to index nil with 'field'
 @std/test/failure.luau:29 function runtimeerror
-@std/test/runner.luau:117 function handlefailure
-<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau:6
-@std/test/runner.luau:130 function run
-@std/test/init.luau:103 function run
-<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau:11
+@std/test/runner.luau:119 function handlefailure
+<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau:7
+@std/test/runner.luau:132 function run
+@std/test/runner.luau:166 function runRegisteredTests
+<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau:12
 
 
 --------------------------------------------------

--- a/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau
+++ b/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("nil_field_suite", function(suite)
 	suite:case("access_field_of_nil", function(assert)
@@ -8,4 +9,4 @@ test.suite("nil_field_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau
+++ b/tests/std/snapshots/runtime_error_doesnt_report_xpcall.snap.luau
@@ -8,4 +8,4 @@ test.suite("nil_field_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap
+++ b/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap
@@ -6,15 +6,15 @@ TEST RESULTS
 Failed Tests (1):
 
 ❌ access_field_of_nil
-	Runtime error: <ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau:5: attempt to index nil with 'field'
+	Runtime error: <ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau:6: attempt to index nil with 'field'
 Stacktrace:
-<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau:5: attempt to index nil with 'field'
+<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau:6: attempt to index nil with 'field'
 @std/test/failure.luau:29 function runtimeerror
-@std/test/runner.luau:87 function handlefailure
-<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau:5
-@std/test/runner.luau:93 function run
-@std/test/init.luau:103 function run
-<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau:9
+@std/test/runner.luau:89 function handlefailure
+<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau:6
+@std/test/runner.luau:95 function run
+@std/test/runner.luau:166 function runRegisteredTests
+<ROOT>/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau:10
 
 
 --------------------------------------------------

--- a/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau
+++ b/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau
@@ -1,4 +1,5 @@
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("access_field_of_nil", function(assert)
 	local t = nil :: any
@@ -6,4 +7,4 @@ test.case("access_field_of_nil", function(assert)
 	print(value)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()

--- a/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau
+++ b/tests/std/snapshots/runtime_error_doesnt_report_xpcall_case.snap.luau
@@ -6,4 +6,4 @@ test.case("access_field_of_nil", function(assert)
 	print(value)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()

--- a/tests/std/test.test.luau
+++ b/tests/std/test.test.luau
@@ -32,8 +32,8 @@ test.suite("LuteStdTestFramework", function(suite)
 		fs.writeStringToFile(
 			testFilePath,
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 test.suite("nil_field_suite", function(suite)
 	suite:case("accessFieldOfNil", function(assert)
 		local t = nil
@@ -68,8 +68,8 @@ runner.runRegisteredTests()
 		fs.writeStringToFile(
 			testFilePath,
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.case("accessFieldOfNil", function(assert)
 	local t = nil
@@ -102,8 +102,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_eq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.case("eqError", function(assert)
 	assert.eq(1, 2)
@@ -120,8 +120,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_eq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.suite("eq_failure_suite", function(suite)
 	suite:case("eqError", function(assert)
@@ -140,8 +140,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_neq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.case("neqError", function(assert)
 	assert.neq(1, 1)
@@ -158,8 +158,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_neq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.suite("neq_failure_suite", function(suite)
 	suite:case("neqError", function(assert)
@@ -178,8 +178,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_tableeq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.case("tableeqError", function(assert)
 	assert.eq({ a = 1 }, { a = 2 })
@@ -196,8 +196,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_tableeq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.suite("tableeq_failure_suite", function(suite)
 	suite:case("tableeqError", function(assert)
@@ -216,8 +216,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_buffereq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.case("buffereqError", function(assert)
 	local buf1 = buffer.create(1)
@@ -236,8 +236,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_buffereq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.suite("buffereq_failure_suite", function(suite)
 	suite:case("buffereqError", function(assert)
@@ -260,8 +260,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_buffereq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.case("throwsWithError", function(assert)
 	assert.throwsWith("expected message", function() return end)
@@ -278,8 +278,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_buffereq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.suite("throwsWith_failure_suite", function(suite)
 	suite:case("throwsWithError", function(assert)
@@ -298,8 +298,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_buffereq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.case("strcontainsError", function(assert)
 	assert.strContains("hello world", "goodbye", -1)
@@ -316,8 +316,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_buffereq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.suite("strcontains_failure_suite", function(suite)
 	suite:case("strcontainsError", function(assert)
@@ -336,8 +336,8 @@ runner.runRegisteredTests()
 		assertErrorsWithMsg(
 			"assert_buffereq_fails",
 			[[
-local test = require("@std/test")
 local runner = require("@std/test/runner")
+local test = require("@std/test")
 
 test.suite("strcontains_failure_suite", function(suite)
 	suite:case("strcontainsError", function(assert)

--- a/tests/std/test.test.luau
+++ b/tests/std/test.test.luau
@@ -33,7 +33,7 @@ test.suite("LuteStdTestFramework", function(suite)
 			testFilePath,
 			[[
 local test = require("@std/test")
-
+local runner = require("@std/test/runner")
 test.suite("nil_field_suite", function(suite)
 	suite:case("accessFieldOfNil", function(assert)
 		local t = nil
@@ -41,7 +41,7 @@ test.suite("nil_field_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]]
 		)
 
@@ -69,13 +69,14 @@ require("@std/test/runner").runRegisteredTests()
 			testFilePath,
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("accessFieldOfNil", function(assert)
 	local t = nil
 	local value = t.field -- This will cause an error
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]]
 		)
 
@@ -89,10 +90,10 @@ require("@std/test/runner").runRegisteredTests()
 		assert.strContains(result.stdout, `Runtime error`)
 		assert.strContains(
 			result.stdout,
-			`{if system.win32 then path.format(testFilePath):gsub("\\", "/") else path.format(testFilePath)}:5`
+			`{if system.win32 then path.format(testFilePath):gsub("\\", "/") else path.format(testFilePath)}:6`
 		)
-		assert.strContains(result.stdout, `nil_field_access_test.test.luau:5: attempt to index nil with 'field'`)
-		assert.strContains(result.stdout, `nil_field_access_test.test.luau:8`)
+		assert.strContains(result.stdout, `nil_field_access_test.test.luau:6: attempt to index nil with 'field'`)
+		assert.strContains(result.stdout, `nil_field_access_test.test.luau:9`)
 
 		fs.remove(testFilePath)
 	end)
@@ -102,12 +103,13 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_eq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("eqError", function(assert)
 	assert.eq(1, 2)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			"eq: 1 ~= 2",
 			assert
@@ -119,6 +121,7 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_eq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("eq_failure_suite", function(suite)
 	suite:case("eqError", function(assert)
@@ -126,7 +129,7 @@ test.suite("eq_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			"eq: 1 ~= 2",
 			assert
@@ -138,12 +141,13 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_neq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("neqError", function(assert)
 	assert.neq(1, 1)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			"neq: 1 == 1",
 			assert
@@ -155,6 +159,7 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_neq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("neq_failure_suite", function(suite)
 	suite:case("neqError", function(assert)
@@ -162,7 +167,7 @@ test.suite("neq_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			"neq: 1 == 1",
 			assert
@@ -174,12 +179,13 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_tableeq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("tableeqError", function(assert)
 	assert.eq({ a = 1 }, { a = 2 })
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			"tableeq: lhs[a] = 1 but rhs[a] = 2",
 			assert
@@ -191,6 +197,7 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_tableeq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("tableeq_failure_suite", function(suite)
 	suite:case("tableeqError", function(assert)
@@ -198,7 +205,7 @@ test.suite("tableeq_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			"tableeq: lhs[a] = 1 but rhs[a] = 2",
 			assert
@@ -210,6 +217,7 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_buffereq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("buffereqError", function(assert)
 	local buf1 = buffer.create(1)
@@ -217,7 +225,7 @@ test.case("buffereqError", function(assert)
 	assert.eq(buf1, buf2)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			"buffers are of unequal length",
 			assert
@@ -229,6 +237,7 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_buffereq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("buffereq_failure_suite", function(suite)
 	suite:case("buffereqError", function(assert)
@@ -240,7 +249,7 @@ test.suite("buffereq_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			"buffereq: lhs[0] = 54, but rhs[0] = 55",
 			assert
@@ -252,12 +261,13 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_buffereq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("throwsWithError", function(assert)
 	assert.throwsWith("expected message", function() return end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			"Expected function to throw/raise error.",
 			assert
@@ -269,6 +279,7 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_buffereq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("throwsWith_failure_suite", function(suite)
 	suite:case("throwsWithError", function(assert)
@@ -276,7 +287,7 @@ test.suite("throwsWith_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			'Expected suffix of error message "expected message", but got ', -- the full message contains tmpdir path to test file
 			assert
@@ -288,12 +299,13 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_buffereq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.case("strcontainsError", function(assert)
 	assert.strContains("hello world", "goodbye", -1)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			"instances must be greater than 0",
 			assert
@@ -305,6 +317,7 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_buffereq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("strcontains_failure_suite", function(suite)
 	suite:case("strcontainsError", function(assert)
@@ -312,7 +325,7 @@ test.suite("strcontains_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			'Expected "hello world" to contain "goodbye".',
 			assert
@@ -324,6 +337,7 @@ require("@std/test/runner").runRegisteredTests()
 			"assert_buffereq_fails",
 			[[
 local test = require("@std/test")
+local runner = require("@std/test/runner")
 
 test.suite("strcontains_failure_suite", function(suite)
 	suite:case("strcontainsError", function(assert)
@@ -331,7 +345,7 @@ test.suite("strcontains_failure_suite", function(suite)
 	end)
 end)
 
-require("@std/test/runner").runRegisteredTests()
+runner.runRegisteredTests()
 			]],
 			'Expected "muahahahaha" to contain "ha" 5 times.',
 			assert

--- a/tests/std/test.test.luau
+++ b/tests/std/test.test.luau
@@ -41,7 +41,7 @@ test.suite("nil_field_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]]
 		)
 
@@ -75,7 +75,7 @@ test.case("accessFieldOfNil", function(assert)
 	local value = t.field -- This will cause an error
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]]
 		)
 
@@ -107,7 +107,7 @@ test.case("eqError", function(assert)
 	assert.eq(1, 2)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			"eq: 1 ~= 2",
 			assert
@@ -126,7 +126,7 @@ test.suite("eq_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			"eq: 1 ~= 2",
 			assert
@@ -143,7 +143,7 @@ test.case("neqError", function(assert)
 	assert.neq(1, 1)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			"neq: 1 == 1",
 			assert
@@ -162,7 +162,7 @@ test.suite("neq_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			"neq: 1 == 1",
 			assert
@@ -179,7 +179,7 @@ test.case("tableeqError", function(assert)
 	assert.eq({ a = 1 }, { a = 2 })
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			"tableeq: lhs[a] = 1 but rhs[a] = 2",
 			assert
@@ -198,7 +198,7 @@ test.suite("tableeq_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			"tableeq: lhs[a] = 1 but rhs[a] = 2",
 			assert
@@ -217,7 +217,7 @@ test.case("buffereqError", function(assert)
 	assert.eq(buf1, buf2)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			"buffers are of unequal length",
 			assert
@@ -240,7 +240,7 @@ test.suite("buffereq_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			"buffereq: lhs[0] = 54, but rhs[0] = 55",
 			assert
@@ -257,7 +257,7 @@ test.case("throwsWithError", function(assert)
 	assert.throwsWith("expected message", function() return end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			"Expected function to throw/raise error.",
 			assert
@@ -276,7 +276,7 @@ test.suite("throwsWith_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			'Expected suffix of error message "expected message", but got ', -- the full message contains tmpdir path to test file
 			assert
@@ -293,7 +293,7 @@ test.case("strcontainsError", function(assert)
 	assert.strContains("hello world", "goodbye", -1)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			"instances must be greater than 0",
 			assert
@@ -312,7 +312,7 @@ test.suite("strcontains_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			'Expected "hello world" to contain "goodbye".',
 			assert
@@ -331,7 +331,7 @@ test.suite("strcontains_failure_suite", function(suite)
 	end)
 end)
 
-test.run()
+require("@std/test/runner").runRegisteredTests()
 			]],
 			'Expected "muahahahaha" to contain "ha" 5 times.',
 			assert


### PR DESCRIPTION
We should still support writing tests without using `lute test`, but now the method for doing this is explicitly moved into @std/test/runner.