### PR TITLE
runtime: fix a bug where durations from `@lute/fs` would not work correctly without requiring `@lute/time`

### DIFF
--- a/definitions/fs.luau
+++ b/definitions/fs.luau
@@ -1,4 +1,6 @@
 -- lute-lint-global-ignore(unused_variable)
+local time = require("./time")
+
 local fs = {}
 
 export type FileHandle = {
@@ -13,9 +15,9 @@ export type FileMetadata = {
 	type: FileType,
 	permissions: { readonly: boolean },
 	size: number,
-	created: any,
-	accessed: any,
-	modified: any,
+	created: time.Duration,
+	accessed: time.Duration,
+	modified: time.Duration,
 }
 
 export type DirectoryEntry = {

--- a/examples/fs_metadata.luau
+++ b/examples/fs_metadata.luau
@@ -1,6 +1,3 @@
--- adding this import changes the behavior of duratio
--- local time = require("@lute/time")
-
 local fs = require("@std/fs")
 local path = require("@std/path")
 local process = require("@std/process")

--- a/examples/fs_metadata.luau
+++ b/examples/fs_metadata.luau
@@ -1,0 +1,13 @@
+-- adding this import changes the behavior of duratio
+-- local time = require("@lute/time")
+
+local fs = require("@std/fs")
+local path = require("@std/path")
+local process = require("@std/process")
+
+local scriptPath = path.resolve(process.cwd(), process.args[1])
+
+local metadata = fs.metadata(scriptPath)
+local created = metadata.created
+
+print(tostring(created))

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -1,6 +1,7 @@
 #include "lute/fs.h"
 
 #include "lute/runtime.h"
+#include "lute/time.h"
 #include "lute/userdatas.h"
 
 #include "lua.h"
@@ -369,6 +370,8 @@ int listdir(lua_State* L)
 
 static void initalizeFS(lua_State* L)
 {
+    init_duration_lib(L);
+
     luaL_newmetatable(L, "WatchHandle");
 
     lua_pushcfunction(

--- a/lute/time/include/lute/time.h
+++ b/lute/time/include/lute/time.h
@@ -21,6 +21,7 @@ double getSecondsFromTimespec(uv_timespec64_t timespec);
 uv_timespec64_t getTimespecFromDuration(lua_State* L, int idx);
 int createDurationFromTimespec(lua_State* L, uv_timespec64_t timespec);
 int createDurationFromSeconds(lua_State* L, double seconds);
+void init_duration_lib(lua_State* L);
 
 namespace duration
 {

--- a/lute/time/src/time.cpp
+++ b/lute/time/src/time.cpp
@@ -460,9 +460,13 @@ int lua_since(lua_State* L)
 }
 } // namespace libtime
 
-static void init_duration_lib(lua_State* L)
+void init_duration_lib(lua_State* L)
 {
-    luaL_newmetatable(L, kDurationType);
+    if (luaL_newmetatable(L, kDurationType) == 0)
+    {
+        lua_pop(L, 1);
+        return;
+    }
 
     // Protect metatable from being changed
     lua_pushstring(L, "The metatable is locked");

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -228,6 +228,30 @@ test.suite("FsSuite", function(suite)
 		assert.eq(fs.exists(file3), false)
 	end)
 
+	suite:case("metadataDurationsHaveWorkingMetatable", function(assert)
+		local file = path.join(tmpdir, "duration_meta_test.txt")
+		fs.writeStringToFile(file, "test")
+
+		local m = fs.metadata(file)
+
+		-- duration methods should work without requiring @lute/time
+		assert.that(m.created:toSeconds() > 0)
+		assert.that(m.accessed:toSeconds() > 0)
+		assert.that(m.modified:toSeconds() > 0)
+
+		-- __tostring should produce "seconds.nanoseconds" format, not "userdata: 0x..."
+		assert.that(tostring(m.created):match("^%d+%.%d+$"))
+
+		-- arithmetic should work
+		local sum = m.created + m.modified
+		assert.that(sum:toSeconds() > 0)
+
+		-- comparisons should work
+		assert.that(m.created <= m.modified or m.modified <= m.created)
+
+		fs.remove(file)
+	end)
+
 	suite:case("removeDirectoryRecursiveFalseWithContents", function(assert)
 		local dir = path.join(tmpdir, "non_empty_dir")
 		fs.createDirectory(dir, { makeParents = true })


### PR DESCRIPTION
A strange bug got reported on Discord (and unfortunately they never made a ticket here) where durations that the user got from `@lute/fs` would ultimately behave incorrectly when `@lute/time` was not imported into that script. The underlying cause is that the metatable was not initialized when `@lute/time` was not imported, and therefore the code that constructs the durations in `@lute/fs` would look for a duration metatable that did not exist and just set the metatable to `nil`. We fix this by making initialization of the duration library idempotent and then invoking that initialization for `@lute/fs` as well.