### PR TITLE
@lute/io: implement `io.write` to write to stdout

### DIFF
--- a/definitions/io.luau
+++ b/definitions/io.luau
@@ -1,5 +1,9 @@
 local io = {}
 
+function io.write(...: string): ()
+	error("unimplemented")
+end
+
 function io.read(): string
 	error("unimplemented")
 end

--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -1,7 +1,6 @@
 #include "lute/io.h"
 
 #include "lute/runtime.h"
-#include "lute/UVRequest.h"
 
 #include "Luau/Variant.h"
 
@@ -80,49 +79,53 @@ static void onTtyRead(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
     handle->closeHandles();
 }
 
-struct IOWrite : uvutils::UVRequest<uv_fs_t>
+struct IOWriteHandle
 {
-    IOWrite(lua_State* L, const char* buf, size_t len)
-        : UVRequest(L)
-        , data(buf, buf + len)
-        , offset(0)
+    Luau::Variant<uv_pipe_t, uv_tty_t> streamVariant;
+    uv_loop_t* loop = nullptr;
+    ResumeToken resumeToken;
+    std::shared_ptr<IOWriteHandle> self;
+    std::vector<char> data;
+    uv_write_t writeReq;
+    uv_buf_t iov;
+
+    void closeHandle()
     {
+        auto closeCb = [](uv_handle_t* handle)
+        {
+            IOWriteHandle* ioh = static_cast<IOWriteHandle*>(handle->data);
+            ioh->self.reset();
+        };
+        uv_close((uv_handle_t*)getStream(), closeCb);
     }
 
-    static void writeCallback(uv_fs_t* req);
-
-    std::vector<char> data;
-    uv_buf_t iov;
-    size_t offset;
+    uv_stream_t* getStream()
+    {
+        return Luau::visit(
+            [](auto& stream) -> uv_stream_t*
+            {
+                return (uv_stream_t*)&stream;
+            },
+            streamVariant
+        );
+    }
 };
 
-void IOWrite::writeCallback(uv_fs_t* req)
+static void onWrite(uv_write_t* req, int status)
 {
-    auto w = uvutils::retake<IOWrite>(req);
-    auto bytesWritten = req->result;
+    IOWriteHandle* handle = static_cast<IOWriteHandle*>(req->data);
 
-    if (bytesWritten < 0)
-    {
-        w->fail("Error writing to stdout: %s", uv_strerror(bytesWritten));
-        return;
-    }
-
-    w->offset += bytesWritten;
-    if (w->offset >= w->data.size())
-    {
-        w->succeed(
+    if (status < 0)
+        handle->resumeToken->fail(uv_strerror(status));
+    else
+        handle->resumeToken->complete(
             [](lua_State* L)
             {
                 return 0;
             }
         );
-        return;
-    }
 
-    // Partial write — write the remainder
-    w->iov = uv_buf_init(w->data.data() + w->offset, w->data.size() - w->offset);
-    uvutils::ScopedUVRequest<IOWrite> scopedReq{std::move(w)};
-    uv_fs_write(scopedReq->getLoop(), &scopedReq->req, fileno(stdout), &scopedReq->iov, 1, -1, IOWrite::writeCallback);
+    handle->closeHandle();
 }
 
 int write(lua_State* L)
@@ -140,9 +143,38 @@ int write(lua_State* L)
     if (toWrite.empty())
         return 0;
 
-    uvutils::ScopedUVRequest<IOWrite> req{L, toWrite.data(), toWrite.size()};
-    req->iov = uv_buf_init(req->data.data(), req->data.size());
-    uv_fs_write(req->getLoop(), &req->req, fileno(stdout), &req->iov, 1, -1, IOWrite::writeCallback);
+    auto handle = std::make_shared<IOWriteHandle>();
+    handle->loop = getRuntimeLoop(L);
+    handle->resumeToken = getResumeToken(L);
+    handle->self = handle;
+    handle->data.assign(toWrite.begin(), toWrite.end());
+
+    uv_handle_type ht = uv_guess_handle(fileno(stdout));
+    if (ht == UV_TTY)
+    {
+        uv_tty_t& tty = handle->streamVariant.emplace<uv_tty_t>();
+        int status = uv_tty_init(handle->loop, &tty, fileno(stdout), 0);
+        if (status < 0)
+            luaL_error(L, "Failed to initialize TTY: %s", uv_strerror(status));
+    }
+    else if (ht == UV_NAMED_PIPE || ht == UV_FILE)
+    {
+        uv_pipe_t& pipe = handle->streamVariant.emplace<uv_pipe_t>();
+        int status = uv_pipe_init(handle->loop, &pipe, 0);
+        if (status < 0)
+            luaL_error(L, "Failed to initialize pipe: %s", uv_strerror(status));
+        uv_pipe_open(&pipe, fileno(stdout));
+    }
+    else
+    {
+        luaL_error(L, "Unsupported stdout type");
+    }
+
+    uv_stream_t* stream = handle->getStream();
+    stream->data = handle.get();
+    handle->iov = uv_buf_init(handle->data.data(), handle->data.size());
+    handle->writeReq.data = handle.get();
+    uv_write(&handle->writeReq, stream, &handle->iov, 1, onWrite);
 
     return lua_yield(L, 0);
 }

