### PR TITLE
Fixes docs for std task and failure

### DIFF
--- a/lute/cli/commands/doc/init.luau
+++ b/lute/cli/commands/doc/init.luau
@@ -13,13 +13,13 @@ local STDLIB_MODULE_ALIASES = {
 	fs = "fslib",
 	io = "iolib",
 	process = "processlib",
-	task = "tasklib",
 	path = "pathlib",
 	system = "systemlib",
 	trivia = "retrieverLib",
 	visitor = "visitorlib",
 	query = "queryLib",
 	printer = "printerLib",
+	failure = "failures",
 }
 
 local tripleDashCommentPattern = "^%s*%-%-%-%s?(.*)$"


### PR DESCRIPTION
`task.md` and `failure.md` weren't rendering bc of outdated alias mapping in doc logic. shows up now!

<img width="904" height="928" alt="image" src="https://github.com/user-attachments/assets/f9038075-832b-41b6-b24b-6f0ce3502159" />

<img width="934" height="881" alt="image" src="https://github.com/user-attachments/assets/577080e9-c3b9-485d-bb86-bde02d6d99e9" />

