### PR TITLE
Codemods for sorting module requires

### DIFF
--- a/lute/std/libs/fs.luau
+++ b/lute/std/libs/fs.luau
@@ -1,13 +1,15 @@
+local fs = require("@lute/fs")
+
+local pathlib = require("@std/path")
+local win32paths = require("@std/path/win32")
+local sys = require("@std/system")
+
 --!strict
 -- @std/fs
 -- stdlib for `@lute/fs`
 -- Provides file system utility functions that handles file paths as path types instead of strings
 
 local deque = require("@batteries/collections/deque")
-local fs = require("@lute/fs")
-local pathlib = require("@std/path")
-local sys = require("@std/system")
-local win32paths = require("@std/path/win32")
 
 local fslib = {}
 

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -1,3 +1,4 @@
+local fs = require("@lute/fs")
 --!strict
 -- @std/luau
 -- stdlib for `@lute/luau`
@@ -5,7 +6,6 @@
 
 local luteLuau = require("@lute/luau")
 
-local fs = require("@lute/fs")
 local path = require("@std/path")
 
 local luau = {}

--- a/lute/std/libs/path/init.luau
+++ b/lute/std/libs/path/init.luau
@@ -1,9 +1,9 @@
 local platform = require("@std/system/platform")
 
 local posix = require("@self/posix")
-local win32 = require("@self/win32")
 
 local pathtypes = require("@self/types")
+local win32 = require("@self/win32")
 
 local pathlib = {}
 

--- a/lute/std/libs/path/posix/init.luau
+++ b/lute/std/libs/path/posix/init.luau
@@ -1,5 +1,7 @@
 local process = require("@lute/process")
+
 local posixtypes = require("@self/types")
+
 local pathinterface = require("./pathinterface")
 
 export type Path = posixtypes.Path

--- a/lute/std/libs/path/win32/init.luau
+++ b/lute/std/libs/path/win32/init.luau
@@ -1,5 +1,7 @@
 local process = require("@lute/process")
+
 local win32types = require("@self/types")
+
 local pathinterface = require("./pathinterface")
 
 export type PathKind = win32types.PathKind

--- a/lute/std/libs/process.luau
+++ b/lute/std/libs/process.luau
@@ -4,6 +4,7 @@
 -- Provides process-related utility functions that handles file paths as path types instead of strings
 
 local process = require("@lute/process")
+
 local pathlib = require("@std/path")
 
 local processlib = {}

--- a/lute/std/libs/syntax/init.luau
+++ b/lute/std/libs/syntax/init.luau
@@ -1,7 +1,7 @@
+local luau = require("@lute/luau")
+
 local parser = require("@self/parser")
 local types = require("@self/types")
-
-local luau = require("@lute/luau")
 
 export type Span = types.Span
 

--- a/lute/std/libs/syntax/parser.luau
+++ b/lute/std/libs/syntax/parser.luau
@@ -3,6 +3,7 @@
 -- Parser for Luau source code into Luau AST nodes
 
 local luau = require("@lute/luau")
+
 local types = require("./types")
 
 local parser = {}

--- a/lute/std/libs/syntax/printer.luau
+++ b/lute/std/libs/syntax/printer.luau
@@ -1,8 +1,8 @@
+local types = require("./types")
 --!strict
 -- @std/syntax/printer
 
 local triviaUtils = require("./utils/trivia")
-local types = require("./types")
 local visitor = require("./visitor")
 
 local printerLib = {}

--- a/lute/std/libs/syntax/query.luau
+++ b/lute/std/libs/syntax/query.luau
@@ -3,6 +3,7 @@
 -- Provides utility functions for querying Luau AST nodes
 
 local tableext = require("@std/tableext")
+
 local types = require("./types")
 local visitor = require("./visitor")
 

--- a/lute/std/libs/system/init.luau
+++ b/lute/std/libs/system/init.luau
@@ -4,7 +4,9 @@
 -- Provides re-exports of `@lute/system` and boolean properties for OS detection
 
 local system = require("@lute/system")
+
 local path = require("@std/path")
+
 local platform = require("@self/platform")
 
 local systemlib = {}

--- a/lute/std/libs/test/assert.luau
+++ b/lute/std/libs/test/assert.luau
@@ -1,9 +1,10 @@
+local stringext = require("@std/stringext")
+
 --!strict
 -- @std/test/assert
 -- Standard assertion library for Luau
 
 local failure = require("./failure")
-local stringext = require("@std/stringext")
 local types = require("./types")
 
 -- types

--- a/lute/std/libs/test/init.luau
+++ b/lute/std/libs/test/init.luau
@@ -1,9 +1,9 @@
+local env = require("@self/env")
 --!strict
 -- @std/test
 -- Standard test library for Luau
 
 local types = require("@self/types")
