### PR TITLE
Allow for forcing unbuffered stdio via env

### DIFF
--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -661,7 +661,7 @@ int cliMain(int argc, char** argv, LuteReporter& reporter)
     Luau::assertHandler() = assertionHandler;
     setLuauFlags();
 
-    if (const char* unbuffered = std::getenv("LUTE_UNBUFFERED"); std::string_view(unbuffered) == "1")
+    if (const char* unbuffered = std::getenv("LUTE_UNBUFFERED"); unbuffered && std::string_view(unbuffered) == "1")
     {
         setvbuf(stdout, nullptr, _IONBF, 0);
         setvbuf(stderr, nullptr, _IONBF, 0);

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -27,6 +27,7 @@
 #include "lualib.h"
 
 #include <chrono>
+#include <cstdlib>
 #include <ctime>
 #include <optional>
 #include <string>
@@ -659,6 +660,12 @@ int cliMain(int argc, char** argv, LuteReporter& reporter)
 {
     Luau::assertHandler() = assertionHandler;
     setLuauFlags();
+
+    if (const char* unbuffered = std::getenv("LUTE_UNBUFFERED"); std::string_view(unbuffered) == "1")
+    {
+        setvbuf(stdout, nullptr, _IONBF, 0);
+        setvbuf(stderr, nullptr, _IONBF, 0);
+    }
 
     std::string err = "";
 


### PR DESCRIPTION
Adds support for `LUTE_UNBUFFERED=1` at CLI startup so lute can disable stdout/stderr buffering when output is being piped or captured. This helps callers that need output to be flushed immediately rather than waiting on buffered writes.

This is inspired by Python's `PYTHONUNBUFFERED=1` option. Did not copy the `-u` flag, as I can't think of a reason to support both at the moment, so I'm leaning towards keeping the CLI cleaner/shorter for now in case our io in lute evolves to a point where this isn't necessary at all.

Also considered adding an option to the `@lute/io` library to set this during runtime, but for my usecase of running "third party" code in lute as a subprocess, this isn't as helpful.