### PR TITLE
Support yielding in net serve handler

### DIFF
--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -1,6 +1,5 @@
 #include "lute/net.h"
 
-#include "lute/common.h"
 #include "lute/runtime.h"
 
 #include "Luau/DenseHash.h"
@@ -8,8 +7,6 @@
 
 #include "lua.h"
 #include "lualib.h"
-
-#include "uv.h"
 
 #include <algorithm>
 #include <atomic>
@@ -182,19 +179,17 @@ struct HttpYieldContext
 };
 
 template <typename ResT>
-static void finishHttpYield(lua_State* L, int status, void* userdata)
+static void finishHttpYield(lua_State* L, int status, const std::shared_ptr<HttpYieldContext<ResT>>& ctx)
 {
-    auto* holder = static_cast<std::shared_ptr<HttpYieldContext<ResT>>*>(userdata);
-    if (!holder || !(*holder))
+    if (!ctx)
     {
         lua_settop(L, 0);
         return;
     }
 
-    auto& ctx = **holder;
-    ResT* res = ctx.res;
+    ResT* res = ctx->res;
 
-    if (!res || ctx.aborted.load())
+    if (!res || ctx->aborted.load())
     {
         lua_settop(L, 0);
         return;
@@ -211,14 +206,8 @@ static void finishHttpYield(lua_State* L, int status, void* userdata)
         res->end("Server error: " + error);
     }
 
-    ctx.res = nullptr;
+    ctx->res = nullptr;
     lua_settop(L, 0);
-}
-
-template <typename ResT>
-static void destroyHttpYield(void* userdata)
-{
-    delete static_cast<std::shared_ptr<HttpYieldContext<ResT>>*>(userdata);
 }
 
 static void processRequest(
@@ -281,12 +270,11 @@ static void processRequest(
             }
         );
 
-        auto* holder = new std::shared_ptr<HttpYieldContext<ResT>>(std::move(ctx));
-
         auto* completion = new ThreadCompletionHandler();
-        completion->onFinish = &finishHttpYield<ResT>;
-        completion->destroy = &destroyHttpYield<ResT>;
-        completion->userdata = holder;
+        completion->onFinish = [ctx](lua_State* L, int completionStatus)
+        {
+            finishHttpYield<ResT>(L, completionStatus, ctx);
+        };
 
         lua_setthreaddata(L, completion);
         lua_settop(L, 0);

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -12,12 +12,14 @@
 #include "uv.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <functional>
 #include <memory>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 
 #include "App.h"
@@ -171,6 +173,54 @@ static void handleResponse(auto* res, lua_State* L, int responseIndex)
     res->end(body);
 }
 
+template <typename ResT>
+struct HttpYieldContext
+{
+    ResT* res = nullptr;
+    std::atomic<bool> aborted{false};
+    std::shared_ptr<Ref> threadRef;
+};
+
+template <typename ResT>
+static void finishHttpYield(lua_State* L, int status, void* userdata)
+{
+    auto* holder = static_cast<std::shared_ptr<HttpYieldContext<ResT>>*>(userdata);
+    if (!holder || !(*holder))
+    {
+        lua_settop(L, 0);
+        return;
+    }
+
+    auto& ctx = **holder;
+    ResT* res = ctx.res;
+
+    if (!res || ctx.aborted.load())
+    {
+        lua_settop(L, 0);
+        return;
+    }
+
+    if (status == LUA_OK)
+    {
+        handleResponse(res, L, -1);
+    }
+    else
+    {
+        std::string error = lua_isstring(L, -1) ? lua_tostring(L, -1) : "Server error";
+        res->writeStatus("500 Internal Server Error");
+        res->end("Server error: " + error);
+    }
+
+    ctx.res = nullptr;
+    lua_settop(L, 0);
+}
+
+template <typename ResT>
+static void destroyHttpYield(void* userdata)
+{
+    delete static_cast<std::shared_ptr<HttpYieldContext<ResT>>*>(userdata);
+}
+
 static void processRequest(
     std::shared_ptr<ServerLoopState> state,
     auto* res,
@@ -214,9 +264,38 @@ static void processRequest(
     lua_remove(L, -3);
 
     int status = lua_resume(L, nullptr, 1);
-    if (status != LUA_OK && status != LUA_YIELD)
+
+    if (status == LUA_YIELD)
     {
-        std::string error = lua_tostring(L, -1);
+        using ResT = std::remove_pointer_t<decltype(res)>;
+
+        auto ctx = std::make_shared<HttpYieldContext<ResT>>();
+        ctx->res = res;
+        ctx->threadRef = std::move(threadRef);
+
+        res->onAborted(
+            [ctx]()
+            {
+                ctx->aborted.store(true);
+                ctx->res = nullptr;
+            }
+        );
+
+        auto* holder = new std::shared_ptr<HttpYieldContext<ResT>>(std::move(ctx));
+
+        auto* completion = new ThreadCompletionHandler();
+        completion->onFinish = &finishHttpYield<ResT>;
+        completion->destroy = &destroyHttpYield<ResT>;
+        completion->userdata = holder;
+
+        lua_setthreaddata(L, completion);
+        lua_settop(L, 0);
+        return;
+    }
+
+    if (status != LUA_OK)
+    {
+        std::string error = lua_isstring(L, -1) ? lua_tostring(L, -1) : "Server error";
         lua_pop(L, 1);
 
         res->writeStatus("500 Internal Server Error");

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -277,7 +277,7 @@ static void processRequest(
             finishHttpYield<ResT>(L, completionStatus, ctx);
         };
 
-        state->runtime->setThreadCompletionHandler(L, std::move(completion));
+        state->runtime->addThreadCompletionHandler(L, std::move(completion));
         lua_settop(L, 0);
         return;
     }

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -271,13 +271,13 @@ static void processRequest(
             }
         );
 
-        auto* completion = new ThreadCompletionHandler();
-        completion->onFinish = [ctx](lua_State* L, int completionStatus)
+        ThreadCompletionHandler completion;
+        completion.onFinish = [ctx](lua_State* L, int completionStatus)
         {
             finishHttpYield<ResT>(L, completionStatus, ctx);
         };
 
-        lua_setthreaddata(L, completion);
+        state->runtime->setThreadCompletionHandler(L, std::move(completion));
         lua_settop(L, 0);
         return;
     }

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -31,9 +31,7 @@ struct ThreadToContinue
 // they finish or error after one or more yields.
 struct ThreadCompletionHandler
 {
-    void (*onFinish)(lua_State* L, int status, void* userdata) = nullptr;
-    void (*destroy)(void* userdata) = nullptr;
-    void* userdata = nullptr;
+    std::function<void(lua_State* L, int status)> onFinish;
 };
 
 struct StepErr

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -27,6 +27,15 @@ struct ThreadToContinue
     std::function<void()> cont;
 };
 