--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -22,15 +22,17 @@ struct IOHandle
     ResumeToken resumeToken;
     std::shared_ptr<IOHandle> self;
     std::vector<char> buffer;
+    uv_write_t writeReq;
+    uv_buf_t iov;
 
-    void closeHandles()
+    static void closeCb(uv_handle_t* handle)
     {
-        auto closeCb = [](uv_handle_t* handle)
-        {
-            IOHandle* ioh = static_cast<IOHandle*>(handle->data);
-            ioh->self.reset();
-        };
+        IOHandle* ioh = static_cast<IOHandle*>(handle->data);
+        ioh->self.reset();
+    }
 
+    void close()
+    {
         uv_stream_t* stream = getStream();
         uv_read_stop(stream);
         uv_close((uv_handle_t*)stream, closeCb);
@@ -76,44 +78,12 @@ static void onTtyRead(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
         handle->resumeToken->fail(uv_strerror(nread));
     }
 
-    handle->closeHandles();
+    handle->close();
 }
-
-struct IOWriteHandle
-{
-    Luau::Variant<uv_pipe_t, uv_tty_t> streamVariant;
-    uv_loop_t* loop = nullptr;
-    ResumeToken resumeToken;
-    std::shared_ptr<IOWriteHandle> self;
-    std::vector<char> data;
-    uv_write_t writeReq;
-    uv_buf_t iov;
-
-    void closeHandle()
-    {
-        auto closeCb = [](uv_handle_t* handle)
-        {
-            IOWriteHandle* ioh = static_cast<IOWriteHandle*>(handle->data);
-            ioh->self.reset();
-        };
-        uv_close((uv_handle_t*)getStream(), closeCb);
-    }
-
-    uv_stream_t* getStream()
-    {
-        return Luau::visit(
-            [](auto& stream) -> uv_stream_t*
-            {
-                return (uv_stream_t*)&stream;
-            },
-            streamVariant
-        );
-    }
-};
 
 static void onWrite(uv_write_t* req, int status)
 {
-    IOWriteHandle* handle = static_cast<IOWriteHandle*>(req->data);
+    IOHandle* handle = static_cast<IOHandle*>(req->data);
 
     if (status < 0)
         handle->resumeToken->fail(uv_strerror(status));
@@ -125,7 +95,7 @@ static void onWrite(uv_write_t* req, int status)
             }
         );
 
-    handle->closeHandle();
+    handle->close();
 }
 
 int write(lua_State* L)
@@ -143,11 +113,11 @@ int write(lua_State* L)
     if (toWrite.empty())
         return 0;
 
-    auto handle = std::make_shared<IOWriteHandle>();
+    auto handle = std::make_shared<IOHandle>();
     handle->loop = getRuntimeLoop(L);
     handle->resumeToken = getResumeToken(L);
     handle->self = handle;
-    handle->data.assign(toWrite.begin(), toWrite.end());
+    handle->buffer.assign(toWrite.begin(), toWrite.end());
 
     uv_handle_type ht = uv_guess_handle(fileno(stdout));
     if (ht == UV_TTY)
