### PR TITLE
Make loom's security check more robust

### DIFF
--- a/lute/cli/commands/pkg/loom-core/src/packagesource/git.luau
+++ b/lute/cli/commands/pkg/loom-core/src/packagesource/git.luau
@@ -36,12 +36,7 @@ local function sanitizePath(path: string): string
 	normalized = normalized:gsub("^/+", "")
 
 	-- Security check - prevent directory traversal via ".." path components
-	if
-		normalized == ".."
-		or normalized:match("^%.%./")
-		or normalized:match("/%.%./")
-		or normalized:match("/%.%.$")
-	then
+	if normalized == ".." or normalized:match("^%.%./") or normalized:match("/%.%./") or normalized:match("/%.%.$") then
 		error("Path contains '..' (directory traversal attempt)")
 	end
 

--- a/lute/cli/commands/pkg/loom-core/src/packagesource/git.luau
+++ b/lute/cli/commands/pkg/loom-core/src/packagesource/git.luau
@@ -24,11 +24,6 @@ local function sanitizePath(path: string): string
 		error("Path too long (max " .. maxPathLength .. " characters)")
 	end
 
-	-- Security checks - prevent directory traversal
-	if path:match("%.%.") then
-		error("Path contains '..' (directory traversal attempt)")
-	end
-
 	-- Remove/reject dangerous characters
 	if path:match("[\0\r\n]") then
 		error("Path contains invalid control characters")
@@ -39,6 +34,16 @@ local function sanitizePath(path: string): string
 
 	-- Remove leading slashes but preserve trailing slash for directories
 	normalized = normalized:gsub("^/+", "")
+
+	-- Security check - prevent directory traversal via ".." path components
+	if
+		normalized == ".."
+		or normalized:match("^%.%./")
+		or normalized:match("/%.%./")
+		or normalized:match("/%.%.$")
+	then
+		error("Path contains '..' (directory traversal attempt)")
+	end
 
 	return normalized
 end


### PR DESCRIPTION
This also fixes a bug where files containing ".." (such as: https://github.com/luau-lang/lute/blob/primary/tests/std/JSONParsingTestSuite/n_structure_angle_bracket_..json) would prevent the repo from being used as a package dependency.