+// Optional completion hook for threads that need native follow-up work once
+// they finish or error after one or more yields.
+struct ThreadCompletionHandler
+{
+    void (*onFinish)(lua_State* L, int status, void* userdata) = nullptr;
+    void (*destroy)(void* userdata) = nullptr;
+    void* userdata = nullptr;
+};
+
 struct StepErr
 {
     lua_State* L;

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -88,7 +88,7 @@ struct Runtime
 
     // Attach native follow-up work to a specific Luau thread. The hook will run
     // once that thread eventually returns or errors after any number of yields.
-    void setThreadCompletionHandler(lua_State* L, ThreadCompletionHandler completion);
+    void addThreadCompletionHandler(lua_State* L, ThreadCompletionHandler completion);
 
     // Run 'f' in a libuv work queue
     void runInWorkQueue(std::function<void()> f);

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -15,6 +15,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 struct lua_State;
@@ -80,6 +81,10 @@ struct Runtime
     // argPusher should push arguments onto the stack and return the count.
     void scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher);
 
+    // Attach native follow-up work to a specific Luau thread. The hook will run
+    // once that thread eventually returns or errors after any number of yields.
+    void setThreadCompletionHandler(lua_State* L, ThreadCompletionHandler completion);
+
     // Run 'f' in a libuv work queue
     void runInWorkQueue(std::function<void()> f);
 
@@ -105,8 +110,12 @@ struct Runtime
     std::vector<std::string> args;
 
 private:
+    bool runThreadCompletionHandler(lua_State* L, int status);
+    void clearThreadCompletionHandler(lua_State* L);
+
     std::mutex continuationMutex;
     std::vector<std::function<void()>> continuations;
+    std::unordered_map<lua_State*, ThreadCompletionHandler> threadCompletionHandlers;
 
     // TODO: can this be handled by libuv?
     std::atomic<bool> stop;

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -129,10 +129,7 @@ RuntimeStep Runtime::runOnce()
         lua_setthreaddata(L, nullptr);
 
         if (completion->onFinish)
-            completion->onFinish(L, status, completion->userdata);
-
-        if (completion->destroy)
-            completion->destroy(completion->userdata);
+            completion->onFinish(L, status);
 
         delete completion;
 

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -123,6 +123,24 @@ RuntimeStep Runtime::runOnce()
         return StepSuccess{L};
     }
 
+    ThreadCompletionHandler* completion = static_cast<ThreadCompletionHandler*>(lua_getthreaddata(L));
+    if (completion)
+    {
+        lua_setthreaddata(L, nullptr);
+
+        if (completion->onFinish)
+            completion->onFinish(L, status, completion->userdata);
+
+        if (completion->destroy)
+            completion->destroy(completion->userdata);
+
+        delete completion;
+
+        // Completion hooks are responsible for consuming/reporting thread errors.
+        if (status != LUA_OK)
+            return StepSuccess{L};
+    }
+
     if (status != LUA_OK)
     {
         return StepErr{L};

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -225,7 +225,7 @@ bool Runtime::hasThreads()
     return !runningThreads.empty();
 }
 
-void Runtime::setThreadCompletionHandler(lua_State* L, ThreadCompletionHandler completion)
+void Runtime::addThreadCompletionHandler(lua_State* L, ThreadCompletionHandler completion)
 {
     threadCompletionHandlers[L] = std::move(completion);
 }