@@ -172,7 +142,7 @@ int write(lua_State* L)
 
     uv_stream_t* stream = handle->getStream();
     stream->data = handle.get();
-    handle->iov = uv_buf_init(handle->data.data(), handle->data.size());
+    handle->iov = uv_buf_init(handle->buffer.data(), handle->buffer.size());
     handle->writeReq.data = handle.get();
     uv_write(&handle->writeReq, stream, &handle->iov, 1, onWrite);
 

--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -1,6 +1,7 @@
 #include "lute/io.h"
 
 #include "lute/runtime.h"
+#include "lute/UVRequest.h"
 
 #include "Luau/Variant.h"
 
@@ -79,6 +80,73 @@ static void onTtyRead(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
     handle->closeHandles();
 }
 
+struct IOWrite : uvutils::UVRequest<uv_fs_t>
+{
+    IOWrite(lua_State* L, const char* buf, size_t len)
+        : UVRequest(L)
+        , data(buf, buf + len)
+        , offset(0)
+    {
+    }
+
+    static void writeCallback(uv_fs_t* req);
+
+    std::vector<char> data;
+    uv_buf_t iov;
+    size_t offset;
+};
+
+void IOWrite::writeCallback(uv_fs_t* req)
+{
+    auto w = uvutils::retake<IOWrite>(req);
+    auto bytesWritten = req->result;
+
+    if (bytesWritten < 0)
+    {
+        w->fail("Error writing to stdout: %s", uv_strerror(bytesWritten));
+        return;
+    }
+
+    w->offset += bytesWritten;
+    if (w->offset >= w->data.size())
+    {
+        w->succeed(
+            [](lua_State* L)
+            {
+                return 0;
+            }
+        );
+        return;
+    }
+
+    // Partial write — write the remainder
+    w->iov = uv_buf_init(w->data.data() + w->offset, w->data.size() - w->offset);
+    uvutils::ScopedUVRequest<IOWrite> scopedReq{std::move(w)};
+    uv_fs_write(scopedReq->getLoop(), &scopedReq->req, fileno(stdout), &scopedReq->iov, 1, -1, IOWrite::writeCallback);
+}
+
+int write(lua_State* L)
+{
+    int nargs = lua_gettop(L);
+
+    std::string toWrite;
+    for (int i = 1; i <= nargs; i++)
+    {
+        size_t len;
+        const char* str = luaL_checklstring(L, i, &len);
+        toWrite.append(str, len);
+    }
+
+    if (toWrite.empty())
+        return 0;
+
+    uvutils::ScopedUVRequest<IOWrite> req{L, toWrite.data(), toWrite.size()};
+    req->iov = uv_buf_init(req->data.data(), req->data.size());
+    uv_fs_write(req->getLoop(), &req->req, fileno(stdout), &req->iov, 1, -1, IOWrite::writeCallback);
+
+    return lua_yield(L, 0);
+}
+
 int read(lua_State* L)
 {
     auto handle = std::make_shared<IOHandle>();
@@ -118,6 +186,7 @@ int read(lua_State* L)
 const char* const IO::properties[] = {nullptr};
 
 const luaL_Reg IO::lib[] = {
+    {"write", write},
     {"read", read},
     {nullptr, nullptr},
 };

--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -35,7 +35,7 @@ struct IOHandle
     {
         uv_stream_t* stream = getStream();
         uv_read_stop(stream);
-        uv_close((uv_handle_t*)stream, closeCb);
+        uv_close(reinterpret_cast<uv_handle_t*>(stream), closeCb);
     }
 
     uv_stream_t* getStream()
@@ -43,7 +43,7 @@ struct IOHandle
         return Luau::visit(
             [](auto& stream) -> uv_stream_t*
             {
-                return (uv_stream_t*)&stream;
+                return reinterpret_cast<uv_stream_t*>(&stream);
             },
             streamVariant
         );
@@ -167,10 +167,10 @@ int read(lua_State* L)
     else if (ht == UV_NAMED_PIPE || ht == UV_FILE)
     {
         uv_pipe_t& pipe = handle->streamVariant.emplace<uv_pipe_t>();
-        int status = uv_pipe_init(handle->loop, static_cast<uv_pipe_t*>(&pipe), 0);
+        int status = uv_pipe_init(handle->loop, &pipe, 0);
         if (status < 0)
             luaL_error(L, "Failed to initialize pipe: %s", uv_strerror(status));
-        uv_pipe_open(static_cast<uv_pipe_t*>(&pipe), fileno(stdin));
+        uv_pipe_open(&pipe, fileno(stdin));
     }
     else
     {

--- a/lute/std/libs/io.luau
+++ b/lute/std/libs/io.luau
@@ -7,12 +7,16 @@ local io = require("@lute/io")
 
 local iolib = {}
 
---- Reads a line from standard input. If `prompt` is provided, it is printed before waiting for input.
+--- Writes one or more strings to standard output without a trailing newline.
+function iolib.write(...: string): ()
+	io.write(...)
+end
+
+--- Reads a line from standard input. If `prompt` is provided, it is written to stdout before waiting for input.
 --- User input can be provided via command line stdin, piped input, or redirection from a file. See `examples/user_input.luau`.
 function iolib.input(prompt: string?): string
 	if prompt then
-		-- We temporarily use `print` for prompt until we have proper stdout support, so there is a `\n` between prompt and input.
-		print(prompt)
+		io.write(prompt)
 	end
 	return io.read()
 end

--- a/tests/std/io.test.luau
+++ b/tests/std/io.test.luau
@@ -20,9 +20,10 @@ test.suite("IoWriteSuite", function(suite)
 	-- Basic: single string argument, no trailing newline.
 	suite:case("writeBasic", function(assert)
 		local r = runScript("io_write_basic", [[
-local io = require("@std/io")
-io.write("hello")
-]])
+			local io = require("@std/io")
+			io.write("hello")
+		]])
+
 		assert.eq(r.exitcode, 0)
 		assert.eq(r.stdout, "hello")
 	end)
