### PR TITLE
Improve net.request errors

### DIFF
--- a/lute/net/src/client.cpp
+++ b/lute/net/src/client.cpp
@@ -84,9 +84,11 @@ static CurlResponse requestData(
 
     std::vector<char> data;
     curl_slist* headerList = nullptr;
+    char errorBuffer[CURL_ERROR_SIZE] = {};
 
     curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errorBuffer);
 
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeFunction);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &data);
@@ -118,7 +120,7 @@ static CurlResponse requestData(
 
     if (res != CURLE_OK)
     {
-        resp.error = curl_easy_strerror(res);
+        resp.error = errorBuffer[0] != '\0' ? errorBuffer : curl_easy_strerror(res);
         curl_easy_cleanup(curl);
         return resp;
     }


### PR DESCRIPTION
`curl_easy_strerror` just turns the `CURLcode` into fixed string based on the enum. `CURLOPT_ERRORBUFFER` will give us a more contextual error for the user, however, it can fail sometimes, so there's a fallback to still use `curl_easy_strerror` in case it's empty.

```luau
net.request("asdf")
```

before:
`network request failed: Could not resolve hostname`

after:
`network request failed: Could not resolve host: asdf`