### PR TITLE
Fixes a bug where the runtime will print "cannot resume coroutine" on a killed task

### DIFF
--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -229,28 +229,38 @@ int symlink(lua_State* L)
 
 struct WatchHandle
 {
-    lua_State* L;
+    WatchHandle(lua_State* L, int callbackIdx)
+        : runtime(getRuntime(L))
+        , callbackReference(std::make_shared<Ref>(L, callbackIdx))
+        , evtHandle(std::make_unique<uv_fs_event_t>())
+    {
+        evtHandle->data = this;
+        int err = uv_fs_event_init(runtime->getEventLoop(), evtHandle.get());
+        if (err)
+            luaL_errorL(L, "%s", uv_strerror(err));
+    }
+
+    Runtime* runtime;
     std::shared_ptr<Ref> callbackReference;
     bool isClosed = false;
-    uv_fs_event_t handle;
+    std::unique_ptr<uv_fs_event_t> evtHandle;
 
     void close()
     {
         if (!isClosed)
         {
-            int err = uv_fs_event_stop(&handle);
-            if (err)
-            {
-                luaL_errorL(L, "Error stopping fs event: %s", uv_strerror(err));
-            }
-
-            uv_close((uv_handle_t*)&handle, nullptr);
 
             isClosed = true;
-
-            getRuntime(L)->releasePendingToken();
-
+            uv_fs_event_stop(evtHandle.get());
             callbackReference.reset();
+            auto raw = evtHandle.release();
+            uv_close(
+                (uv_handle_t*)raw,
+                [](uv_handle_t* handle)
+                {
+                    delete (uv_fs_event_t*)handle;
+                }
+            );
         }
     }
 
@@ -280,44 +290,27 @@ int fs_watch(lua_State* L)
     const char* path = luaL_checkstring(L, 1);
     luaL_checktype(L, 2, LUA_TFUNCTION);
 
-    auto* event = new (static_cast<WatchHandle*>(lua_newuserdatataggedwithmetatable(L, sizeof(WatchHandle), kWatchHandleTag))) WatchHandle{};
-
-    event->L = L;
-    event->callbackReference = std::make_shared<Ref>(L, 2);
-    event->handle.data = event;
-
-    int init_err = uv_fs_event_init(getRuntimeLoop(L), &event->handle);
-
-    if (init_err)
-    {
-        luaL_errorL(L, "%s", uv_strerror(init_err));
-    }
+    void* storage = lua_newuserdatataggedwithmetatable(L, sizeof(WatchHandle), kWatchHandleTag);
+    auto* event = new (storage) WatchHandle(L, 2);
 
     int event_start_err = uv_fs_event_start(
-        &event->handle,
+        event->evtHandle.get(),
         [](uv_fs_event_t* handle, const char* filenamePtr, int events, int status)
         {
             auto* eventHandle = static_cast<WatchHandle*>(handle->data);
 
-            lua_State* newThread = lua_newthread(eventHandle->L);
-            std::shared_ptr<Ref> ref = getRefForThread(newThread);
-            Runtime* runtime = getRuntime(newThread);
+            if (status < 0)
+                return;
 
             std::string filename = filenamePtr ? filenamePtr : "";
 
-            runtime->scheduleLuauResume(
-                ref,
-                [=, filename = std::move(filename)](lua_State* L)
+            eventHandle->runtime->scheduleLuauCallback(
+                eventHandle->callbackReference,
+                [filename = std::move(filename), events](lua_State* L)
                 {
-                    // the function to the back of the stack, omit from nret
-                    eventHandle->callbackReference->push(L);
-
-                    // filename
                     lua_pushlstring(L, filename.c_str(), filename.size());
 
-                    // events
                     lua_createtable(L, 0, 2);
-
                     lua_pushboolean(L, (events & UV_RENAME) != 0);
                     lua_setfield(L, -2, "rename");
                     lua_pushboolean(L, (events & UV_CHANGE) != 0);
@@ -326,8 +319,6 @@ int fs_watch(lua_State* L)
                     return 2;
                 }
             );
-
-            uv_stop(handle->loop);
         },
         path,
         0
@@ -337,8 +328,6 @@ int fs_watch(lua_State* L)
     {
         luaL_errorL(L, "%s", uv_strerror(event_start_err));
     }
-
-    getRuntime(L)->addPendingToken();
 
     return 1; // return the watch handle
 }

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -69,6 +69,10 @@ struct Runtime
     // Resume thread with the results computed by the continuation
     void scheduleLuauResume(std::shared_ptr<Ref> ref, std::function<int(lua_State*)> cont);
 
+    // Invoke a Luau callback function on a fresh thread.
+    // argPusher should push arguments onto the stack and return the count.
+    void scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher);
+
     // Run 'f' in a libuv work queue
     void runInWorkQueue(std::function<void()> f);
 

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -265,6 +265,27 @@ void Runtime::scheduleLuauResume(std::shared_ptr<Ref> ref, std::function<int(lua
     runLoopCv.notify_one();
 }
 
+void Runtime::scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher)
+{
+    std::unique_lock lock(continuationMutex);
+
+    continuations.push_back(
+        [this, callbackRef = std::move(callbackRef), argPusher = std::move(argPusher)]() mutable
+        {
+            lua_State* newThread = lua_newthread(GL);
+            std::shared_ptr<Ref> threadRef = getRefForThread(newThread);
+            lua_pop(GL, 1);
+
+            callbackRef->push(newThread);
+            int nargs = argPusher(newThread);
+
+            runningThreads.push_back({true, threadRef, nargs});
+        }
+    );
+
+    runLoopCv.notify_one();
+}
+
 void Runtime::runInWorkQueue(std::function<void()> f)
 {
     auto loop = getEventLoop();

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -253,8 +253,12 @@ void Runtime::scheduleLuauResume(std::shared_ptr<Ref> ref, std::function<int(lua
             lua_State* L = lua_tothread(GL, -1);
             lua_pop(GL, 1);
 
+            bool isAlive = !lua_isthreadreset(L);
             int results = cont(L);
-            runningThreads.push_back({true, ref, results});
+            if (isAlive)
+            {
+                runningThreads.push_back({true, ref, results});
+            }
         }
     );
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(Lute.Test PRIVATE
     src/moduleresolver.test.cpp
     src/packagerequire.test.cpp
     src/require.test.cpp
+    src/runtime.test.cpp
     src/typeserializer.test.cpp
     src/staticrequires.test.cpp
     src/stdsystem.test.cpp

--- a/tests/src/runtime.test.cpp
+++ b/tests/src/runtime.test.cpp
@@ -1,0 +1,21 @@
+#include "cliruntimefixture.h"
+#include "doctest.h"
+
+TEST_CASE_FIXTURE(CliRuntimeFixture, "runtime_will_not_resume_cancelled_task_spawn")
+{
+    runCode(R"(
+        local task = require("@std/task")
+        local t = task.spawn(function()
+            task.wait(2)
+        end)
+
+        task.cancel(t)
+    )");
+
+    auto reporter = getReporter();
+    for (auto s : reporter.getErrors())
+    {
+        auto idx = s.find("cannot resume dead coroutine");
+        CHECK(idx == std::string::npos);
+    }
+}


### PR DESCRIPTION
Cancelling a task should error at call time if closing a coroutine is not possible, but should not create errors in the runtime. Currently, running code like:
```
        local task = require("@std/task")
        local t = task.spawn(function()
            task.wait(2)
        end)

        task.cancel(t)/coroutine.close(t)
```
will cause the runtime to print "cannot resume dead coroutine". The reason that this happens is because of how scheduling resumes works. When the user calls `coroutine.close()` on the task, we reset the thread state to 'dead'. If the function passed to `spawn` schedules a continuation in the runtime, then when this continuation is called, we **may** end up mutating the state of a cancelled thread.

For example, the `WaitData` uses the resumeToken to schedule a callback that pushes one value onto the stack associated with the callback. Because this thread is dead by the time the wait elapses, we end up pushing a number onto the stack, which makes it so that callback's top and base are not the same. When this happens, the runtime check for this thread's state using `lua_costatus` will return CO_SUS instead of CO_FIN, which causes the subsequent resume in the runtime to fail.

This uncovered another bug with the FS Watch handle, whereby the combination of task.wait and fs.watch caused a pending token to be registered with the runtime that never got cleared, which caused the runtime to loop forever. I refactored the watch handle code a bit to make it's initialization and tear down clearer, and removed the pending token, as the existence of a `uv_fs_event_t` handle is already tracked by the event loop to prevent premature shutdown.