@@ -30,9 +31,10 @@ io.write("hello")
 	-- Multiple arguments are concatenated with no separator and no trailing newline.
 	suite:case("writeMultipleArgs", function(assert)
 		local r = runScript("io_write_multi", [[
-local io = require("@std/io")
-io.write("foo", "bar", "baz")
-]])
+			local io = require("@std/io")
+			io.write("foo", "bar", "baz")
+		]])
+
 		assert.eq(r.exitcode, 0)
 		assert.eq(r.stdout, "foobarbaz")
 	end)
@@ -40,9 +42,10 @@ io.write("foo", "bar", "baz")
 	-- io.write does not append a newline; print() does.
 	suite:case("writeNoTrailingNewline", function(assert)
 		local r = runScript("io_write_newline", [[
-local io = require("@std/io")
-io.write("hello")
-]])
+			local io = require("@std/io")
+			io.write("hello")
+		]])
+
 		assert.eq(r.exitcode, 0)
 		assert.eq(r.stdout, "hello")
 		assert.neq(r.stdout:sub(-1), "\n")
@@ -54,61 +57,56 @@ io.write("hello")
 	-- When mixing the two, use strContains rather than exact equality.
 	suite:case("writeMixedWithPrint", function(assert)
 		local r = runScript("io_write_print", [[
-local io = require("@std/io")
-io.write("from-io-write")
-print("from-print")
-]])
+			local io = require("@std/io")
+			io.write("from-io-write")
+			print("from-print")
+		]])
+
 		assert.eq(r.exitcode, 0)
 		assert.strContains(r.stdout, "from-io-write")
 		assert.strContains(r.stdout, "from-print")
 	end)
 
-	-- io.write("") takes the early-return path (no yield) and produces no output.
-	-- Note: this means io.write("") is synchronous while io.write("x") yields —
-	-- a minor behavioural inconsistency documented here.
 	suite:case("writeEmptyString", function(assert)
 		local r = runScript("io_write_empty", [[
-local io = require("@std/io")
-io.write("")
-io.write("done")
-]])
+			local io = require("@std/io")
+			io.write("")
+			io.write("done")
+		]])
+
 		assert.eq(r.exitcode, 0)
 		assert.eq(r.stdout, "done")
 	end)
 