@@ -237,7 +237,7 @@ bool Runtime::runThreadCompletionHandler(lua_State* L, int status)
         return false;
 
     ThreadCompletionHandler completion = std::move(it->second);
-    threadCompletionHandlers.erase(it);
+    clearThreadCompletionHandler(L);
 
     if (completion.onFinish)
         completion.onFinish(L, status);

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -110,6 +110,7 @@ RuntimeStep Runtime::runOnce()
     int co_status = lua_costatus(GL, L);
     if (co_status == LUA_COFIN)
     {
+        clearThreadCompletionHandler(L);
         return StepSuccess{L};
     }
 
@@ -123,20 +124,9 @@ RuntimeStep Runtime::runOnce()
         return StepSuccess{L};
     }
 
-    ThreadCompletionHandler* completion = static_cast<ThreadCompletionHandler*>(lua_getthreaddata(L));
-    if (completion)
-    {
-        lua_setthreaddata(L, nullptr);
-
-        if (completion->onFinish)
-            completion->onFinish(L, status);
-
-        delete completion;
-
-        // Completion hooks are responsible for consuming/reporting thread errors.
-        if (status != LUA_OK)
-            return StepSuccess{L};
-    }
+    bool ranCompletionHandler = runThreadCompletionHandler(L, status);
+    if (ranCompletionHandler && status != LUA_OK)
+        return StepSuccess{L};
 
     if (status != LUA_OK)
     {
@@ -227,6 +217,31 @@ bool Runtime::hasContinuations()
 bool Runtime::hasThreads()
 {
     return !runningThreads.empty();
+}
+
+void Runtime::setThreadCompletionHandler(lua_State* L, ThreadCompletionHandler completion)
+{
+    threadCompletionHandlers[L] = std::move(completion);
+}
+
+bool Runtime::runThreadCompletionHandler(lua_State* L, int status)
+{
+    auto it = threadCompletionHandlers.find(L);
+    if (it == threadCompletionHandlers.end())
+        return false;
+
+    ThreadCompletionHandler completion = std::move(it->second);
+    threadCompletionHandlers.erase(it);
+
+    if (completion.onFinish)
+        completion.onFinish(L, status);
+
+    return true;
+}
+
+void Runtime::clearThreadCompletionHandler(lua_State* L)
+{
+    threadCompletionHandlers.erase(L);
 }
 
 void Runtime::schedule(std::function<void()> f)

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -125,6 +125,8 @@ RuntimeStep Runtime::runOnce()
     }
 
     bool ranCompletionHandler = runThreadCompletionHandler(L, status);
+    // Completion handlers are responsible for consuming/reporting terminal errors
+    // for threads they own (for example, turning a failed HTTP handler into a 500).
     if (ranCompletionHandler && status != LUA_OK)
         return StepSuccess{L};
 

--- a/tests/std/net.test.luau
+++ b/tests/std/net.test.luau
@@ -1,8 +1,31 @@
 local net = require("@std/net")
 local server = require("@lute/net/server")
+local task = require("@lute/task")
 local test = require("@std/test")
 
 test.suite("NetTestSuite", function(suite)
+	suite:case("serveHandlerCanYield", function(assert)
+		local instance = server.serve({
+			handler = function(_req: server.ReceivedRequest): server.ServerResponse
+				task.wait(0.01)
+				task.wait(0.01)
+				return {
+					status = 200,
+					body = "ok",
+				}
+			end,
+		})
+
+		local response = net.request(`{instance.hostname}:{instance.port}`, {
+			method = "GET",
+		})
+		assert.eq(true, response.ok)
+		assert.eq(200, response.status)
+		assert.eq("ok", response.body)
+
+		instance.close()
+	end)
+
 	suite:case("serveLocallyAndRequest", function(assert)
 		local server = server.serve({
 			handler = function(_req: server.ReceivedRequest): server.ServerResponse

--- a/tests/std/net.test.luau
+++ b/tests/std/net.test.luau
@@ -27,7 +27,7 @@ test.suite("NetTestSuite", function(suite)
 	end)
 
 	suite:case("serveLocallyAndRequest", function(assert)
-		local server = server.serve({
+		local instance = server.serve({
 			handler = function(_req: server.ReceivedRequest): server.ServerResponse
 				return {
 					status = 200,
@@ -36,13 +36,13 @@ test.suite("NetTestSuite", function(suite)
 			end,
 		})
 
-		local response = net.request(`{server.hostname}:{server.port}`, {
+		local response = net.request(`{instance.hostname}:{instance.port}`, {
 			method = "GET",
 		})
 		assert.eq(true, response.ok)
 		assert.eq(200, response.status)
 		assert.eq("Hello, World!", response.body)
 
-		server.close()
+		instance.close()
 	end)
 end)


### PR DESCRIPTION
net's server handler would just immediately return a response even if the lua thread yielded, so yielding was basically broken. by adding a completion hook to `runOnce` we can properly wait and notify the server when the lua thread yields