### PR TITLE
`@std/task`: fix documentation generation by renaming `taskLib` to `task`

### DIFF
--- a/lute/std/libs/task.luau
+++ b/lute/std/libs/task.luau
@@ -5,31 +5,31 @@
 
 local lutetask = require("@lute/task")
 
-local taskLib = {}
+local task = {}
 
 --- Schedules `routine` to run immediately on the next resumption cycle, passing any additional arguments to it. Returns the thread.
-function taskLib.spawn<T..., U...>(routine: ((T...) -> U...) | thread, ...: T...): thread
+function task.spawn<T..., U...>(routine: ((T...) -> U...) | thread, ...: T...): thread
 	return lutetask.spawn(routine, ...)
 end
 
 --- Schedules `routine` to run after the current thread yields, passing any additional arguments to it. Returns the thread.
-function taskLib.defer<T..., U...>(routine: ((T...) -> U...) | thread, ...: T...): thread
+function task.defer<T..., U...>(routine: ((T...) -> U...) | thread, ...: T...): thread
 	return lutetask.defer(routine, ...)
 end
 
 --- Schedules `routine` to run after `dur` seconds, passing any additional arguments to it. Returns the thread.
-function taskLib.delay<T..., U...>(dur: number, routine: ((T...) -> U...) | thread, ...: T...): thread
+function task.delay<T..., U...>(dur: number, routine: ((T...) -> U...) | thread, ...: T...): thread
 	return lutetask.delay(dur, routine, ...)
 end
 
 --- Yields the current thread for `dur` seconds (or until the next cycle if `dur` is omitted). Returns the actual time waited.
-function taskLib.wait(dur: number?): number
+function task.wait(dur: number?): number
 	return lutetask.wait(dur)
 end
 
 --- Cancels `thread`, preventing it from being resumed again.
-function taskLib.cancel(thread: thread)
+function task.cancel(thread: thread)
 	coroutine.close(thread)
 end
 
-return table.freeze(taskLib)
+return table.freeze(task)


### PR DESCRIPTION
The documentation generation for `@std/task` is broken, and I believe it is because the table is named `taskLib` and not `task`. We can fix this trivially by renaming it, and that's honestly worth for consistency doing even if it didn't fix the documentation.