### PR TITLE
Fixes invalid yaml in nightly job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,6 +53,8 @@ jobs:
   release-common:
     needs: changes
     if: ${{ needs.changes.outputs.proceed == 'true' }}
+    permissions:
+      contents: write
     uses: ./.github/workflows/release-common.yml
     with:
       branch: primary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,8 @@ jobs:
 
   release-common:
     needs: validate
+    permissions:
+      contents: write
     uses: ./.github/workflows/release-common.yml
     with:
       branch: ${{ github.ref_name }}


### PR DESCRIPTION
The nightly job didn't set any permissions, so the release job in release-common inherits default read permissions.