### PR TITLE
Loom: Path dependencies

### DIFF
--- a/lute/cli/commands/pkg/loom-core/src/github.luau
+++ b/lute/cli/commands/pkg/loom-core/src/github.luau
@@ -3,7 +3,6 @@ local fs = require("@std/fs")
 local net = require("@std/net")
 local path = require("@std/path")
 local process = require("@std/process")
-local projectmanifest = require("./projectmanifest")
 local unzip = require("../extern/unzip")
 
 local function sanitizePath(path: string): string
@@ -90,8 +89,8 @@ local function downloadFromGitHubArchive(url: string): string
 	return response.body
 end
 
-local function installPackage(pkg: projectmanifest.DependencySpec, installPath: string): ()
-	local url = `{pkg.source}/archive/{pkg.rev}.zip`
+local function installPackage(source: string, rev: string, installPath: string): ()
+	local url = `{source}/archive/{rev}.zip`
 	local zipArchive = downloadFromGitHubArchive(url)
 	installZipArchive(zipArchive, installPath)
 end

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -18,7 +18,10 @@ export type Lockfile = {
 local function validatePackageEntry(key: string, entry: any)
 	assert(type(entry) == "table", `Expected table for dependency '{key}'`)
 	assert(type(entry.name) == "string", `Expected 'name' field in dependency '{key}'`)
-	assert(entry.rev == nil or type(entry.rev) == "string", `Expected 'rev' field to be a string or nil for dependency '{key}'`)
+	assert(
+		entry.rev == nil or type(entry.rev) == "string",
+		`Expected 'rev' field to be a string or nil for dependency '{key}'`
+	)
 	assert(type(entry.source) == "string", `Expected 'source' field in dependency '{key}'`)
 	assert(type(entry.sourceKind) == "string", `Expected 'sourceKind' field in dependency '{key}'`)
 	assert(type(entry.installPath) == "string", `Expected 'installPath' field in dependency '{key}'`)

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -2,7 +2,7 @@ local luau = require("@std/luau")
 
 export type LockfileDependency = {
 	read name: string,
-	read rev: string,
+	read rev: string?,
 	read source: string,
 	read sourceKind: string,
 	read installPath: string,
@@ -18,7 +18,7 @@ export type Lockfile = {
 local function validatePackageEntry(key: string, entry: any)
 	assert(type(entry) == "table", `Expected table for dependency '{key}'`)
 	assert(type(entry.name) == "string", `Expected 'name' field in dependency '{key}'`)
-	assert(type(entry.rev) == "string", `Expected 'rev' field in dependency '{key}'`)
+	assert(entry.rev == nil or type(entry.rev) == "string", `Expected 'rev' field to be a string or nil for dependency '{key}'`)
 	assert(type(entry.source) == "string", `Expected 'source' field in dependency '{key}'`)
 	assert(type(entry.sourceKind) == "string", `Expected 'sourceKind' field in dependency '{key}'`)
 	assert(type(entry.installPath) == "string", `Expected 'installPath' field in dependency '{key}'`)

--- a/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
@@ -37,7 +37,11 @@ local function hasConflict(specA: projectmanifest.DependencySpec, specB: project
 	return specA.rev ~= specB.rev or specA.source ~= specB.source or specA.sourceKind ~= specB.sourceKind
 end
 
-local function normalizePathDependency(spec: projectmanifest.DependencySpec, installPath: string, rootDirectory: string): projectmanifest.DependencySpec
+local function normalizePathDependency(
+	spec: projectmanifest.DependencySpec,
+	installPath: string,
+	rootDirectory: string
+): projectmanifest.DependencySpec
 	if spec.sourceKind == "path" then
 		local sourcePath = path.format(path.resolve(installPath, spec.source))
 		if not fs.exists(sourcePath) then

--- a/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
@@ -1,6 +1,7 @@
 local fs = require("@std/fs")
 local github = require("./github")
 local lockfile = require("./lockfile")
+local path = require("@std/path")
 local pp = require("@batteries/pp")
 local projectmanifest = require("./projectmanifest")
 
@@ -18,16 +19,55 @@ local function getLockfilePath(directory: string): string
 	return `{directory}/loom.lock.luau`
 end
 
-local function getInstallPath(key: string): string
-	return `Packages/{key}`
+local function getKey(spec: projectmanifest.DependencySpec): string
+	if spec.rev ~= nil then
+		return `{spec.name}@{spec.rev}`
+	end
+	return spec.name
 end
 
-local function getKey(spec: projectmanifest.DependencySpec): string
-	return `{spec.name}@{spec.rev}`
+local function getInstallPath(spec: projectmanifest.DependencySpec): string
+	if spec.sourceKind == "path" then
+		return spec.source
+	end
+	return `Packages/{getKey(spec)}`
 end
 
 local function hasConflict(specA: projectmanifest.DependencySpec, specB: projectmanifest.DependencySpec): boolean
 	return specA.rev ~= specB.rev or specA.source ~= specB.source or specA.sourceKind ~= specB.sourceKind
+end
+
+local function normalizePathDependency(spec: projectmanifest.DependencySpec, installPath: string, rootDirectory: string): projectmanifest.DependencySpec
+	if spec.sourceKind == "path" then
+		local sourcePath = path.format(path.resolve(installPath, spec.source))
+		if not fs.exists(sourcePath) then
+			error(`Path dependency directory not found: {sourcePath} (for package '{spec.name}')`)
+		end
+		return table.freeze({
+			name = spec.name,
+			rev = spec.rev,
+			source = path.format(path.relative(rootDirectory, sourcePath)),
+			sourceKind = spec.sourceKind,
+		})
+	end
+	return spec
+end
+
+local function fetchSource(spec: projectmanifest.DependencySpec, rootDirectory: string): string
+	if spec.sourceKind == "path" then
+		local sourcePath = path.format(path.resolve(rootDirectory, spec.source))
+		if not fs.exists(sourcePath) then
+			error(`Path dependency directory not found: {sourcePath} (for package '{spec.name}')`)
+		end
+		return sourcePath
+	elseif spec.sourceKind == "github" then
+		assert(spec.rev ~= nil, `Expected rev to be non-nil for GitHub package '{spec.name}'`)
+		local sourcePath = `{rootDirectory}/{getInstallPath(spec)}`
+		github.installPackage(spec.source, spec.rev, sourcePath)
+		return sourcePath
+	else
+		error(`Unsupported source kind: {spec.sourceKind} for package {spec.name}`)
+	end
 end
 
 local function createLockfile(resolved: ResolvedGraph): lockfile.Lockfile
@@ -39,7 +79,7 @@ local function createLockfile(resolved: ResolvedGraph): lockfile.Lockfile
 			rev = pkg.rev,
 			source = pkg.source,
 			sourceKind = pkg.sourceKind,
-			installPath = getInstallPath(key),
+			installPath = getInstallPath(pkg),
 			dependencies = resolved.graph[key] or {},
 		}
 	end
@@ -61,7 +101,7 @@ local function resolve(rootDirectory: string): ResolvedGraph
 	-- TODO: read lockfile and diff against manifest to determine which packages need to be updated, deleted, etc.
 	-- local lockfile = lockfile.parseFile(lockfilePath)
 	-- for now, just clear the installation directory if it exists
-	local rootInstallPath = `{rootDirectory}/{getInstallPath("")}`
+	local rootInstallPath = `{rootDirectory}/Packages/`
 	if fs.exists(rootInstallPath) then
 		fs.removeDirectory(rootInstallPath, { recursive = true })
 	end
@@ -115,20 +155,17 @@ local function resolve(rootDirectory: string): ResolvedGraph
 		graph[key] = {}
 
 		-- Download and install
-		local installPath = `{rootDirectory}/{getInstallPath(key)}`
-		if spec.sourceKind == "github" then
-			github.installPackage(spec, installPath)
-		else
-			error(`Unsupported source kind: {spec.sourceKind} for package {spec.name}`)
-		end
+		local installPath = fetchSource(spec, rootDirectory)
 
 		-- Check for transitive dependencies
 		local nestedManifestPath = getManifestPath(installPath)
 		if fs.exists(nestedManifestPath) then
 			local depManifest = projectmanifest.parseFile(nestedManifestPath)
 			for depAlias, depSpec in depManifest.package.dependencies do
-				graph[key][depAlias] = getKey(depSpec)
-				table.insert(queue, depSpec)
+				-- Normalize transitive path dep sources to be rootDirectory-relative
+				local normalizedSpec = normalizePathDependency(depSpec, installPath, rootDirectory)
+				graph[key][depAlias] = getKey(normalizedSpec)
+				table.insert(queue, normalizedSpec)
 			end
 		end
 

--- a/lute/cli/commands/pkg/loom-core/src/projectmanifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/projectmanifest.luau
@@ -1,9 +1,8 @@
 local luau = require("@std/luau")
 
--- TODO: Support path/registry dependencies
 export type DependencySpec = {
 	read name: string,
-	read rev: string,
+	read rev: string?,
 	read source: string,
 	read sourceKind: string,
 }
@@ -37,8 +36,8 @@ local function parseManifest(t: any): ProjectManifest
 				`Optional 'name' field in dependency spec for '{name}' expected to be a string`
 			)
 			assert(
-				spec.rev ~= nil and type(spec.rev) == "string",
-				`Expected 'rev' field in dependency spec for '{name}'`
+				spec.rev == nil or type(spec.rev) == "string",
+				`Expected 'rev' field to be a string or nil in dependency spec for '{name}'`
 			)
 			assert(
 				spec.sourceKind ~= nil and type(spec.sourceKind) == "string",

--- a/lute/cli/src/packagerun.cpp
+++ b/lute/cli/src/packagerun.cpp
@@ -136,17 +136,18 @@ std::pair<std::vector<Package::Identifier>, std::vector<std::pair<Package::Ident
             return {};
 
         const Luau::ConfigTable* entry = v.get_if<Luau::ConfigTable>();
-        if (!entry || !entry->contains("name") || !entry->contains("rev"))
+        if (!entry || !entry->contains("name"))
             return {};
 
         const std::string* name = (*entry).find("name")->get_if<std::string>();
-        const std::string* rev = (*entry).find("rev")->get_if<std::string>();
-        if (!name || !rev)
+        if (!name)
             return {};
+
+        const std::string* rev = entry->contains("rev") ? (*entry).find("rev")->get_if<std::string>() : nullptr;
 
         Package::Identifier id;
         id.name = toLower(*name);
-        id.version = *rev;
+        id.version = rev ? *rev : "";
         keyToIdentifier[*packageKey] = id;
 
         Package::Info info;

--- a/tests/src/packagerequire.test.cpp
+++ b/tests/src/packagerequire.test.cpp
@@ -111,3 +111,15 @@ TEST_CASE_FIXTURE(LuteFixture, "pkgrun_transitive_deps")
 
     CHECK_EQ(cliMain(argv.size(), argv.data(), getReporter()), 0);
 }
+
+TEST_CASE_FIXTURE(LuteFixture, "pkgrun_deep_path_deps")
+{
+    std::string entry = getLuteProjectRootAbsolute() + "/tests/src/packages/pkgrun_deep_path_deps/packageentry/entry.luau";
+
+    char executablePlaceholder[] = "lute";
+    char command[] = "pkg";
+    char subcommand[] = "run";
+    std::vector<char*> argv = {executablePlaceholder, command, subcommand, entry.data()};
+
+    CHECK_EQ(cliMain(argv.size(), argv.data(), getReporter()), 0);
+}

--- a/tests/src/packages/pkgrun_deep_path_deps/loom.lock.luau
+++ b/tests/src/packages/pkgrun_deep_path_deps/loom.lock.luau
@@ -1,0 +1,40 @@
+return {
+	version = 2,
+	packages = { "app" },
+	dependencies = {
+		["app"] = {
+			name = "app",
+			source = "packages/app",
+			sourceKind = "path",
+			installPath = "packages/app",
+			dependencies = {
+				lib = "lib",
+				shared = "shared",
+			},
+		},
+		["lib"] = {
+			name = "lib",
+			source = "packages/lib",
+			sourceKind = "path",
+			installPath = "packages/lib",
+			dependencies = {
+				utils = "shared",
+				h = "helpers",
+			},
+		},
+		["shared"] = {
+			name = "shared",
+			source = "packages/shared",
+			sourceKind = "path",
+			installPath = "packages/shared",
+			dependencies = {},
+		},
+		["helpers"] = {
+			name = "helpers",
+			source = "packages/helpers",
+			sourceKind = "path",
+			installPath = "packages/helpers",
+			dependencies = {},
+		},
+	},
+}

--- a/tests/src/packages/pkgrun_deep_path_deps/packageentry/entry.luau
+++ b/tests/src/packages/pkgrun_deep_path_deps/packageentry/entry.luau
@@ -1,0 +1,3 @@
+--!strict
+local result = require("@app")
+assert(result == "app+lib+shared+helpers+shared")

--- a/tests/src/packages/pkgrun_deep_path_deps/packages/app/loom.config.luau
+++ b/tests/src/packages/pkgrun_deep_path_deps/packages/app/loom.config.luau
@@ -1,0 +1,16 @@
+return {
+	package = {
+		name = "app",
+		version = "0.0.0",
+		dependencies = {
+			lib = {
+				sourceKind = "path",
+				source = "../lib",
+			},
+			shared = {
+				sourceKind = "path",
+				source = "../shared",
+			},
+		},
+	},
+}

--- a/tests/src/packages/pkgrun_deep_path_deps/packages/app/src/init.luau
+++ b/tests/src/packages/pkgrun_deep_path_deps/packages/app/src/init.luau
@@ -1,0 +1,3 @@
+local lib = require("@lib")
+local shared = require("@shared")
+return `app+{lib}+{shared}`

--- a/tests/src/packages/pkgrun_deep_path_deps/packages/helpers/src/init.luau
+++ b/tests/src/packages/pkgrun_deep_path_deps/packages/helpers/src/init.luau
@@ -1,0 +1,1 @@
+return "helpers"

--- a/tests/src/packages/pkgrun_deep_path_deps/packages/lib/loom.config.luau
+++ b/tests/src/packages/pkgrun_deep_path_deps/packages/lib/loom.config.luau
@@ -1,0 +1,18 @@
+return {
+	package = {
+		name = "lib",
+		version = "0.0.0",
+		dependencies = {
+			utils = {
+				name = "shared",
+				sourceKind = "path",
+				source = "../shared",
+			},
+			h = {
+				name = "helpers",
+				sourceKind = "path",
+				source = "../helpers",
+			},
+		},
+	},
+}

--- a/tests/src/packages/pkgrun_deep_path_deps/packages/lib/src/init.luau
+++ b/tests/src/packages/pkgrun_deep_path_deps/packages/lib/src/init.luau
@@ -1,0 +1,3 @@
+local utils = require("@utils")
+local h = require("@h")
+return `lib+{utils}+{h}`

--- a/tests/src/packages/pkgrun_deep_path_deps/packages/shared/src/init.luau
+++ b/tests/src/packages/pkgrun_deep_path_deps/packages/shared/src/init.luau
@@ -1,0 +1,1 @@
+return "shared"


### PR DESCRIPTION
### Overview

- Adds `sourceKind = "path"` to loom, allowing packages to depend on local directories instead of GitHub archives. Path dependencies resolve directly to an existing directory.
- When resolving transitive dependencies, we normalize any new path dependencies relative to the parent project root.

e.g.:
```luau
dependencies = {
    mylib = {
        sourceKind = "path",
        source = "packages/mylib", -- relative to project root
    },
}
```