-	-- io.write() with no arguments also takes the early-return path.
 	suite:case("writeNoArgs", function(assert)
 		local r = runScript("io_write_noargs", [[
-local io = require("@std/io")
-io.write()
-io.write("done")
-]])
+			local io = require("@std/io")
+			io.write()
+			io.write("done")
+		]])
+
 		assert.eq(r.exitcode, 0)
 		assert.eq(r.stdout, "done")
 	end)
 
-	-- Numbers are coerced to strings by luaL_checklstring (Lua convention), so
-	-- io.write(42) succeeds and writes "42". A truly non-coercible type such as a
-	-- table must be used to trigger a runtime error.
 	suite:case("writeTypeError", function(assert)
 		local r = runScript("io_write_typeerr", [[
-local io = require("@std/io")
-io.write({} :: any)
-]])
+			local io = require("@std/io")
+			io.write({} :: any)
+		]])
+
 		assert.eq(r.exitcode, 1)
 	end)
 
 	-- Many sequential writes must arrive in order without corruption.
-	-- Each write constructs a fresh IOWrite/uv_fs_t; uv_fs_req_cleanup is invoked
-	-- via ~UVRequest() on completion. This confirms there is no state leak between
-	-- successive calls.
 	suite:case("writeSequential", function(assert)
 		local r = runScript("io_write_sequential", [[
-local io = require("@std/io")
-for i = 1, 100 do
-    io.write(tostring(i) .. ",")
-end
-]])
+			local io = require("@std/io")
+			for i = 1, 100 do
+			    io.write(tostring(i) .. ",")
+			end
+		]])
+
 		assert.eq(r.exitcode, 0)
 		local expected = ""
 		for i = 1, 100 do
@@ -117,24 +115,13 @@ end
 		assert.eq(r.stdout, expected)
 	end)
 
-	-- A single io.write call with >64 KB of data exercises the uv_fs_write
-	-- thread-pool path. When stdout is a pipe and the kernel returns a partial
-	-- write, execution reaches the retry loop in writeCallback.
-	--
-	-- Bug: the partial-write retry reuses the uv_fs_t without calling
-	-- uv_fs_req_cleanup first, violating the libuv API contract. Under ASan/MSan
-	-- or on platforms where cleanup is not a no-op for fs-write requests, this
-	-- causes undefined behaviour.
-	--
-	-- A secondary bug: if uv_fs_write ever returns 0 bytes written (no error),
-	-- the retry loop spins forever. That condition cannot be forced reliably
-	-- against a blocking fd, but a hang here would indicate it.
 	suite:case("writeLargeData", function(assert)
 		local r = runScript("io_write_large", [[
-local io = require("@std/io")
--- 200 KB: well above the typical pipe-buffer limit of 64 KB.
-io.write(string.rep("x", 200 * 1024))
-]])
+			local io = require("@std/io")
+			-- 200 KB: well above the typical pipe-buffer limit of 64 KB.
+			io.write(string.rep("x", 200 * 1024))
+		]])
+
 		assert.eq(r.exitcode, 0)
 		assert.eq(#r.stdout, 200 * 1024)
 		assert.eq(r.stdout, string.rep("x", 200 * 1024))
@@ -144,24 +131,11 @@ io.write(string.rep("x", 200 * 1024))
 	-- through unchanged.
 	suite:case("writeNulByteSafe", function(assert)
 		local r = runScript("io_write_nul", [[
-local io = require("@std/io")
-io.write("a\0b")
-]])
+			local io = require("@std/io")
+			io.write("a\0b")
+		]])
+
 		assert.eq(r.exitcode, 0)
 		assert.eq(#r.stdout, 3)
-	end)
-
-	-- io.input's prompt must arrive without a trailing newline. Prior to this PR,
-	-- print(prompt) was used, which appended '\n' and left an awkward blank line
-	-- between the prompt and the user's input. The fix replaced it with
-	-- io.write(prompt).
-	suite:case("writePromptNoNewline", function(assert)
-		local r = runScript("io_write_prompt", [[
-local io = require("@std/io")
-io.write("Enter value: ")
-]])
-		assert.eq(r.exitcode, 0)
-		assert.eq(r.stdout, "Enter value: ")
-		assert.that(r.stdout:find("\n", 1, true) == nil)
 	end)
 end)

