### PR TITLE
infra: improve luthier error behavior and help dialogues (and update `@batteries/cli` a bit in support of that)

### DIFF
--- a/batteries/cli.luau
+++ b/batteries/cli.luau
@@ -180,12 +180,13 @@ function cli.forwarded(self: Parser): { string }?
 	return self.parsed.fwdArgs
 end
 
-function cli.help(self: Parser): ()
-	print("Usage:")
+function cli.help(self: Parser, formatter: ((s: string) -> string)?): ()
+	local fmt = formatter or function(s) return s end
+	print(fmt("Usage:"))
 	for _, argument in self.arguments do
 		local aliasStr = table.concat(argument.options.aliases or {}, ", ")
 		local reqStr = if argument.options.required then "(required) " else ""
-		print(string.format("  --%s (-%s) - %s%s", argument.name, aliasStr, reqStr, argument.options.help or ""))
+		print(fmt(string.format("  --%s (-%s) - %s%s", argument.name, aliasStr, reqStr, argument.options.help or "")))
 	end
 end
 

--- a/batteries/cli.luau
+++ b/batteries/cli.luau
@@ -7,6 +7,7 @@ type ArgOptions = {
 	aliases: { string }?,
 	default: string?,
 	required: boolean?,
+	hidden: boolean?,
 }
 
 type ArgData = {
@@ -180,10 +181,46 @@ function cli.forwarded(self: Parser): { string }?
 	return self.parsed.fwdArgs
 end
 
+function cli.usage(self: Parser, name: string): string
+	local parts = { name }
+
+	for _, arg in self.positional do
+		if not arg.options.hidden then
+			if arg.options.required then
+				table.insert(parts, `<{arg.name}>`)
+			else
+				table.insert(parts, `[{arg.name}]`)
+			end
+		end
+	end
+
+	for _, arg in self.arguments do
+		if not arg.options.hidden and arg.kind ~= "positional" and arg.kind ~= "variadic" then
+			table.insert(parts, "[options]")
+			break
+		end
+	end
+
+	if self.variadicArg and not self.variadicArg.options.hidden then
+		local v = self.variadicArg
+		if v.options.required then
+			table.insert(parts, `<{v.name}...>`)
+		else
+			table.insert(parts, `[{v.name}...]`)
+		end
+	end
+
+	return table.concat(parts, " ")
+end
+
 function cli.help(self: Parser, formatter: ((s: string) -> string)?): ()
 	local fmt = formatter or function(s) return s end
 	print(fmt("Usage:"))
 	for _, argument in self.arguments do
+		if argument.options.hidden then
+			continue
+		end
+
 		local aliasStr = table.concat(argument.options.aliases or {}, ", ")
 		local reqStr = if argument.options.required then "(required) " else ""
 		print(fmt(string.format("  --%s (-%s) - %s%s", argument.name, aliasStr, reqStr, argument.options.help or "")))

--- a/batteries/cli.luau
+++ b/batteries/cli.luau
@@ -214,7 +214,10 @@ function cli.usage(self: Parser, name: string): string
 end
 
 function cli.help(self: Parser, formatter: ((s: string) -> string)?): ()
-	local fmt = formatter or function(s) return s end
+	local fmt = formatter or function(s)
+		return s
+	end
+
 	print(fmt("Usage:"))
 	for _, argument in self.arguments do
 		if argument.options.hidden then

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -557,6 +557,26 @@ local function subcommandUsage(subcommand: string): string
 	return args:usage(`luthier {subcommand}`)
 end
 
+local subcommands: { { string } } = {
+	{ "fetch" },
+	{ "generate" },
+	{ "configure", "tune" },
+	{ "build", "craft" },
+	{ "run", "play" },
+}
+
+local function availableSubcommands(): string
+	local parts = {}
+	for _, group in subcommands do
+		if #group > 1 then
+			table.insert(parts, `{group[1]} (or {group[2]})`)
+		else
+			table.insert(parts, group[1])
+		end
+	end
+	return `Available subcommands: {table.concat(parts, ", ")}`
+end
+
 local function availableTargets(): string
 	local targets = {}
 	for name in targetMap do
@@ -700,7 +720,7 @@ local ok, err = pcall(args.parse, args, { ... })
 if not ok then
 	-- Strip the "file:line: " prefix that Lua prepends to error messages
 	local message = string.gsub(tostring(err), "^.+:%d+: ", "")
-	usageError(message)
+	usageError(message, availableSubcommands())
 end
 
 cwd = getSourceRoot()
@@ -755,9 +775,9 @@ elseif subcommand == "run" or subcommand == "play" then
 
 	exitCode = run()
 elseif subcommand ~= nil then
-	usageError(`Unknown subcommand '{subcommand}'`)
+	usageError(`Unknown subcommand '{subcommand}'`, availableSubcommands())
 else
-	usageError("No subcommand given.")
+	usageError("No subcommand given.", availableSubcommands())
 end
 
 if exitCode ~= 0 then

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -67,8 +67,8 @@ local targetMap: { [string]: { exeName: string } } = {
 local args = cli.parser()
 
 args:add("help", "flag", { help = "show the help message" })
-args:add("luthier", "positional", { help = "the luthier script", required = true }) -- should this be handled automatically?
-args:add("subcommand", "positional", { help = "command to execute", required = true })
+args:add("luthier", "positional", { help = "the luthier script", required = true, hidden = true }) -- should this be handled automatically?
+args:add("subcommand", "positional", { help = "command to execute", required = true, hidden = true })
 args:add("target", "positional", { help = "the thing to build or run" })
 args:add("verbose", "flag", { help = "show verbose compile output", aliases = { "v" } })
 args:add("config", "option", { help = "configuration (default is debug)", default = "debug" })
@@ -541,15 +541,20 @@ local function printHelp()
 	end)
 end
 
-local function usageError(message: string, details: string?)
+local function usageError(message: string, details: string?, usage: string?)
 	local lowercased = string.lower(string.sub(message, 1, 1)) .. string.sub(message, 2)
 	print(richterm.combine(richterm.bold, richterm.red)(`Error: {lowercased}`))
+	print(richterm.combine(richterm.bold, richterm.yellow)(`Usage: {usage or args:usage("luthier <subcommand>")}`))
 	if details then
 		print(richterm.combine(richterm.bold, richterm.yellow)(details))
 	end
 	print()
 	printHelp()
 	process.exit(1)
+end
+
+local function subcommandUsage(subcommand: string): string
+	return args:usage(`luthier {subcommand}`)
 end
 
 local function availableTargets(): string
@@ -694,7 +699,8 @@ end
 local ok, err = pcall(args.parse, args, { ... })
 if not ok then
 	-- Strip the "file:line: " prefix that Lua prepends to error messages
-	usageError(string.gsub(tostring(err), "^.+:%d+: ", ""))
+	local message = string.gsub(tostring(err), "^.+:%d+: ", "")
+	usageError(message)
 end
 
 cwd = getSourceRoot()
@@ -722,7 +728,7 @@ elseif subcommand == "configure" or subcommand == "tune" then
 	exitCode = configure()
 elseif subcommand == "build" or subcommand == "craft" then
 	if not args:get("target") then
-		usageError(`{subcommand} requires a target`, availableTargets())
+		usageError(`{subcommand} requires a target`, availableTargets(), subcommandUsage(subcommand))
 	end
 
 	generateFilesIfNeeded()
@@ -734,7 +740,7 @@ elseif subcommand == "build" or subcommand == "craft" then
 	exitCode = build()
 elseif subcommand == "run" or subcommand == "play" then
 	if not args:get("target") then
-		usageError(`{subcommand} requires a target`, availableTargets())
+		usageError(`{subcommand} requires a target`, availableTargets(), subcommandUsage(subcommand))
 	end
 
 	generateFilesIfNeeded()

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -533,6 +533,13 @@ local function check(exitCode: number)
 	end
 end
 
+local function usageError(message: string)
+	print(`Error: {message}`)
+	print()
+	args:help()
+	process.exit(1)
+end
+
 local function fetchDependency(dependencyInfo: Tune)
 	local dependency = dependencyInfo.dependency
 
@@ -663,7 +670,11 @@ local function run()
 	return call(cmd)
 end
 
-args:parse({ ... })
+local ok, err = pcall(args.parse, args, { ... })
+if not ok then
+	-- Strip the "file:line: " prefix that Lua prepends to error messages
+	usageError(string.gsub(tostring(err), "^.+:%d+: ", ""))
+end
 
 cwd = getSourceRoot()
 
@@ -709,9 +720,9 @@ elseif subcommand == "run" or subcommand == "play" then
 
 	exitCode = run()
 elseif subcommand ~= nil then
-	error("Unknown subcommand " .. subcommand)
+	usageError(`Unknown subcommand '{subcommand}'`)
 else
-	error("No subcommand given.")
+	usageError("No subcommand given.")
 end
 
 if exitCode ~= 0 then

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -5,6 +5,7 @@ local fs = require("@lute/fs")
 local process = require("@lute/process")
 local system = require("@lute/system")
 local cli = require("@batteries/cli")
+local richterm = require("@batteries/richterm")
 local toml = require("@batteries/toml")
 
 type Tune = {
@@ -534,7 +535,7 @@ local function check(exitCode: number)
 end
 
 local function usageError(message: string)
-	print(`Error: {message}`)
+	print(richterm.combine(richterm.bold, richterm.red)(`Error: {message}`))
 	print()
 	args:help()
 	process.exit(1)

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -534,10 +534,18 @@ local function check(exitCode: number)
 	end
 end
 
+local function printHelp()
+	print("luthier — a build tool for lute")
+	args:help(function(str)
+		return richterm.combine(richterm.bold, richterm.yellow)(str)
+	end)
+end
+
 local function usageError(message: string)
-	print(richterm.combine(richterm.bold, richterm.red)(`Error: {message}`))
+	local lowercased = string.lower(string.sub(message, 1, 1)) .. string.sub(message, 2)
+	print(richterm.combine(richterm.bold, richterm.red)(`Error: {lowercased}`))
 	print()
-	args:help()
+	printHelp()
 	process.exit(1)
 end
 
@@ -680,7 +688,7 @@ end
 cwd = getSourceRoot()
 
 if args:has("help") then
-	print(args:help())
+	printHelp()
 	return
 end
 

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -69,7 +69,7 @@ local args = cli.parser()
 args:add("help", "flag", { help = "show the help message" })
 args:add("luthier", "positional", { help = "the luthier script", required = true }) -- should this be handled automatically?
 args:add("subcommand", "positional", { help = "command to execute", required = true })
-args:add("target", "positional", { help = "the thing to build or run", required = true })
+args:add("target", "positional", { help = "the thing to build or run" })
 args:add("verbose", "flag", { help = "show verbose compile output", aliases = { "v" } })
 args:add("config", "option", { help = "configuration (default is debug)", default = "debug" })
 args:add("clean", "flag", { help = "perform a clean build" })
@@ -541,12 +541,24 @@ local function printHelp()
 	end)
 end
 
-local function usageError(message: string)
+local function usageError(message: string, details: string?)
 	local lowercased = string.lower(string.sub(message, 1, 1)) .. string.sub(message, 2)
 	print(richterm.combine(richterm.bold, richterm.red)(`Error: {lowercased}`))
+	if details then
+		print(richterm.combine(richterm.bold, richterm.yellow)(details))
+	end
 	print()
 	printHelp()
 	process.exit(1)
+end
+
+local function availableTargets(): string
+	local targets = {}
+	for name in targetMap do
+		table.insert(targets, name)
+	end
+	table.sort(targets)
+	return `available targets: {table.concat(targets, ", ")}`
 end
 
 local function fetchDependency(dependencyInfo: Tune)
@@ -709,6 +721,10 @@ elseif subcommand == "configure" or subcommand == "tune" then
 	generateFilesIfNeeded()
 	exitCode = configure()
 elseif subcommand == "build" or subcommand == "craft" then
+	if not args:get("target") then
+		usageError(`{subcommand} requires a target`, availableTargets())
+	end
+
 	generateFilesIfNeeded()
 
 	if not projectPathExists() or not areTuneFilesUpToDate() then
@@ -717,6 +733,10 @@ elseif subcommand == "build" or subcommand == "craft" then
 
 	exitCode = build()
 elseif subcommand == "run" or subcommand == "play" then
+	if not args:get("target") then
+		usageError(`{subcommand} requires a target`, availableTargets())
+	end
+
 	generateFilesIfNeeded()
 
 	if not projectPathExists() or not areTuneFilesUpToDate() then


### PR DESCRIPTION
I got annoyed by luthier being kinda jank when you do incorrect invocations, so I put in some work to make the UX of the tool better. It has colorized help output now, and now will list subcommands and usage formats for the commands to the user, along side showing the full help output whenever you invoke it. Longer-term, it would probably be better if the cli library actually had a proper concept of subcommands because it could streamline _a lot_ of this logic, but this is an improvement for now.