### PR TITLE
`@lute/process`: implement stdin support for default and inherit stdio kinds.

### DIFF
--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -42,6 +42,7 @@ void convertCRLFtoLF(std::string& str)
 struct ProcessHandle
 {
     uv_process_t process;
+    uv_pipe_t stdinPipe;
     uv_pipe_t stdoutPipe;
     uv_pipe_t stderrPipe;
     uv_loop_t* loop = nullptr;
@@ -65,12 +66,20 @@ struct ProcessHandle
             }
         };
 
+        if (!uv_is_closing((uv_handle_t*)&stdinPipe))
+        {
+            pendingCloses++;
+            uv_read_stop((uv_stream_t*)&stdinPipe);
+            uv_close((uv_handle_t*)&stdinPipe, closeCb);
+        }
+
         if (!uv_is_closing((uv_handle_t*)&stdoutPipe))
         {
             pendingCloses++;
             uv_read_stop((uv_stream_t*)&stdoutPipe);
             uv_close((uv_handle_t*)&stdoutPipe, closeCb);
         }
+
         if (!uv_is_closing((uv_handle_t*)&stderrPipe))
         {
             pendingCloses++;
@@ -106,6 +115,7 @@ struct ProcessHandle
         {
             int64_t finalExitCode = exitCode;
             int finalTermSignal = termSignal;
+            // TODO: should we we put any leftover stdin data into the output here?
             std::string finalStdout = stdoutData;
             std::string finalStderr = stderrData;
             std::string finalSignalStr = finalTermSignal ? std::to_string(finalTermSignal) : "";
@@ -283,19 +293,22 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
         options.cwd = opts.cwd.c_str();
     }
 
+    uv_pipe_init(handle->loop, &handle->stdinPipe, 0);
     uv_pipe_init(handle->loop, &handle->stdoutPipe, 0);
     uv_pipe_init(handle->loop, &handle->stderrPipe, 0);
 
     options.stdio_count = 3;
     uv_stdio_container_t stdio[3];
-    stdio[0].flags = UV_IGNORE;
     if (opts.stdioKind == kStdioKindNone)
     {
+        stdio[0].flags = UV_IGNORE;
         stdio[1].flags = UV_IGNORE;
         stdio[2].flags = UV_IGNORE;
     }
     else if (opts.stdioKind == kStdioKindInherit)
     {
+        stdio[0].flags = UV_INHERIT_FD;
+        stdio[0].data.fd = fileno(stdin);
         stdio[1].flags = UV_INHERIT_FD;
         stdio[1].data.fd = fileno(stdout);
         stdio[2].flags = UV_INHERIT_FD;
@@ -303,6 +316,8 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
     }
     else if (opts.stdioKind == kStdioKindDefault || opts.stdioKind.empty())
     {
+        stdio[0].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
+        stdio[0].data.stream = (uv_stream_t*)&handle->stdinPipe;
         stdio[1].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
         stdio[1].data.stream = (uv_stream_t*)&handle->stdoutPipe;
         stdio[2].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
@@ -315,6 +330,7 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
     options.stdio = stdio;
 
     handle->process.data = handle.get();
+    handle->stdinPipe.data = handle.get();
     handle->stdoutPipe.data = handle.get();
     handle->stderrPipe.data = handle.get();
 

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -316,7 +316,7 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
     }
     else if (opts.stdioKind == kStdioKindDefault || opts.stdioKind.empty())
     {
-        stdio[0].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
+        stdio[0].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_READABLE_PIPE);
         stdio[0].data.stream = (uv_stream_t*)&handle->stdinPipe;
         stdio[1].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
         stdio[1].data.stream = (uv_stream_t*)&handle->stdoutPipe;


### PR DESCRIPTION
I went on a wild goose chase for a few days thinking there was something wrong with `io.read` where it seemed like it was closing the file descriptor for `stdin` on the first read call, and subsequent calls would break. It turns out the actual underlying issue is that I'm always invoking my local version of `lute` by doing a `luthier run` call, and this revealed an issue with the process library itself: we were always setting `stdio` to `UV_IGNORE` meaning we were always closing out the stdin handle for subprocesses, regardless of stdio kind setting. This resulted in a simple program that takes an input giving EOF with any invocation through a `luthier` executed copy of `lute`. The fix is straightforward, we should set up the `0` fd, not just `1` and `2`, in our process library.