### PR TITLE
runtime: introduce `LuteLibrary` shared interface for runtime modules.

### DIFF
--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -610,7 +610,7 @@ int handleCompileCommand(int argc, char** argv, int argOffset, LuteReporter& rep
 
     // Get current executable path
     std::string errorMsg;
-    std::optional<std::string> exePath = process::getExecPath(&errorMsg);
+    std::optional<std::string> exePath = Process::getExecPath(&errorMsg);
     if (!exePath)
     {
         reporter.formatError("Error: Failed to get executable path: %s", errorMsg.c_str());

--- a/lute/common/include/lute/library.h
+++ b/lute/common/include/lute/library.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "lua.h"
+#include "lualib.h"
+
+// CRTP base for all lute runtime libraries.
+// Each Derived must provide:
+//   static constexpr const char kName[];   -- the Lua global name (e.g. "task")
+//   static int pushLibrary(lua_State* L);  -- push the library table onto the stack
+//   static const luaL_Reg lib[];           -- function registration table (where applicable)
+template<typename Derived>
+struct LuteLibrary
+{
+    static int openAsGlobal(lua_State* L)
+    {
+        Derived::pushLibrary(L);
+        lua_setglobal(L, Derived::kName);
+        return 1;
+    }
+};

--- a/lute/common/include/lute/library.h
+++ b/lute/common/include/lute/library.h
@@ -5,9 +5,10 @@
 
 // CRTP base for all lute runtime libraries.
 // Each Derived must provide:
-//   static constexpr const char kName[];   -- the Lua global name (e.g. "task")
-//   static int pushLibrary(lua_State* L);  -- push the library table onto the stack
-//   static const luaL_Reg lib[];           -- function registration table (where applicable)
+//   static constexpr const char kName[];          -- the Lua global name (e.g. "task")
+//   static int pushLibrary(lua_State* L);         -- push the library table onto the stack
+//   static const luaL_Reg lib[];                  -- function registration table
+//   static const char* const properties[];        -- non-function table keys (empty array if none)
 template<typename Derived>
 struct LuteLibrary
 {

--- a/lute/common/include/lute/library.h
+++ b/lute/common/include/lute/library.h
@@ -3,17 +3,48 @@
 #include "lua.h"
 #include "lualib.h"
 
-// CRTP base for all lute runtime libraries.
-// Each Derived must provide:
-//   static constexpr const char kName[];          -- the Lua global name (e.g. "task")
-//   static int pushLibrary(lua_State* L);         -- push the library table onto the stack
-//   static const luaL_Reg lib[];                  -- function registration table
-//   static const char* const properties[];        -- non-function table keys (empty array if none)
+#include <type_traits>
+
+// A uniform interface for Lute libraries.
+//
+// Each `Derived` Lute library must provide:
+//   static constexpr const char kName[];      -- the Luau library name (e.g. "task")
+//   static int pushLibrary(lua_State* L);     -- push the library table onto the stack
+//   static const luaL_Reg lib[];              -- function registration table
+//   static const char* const properties[];    -- non-function table keys (empty array if none)
 template<typename Derived>
 struct LuteLibrary
 {
+    // Verifies that the type given as `Derived` satisfies the interface contract.
+    //
+    // This must be implemented as a function (not in the class scope) because `Derived` is
+    // incomplete when `LuteLibrary<Derived>` is instantiated (CRTP constraint).
+    static void verifyInterface()
+    {
+        static_assert(
+            std::is_array_v<decltype(Derived::kName)> &&
+                std::is_same_v<std::remove_extent_t<decltype(Derived::kName)>, const char>,
+            "LuteLibrary must declare: static constexpr const char kName[]"
+        );
+        static_assert(
+            std::is_same_v<decltype(&Derived::pushLibrary), int (*)(lua_State*)>,
+            "LuteLibrary must declare: static int pushLibrary(lua_State* L)"
+        );
+        static_assert(
+            std::is_array_v<decltype(Derived::lib)> &&
+                std::is_same_v<std::remove_extent_t<decltype(Derived::lib)>, const luaL_Reg>,
+            "LuteLibrary must declare: static const luaL_Reg lib[]"
+        );
+        static_assert(
+            std::is_array_v<decltype(Derived::properties)> &&
+                std::is_same_v<std::remove_extent_t<decltype(Derived::properties)>, const char* const>,
+            "LuteLibrary must declare: static const char* const properties[]"
+        );
+    }
+
     static int openAsGlobal(lua_State* L)
     {
+        verifyInterface();
         Derived::pushLibrary(L);
         lua_setglobal(L, Derived::kName);
         return 1;

--- a/lute/crypto/include/lute/crypto.h
+++ b/lute/crypto/include/lute/crypto.h
@@ -15,4 +15,5 @@ struct Crypto : LuteLibrary<Crypto>
     static constexpr const char kName[] = "crypto";
     static int pushLibrary(lua_State* L);
     static const luaL_Reg lib[];
+    static const char* const properties[];
 };

--- a/lute/crypto/include/lute/crypto.h
+++ b/lute/crypto/include/lute/crypto.h
@@ -1,50 +1,18 @@
 #pragma once
 
+#include "lute/library.h"
+
 #include "lua.h"
 #include "lualib.h"
-
-#include <string>
 
 // open the library as a standard global luau library
 int luaopen_crypto(lua_State* L);
 // open the library as a table on top of the stack
 int luteopen_crypto(lua_State* L);
 
-namespace crypto
+struct Crypto : LuteLibrary<Crypto>
 {
-
-static const char kHashProperty[] = "hash";
-static const char kSecretboxProperty[] = "secretbox";
-static const char kPasswordProperty[] = "password";
-
-static const char kDigestName[] = "digest";
-int lua_digest(lua_State* L);
-
-static const char kCiphertextField[] = "ciphertext";
-static const char kKeyField[] = "key";
-static const char kNonceField[] = "nonce";
-
-static const char kKeygenName[] = "keygen";
-int lua_secretbox_keygen(lua_State* L);
-
-static const char kSealName[] = "seal";
-int lua_secretbox_seal(lua_State* L);
-
-static const char kOpenName[] = "open";
-int lua_secretbox_open(lua_State* L);
-
-static const char kPasswordHashName[] = "hash";
-int lua_pwhash(lua_State* L);
-
-static const char kVerifyPasswordHashName[] = "verify";
-int lua_pwhash_verify(lua_State* L);
-
-static const luaL_Reg lib[] = {{kDigestName, lua_digest}, {nullptr, nullptr}};
-
-static const std::string properties[] = {
-    kHashProperty,
-    kSecretboxProperty,
-    kPasswordProperty,
+    static constexpr const char kName[] = "crypto";
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
 };
-
-} // namespace crypto

--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -123,7 +123,7 @@ int lua_secretbox_keygen(lua_State* L)
 
     uint8_t* key = static_cast<uint8_t*>(lua_newbuffer(L, crypto_secretbox_keybytes()));
     crypto_secretbox_keygen(key);
-    
+
     return 1;
 }
 
@@ -160,7 +160,7 @@ int lua_secretbox_seal(lua_State* L)
         crypto_secretbox_keygen(key);
         lua_setfield(L, -2, kKeyField);
     }
-    
+
     // nonce
     uint8_t* nonce = static_cast<uint8_t*>(lua_newbuffer(L, crypto_secretbox_noncebytes()));
     randombytes_buf(nonce, crypto_secretbox_noncebytes());
@@ -297,7 +297,7 @@ const luaL_Reg Crypto::lib[] = {
 
 int Crypto::pushLibrary(lua_State* L)
 {
-    lua_createtable(L, 0, std::size(Crypto::lib) + std::size(properties));
+    lua_createtable(L, 0, std::size(Crypto::lib) + std::size(Crypto::properties));
 
     for (auto& [name, func] : Crypto::lib)
     {

--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -284,7 +284,7 @@ int makePasswordHashLibrary(lua_State* L)
 
 } // namespace crypto
 
-static const std::string properties[] = {
+const char* const Crypto::properties[] = {
     crypto::kHashProperty,
     crypto::kSecretboxProperty,
     crypto::kPasswordProperty,

--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -15,6 +15,22 @@
 namespace crypto
 {
 
+static const char kHashProperty[] = "hash";
+static const char kSecretboxProperty[] = "secretbox";
+static const char kPasswordProperty[] = "password";
+
+static const char kDigestName[] = "digest";
+
+static const char kCiphertextField[] = "ciphertext";
+static const char kKeyField[] = "key";
+static const char kNonceField[] = "nonce";
+
+static const char kKeygenName[] = "keygen";
+static const char kSealName[] = "seal";
+static const char kOpenName[] = "open";
+static const char kPasswordHashName[] = "hash";
+static const char kVerifyPasswordHashName[] = "verify";
+
 struct HashFunction
 {
     std::string name;
@@ -268,19 +284,22 @@ int makePasswordHashLibrary(lua_State* L)
 
 } // namespace crypto
 
-int luaopen_crypto(lua_State* L)
+static const std::string properties[] = {
+    crypto::kHashProperty,
+    crypto::kSecretboxProperty,
+    crypto::kPasswordProperty,
+};
+
+const luaL_Reg Crypto::lib[] = {
+    {crypto::kDigestName, crypto::lua_digest},
+    {nullptr, nullptr},
+};
+
+int Crypto::pushLibrary(lua_State* L)
 {
-    luteopen_crypto(L);
-    lua_setglobal(L, "crypto");
+    lua_createtable(L, 0, std::size(Crypto::lib) + std::size(properties));
 
-    return 1;
-}
-
-int luteopen_crypto(lua_State* L)
-{
-    lua_createtable(L, 0, std::size(crypto::lib) + std::size(crypto::properties));
-
-    for (auto& [name, func] : crypto::lib)
+    for (auto& [name, func] : Crypto::lib)
     {
         if (!name || !func)
             break;
@@ -298,7 +317,17 @@ int luteopen_crypto(lua_State* L)
     crypto::makePasswordHashLibrary(L);
     lua_setfield(L, -2, crypto::kPasswordProperty);
 
-    lua_setreadonly(L, -1, true);
+    lua_setreadonly(L, -1, 1);
 
     return 1;
+}
+
+int luaopen_crypto(lua_State* L)
+{
+    return Crypto::openAsGlobal(L);
+}
+
+int luteopen_crypto(lua_State* L)
+{
+    return Crypto::pushLibrary(L);
 }

--- a/lute/fs/include/lute/fs.h
+++ b/lute/fs/include/lute/fs.h
@@ -15,4 +15,5 @@ struct FS : LuteLibrary<FS>
     static constexpr const char kName[] = "fs";
     static int pushLibrary(lua_State* L);
     static const luaL_Reg lib[];
+    static const char* const properties[];
 };

--- a/lute/fs/include/lute/fs.h
+++ b/lute/fs/include/lute/fs.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "lute/library.h"
+
 #include "lua.h"
 #include "lualib.h"
 
@@ -8,88 +10,9 @@ int luaopen_fs(lua_State* L);
 // open the library as a table on top of the stack
 int luteopen_fs(lua_State* L);
 
-namespace fs
+struct FS : LuteLibrary<FS>
 {
-
-// TODO: add the ability to open as bytes
-/* Takes  path: string, a mode: 'r|a|w|x|+' (defaulting to r when omitted)
-   Returns a table representing a handle to the file the state of a file {fd : number, error : ...}
- */
-int open(lua_State* L);
-
-/* Reads a file into a string. Takes a file handle obtained from openfile */
-int read(lua_State* L);
-
-/* Writes a string to a file without closing it*/
-int write(lua_State* L);
-
-/* takes a file handle into a string and then closes it */
-int close(lua_State* L);
-
-/* reads a whole file into a string and then closes it */
-int readfiletostring(lua_State* L);
-/* writes a st */
-int writestringtofile(lua_State* L);
-
-/* Reads a file without blocking */
-int readasync(lua_State* L);
-
-/* Removes a file */
-int remove(lua_State* L);
-
-/* Creates a folder */
-int mkdir(lua_State* L);
-
-/* Removes a directory */
-int rmdir(lua_State* L);
-
-/* Gets the metadata of a file */
-int stat(lua_State* L);
-
-/* Checks if a file exists */
-int exists(lua_State* L);
-
-/* Copies a file to another path */
-int copy(lua_State* L);
-
-/* Creates a link to a file */
-int link(lua_State* L);
-
-/* Creates a symlink to a file */
-int symlink(lua_State* L);
-
-/* Gets the type of a file entry */
-int type(lua_State* L);
-
-/* Sets up a filesystem watch event */
-int fs_watch(lua_State* L);
-
-/* Lists the contents of a directory */
-int listdir(lua_State* L);
-
-static const luaL_Reg lib[] = {
-    /* Manual control apis - you are responsible for calling close / open*/
-    {"open", open},
-    {"read", read},
-    {"write", write},
-    {"close", close},
-
-    {"remove", remove},
-
-    {"stat", stat},
-    {"exists", exists},
-    {"type", type},
-
-    {"watch", fs_watch},
-    {"link", link},
-    {"symlink", symlink},
-    {"copy", copy},
-
-    {"mkdir", mkdir},
-    {"listdir", listdir},
-    {"rmdir", rmdir},
-
-    {NULL, NULL},
+    static constexpr const char kName[] = "fs";
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
 };
-
-} // namespace fs

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -408,7 +408,7 @@ static void initalizeFS(lua_State* L)
     lua_setuserdatametatable(L, kWatchHandleTag);
 }
 
-const char* const FS::properties[] = {};
+const char* const FS::properties[] = {nullptr};
 
 const luaL_Reg FS::lib[] = {
     {"open", fs::open},

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -405,6 +405,8 @@ static void initalizeFS(lua_State* L)
     lua_setuserdatametatable(L, kWatchHandleTag);
 }
 
+const char* const FS::properties[] = {};
+
 const luaL_Reg FS::lib[] = {
     {"open", fs::open},
     {"read", fs::read},

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -405,18 +405,35 @@ static void initalizeFS(lua_State* L)
     lua_setuserdatametatable(L, kWatchHandleTag);
 }
 
-int luaopen_fs(lua_State* L)
-{
-    luaL_register(L, "fs", fs::lib);
-    initalizeFS(L);
-    return 1;
-}
+const luaL_Reg FS::lib[] = {
+    {"open", fs::open},
+    {"read", fs::read},
+    {"write", fs::write},
+    {"close", fs::close},
 
-int luteopen_fs(lua_State* L)
-{
-    lua_createtable(L, 0, std::size(fs::lib));
+    {"remove", fs::remove},
 
-    for (auto& [name, func] : fs::lib)
+    {"stat", fs::stat},
+    {"exists", fs::exists},
+    {"type", fs::type},
+
+    {"watch", fs::fs_watch},
+    {"link", fs::link},
+    {"symlink", fs::symlink},
+    {"copy", fs::copy},
+
+    {"mkdir", fs::mkdir},
+    {"listdir", fs::listdir},
+    {"rmdir", fs::rmdir},
+
+    {nullptr, nullptr},
+};
+
+int FS::pushLibrary(lua_State* L)
+{
+    lua_createtable(L, 0, std::size(FS::lib));
+
+    for (auto& [name, func] : FS::lib)
     {
         if (!name || !func)
             break;
@@ -430,4 +447,14 @@ int luteopen_fs(lua_State* L)
     initalizeFS(L);
 
     return 1;
+}
+
+int luaopen_fs(lua_State* L)
+{
+    return FS::openAsGlobal(L);
+}
+
+int luteopen_fs(lua_State* L)
+{
+    return FS::pushLibrary(L);
 }

--- a/lute/io/include/lute/io.h
+++ b/lute/io/include/lute/io.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "lute/library.h"
+
 #include "lua.h"
 #include "lualib.h"
 
@@ -8,15 +10,9 @@ int luaopen_io(lua_State* L);
 // open the library as a table on top of the stack
 int luteopen_io(lua_State* L);
 
-namespace io
+struct IO : LuteLibrary<IO>
 {
-
-int read(lua_State* L);
-
-static const luaL_Reg lib[] = {
-    {"read", read},
-
-    {nullptr, nullptr}
+    static constexpr const char kName[] = "io";
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
 };
-
-} // namespace io

--- a/lute/io/include/lute/io.h
+++ b/lute/io/include/lute/io.h
@@ -15,4 +15,5 @@ struct IO : LuteLibrary<IO>
     static constexpr const char kName[] = "io";
     static int pushLibrary(lua_State* L);
     static const luaL_Reg lib[];
+    static const char* const properties[];
 };

--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -115,6 +115,8 @@ int read(lua_State* L)
 
 } // anonymous namespace
 
+const char* const IO::properties[] = {};
+
 const luaL_Reg IO::lib[] = {
     {"read", read},
     {nullptr, nullptr},

--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -12,7 +12,7 @@
 #include <memory>
 
 
-namespace io
+namespace
 {
 
 struct IOHandle
@@ -113,19 +113,18 @@ int read(lua_State* L)
     return lua_yield(L, 0);
 }
 
-} // namespace io
+} // anonymous namespace
 
-int luaopen_io(lua_State* L)
+const luaL_Reg IO::lib[] = {
+    {"read", read},
+    {nullptr, nullptr},
+};
+
+int IO::pushLibrary(lua_State* L)
 {
-    luaL_register(L, "io", io::lib);
-    return 1;
-}
+    lua_createtable(L, 0, std::size(IO::lib));
 
-int luteopen_io(lua_State* L)
-{
-    lua_createtable(L, 0, std::size(io::lib));
-
-    for (auto& [name, func] : io::lib)
+    for (auto& [name, func] : IO::lib)
     {
         if (!name || !func)
             break;
@@ -137,4 +136,14 @@ int luteopen_io(lua_State* L)
     lua_setreadonly(L, -1, 1);
 
     return 1;
+}
+
+int luaopen_io(lua_State* L)
+{
+    return IO::openAsGlobal(L);
+}
+
+int luteopen_io(lua_State* L)
+{
+    return IO::pushLibrary(L);
 }

--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -115,7 +115,7 @@ int read(lua_State* L)
 
 } // anonymous namespace
 
-const char* const IO::properties[] = {};
+const char* const IO::properties[] = {nullptr};
 
 const luaL_Reg IO::lib[] = {
     {"read", read},

--- a/lute/luau/include/lute/luau.h
+++ b/lute/luau/include/lute/luau.h
@@ -16,4 +16,5 @@ struct LuauLib : LuteLibrary<LuauLib>
     static constexpr const char kName[] = "luau";
     static int pushLibrary(lua_State* L);
     static const luaL_Reg lib[];
+    static const char* const properties[];
 };

--- a/lute/luau/include/lute/luau.h
+++ b/lute/luau/include/lute/luau.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "lute/library.h"
 #include "lute/resolvemodule.h"
 
 #include "lua.h"
@@ -10,35 +11,9 @@ int luaopen_luau(lua_State* L);
 // open the library as a table on top of the stack
 int luteopen_luau(lua_State* L);
 
-namespace luau
+struct LuauLib : LuteLibrary<LuauLib>
 {
-
-static const char kSpanType[] = "span";
-static const char kCompileResultType[] = "CompileResult";
-static const char kSpanCreateName[] = "span.create";
-
-int luau_parse(lua_State* L);
-
-int luau_parseexpr(lua_State* L);
-
-int compile_luau(lua_State* L);
-
-int load_luau(lua_State* L);
-
-int typeofModule_luau(lua_State* L);
-
-static const luaL_Reg lib[] = {
-    {"parse", luau_parse},
-    {"parseExpr", luau_parseexpr},
-    {"compile", compile_luau},
-    {"load", load_luau},
-    {"resolveModule", resolveModule_luau},
-    {"typeofModule", typeofModule_luau},
-    {nullptr, nullptr},
+    static constexpr const char kName[] = "luau";
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
 };
-
-static const std::string properties[] = {
-    kSpanType,
-};
-
-} // namespace luau

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -3091,7 +3091,7 @@ static int initLuauLibrary(lua_State* L)
 
 } // namespace luau
 
-static const std::string properties[] = {luau::kSpanType};
+const char* const LuauLib::properties[] = {luau::kSpanType};
 
 const luaL_Reg LuauLib::lib[] = {
     {"parse", luau::luau_parse},

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -3105,7 +3105,7 @@ const luaL_Reg LuauLib::lib[] = {
 
 int LuauLib::pushLibrary(lua_State* L)
 {
-    lua_createtable(L, 0, std::size(LuauLib::lib) + std::size(properties));
+    lua_createtable(L, 0, std::size(LuauLib::lib) + std::size(LuauLib::properties));
 
     luau::makeSpanLibrary(L);
     lua_setfield(L, -2, luau::kSpanType);

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -29,6 +29,10 @@
 namespace luau
 {
 
+static constexpr const char kSpanType[] = "span";
+static constexpr const char kCompileResultType[] = "CompileResult";
+static constexpr const char kSpanCreateName[] = "span.create";
+
 // Recursively freezes the table at the top of the stack and any descendant tables.
 // The table must be at the top of the stack when called.
 static void deepFreeze(lua_State* L)
@@ -3087,22 +3091,26 @@ static int initLuauLibrary(lua_State* L)
 
 } // namespace luau
 
-int luaopen_luau(lua_State* L)
+static const std::string properties[] = {luau::kSpanType};
+
+const luaL_Reg LuauLib::lib[] = {
+    {"parse", luau::luau_parse},
+    {"parseExpr", luau::luau_parseexpr},
+    {"compile", luau::compile_luau},
+    {"load", luau::load_luau},
+    {"resolveModule", resolveModule_luau},
+    {"typeofModule", luau::typeofModule_luau},
+    {nullptr, nullptr},
+};
+
+int LuauLib::pushLibrary(lua_State* L)
 {
-    luaL_register(L, "luau", luau::lib);
+    lua_createtable(L, 0, std::size(LuauLib::lib) + std::size(properties));
 
-    return luau::initLuauLibrary(L);
-}
-
-int luteopen_luau(lua_State* L)
-{
-    lua_createtable(L, 0, std::size(luau::lib) + std::size(luau::properties));
-
-    // span library
     luau::makeSpanLibrary(L);
     lua_setfield(L, -2, luau::kSpanType);
 
-    for (auto& [name, func] : luau::lib)
+    for (auto& [name, func] : LuauLib::lib)
     {
         if (!name || !func)
             break;
@@ -3114,4 +3122,14 @@ int luteopen_luau(lua_State* L)
     lua_setreadonly(L, -1, 1);
 
     return luau::initLuauLibrary(L);
+}
+
+int luaopen_luau(lua_State* L)
+{
+    return LuauLib::openAsGlobal(L);
+}
+
+int luteopen_luau(lua_State* L)
+{
+    return LuauLib::pushLibrary(L);
 }

--- a/lute/net/include/lute/net.h
+++ b/lute/net/include/lute/net.h
@@ -18,6 +18,7 @@ struct NetClient : LuteLibrary<NetClient>
     static constexpr const char kName[] = "net.client";
     static int pushLibrary(lua_State* L);
     static const luaL_Reg lib[];
+    static const char* const properties[];
 };
 
 struct NetServer : LuteLibrary<NetServer>
@@ -25,10 +26,12 @@ struct NetServer : LuteLibrary<NetServer>
     static constexpr const char kName[] = "net.server";
     static int pushLibrary(lua_State* L);
     static const luaL_Reg lib[];
+    static const char* const properties[];
 };
 
 struct Net : LuteLibrary<Net>
 {
     static constexpr const char kName[] = "net";
     static int pushLibrary(lua_State* L);
+    static const char* const properties[];
 };

--- a/lute/net/include/lute/net.h
+++ b/lute/net/include/lute/net.h
@@ -33,5 +33,6 @@ struct Net : LuteLibrary<Net>
 {
     static constexpr const char kName[] = "net";
     static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
     static const char* const properties[];
 };

--- a/lute/net/include/lute/net.h
+++ b/lute/net/include/lute/net.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "lute/library.h"
+
 #include "lua.h"
 #include "lualib.h"
 
@@ -11,26 +13,22 @@ int luteopen_net(lua_State* L);
 int luteopen_net_client(lua_State* L);
 int luteopen_net_server(lua_State* L);
 
-namespace net::client
+struct NetClient : LuteLibrary<NetClient>
 {
-
-int request(lua_State* L);
-
-static const luaL_Reg lib[] = {
-    {"request", request},
-    {nullptr, nullptr},
+    static constexpr const char kName[] = "net.client";
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
 };
 
-} // namespace net::client
-
-namespace net::server
+struct NetServer : LuteLibrary<NetServer>
 {
-
-int serve(lua_State* L);
-
-static const luaL_Reg lib[] = {
-    {"serve", serve},
-    {nullptr, nullptr},
+    static constexpr const char kName[] = "net.server";
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
 };
 
-} // namespace net::server
+struct Net : LuteLibrary<Net>
+{
+    static constexpr const char kName[] = "net";
+    static int pushLibrary(lua_State* L);
+};

--- a/lute/net/src/client.cpp
+++ b/lute/net/src/client.cpp
@@ -242,6 +242,8 @@ int request(lua_State* L)
 
 } // namespace net::client
 
+const char* const NetClient::properties[] = {};
+
 const luaL_Reg NetClient::lib[] = {
     {"request", net::client::request},
     {nullptr, nullptr},

--- a/lute/net/src/client.cpp
+++ b/lute/net/src/client.cpp
@@ -242,13 +242,18 @@ int request(lua_State* L)
 
 } // namespace net::client
 
-int luteopen_net_client(lua_State* L)
+const luaL_Reg NetClient::lib[] = {
+    {"request", net::client::request},
+    {nullptr, nullptr},
+};
+
+int NetClient::pushLibrary(lua_State* L)
 {
     globalCurlInit();
 
-    lua_createtable(L, 0, 1);
+    lua_createtable(L, 0, std::size(NetClient::lib));
 
-    for (auto& [name, func] : net::client::lib)
+    for (auto& [name, func] : NetClient::lib)
     {
         if (!name || !func)
             break;
@@ -260,4 +265,9 @@ int luteopen_net_client(lua_State* L)
     lua_setreadonly(L, -1, 1);
 
     return 1;
+}
+
+int luteopen_net_client(lua_State* L)
+{
+    return NetClient::pushLibrary(L);
 }

--- a/lute/net/src/client.cpp
+++ b/lute/net/src/client.cpp
@@ -242,7 +242,7 @@ int request(lua_State* L)
 
 } // namespace net::client
 
-const char* const NetClient::properties[] = {};
+const char* const NetClient::properties[] = {nullptr};
 
 const luaL_Reg NetClient::lib[] = {
     {"request", net::client::request},

--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -2,9 +2,13 @@
 
 #include "lua.h"
 
+#include <iterator>
+
+const char* const Net::properties[] = {"client", "server"};
+
 int Net::pushLibrary(lua_State* L)
 {
-    lua_createtable(L, 0, 2);
+    lua_createtable(L, 0, std::size(Net::properties));
 
     NetClient::pushLibrary(L);
     lua_setfield(L, -2, "client");

--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -4,15 +4,21 @@
 
 #include <iterator>
 
+const luaL_Reg Net::lib[] = {
+    {nullptr, nullptr},
+};
+
 const char* const Net::properties[] = {"client", "server"};
 
 int Net::pushLibrary(lua_State* L)
 {
     lua_createtable(L, 0, std::size(Net::properties));
 
+    NetClient::verifyInterface();
     NetClient::pushLibrary(L);
     lua_setfield(L, -2, "client");
 
+    NetServer::verifyInterface();
     NetServer::pushLibrary(L);
     lua_setfield(L, -2, "server");
 

--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -2,25 +2,27 @@
 
 #include "lua.h"
 
-int luaopen_net(lua_State* L)
-{
-    luteopen_net(L);
-    lua_setglobal(L, "net");
-
-    return 1;
-}
-
-int luteopen_net(lua_State* L)
+int Net::pushLibrary(lua_State* L)
 {
     lua_createtable(L, 0, 2);
 
-    luteopen_net_client(L);
+    NetClient::pushLibrary(L);
     lua_setfield(L, -2, "client");
 
-    luteopen_net_server(L);
+    NetServer::pushLibrary(L);
     lua_setfield(L, -2, "server");
 
     lua_setreadonly(L, -1, 1);
 
     return 1;
+}
+
+int luaopen_net(lua_State* L)
+{
+    return Net::openAsGlobal(L);
+}
+
+int luteopen_net(lua_State* L)
+{
+    return Net::pushLibrary(L);
 }

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -491,7 +491,7 @@ int serve(lua_State* L)
 
 } // namespace net::server
 
-const char* const NetServer::properties[] = {};
+const char* const NetServer::properties[] = {nullptr};
 
 const luaL_Reg NetServer::lib[] = {
     {"serve", net::server::serve},

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -491,6 +491,8 @@ int serve(lua_State* L)
 
 } // namespace net::server
 
+const char* const NetServer::properties[] = {};
+
 const luaL_Reg NetServer::lib[] = {
     {"serve", net::server::serve},
     {nullptr, nullptr},

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -491,11 +491,16 @@ int serve(lua_State* L)
 
 } // namespace net::server
 
-int luteopen_net_server(lua_State* L)
-{
-    lua_createtable(L, 0, 1);
+const luaL_Reg NetServer::lib[] = {
+    {"serve", net::server::serve},
+    {nullptr, nullptr},
+};
 
-    for (auto& [name, func] : net::server::lib)
+int NetServer::pushLibrary(lua_State* L)
+{
+    lua_createtable(L, 0, std::size(NetServer::lib));
+
+    for (auto& [name, func] : NetServer::lib)
     {
         if (!name || !func)
             break;
@@ -507,4 +512,9 @@ int luteopen_net_server(lua_State* L)
     lua_setreadonly(L, -1, 1);
 
     return 1;
+}
+
+int luteopen_net_server(lua_State* L)
+{
+    return NetServer::pushLibrary(L);
 }

--- a/lute/process/include/lute/process.h
+++ b/lute/process/include/lute/process.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "lute/library.h"
+
 #include "lua.h"
 #include "lualib.h"
 
@@ -11,29 +13,11 @@ int luaopen_process(lua_State* L);
 // open the library as a table on top of the stack
 int luteopen_process(lua_State* L);
 
-namespace process
+struct Process : LuteLibrary<Process>
 {
+    static constexpr const char kName[] = "process";
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
 
-int run(lua_State* L);
-int system(lua_State* L);
-
-int homedir(lua_State* L);
-int cwd(lua_State* L);
-
-int exitFunc(lua_State* L);
-
-std::optional<std::string> getExecPath(std::string* error);
-int execPath(lua_State* L);
-
-static const luaL_Reg lib[] = {
-    {"run", run},
-    {"system", system},
-    {"homedir", homedir},
-    {"cwd", cwd},
-    {"exit", exitFunc},
-    {"execPath", execPath},
-
-    {nullptr, nullptr}
+    static std::optional<std::string> getExecPath(std::string* error);
 };
-
-} // namespace process

--- a/lute/process/include/lute/process.h
+++ b/lute/process/include/lute/process.h
@@ -18,6 +18,7 @@ struct Process : LuteLibrary<Process>
     static constexpr const char kName[] = "process";
     static int pushLibrary(lua_State* L);
     static const luaL_Reg lib[];
+    static const char* const properties[];
 
     static std::optional<std::string> getExecPath(std::string* error);
 };

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -653,6 +653,8 @@ std::optional<std::string> Process::getExecPath(std::string* error)
     return *cachedPath;
 }
 
+const char* const Process::properties[] = {"env", "args"};
+
 const luaL_Reg Process::lib[] = {
     {"run", process::run},
     {"system", process::system},
@@ -665,7 +667,7 @@ const luaL_Reg Process::lib[] = {
 
 int Process::pushLibrary(lua_State* L)
 {
-    lua_createtable(L, 0, std::size(Process::lib));
+    lua_createtable(L, 0, std::size(Process::lib) + std::size(Process::properties));
 
     for (auto& [name, func] : Process::lib)
     {

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -494,32 +494,10 @@ int cwd(lua_State* L)
     return 1;
 };
 
-std::optional<std::string> getExecPath(std::string* error)
-{
-    // Executable path is not expected to change during process lifetime, so we
-    // can safely cache it after the first retrieval.
-    static std::optional<std::string> cachedPath = std::nullopt;
-    if (cachedPath)
-        return *cachedPath;
-
-    char buf[LUTE_PATH_MAX];
-    size_t len = sizeof(buf);
-
-    if (int status = uv_exepath(buf, &len); status < 0)
-    {
-        if (error)
-            *error = uv_strerror(status);
-        return std::nullopt;
-    }
-
-    cachedPath = std::string(buf, len);
-    return *cachedPath;
-}
-
 int execPath(lua_State* L)
 {
     std::string error;
-    std::optional<std::string> execPath = getExecPath(&error);
+    std::optional<std::string> execPath = Process::getExecPath(&error);
     if (!execPath)
         luaL_error(L, "Failed to get executable path: %s", error.c_str());
 
@@ -653,17 +631,43 @@ static int envIter(lua_State* L)
 static const luaL_Reg processEnvMeta[] =
     {{"__index", process::envIndex}, {"__newindex", process::envNewindex}, {"__iter", process::envIter}, {nullptr, nullptr}};
 
-int luaopen_process(lua_State* L)
+std::optional<std::string> Process::getExecPath(std::string* error)
 {
-    luaL_register(L, "process", process::lib);
-    return 1;
+    // Executable path is not expected to change during process lifetime, so we
+    // can safely cache it after the first retrieval.
+    static std::optional<std::string> cachedPath = std::nullopt;
+    if (cachedPath)
+        return *cachedPath;
+
+    char buf[LUTE_PATH_MAX];
+    size_t len = sizeof(buf);
+
+    if (int status = uv_exepath(buf, &len); status < 0)
+    {
+        if (error)
+            *error = uv_strerror(status);
+        return std::nullopt;
+    }
+
+    cachedPath = std::string(buf, len);
+    return *cachedPath;
 }
 
-int luteopen_process(lua_State* L)
-{
-    lua_createtable(L, 0, std::size(process::lib));
+const luaL_Reg Process::lib[] = {
+    {"run", process::run},
+    {"system", process::system},
+    {"homedir", process::homedir},
+    {"cwd", process::cwd},
+    {"exit", process::exitFunc},
+    {"execPath", process::execPath},
+    {nullptr, nullptr},
+};
 
-    for (auto& [name, func] : process::lib)
+int Process::pushLibrary(lua_State* L)
+{
+    lua_createtable(L, 0, std::size(Process::lib));
+
+    for (auto& [name, func] : Process::lib)
     {
         if (!name || !func)
             break;
@@ -699,4 +703,14 @@ int luteopen_process(lua_State* L)
     lua_setreadonly(L, -1, 1); // process table
 
     return 1;
+}
+
+int luaopen_process(lua_State* L)
+{
+    return Process::openAsGlobal(L);
+}
+
+int luteopen_process(lua_State* L)
+{
+    return Process::pushLibrary(L);
 }

--- a/lute/system/include/lute/system.h
+++ b/lute/system/include/lute/system.h
@@ -1,44 +1,18 @@
 #pragma once
 
+#include "lute/library.h"
+
 #include "lua.h"
 #include "lualib.h"
-
-#include <string>
 
 // open the library as a standard global luau library
 int luaopen_system(lua_State* L);
 // open the library as a table on top of the stack
 int luteopen_system(lua_State* L);
 
-namespace libsystem
+struct System : LuteLibrary<System>
 {
-
-static const char kArchitectureProperty[] = "arch";
-static const char kOperatingSystemProperty[] = "os";
-
-int lua_cpus(lua_State* L);
-int lua_threadcount(lua_State* L);
-int lua_freememory(lua_State* L);
-int lua_totalmemory(lua_State* L);
-int lua_hostname(lua_State* L);
-int lua_uptime(lua_State* L);
-int lua_tmpdir(lua_State* L);
-
-static const luaL_Reg lib[] = {
-    {"cpus", lua_cpus},
-    {"threadCount", lua_threadcount},
-    {"freeMemory", lua_freememory},
-    {"totalMemory", lua_totalmemory},
-    {"hostName", lua_hostname},
-    {"uptime", lua_uptime},
-    {"tmpdir", lua_tmpdir},
-
-    {nullptr, nullptr}
+    static constexpr const char kName[] = "system";
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
 };
-
-static const std::string properties[] = {
-    kArchitectureProperty,
-    kOperatingSystemProperty,
-};
-
-} // namespace libsystem

--- a/lute/system/include/lute/system.h
+++ b/lute/system/include/lute/system.h
@@ -15,4 +15,5 @@ struct System : LuteLibrary<System>
     static constexpr const char kName[] = "system";
     static int pushLibrary(lua_State* L);
     static const luaL_Reg lib[];
+    static const char* const properties[];
 };

--- a/lute/system/src/system.cpp
+++ b/lute/system/src/system.cpp
@@ -15,6 +15,10 @@
 
 namespace libsystem
 {
+
+static const char kArchitectureProperty[] = "arch";
+static const char kOperatingSystemProperty[] = "os";
+
 int lua_cpus(lua_State* L)
 {
     int count = uv_available_parallelism();
@@ -128,19 +132,27 @@ int lua_tmpdir(lua_State* L)
 }
 } // namespace libsystem
 
-int luaopen_system(lua_State* L)
+static const std::string properties[] = {
+    libsystem::kArchitectureProperty,
+    libsystem::kOperatingSystemProperty,
+};
+
+const luaL_Reg System::lib[] = {
+    {"cpus", libsystem::lua_cpus},
+    {"threadCount", libsystem::lua_threadcount},
+    {"freeMemory", libsystem::lua_freememory},
+    {"totalMemory", libsystem::lua_totalmemory},
+    {"hostName", libsystem::lua_hostname},
+    {"uptime", libsystem::lua_uptime},
+    {"tmpdir", libsystem::lua_tmpdir},
+    {nullptr, nullptr},
+};
+
+int System::pushLibrary(lua_State* L)
 {
-    luteopen_system(L);
-    lua_setglobal(L, "system");
+    lua_createtable(L, 0, std::size(System::lib) + std::size(properties));
 
-    return 1;
-}
-
-int luteopen_system(lua_State* L)
-{
-    lua_createtable(L, 0, std::size(libsystem::lib) + std::size(libsystem::properties));
-
-    for (auto& [name, func] : libsystem::lib)
+    for (auto& [name, func] : System::lib)
     {
         if (!name || !func)
             break;
@@ -162,4 +174,14 @@ int luteopen_system(lua_State* L)
     lua_setreadonly(L, -1, 1);
 
     return 1;
+}
+
+int luaopen_system(lua_State* L)
+{
+    return System::openAsGlobal(L);
+}
+
+int luteopen_system(lua_State* L)
+{
+    return System::pushLibrary(L);
 }

--- a/lute/system/src/system.cpp
+++ b/lute/system/src/system.cpp
@@ -150,7 +150,7 @@ const luaL_Reg System::lib[] = {
 
 int System::pushLibrary(lua_State* L)
 {
-    lua_createtable(L, 0, std::size(System::lib) + std::size(properties));
+    lua_createtable(L, 0, std::size(System::lib) + std::size(System::properties));
 
     for (auto& [name, func] : System::lib)
     {

--- a/lute/system/src/system.cpp
+++ b/lute/system/src/system.cpp
@@ -132,7 +132,7 @@ int lua_tmpdir(lua_State* L)
 }
 } // namespace libsystem
 
-static const std::string properties[] = {
+const char* const System::properties[] = {
     libsystem::kArchitectureProperty,
     libsystem::kOperatingSystemProperty,
 };

--- a/lute/task/include/lute/task.h
+++ b/lute/task/include/lute/task.h
@@ -15,4 +15,5 @@ struct Task : LuteLibrary<Task>
     static constexpr const char kName[] = "task";
     static int pushLibrary(lua_State* L);
     static const luaL_Reg lib[];
+    static const char* const properties[];
 };

--- a/lute/task/include/lute/task.h
+++ b/lute/task/include/lute/task.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "lute/library.h"
+
 #include "lua.h"
 #include "lualib.h"
 
@@ -8,24 +10,9 @@ int luaopen_task(lua_State* L);
 // open the library as a table on top of the stack
 int luteopen_task(lua_State* L);
 
-namespace task
+struct Task : LuteLibrary<Task>
 {
-
-int lua_defer(lua_State* L);
-int lua_deferSelf(lua_State* L);
-int lua_wait(lua_State* L);
-int lua_spawn(lua_State* L);
-int lute_resume(lua_State* L);
-int lua_delay(lua_State* L);
-
-static const luaL_Reg lib[] = {
-    {"spawn", lua_spawn},
-    {"defer", lua_defer},
-    {"resume", lute_resume},
-    {"deferSelf", lua_deferSelf},
-    {"wait", lua_wait},
-    {"delay", lua_delay},
-    {nullptr, nullptr},
+    static constexpr const char kName[] = "task";
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
 };
-
-} // namespace task

--- a/lute/task/src/task.cpp
+++ b/lute/task/src/task.cpp
@@ -89,7 +89,7 @@ static void yieldLuaStateFor(lua_State* L, uint64_t milliseconds, bool putDeltaT
     );
 }
 
-namespace task
+namespace
 {
 
 struct LuaThread
@@ -309,20 +309,23 @@ int lua_wait(lua_State* L)
     return lua_yield(L, 0);
 }
 
-} // namespace task
+} // anonymous namespace
 
-int luaopen_task(lua_State* L)
+const luaL_Reg Task::lib[] = {
+    {"spawn", lua_spawn},
+    {"defer", lua_defer},
+    {"resume", lute_resume},
+    {"deferSelf", lua_deferSelf},
+    {"wait", lua_wait},
+    {"delay", lua_delay},
+    {nullptr, nullptr},
+};
+
+int Task::pushLibrary(lua_State* L)
 {
-    luaL_register(L, "task", task::lib);
+    lua_createtable(L, 0, std::size(Task::lib));
 
-    return 1;
-}
-
-int luteopen_task(lua_State* L)
-{
-    lua_createtable(L, 0, std::size(task::lib));
-
-    for (auto& [name, func] : task::lib)
+    for (auto& [name, func] : Task::lib)
     {
         if (!name || !func)
             break;
@@ -334,4 +337,14 @@ int luteopen_task(lua_State* L)
     lua_setreadonly(L, -1, 1);
 
     return 1;
+}
+
+int luaopen_task(lua_State* L)
+{
+    return Task::openAsGlobal(L);
+}
+
+int luteopen_task(lua_State* L)
+{
+    return Task::pushLibrary(L);
 }

--- a/lute/task/src/task.cpp
+++ b/lute/task/src/task.cpp
@@ -311,6 +311,8 @@ int lua_wait(lua_State* L)
 
 } // anonymous namespace
 
+const char* const Task::properties[] = {};
+
 const luaL_Reg Task::lib[] = {
     {"spawn", lua_spawn},
     {"defer", lua_defer},

--- a/lute/task/src/task.cpp
+++ b/lute/task/src/task.cpp
@@ -311,7 +311,7 @@ int lua_wait(lua_State* L)
 
 } // anonymous namespace
 
-const char* const Task::properties[] = {};
+const char* const Task::properties[] = {nullptr};
 
 const luaL_Reg Task::lib[] = {
     {"spawn", lua_spawn},

--- a/lute/time/include/lute/time.h
+++ b/lute/time/include/lute/time.h
@@ -57,4 +57,5 @@ struct Time : LuteLibrary<Time>
     static constexpr const char kName[] = "time";
     static int pushLibrary(lua_State* L);
     static const luaL_Reg lib[];
+    static const char* const properties[];
 };

--- a/lute/time/include/lute/time.h
+++ b/lute/time/include/lute/time.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "lute/library.h"
+
 #include "lua.h"
 #include "lualib.h"
 
@@ -50,20 +52,9 @@ static const luaL_Reg lib[] = {
 
 } // namespace duration
 
-namespace libtime
+struct Time : LuteLibrary<Time>
 {
-int lua_now(lua_State* L);
-int lua_since(lua_State* L);
-
-static const luaL_Reg lib[] = {
-    {"now", lua_now},
-    {"since", lua_since},
-
-    {nullptr, nullptr},
+    static constexpr const char kName[] = "time";
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
 };
-
-static const std::string properties[] = {
-    kDurationLibraryIdentifier,
-};
-
-} // namespace libtime

--- a/lute/time/src/time.cpp
+++ b/lute/time/src/time.cpp
@@ -600,7 +600,7 @@ int Time::pushLibrary(lua_State* L)
 {
     init_luau_lib(L);
 
-    lua_createtable(L, 0, std::size(Time::lib) + std::size(properties));
+    lua_createtable(L, 0, std::size(Time::lib) + std::size(Time::properties));
 
     // Duration sub-table
     lua_createtable(L, 0, std::size(duration::lib));

--- a/lute/time/src/time.cpp
+++ b/lute/time/src/time.cpp
@@ -434,9 +434,7 @@ int lua_weeks(lua_State* L)
 
 } // namespace duration
 
-namespace libtime
-{
-int lua_now(lua_State* L)
+static int lua_now(lua_State* L)
 {
     uv_timespec64_t now;
 
@@ -453,12 +451,11 @@ int lua_now(lua_State* L)
     return 1;
 }
 
-int lua_since(lua_State* L)
+static int lua_since(lua_State* L)
 {
     lua_pushnumber(L, sinceTimespec(getTimespecFromInstant(L, 1)));
     return 1;
 }
-} // namespace libtime
 
 static void init_duration_lib(lua_State* L)
 {
@@ -532,13 +529,13 @@ static void init_duration_lib(lua_State* L)
     lua_pushcfunction(L, duration_subsecmillis, "Duration__subsecmillis");
     lua_setfield(L, -2, "subsecmillis");
 
-    lua_setreadonly(L, -1, true);
+    lua_setreadonly(L, -1, 1);
 
     // set __index
     lua_setfield(L, -2, "__index");
 
     // metatable is now in stack spot 1
-    lua_setreadonly(L, -1, true);
+    lua_setreadonly(L, -1, 1);
 
     lua_pop(L, 1);
 }
@@ -573,12 +570,12 @@ static void init_instant_lib(lua_State* L)
     lua_pushcfunction(L, instant_elapsed, "Instant__elapsed");
     lua_setfield(L, -2, "elapsed");
 
-    lua_setreadonly(L, -1, true);
+    lua_setreadonly(L, -1, 1);
 
     // __index set
     lua_setfield(L, -2, "__index");
 
-    lua_setreadonly(L, -1, true);
+    lua_setreadonly(L, -1, 1);
 
     lua_pop(L, 1);
 }
@@ -591,21 +588,19 @@ static int init_luau_lib(lua_State* L)
     return 0;
 }
 
-int luaopen_time(lua_State* L)
+static const std::string properties[] = {kDurationLibraryIdentifier};
+
+const luaL_Reg Time::lib[] = {
+    {"now", lua_now},
+    {"since", lua_since},
+    {nullptr, nullptr},
+};
+
+int Time::pushLibrary(lua_State* L)
 {
     init_luau_lib(L);
 
-    luaL_register(L, "time", libtime::lib);
-    lua_setglobal(L, "time");
-
-    return 1;
-}
-
-int luteopen_time(lua_State* L)
-{
-    init_luau_lib(L);
-
-    lua_createtable(L, 0, std::size(libtime::lib) + std::size(libtime::properties));
+    lua_createtable(L, 0, std::size(Time::lib) + std::size(properties));
 
     // Duration sub-table
     lua_createtable(L, 0, std::size(duration::lib));
@@ -619,8 +614,7 @@ int luteopen_time(lua_State* L)
     }
     lua_setfield(L, -2, kDurationLibraryIdentifier);
 
-    // Main time library
-    for (auto& [name, func] : libtime::lib)
+    for (auto& [name, func] : Time::lib)
     {
         if (!name || !func)
             break;
@@ -632,4 +626,14 @@ int luteopen_time(lua_State* L)
     lua_setreadonly(L, -1, 1);
 
     return 1;
+}
+
+int luaopen_time(lua_State* L)
+{
+    return Time::openAsGlobal(L);
+}
+
+int luteopen_time(lua_State* L)
+{
+    return Time::pushLibrary(L);
 }

--- a/lute/time/src/time.cpp
+++ b/lute/time/src/time.cpp
@@ -588,7 +588,7 @@ static int init_luau_lib(lua_State* L)
     return 0;
 }
 
-static const std::string properties[] = {kDurationLibraryIdentifier};
+const char* const Time::properties[] = {kDurationLibraryIdentifier};
 
 const luaL_Reg Time::lib[] = {
     {"now", lua_now},

--- a/lute/vm/include/lute/spawn.h
+++ b/lute/vm/include/lute/spawn.h
@@ -1,10 +1,3 @@
 #pragma once
 
-struct lua_State;
-
-namespace vm
-{
-
-int lua_spawn(lua_State* L);
-
-} // namespace vm
+#include "lute/vm.h"

--- a/lute/vm/include/lute/vm.h
+++ b/lute/vm/include/lute/vm.h
@@ -16,4 +16,5 @@ struct VM : LuteLibrary<VM>
     static int lua_spawn(lua_State* L);
     static int pushLibrary(lua_State* L);
     static const luaL_Reg lib[];
+    static const char* const properties[];
 };

--- a/lute/vm/include/lute/vm.h
+++ b/lute/vm/include/lute/vm.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "lute/spawn.h"
+#include "lute/library.h"
 
 #include "lua.h"
 #include "lualib.h"
@@ -10,14 +10,10 @@ int luaopen_vm(lua_State* L);
 // open the library as a table on top of the stack
 int luteopen_vm(lua_State* L);
 
-namespace vm
+struct VM : LuteLibrary<VM>
 {
-
-int lua_defer(lua_State* L);
-
-static const luaL_Reg lib[] = {
-    {"create", lua_spawn},
-    {nullptr, nullptr},
+    static constexpr const char kName[] = "vm";
+    static int lua_spawn(lua_State* L);
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
 };
-
-} // namespace vm

--- a/lute/vm/src/spawn.cpp
+++ b/lute/vm/src/spawn.cpp
@@ -1,4 +1,4 @@
-#include "lute/spawn.h"
+#include "lute/vm.h"
 
 #include "lute/ref.h"
 #include "lute/require.h"
@@ -169,9 +169,6 @@ static int crossVmMarshallCont(lua_State* L, int status)
     return 0;
 }
 
-namespace vm
-{
-
 static void* createChildVmRequireContext(lua_State* L)
 {
     void* ctx = lua_newuserdatadtor(
@@ -197,7 +194,7 @@ static void* createChildVmRequireContext(lua_State* L)
     return ctx;
 }
 
-int lua_spawn(lua_State* L)
+int VM::lua_spawn(lua_State* L)
 {
     const char* file = luaL_checkstring(L, 1);
 
@@ -293,5 +290,3 @@ int lua_spawn(lua_State* L)
 
     return 1;
 }
-
-} // namespace vm

--- a/lute/vm/src/vm.cpp
+++ b/lute/vm/src/vm.cpp
@@ -2,7 +2,7 @@
 
 #include "lute/runtime.h"
 
-const char* const VM::properties[] = {};
+const char* const VM::properties[] = {nullptr};
 
 const luaL_Reg VM::lib[] = {
     {"create", VM::lua_spawn},

--- a/lute/vm/src/vm.cpp
+++ b/lute/vm/src/vm.cpp
@@ -2,18 +2,16 @@
 
 #include "lute/runtime.h"
 
-int luaopen_vm(lua_State* L)
+const luaL_Reg VM::lib[] = {
+    {"create", VM::lua_spawn},
+    {nullptr, nullptr},
+};
+
+int VM::pushLibrary(lua_State* L)
 {
-    luaL_register(L, "vm", vm::lib);
+    lua_createtable(L, 0, std::size(VM::lib));
 
-    return 1;
-}
-
-int luteopen_vm(lua_State* L)
-{
-    lua_createtable(L, 0, std::size(vm::lib));
-
-    for (auto& [name, func] : vm::lib)
+    for (auto& [name, func] : VM::lib)
     {
         if (!name || !func)
             break;
@@ -25,4 +23,14 @@ int luteopen_vm(lua_State* L)
     lua_setreadonly(L, -1, 1);
 
     return 1;
+}
+
+int luaopen_vm(lua_State* L)
+{
+    return VM::openAsGlobal(L);
+}
+
+int luteopen_vm(lua_State* L)
+{
+    return VM::pushLibrary(L);
 }

--- a/lute/vm/src/vm.cpp
+++ b/lute/vm/src/vm.cpp
@@ -2,6 +2,8 @@
 
 #include "lute/runtime.h"
 
+const char* const VM::properties[] = {};
+
 const luaL_Reg VM::lib[] = {
     {"create", VM::lua_spawn},
     {nullptr, nullptr},


### PR DESCRIPTION
There's a lot of inconsistency between the different runtime library definitions, and it's bothered me for a while. To try to make things more structured, this PR introduces a shared interface `LuteLibrary` and refactors each library namespace to instead be a `struct` that implements that `LuteLibrary` interface. The goal here is to make it more difficult to author a library that isn't structured how we would expect, and to bring all of the existing libraries into that uniform structure.

---

I'm not necessarily 100% convinced that this is worth it, but I think it came together well enough that I want to solicit other opinions on it. Does this look and feel better to work on going forward? It definitely looks to make headers, especially, a lot more uniform. The static_asserts in particular are a bit janky, but it seems arguably nicer than the alternative of doing an abstract class with all of these fields virtual.