### PR TITLE
Fixes vitepress excluding test/ dir in doc generation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -27,6 +27,6 @@ export default withSidebar(
     hyphenToSpace: true,
     sortMenusByFrontmatterOrder: true,
     frontmatterOrderDefaultValue: 100,
-    excludeByGlobPattern: ['**/test/**', 'README.md'],
+    excludeByGlobPattern: ['README.md'],
   }
 )


### PR DESCRIPTION
previously had some test files here in `docs/` that we wanted to ignore, but those have been moved and excluding `/test/` caused our `std/test` doc files and the CLI docs for `test` to not get generated

`@std/test` is now being generated
<img width="224" height="228" alt="image" src="https://github.com/user-attachments/assets/4bf18b89-3d36-4ed3-bede-9f61a8ab63d0" />

same with CLI test docs
<img width="124" height="103" alt="image" src="https://github.com/user-attachments/assets/a2bf5fcf-99c7-4191-a756-5ee48f6b5c4f" />

ty @Vighnesh-V for the catch!