### PR TITLE
Sets up a release job for Lute

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["primary"]
+    branches: ["primary", "release/**"]
   pull_request:
     branches: ["primary"]
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,59 @@
+name: Nightly Release
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes since last nightly tag
+        id: check
+        run: |
+          PROCEED="true"
+
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "Schedule trigger: Checking changes..."
+
+            LATEST_NIGHTLY_TAG=$(git tag --sort=-creatordate --list '*-nightly.*' | head -n 1)
+
+            if [[ -n "$LATEST_NIGHTLY_TAG" ]]; then
+              echo "Latest nightly tag found: $LATEST_NIGHTLY_TAG"
+              LATEST_NIGHTLY_COMMIT=$(git rev-list -n 1 "$LATEST_NIGHTLY_TAG" 2>/dev/null)
+              CURRENT_HEAD_COMMIT=$(git rev-parse HEAD)
+
+              echo "Commit for tag $LATEST_NIGHTLY_TAG: $LATEST_NIGHTLY_COMMIT"
+              echo "Current HEAD commit: $CURRENT_HEAD_COMMIT"
+
+              if [[ "$LATEST_NIGHTLY_COMMIT" == "$CURRENT_HEAD_COMMIT" ]]; then
+                echo "No code changes detected since the last nightly release ($LATEST_NIGHTLY_TAG)."
+                PROCEED="false"
+              else
+                echo "Code changes detected since $LATEST_NIGHTLY_TAG. Proceeding with build."
+              fi
+            else
+              echo "No previous nightly tag found. Proceeding with build."
+            fi
+          else
+            echo "Manual trigger. Proceeding with build."
+          fi
+
+          echo "proceed=$PROCEED" >> $GITHUB_OUTPUT
+
+  build-and-release:
+    needs: changes
+    if: ${{ needs.changes.outputs.proceed == 'true' }}
+    uses: ./.github/workflows/shared-build.yml
+    with:
+      branch: primary
+    secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,7 +50,7 @@ jobs:
 
           echo "proceed=$PROCEED" >> $GITHUB_OUTPUT
 
-  build-and-release:
+  release-common:
     needs: changes
     if: ${{ needs.changes.outputs.proceed == 'true' }}
     uses: ./.github/workflows/shared-build.yml

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -1,4 +1,4 @@
-name: _shared_release
+name: release-common
 
 on:
   workflow_call:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,188 +1,26 @@
-name: Build and Release
+name: Release
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
   workflow_dispatch:
-    inputs:
-      nightly:
-        description: "Trigger a nightly build"
-        required: false
-        default: false
-        type: boolean
 
 jobs:
-  check:
+  validate:
     runs-on: ubuntu-latest
-    outputs:
-      proceed: ${{ steps.check.outputs.proceed }}
-      nightly_tag: ${{ steps.set_nightly.outputs.nightly_tag }}
-    permissions:
-      contents: read
 
     steps:
-      - name: Validate CI status
+      - name: Validate branch format
         run: |
-          LAST_STATUS=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/luau-lang/lute/actions/workflows/ci.yml/runs?branch=primary&status=completed&per_page=1" \
-            | jq -r '.workflow_runs[0].conclusion')
+          BRANCH="${{ github.ref_name }}"
 