--- a/tests/std/io.test.luau
+++ b/tests/std/io.test.luau
@@ -1,0 +1,167 @@
+--!strict
+local fs = require("@std/fs")
+local path = require("@std/path")
+local process = require("@std/process")
+local system = require("@std/system")
+local test = require("@std/test")
+
+local lutePath = path.format(process.execPath())
+local tmpDir = system.tmpdir()
+
+local function runScript(name: string, script: string): process.ProcessResult
+	local file = path.join(tmpDir, `{name}.luau`)
+	fs.writeStringToFile(file, script)
+	local result = process.run({ lutePath, path.format(file) })
+	fs.remove(file)
+	return result
+end
+
+test.suite("IoWriteSuite", function(suite)
+	-- Basic: single string argument, no trailing newline.
+	suite:case("writeBasic", function(assert)
+		local r = runScript("io_write_basic", [[
+local io = require("@std/io")
+io.write("hello")
+]])
+		assert.eq(r.exitcode, 0)
+		assert.eq(r.stdout, "hello")
+	end)
+
+	-- Multiple arguments are concatenated with no separator and no trailing newline.
+	suite:case("writeMultipleArgs", function(assert)
+		local r = runScript("io_write_multi", [[
+local io = require("@std/io")
+io.write("foo", "bar", "baz")
+]])
+		assert.eq(r.exitcode, 0)
+		assert.eq(r.stdout, "foobarbaz")
+	end)
+
+	-- io.write does not append a newline; print() does.
+	suite:case("writeNoTrailingNewline", function(assert)
+		local r = runScript("io_write_newline", [[
+local io = require("@std/io")
+io.write("hello")
+]])
+		assert.eq(r.exitcode, 0)
+		assert.eq(r.stdout, "hello")
+		assert.neq(r.stdout:sub(-1), "\n")
+	end)
+
+	-- io.write and print can appear in the same program, but their relative output
+	-- order is NOT guaranteed: io.write issues a direct fd-level write via the libuv
+	-- thread pool, while print writes to C's buffered FILE* stdout (flushed at exit).
+	-- When mixing the two, use strContains rather than exact equality.
+	suite:case("writeMixedWithPrint", function(assert)
+		local r = runScript("io_write_print", [[
+local io = require("@std/io")
+io.write("from-io-write")
+print("from-print")
+]])
+		assert.eq(r.exitcode, 0)
+		assert.strContains(r.stdout, "from-io-write")
+		assert.strContains(r.stdout, "from-print")
+	end)
+
+	-- io.write("") takes the early-return path (no yield) and produces no output.
+	-- Note: this means io.write("") is synchronous while io.write("x") yields —
+	-- a minor behavioural inconsistency documented here.
+	suite:case("writeEmptyString", function(assert)
+		local r = runScript("io_write_empty", [[
+local io = require("@std/io")
+io.write("")
+io.write("done")
+]])
+		assert.eq(r.exitcode, 0)
+		assert.eq(r.stdout, "done")
+	end)
+
+	-- io.write() with no arguments also takes the early-return path.
+	suite:case("writeNoArgs", function(assert)
+		local r = runScript("io_write_noargs", [[
+local io = require("@std/io")
+io.write()
+io.write("done")
+]])
+		assert.eq(r.exitcode, 0)
+		assert.eq(r.stdout, "done")
+	end)
+
+	-- Numbers are coerced to strings by luaL_checklstring (Lua convention), so
+	-- io.write(42) succeeds and writes "42". A truly non-coercible type such as a
+	-- table must be used to trigger a runtime error.
+	suite:case("writeTypeError", function(assert)
+		local r = runScript("io_write_typeerr", [[
+local io = require("@std/io")
+io.write({} :: any)
+]])
+		assert.eq(r.exitcode, 1)
+	end)
+
+	-- Many sequential writes must arrive in order without corruption.
+	-- Each write constructs a fresh IOWrite/uv_fs_t; uv_fs_req_cleanup is invoked
+	-- via ~UVRequest() on completion. This confirms there is no state leak between
+	-- successive calls.
+	suite:case("writeSequential", function(assert)
+		local r = runScript("io_write_sequential", [[
+local io = require("@std/io")
+for i = 1, 100 do
+    io.write(tostring(i) .. ",")
+end
+]])
+		assert.eq(r.exitcode, 0)
+		local expected = ""
+		for i = 1, 100 do
+			expected ..= tostring(i) .. ","
+		end
+		assert.eq(r.stdout, expected)
+	end)
+
+	-- A single io.write call with >64 KB of data exercises the uv_fs_write
+	-- thread-pool path. When stdout is a pipe and the kernel returns a partial
+	-- write, execution reaches the retry loop in writeCallback.
+	--
+	-- Bug: the partial-write retry reuses the uv_fs_t without calling
+	-- uv_fs_req_cleanup first, violating the libuv API contract. Under ASan/MSan
+	-- or on platforms where cleanup is not a no-op for fs-write requests, this
+	-- causes undefined behaviour.
+	--
+	-- A secondary bug: if uv_fs_write ever returns 0 bytes written (no error),
+	-- the retry loop spins forever. That condition cannot be forced reliably
+	-- against a blocking fd, but a hang here would indicate it.
+	suite:case("writeLargeData", function(assert)
+		local r = runScript("io_write_large", [[
+local io = require("@std/io")
+-- 200 KB: well above the typical pipe-buffer limit of 64 KB.
+io.write(string.rep("x", 200 * 1024))
+]])
+		assert.eq(r.exitcode, 0)
+		assert.eq(#r.stdout, 200 * 1024)
+		assert.eq(r.stdout, string.rep("x", 200 * 1024))
+	end)
+
+	-- luaL_checklstring is length-aware, so io.write must pass embedded NUL bytes
+	-- through unchanged.
+	suite:case("writeNulByteSafe", function(assert)
+		local r = runScript("io_write_nul", [[
+local io = require("@std/io")
+io.write("a\0b")
+]])
+		assert.eq(r.exitcode, 0)
+		assert.eq(#r.stdout, 3)
+	end)
+
+	-- io.input's prompt must arrive without a trailing newline. Prior to this PR,
+	-- print(prompt) was used, which appended '\n' and left an awkward blank line
+	-- between the prompt and the user's input. The fix replaced it with
+	-- io.write(prompt).
+	suite:case("writePromptNoNewline", function(assert)
+		local r = runScript("io_write_prompt", [[
+local io = require("@std/io")
+io.write("Enter value: ")
+]])
+		assert.eq(r.exitcode, 0)
+		assert.eq(r.stdout, "Enter value: ")
+		assert.that(r.stdout:find("\n", 1, true) == nil)
+	end)
+end)

--- a/tests/std/io.test.luau
+++ b/tests/std/io.test.luau
@@ -19,10 +19,13 @@ end
 test.suite("IoWriteSuite", function(suite)
 	-- Basic: single string argument, no trailing newline.
 	suite:case("writeBasic", function(assert)
-		local r = runScript("io_write_basic", [[
+		local r = runScript(
+			"io_write_basic",
+			[[
 			local io = require("@std/io")
 			io.write("hello")
-		]])
+		]]
+		)
 
 		assert.eq(r.exitcode, 0)
 		assert.eq(r.stdout, "hello")
@@ -30,10 +33,13 @@ test.suite("IoWriteSuite", function(suite)
 
 	-- Multiple arguments are concatenated with no separator and no trailing newline.
 	suite:case("writeMultipleArgs", function(assert)
-		local r = runScript("io_write_multi", [[
+		local r = runScript(
+			"io_write_multi",
+			[[
 			local io = require("@std/io")
 			io.write("foo", "bar", "baz")
-		]])
+		]]
+		)
 
 		assert.eq(r.exitcode, 0)
 		assert.eq(r.stdout, "foobarbaz")
@@ -41,10 +47,13 @@ test.suite("IoWriteSuite", function(suite)
 
 	-- io.write does not append a newline; print() does.
 	suite:case("writeNoTrailingNewline", function(assert)
-		local r = runScript("io_write_newline", [[
+		local r = runScript(
+			"io_write_newline",
+			[[
 			local io = require("@std/io")
 			io.write("hello")
-		]])
+		]]
+		)
 
 		assert.eq(r.exitcode, 0)
 		assert.eq(r.stdout, "hello")
@@ -56,11 +65,14 @@ test.suite("IoWriteSuite", function(suite)
 	-- thread pool, while print writes to C's buffered FILE* stdout (flushed at exit).
 	-- When mixing the two, use strContains rather than exact equality.
 	suite:case("writeMixedWithPrint", function(assert)
-		local r = runScript("io_write_print", [[
+		local r = runScript(
+			"io_write_print",
+			[[
 			local io = require("@std/io")
 			io.write("from-io-write")
 			print("from-print")
-		]])
+		]]
+		)
 
 		assert.eq(r.exitcode, 0)
 		assert.strContains(r.stdout, "from-io-write")
@@ -68,44 +80,56 @@ test.suite("IoWriteSuite", function(suite)
 	end)
 
 	suite:case("writeEmptyString", function(assert)
-		local r = runScript("io_write_empty", [[
+		local r = runScript(
+			"io_write_empty",
+			[[
 			local io = require("@std/io")
 			io.write("")
 			io.write("done")
-		]])
+		]]
+		)
 
 		assert.eq(r.exitcode, 0)
 		assert.eq(r.stdout, "done")
 	end)
 
 	suite:case("writeNoArgs", function(assert)
-		local r = runScript("io_write_noargs", [[
+		local r = runScript(
+			"io_write_noargs",
+			[[
 			local io = require("@std/io")
 			io.write()
 			io.write("done")
-		]])
+		]]
+		)
 
 		assert.eq(r.exitcode, 0)
 		assert.eq(r.stdout, "done")
 	end)
 
 	suite:case("writeTypeError", function(assert)
-		local r = runScript("io_write_typeerr", [[
+		local r = runScript(
+			"io_write_typeerr",
+			[[
 			local io = require("@std/io")
 			io.write({} :: any)
-		]])
+		]]
+		)
 
 		assert.eq(r.exitcode, 1)
 	end)
 
 	-- Many sequential writes must arrive in order without corruption.
 	suite:case("writeSequential", function(assert)
-		local r = runScript("io_write_sequential", [[
+		local r = runScript(
+			"io_write_sequential",
+			[[
 			local io = require("@std/io")
 			for i = 1, 100 do
 			    io.write(tostring(i) .. ",")
 			end
-		]])
+		]]
+		)
 
 		assert.eq(r.exitcode, 0)
 		local expected = ""
@@ -116,11 +140,14 @@ test.suite("IoWriteSuite", function(suite)
 	end)
 
 	suite:case("writeLargeData", function(assert)
-		local r = runScript("io_write_large", [[
+		local r = runScript(
+			"io_write_large",
+			[[
 			local io = require("@std/io")
 			-- 200 KB: well above the typical pipe-buffer limit of 64 KB.
 			io.write(string.rep("x", 200 * 1024))
-		]])
+		]]
+		)
 
 		assert.eq(r.exitcode, 0)
 		assert.eq(#r.stdout, 200 * 1024)
@@ -130,10 +157,13 @@ test.suite("IoWriteSuite", function(suite)
 	-- luaL_checklstring is length-aware, so io.write must pass embedded NUL bytes
 	-- through unchanged.
 	suite:case("writeNulByteSafe", function(assert)
-		local r = runScript("io_write_nul", [[
+		local r = runScript(
+			"io_write_nul",
+			[[
 			local io = require("@std/io")
 			io.write("a\0b")
-		]])
+		]]
+		)
 
 		assert.eq(r.exitcode, 0)
 		assert.eq(#r.stdout, 3)


### PR DESCRIPTION
We've had a few requests come in through various channels for the ability to write to stdout without appending a newline and guaranteed flushing any TTY buffers. There's a variety of use cases for this, but it's a pretty normal IO capability, and it pairs well with the other one already present in the runtime, `io.read`. This PR implements the `io.write` function into the runtime, and a wrapper for it in `@std/io`. It also updates `io.input` in `@std/io` to use `io.write` to author the prompt for the input request, resolving a pre-existing TODO in the code to eliminate the undesired newline there.