### PR TITLE
Fixes the nightly and release jobs to point to the correct file

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
   release-common:
     needs: changes
     if: ${{ needs.changes.outputs.proceed == 'true' }}
-    uses: ./.github/workflows/shared-build.yml
+    uses: ./.github/workflows/release-common.yml
     with:
       branch: primary
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
   release-common:
     needs: validate
-    uses: ./.github/workflows/shared-build.yml
+    uses: ./.github/workflows/release-common.yml
     with:
       branch: ${{ github.ref_name }}
     secrets: inherit


### PR DESCRIPTION
I updated the name of the build job in the previous PR, but not the path to the actual workflow file. 