-          if [[ "$LAST_STATUS" != "success" ]]; then
-            echo "The latest CI run on 'primary' branch did not succeed. Aborting release."
+          if [[ ! "$BRANCH" =~ ^release/v[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "Invalid branch format: $BRANCH. Expected release/v{Major}.{Minor}.x"
+            echo "Dispatch this workflow on a release branch (e.g. release/v0.1.x)"
             exit 1
           fi
 
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check for changes since last nightly tag
-        id: check
-        run: |
-          PROCEED="true"
-
-          if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            echo "Schedule trigger: Checking changes..."
-
-            LATEST_NIGHTLY_TAG=$(git tag --sort=-creatordate --list '*-nightly.*' | head -n 1)
-
-            if [[ -n "$LATEST_NIGHTLY_TAG" ]]; then
-              echo "Latest nightly tag found: $LATEST_NIGHTLY_TAG"
-              LATEST_NIGHTLY_COMMIT=$(git rev-list -n 1 "$LATEST_NIGHTLY_TAG" 2>/dev/null)
-              CURRENT_HEAD_COMMIT=$(git rev-parse HEAD)
-
-              echo "Commit for tag $LATEST_NIGHTLY_TAG: $LATEST_NIGHTLY_COMMIT"
-              echo "Current HEAD commit: $CURRENT_HEAD_COMMIT"
-
-              if [[ "$LATEST_NIGHTLY_COMMIT" == "$CURRENT_HEAD_COMMIT" ]]; then
-                echo "No code changes detected since the last nightly release ($LATEST_NIGHTLY_TAG)."
-                PROCEED="false"
-              else
-                echo "Code changes detected since $LATEST_NIGHTLY_TAG. Proceeding with build."
-              fi
-            else
-              echo "No previous nightly tag found. Proceeding with build."
-            fi
-          else
-            echo "Manual trigger ('${{ github.event_name }}'). Proceeding with build."
-          fi
-
-          echo "proceed=$PROCEED" >> $GITHUB_OUTPUT
-
-      - name: Set nightly version suffix
-        id: set_nightly
-        if: github.event_name == 'schedule' || github.event.inputs.nightly
-        run: |
-          DATE=$(date +%Y%m%d)
-          echo "nightly_tag=nightly.$DATE" >> "$GITHUB_OUTPUT"
-
-  build:
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            artifact_name: lute-linux-x86_64
-            options: --c-compiler clang --cxx-compiler clang++
-          - os: ubuntu-22.04-arm
-            artifact_name: lute-linux-aarch64
-            options: --c-compiler clang --cxx-compiler clang++
-            use-bootstrap: true
-          - os: macos-latest
-            artifact_name: lute-macos-aarch64
-          - os: windows-latest
-            artifact_name: lute-windows-x86_64
-      fail-fast: false
-
-    needs: check
-    if: ${{ needs.check.outputs.proceed == 'true' }}
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      # Used for lute --version
-      - name: Set nightly version suffix
-        if: needs.check.outputs.nightly_tag
-        run: echo "LUTE_VERSION_SUFFIX=${{ needs.check.outputs.nightly_tag }}" >> "$GITHUB_ENV"
-
-      - name: Setup and Build Lute
-        id: build_lute
-        uses: ./.github/actions/setup-and-build
-        with:
-          target: Lute.CLI
-          config: release
-          options: ${{ matrix.options }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          use-bootstrap: ${{ matrix.use-bootstrap || 'false' }}
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          path: ${{ steps.build_lute.outputs.exe_path }}
-          name: ${{ matrix.artifact_name }}
-
-  release:
-    needs: [check, build]
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: CMakeBuild/get_version.cmake
-
-      - name: Download Artifact
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - run: |
-          mkdir release
-          for dir in ./artifacts/*; do
-            base_name=$(basename "$dir")
-            chmod 755 "$dir"/* # Artifacts don't preserve permissions, so re-add them.
-            zip -rj release/"${base_name}.zip" "$dir"/*
-          done
-
-      - name: Get project version
-        id: get_version
-        run: |
-          VERSION=$(cmake -P CMakeBuild/get_version.cmake 2>&1)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Create Nightly Tag
-        id: tag_step
-        if: needs.check.outputs.nightly_tag
-        run: |
-          echo "tag=-${{ needs.check.outputs.nightly_tag }}" >> $GITHUB_OUTPUT
-
-      - name: Create Release Tag
-        id: tag_release
-        run: |
-          VERSION=${{ steps.get_version.outputs.version }}
-          NIGHTLY_TAG=${{ steps.tag_step.outputs.tag }}
-          RELEASE_TAG="$VERSION$NIGHTLY_TAG"
-          echo "tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
-
-      - name: Create Draft Release
-        uses: luau-lang/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.tag_release.outputs.tag }}
-          name: ${{ steps.tag_release.outputs.tag }}
-          draft: true
-          prerelease: ${{ github.event.inputs.nightly || github.event_name == 'schedule' }}
-          generate_release_notes: true
-          files: release/*.zip
-
-      - name: Wait for Tag Creation in GitHub
-        run: sleep 5
-
-      - name: Publish Release
-        run: gh release edit "${{ steps.tag_release.outputs.tag }}" --draft=false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build-and-release:
+    needs: validate
+    uses: ./.github/workflows/shared-build.yml
+    with:
+      branch: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             exit 1
           fi
 
-  build-and-release:
+  release-common:
     needs: validate
     uses: ./.github/workflows/shared-build.yml
     with:

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -1,0 +1,140 @@
+name: _shared_release
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "Branch to use for the release. 'primary' triggers a nightly build."
+        required: false
+        default: "primary"
+        type: string
+
+env:
+  IS_NIGHTLY: ${{ inputs.branch == 'primary' }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Validate CI status
+        id: check
+        run: |
+          LAST_STATUS=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/luau-lang/lute/actions/workflows/ci.yml/runs?branch=${{ inputs.branch }}&status=completed&per_page=1" \
+            | jq -r '.workflow_runs[0].conclusion')
+          if [[ "$LAST_STATUS" != "success" ]]; then
+            echo "The latest CI run on '${{ inputs.branch }}' branch did not succeed. Aborting release."
+            exit 1
+          fi
+
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            artifact_name: lute-linux-x86_64
+            options: --c-compiler clang --cxx-compiler clang++
+          - os: ubuntu-22.04-arm
+            artifact_name: lute-linux-aarch64
+            options: --c-compiler clang --cxx-compiler clang++
+            use-bootstrap: true
+          - os: macos-latest
+            artifact_name: lute-macos-aarch64
+          - os: windows-latest
+            artifact_name: lute-windows-x86_64
+      fail-fast: false
+
+    needs: check
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Set nightly version suffix
+        if: ${{ env.IS_NIGHTLY == 'true' }}
+        run: echo "LUTE_VERSION_SUFFIX=nightly.$(date +%Y%m%d)" >> "$GITHUB_ENV"
+
+      - name: Setup and Build Lute
+        id: build_lute
+        uses: ./.github/actions/setup-and-build
+        with:
+          target: Lute.CLI
+          config: release
+          options: ${{ matrix.options }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          use-bootstrap: ${{ matrix.use-bootstrap || 'false' }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: ${{ steps.build_lute.outputs.exe_path }}
+          name: ${{ matrix.artifact_name }}
+
+  release:
+    needs: [check, build]
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+          sparse-checkout: CMakeBuild/get_version.cmake
+
+      - name: Set nightly version suffix
+        if: ${{ env.IS_NIGHTLY == 'true' }}
+        run: echo "LUTE_VERSION_SUFFIX=nightly.$(date +%Y%m%d)" >> "$GITHUB_ENV"
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - run: |
+          mkdir release
+          for dir in ./artifacts/*; do
+            base_name=$(basename "$dir")
+            chmod 755 "$dir"/* # Artifacts don't preserve permissions, so re-add them.
+            zip -rj release/"${base_name}.zip" "$dir"/*
+          done
+
+      - name: Get project version
+        id: get_version
+        run: |
+          VERSION=$(cmake -P CMakeBuild/get_version.cmake 2>&1)
+          echo "Resolved version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create release tag
+        id: tag_release
+        run: |
+          TAG="v${{ steps.get_version.outputs.version }}"
+          echo "Release tag: $TAG"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Create Draft Release
+        uses: luau-lang/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag_release.outputs.tag }}
+          name: ${{ steps.tag_release.outputs.tag }}
+          draft: true
+          prerelease: ${{ env.IS_NIGHTLY == 'true' }}
+          generate_release_notes: ${{ env.IS_NIGHTLY == 'true' }}
+          files: release/*.zip
+
+      - name: Wait for Tag Creation in GitHub
+        run: sleep 5
+
+      - name: Publish Release
+        run: gh release edit "${{ steps.tag_release.outputs.tag }}" --draft=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,15 +1,25 @@
 # Release Process
 
-Lute uses branches with the format: `release/v{Major}.{Minor}.x` to store changes associated with a given release.
-We tag commits with the format `v{Major}.{Minor}.{Patch}` to indicate that a commit should be build as that release version.
-Changes like security updates, hotfixes, etc, occur on these branches and go through the code review process in order to be merged.
-These release branches exist so that we can continue to support older versions of lute according to some currently unknown SLA, but continue
-development on the mainline branch. Release notes must be cut manually.
+Lute uses branches with the format: `release/v{Major}.{Minor}.x` to store
+changes associated with a given release. We tag commits on these branches with
+the format `v{Major}.{Minor}.{Patch}` to indicate that a commit should be build
+as that release version. These release branches exist so that we can continue to
+support older versions of lute according to some currently unknown SLA, but
+continue development on the primary branch. Release notes must be written
+manually.
 
+## Working on release branches
+As much as possible, we should avoid manually making changes to release
+branches, and prefer to develop directly to primary. If changes need to be
+applied to release branches (security vulnerabilities or hotfixes), we should
+cherry-pick those in as appropriate, only applying changes manually as a last
+resort.
 
 ## Cutting a release
-Cutting a release should be mostly automatic. Navigate to github.com/luau-lang/lute > actions > release. For this action, select a release branch 
-from the dropdown to cut the release from - it should start with `release/v{Major}.{Minor}.x`. 
+Cutting a release should be mostly automatic. Navigate to
+github.com/luau-lang/lute > actions > release. For this action, select a release
+branch from the dropdown to cut the release from - it should start with
+`release/v{Major}.{Minor}.x`. 
 
 This job will:
 1) Checkout the branch `release/v{Major}.{Minor}.x`.
@@ -21,6 +31,7 @@ This job will:
 You should add patch notes for this release manually.
 
 ## Nightly releases
-Nightlies can be scheduled or triggered manually. Patch notes will be automatically generated for nightlies.
+Nightlies can be scheduled or triggered manually. Patch notes will be
+automatically generated for nightlies.
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,26 @@
+# Release Process
+
+Lute uses branches with the format: `release/v{Major}.{Minor}.x` to store changes associated with a given release.
+We tag commits with the format `v{Major}.{Minor}.{Patch}` to indicate that a commit should be build as that release version.
+Changes like security updates, hotfixes, etc, occur on these branches and go through the code review process in order to be merged.
+These release branches exist so that we can continue to support older versions of lute according to some currently unknown SLA, but continue
+development on the mainline branch. Release notes must be cut manually.
+
+
+## Cutting a release
+Cutting a release should be mostly automatic. Navigate to github.com/luau-lang/lute > actions > release. For this action, select a release branch 
+from the dropdown to cut the release from - it should start with `release/v{Major}.{Minor}.x`. 
+
+This job will:
+1) Checkout the branch `release/v{Major}.{Minor}.x`.
+2) Ensure that this branch passes all status checks
+3) Derive a tag in the format `v{Major}.{Minor}.{Patch}`
+4) Build `lute` for a bunch of different platforms
+5) Create a draft release with the artifacts built in 4)
+
+You should add patch notes for this release manually.
+
+## Nightly releases
+Nightlies can be scheduled or triggered manually. Patch notes will be automatically generated for nightlies.
+
+


### PR DESCRIPTION
The job that will be used for automating releases and the job that will be used for nightlies share a lot of common actions. This PR separates the common chunk out into a re-usable workflow, called shared-build which is parameterized on the branch name.

1) Nightlies can be manually kicked off, but will continue to run with the current cadence. These will automatically run of the 'primary' branch.
2) Releases will be kicked off on release/v{Major}.{Minor}.x branches. 

In both cases the job will check out the branch and derive the tag name directly from the get_version.cmake command. If the branch is primary, we'll get 'nightly.YYYMMDD' appended.