-local env = require("@self/env")
 
 type Test = types.Test
 type TestCase = types.TestCase

--- a/lute/std/libs/test/runner.luau
+++ b/lute/std/libs/test/runner.luau
@@ -4,10 +4,10 @@
 local ps = require("@std/process")
 
 local asserts = require("./assert")
+local env = require("./env")
 local failure = require("./failure")
 local reporter = require("./reporter")
 local types = require("./types")
-local env = require("./env")
 
 type Test = types.Test
 type TestCase = types.TestCase

--- a/lute/std/libs/time/init.luau
+++ b/lute/std/libs/time/init.luau
@@ -3,6 +3,7 @@
 -- Provides utility functions for time
 
 local luteTime = require("@lute/time")
+
 local duration = require("@self/duration")
 
 local time = {}

--- a/tools/sort_requires.luau
+++ b/tools/sort_requires.luau
@@ -1,0 +1,107 @@
+-- run with lute transform tools/sort_requires.luau globpath
+local syntax_utils = require("@std/syntax/utils")
+local pp = require("@std/syntax/printer")
+local syntax = require("@std/syntax")
+local fs = require("@std/fs")
+local path = require("@std/path")
+
+type AstStat = syntax.AstStat
+
+local GROUP_ORDER: { [string]: number } = {
+	["@lute/"] = 1,
+	["@std/"] = 2,
+	["@batteries/"] = 3,
+	["@self/"] = 4,
+}
+
+local function getGroupOrder(path: string): (string?, number)
+	for prefix, order in GROUP_ORDER do
+		if path:sub(1, #prefix) == prefix then
+			return prefix, order
+		end
+	end
+	return nil, 5
+end
+
+type RequireDetail = { node: syntax.AstNode, path: string, name: string, order: number }
+
+local function isRequireStatement(stat: syntax.AstStat): boolean
+	if stat.tag ~= "local" then
+		return false
+	end
+	if #stat.values == 0 then
+		return false
+	end
+	return syntax_utils.isRequireCall(stat.values[1].node) ~= nil
+end
+
+-- assumes you've run 'isRequireStatement' in your query
+local function extractRequireDetail(stat: syntax.AstStatLocal): RequireDetail
+	local node: syntax.AstExpr = stat.values[1].node
+	assert(node ~= nil)
+	assert(node.tag == "call")
+	assert(node.kind == "expr")
+	assert(node.arguments[1] ~= nil)
+	assert((node.arguments[1] :: any).tag == "string")
+
+	local name: string = stat.variables[1].node.name.text
+	local path = (node.arguments[1].node :: any).token.text
+	local _prefix, order = getGroupOrder(path)
+	return { node = stat, path = path, name = name, order = order }
+end
+
+local function transform(ctx)
+	local root: syntax.AstStatBlock = ctx.parseresult.root
+
+	-- Find contiguous block of require statements from the top
+	local requireStats: { RequireDetail } = {}
+	local required = {}
+	for _, stat in root.statements do
+		if isRequireStatement(stat :: syntax.AstStat) then
+			print("found require")
+			local requireDetail = extractRequireDetail(stat :: syntax.AstStatLocal)
+			table.insert(requireStats, requireDetail)
+			required[stat] = true
+		else
+			break
+		end
+	end
+
+	-- Sort: by group order, then alphabetically by path
+	table.sort(requireStats, function(a: RequireDetail, b)
+		if a.order ~= b.order then
+			return a.order < b.order
+		end
+
+		return a.path < b.path
+	end)
+
+	-- Replace the require block in the source
+	-- compute a shuffle from [st, req, st, req ...] -> [req, req, st, st]
+
+	local buf = {}
+
+	for i, st in requireStats do
+		local v = pp.printNode(st.node)
+		table.insert(buf, v)
+		if i + 1 <= #requireStats and st.order ~= requireStats[i + 1].order then
+			table.insert(buf, "\n")
+		end
+	end
+
+	for _, st in root.statements do
+		if required[st] ~= nil then
+			continue
+		end
+		table.insert(buf, pp.printNode(st))
+	end
+
+	-- We have to do this because this currently inserts extra trivia for comments
+
+	local fmt = table.concat(buf, "")
+	print(fmt)
+	fs.writeStringToFile(path.parse(ctx.path), fmt)
+	return {}
+end
+
+return transform


### PR DESCRIPTION
This codemod groups requires by `@lute, @std, @batteries, @self, .... all the other imports`. Requires within each group are sorted lexicographically by require path. Each group of imports renders with a new line.

The current transform library doesn't offer a way to replace without trivia, which ends up duplicating comments at the top of files, for pretty much every file in this repo. I've just returned no replacements, and manually `writeStringToFile` until we can fix that issue.