### PR TITLE
Fix docs gen

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,4 +11,4 @@ The terminal output should then tell you which `localhost` port the docsite is r
 
 ## Regenerating documentation files
 
-If you want to regenerate the documentation files in `docs/reference`, you will need to run `<path-to-lute> doc -o ./ ../definitions ../lute/std/libs` from the `docs` folder using a version of `lute` which supports `lute doc`.
+Run `npm run gen` from the `docs` folder to regenerate the reference content in `docs/std` and `docs/lute`. This uses `docgen.luau`, which maps `../lute/std/libs` to `docs/std` and `../definitions` to `docs/lute`.

--- a/docs/docgen.luau
+++ b/docs/docgen.luau
@@ -1,4 +1,4 @@
 return {
-	["../lute/std/libs"] = { alias = "@std", destination = "std" },
-	["../definitions"] = { alias = "@lute", destination = "lute" },
+	["../lute/std/libs"] = { alias = "std", destination = "std" },
+	["../definitions"] = { alias = "lute", destination = "lute" },
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ hero:
       link: /guide/installation
     - theme: alt
       text: Reference
-      link: /reference/lute/crypto
+      link: /std
 
 # TODO: add buzz words
 # features:

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,3 +1,3 @@
 [tools]
 stylua = { github = "JohnnyMorganz/StyLua", version = "2.4.0" }
-lute = { github = "luau-lang/lute", version = "=0.1.0-nightly.20260409" }
+lute = { github = "luau-lang/lute", version = "=0.1.0-nightly.20260415" }

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,3 +1,3 @@
 [tools]
 stylua = "JohnnyMorganz/StyLua@2.4.0"
-lute = "luau-lang/lute@0.1.0-nightly.20260409"
+lute = "luau-lang/lute@0.1.0-nightly.20260415"


### PR DESCRIPTION
Removes double `@` in docs pages, upgrades lute for the docs gen step, and updates the readme.

I'd like to see the module table get revived at some point since it's missing with this new mapping. Maybe we could have lute doc append a generated table to an existing index.md if it exists or something? Or we could define a human name for the alias in the mapping file?