### PR TITLE
Shrink release binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,9 +56,13 @@ if (LUTE_OPTIMIZE_SIZE AND NOT LUTE_ENABLE_SANITIZERS)
     else()
         # MSVC equivalents: /Gy = function-level linking, /Gw = package
         # global data, /OPT:REF + /OPT:ICF = drop unused + fold identical.
+        # Restrict compile flags to C/C++ so they don't leak into the nasm
+        # invocations used by BoringSSL's AVX assembly on Windows (nasm
+        # treats `/Gy` as an input filename and errors out).
+        set(_lute_cxx_lang "$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>")
         add_compile_options(
-            "$<${_lute_release_cfg}:/Gy>"
-            "$<${_lute_release_cfg}:/Gw>"
+            "$<${_lute_release_cfg}:$<${_lute_cxx_lang}:/Gy>>"
+            "$<${_lute_release_cfg}:$<${_lute_cxx_lang}:/Gw>>"
         )
         add_link_options(
             "$<${_lute_release_cfg}:/OPT:REF>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ if (LUTE_OPTIMIZE_SIZE AND NOT LUTE_ENABLE_SANITIZERS)
         add_compile_options(
             "$<${_lute_release_cfg}:-ffunction-sections>"
             "$<${_lute_release_cfg}:-fdata-sections>"
+            "$<${_lute_release_cfg}:-fvisibility=hidden>"
+            "$<${_lute_release_cfg}:$<$<COMPILE_LANGUAGE:CXX>:-fvisibility-inlines-hidden>>"
         )
 
         if (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.13)
 
 # Make sure 'set' for variables is respected by options in nested files
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+# Honor CMAKE_INTERPROCEDURAL_OPTIMIZATION in subprojects (e.g. boringssl, luau)
+# whose minimum CMake version predates CMP0069 defaulting to NEW.
+set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -22,6 +25,59 @@ if (LUTE_ENABLE_SANITIZERS)
     if(NOT MSVC)
         add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
         add_link_options(-fsanitize=address,undefined)
+    endif()
+endif()
+
+# Size-optimization knobs applied globally so external libraries (luau,
+# boringssl, curl, libuv, zlib, ...) pick them up too. These are the biggest
+# single lever for reducing the final binary size, especially on Linux where
+# ld doesn't strip unreferenced functions by default.
+option(LUTE_OPTIMIZE_SIZE "Enable binary size optimizations for release builds" ON)
+if (LUTE_OPTIMIZE_SIZE AND NOT LUTE_ENABLE_SANITIZERS)
+    # Generator expression that is true for any non-Debug config. We want
+    # these flags for Release, MinSizeRel and RelWithDebInfo but not Debug.
+    set(_lute_release_cfg "$<NOT:$<CONFIG:Debug>>")
+
+    if (NOT MSVC)
+        # Emit each function/data symbol into its own section so the linker
+        # can drop unreferenced ones.
+        add_compile_options(
+            "$<${_lute_release_cfg}:-ffunction-sections>"
+            "$<${_lute_release_cfg}:-fdata-sections>"
+        )
+
+        if (APPLE)
+            # ld64 already dead-strips by default; make it explicit.
+            add_link_options("$<${_lute_release_cfg}:-Wl,-dead_strip>")
+        else()
+            # GNU ld / lld / gold
+            add_link_options("$<${_lute_release_cfg}:-Wl,--gc-sections>")
+        endif()
+    else()
+        # MSVC equivalents: /Gy = function-level linking, /Gw = package
+        # global data, /OPT:REF + /OPT:ICF = drop unused + fold identical.
+        add_compile_options(
+            "$<${_lute_release_cfg}:/Gy>"
+            "$<${_lute_release_cfg}:/Gw>"
+        )
+        add_link_options(
+            "$<${_lute_release_cfg}:/OPT:REF>"
+            "$<${_lute_release_cfg}:/OPT:ICF>"
+        )
+    endif()
+
+    # Enable LTO/IPO for size-relevant configs if the toolchain supports it.
+    # Setting the per-config variable here means every target created in
+    # subsequent add_subdirectory() calls inherits it.
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT LUTE_IPO_SUPPORTED OUTPUT LUTE_IPO_ERROR)
+    if (LUTE_IPO_SUPPORTED)
+        message(STATUS "Lute: enabling LTO for Release/MinSizeRel/RelWithDebInfo")
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL TRUE)
+        set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO TRUE)
+    else()
+        message(STATUS "Lute: LTO not supported by this toolchain: ${LUTE_IPO_ERROR}")
     endif()
 endif()
 
@@ -88,6 +144,30 @@ set(BUILD_EXAMPLES OFF)
 set(BUILD_CURL_EXE OFF)
 set(BUILD_SHARED_LIBS OFF)
 set(BUILD_STATIC_LIBS ON)
+
+# Disable curl protocols that lute/net never uses. The net client in
+# `lute/net/src/client.cpp` only speaks HTTP/HTTPS, and the websocket client
+# in `lute/net/src/client_websocket.cpp` uses CURLOPT_CONNECT_ONLY=2 (curl's
+# WebSocket mode), so HTTP and WebSockets must remain enabled.
+#
+# We intentionally leave the following enabled since they affect user-visible
+# behavior for HTTP: cookies, auth (basic/bearer/digest/kerberos/negotiate/
+# NTLM), proxy, netrc, HSTS, alt-svc, DoH, verbose error strings.
+set(CURL_DISABLE_FTP    ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_TFTP   ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_FILE   ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_DICT   ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_TELNET ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_LDAP   ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_LDAPS  ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_SMB    ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_SMTP   ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_IMAP   ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_POP3   ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_GOPHER ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_RTSP   ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_MQTT   ON CACHE BOOL "" FORCE)
+set(CURL_DISABLE_IPFS   ON CACHE BOOL "" FORCE)
 
 set(HAVE_BORINGSSL ON)
 add_subdirectory(extern/curl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.13)
 
 # Make sure 'set' for variables is respected by options in nested files
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-# Honor CMAKE_INTERPROCEDURAL_OPTIMIZATION in subprojects (e.g. boringssl, luau)
-# whose minimum CMake version predates CMP0069 defaulting to NEW.
+# Let subprojects inherit CMAKE_INTERPROCEDURAL_OPTIMIZATION.
 set(CMAKE_POLICY_DEFAULT_CMP0069 NEW)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -28,37 +27,23 @@ if (LUTE_ENABLE_SANITIZERS)
     endif()
 endif()
 
-# Size-optimization knobs applied globally so external libraries (luau,
-# boringssl, curl, libuv, zlib, ...) pick them up too. These are the biggest
-# single lever for reducing the final binary size, especially on Linux where
-# ld doesn't strip unreferenced functions by default.
 option(LUTE_OPTIMIZE_SIZE "Enable binary size optimizations for release builds" ON)
 if (LUTE_OPTIMIZE_SIZE AND NOT LUTE_ENABLE_SANITIZERS)
-    # Generator expression that is true for any non-Debug config. We want
-    # these flags for Release, MinSizeRel and RelWithDebInfo but not Debug.
     set(_lute_release_cfg "$<NOT:$<CONFIG:Debug>>")
 
     if (NOT MSVC)
-        # Emit each function/data symbol into its own section so the linker
-        # can drop unreferenced ones.
         add_compile_options(
             "$<${_lute_release_cfg}:-ffunction-sections>"
             "$<${_lute_release_cfg}:-fdata-sections>"
         )
 
         if (APPLE)
-            # ld64 already dead-strips by default; make it explicit.
             add_link_options("$<${_lute_release_cfg}:-Wl,-dead_strip>")
         else()
-            # GNU ld / lld / gold
             add_link_options("$<${_lute_release_cfg}:-Wl,--gc-sections>")
         endif()
     else()
-        # MSVC equivalents: /Gy = function-level linking, /Gw = package
-        # global data, /OPT:REF + /OPT:ICF = drop unused + fold identical.
-        # Restrict compile flags to C/C++ so they don't leak into the nasm
-        # invocations used by BoringSSL's AVX assembly on Windows (nasm
-        # treats `/Gy` as an input filename and errors out).
+        # Restrict to C/C++ so /Gy and /Gw don't leak into NASM invocations.
         set(_lute_cxx_lang "$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>")
         add_compile_options(
             "$<${_lute_release_cfg}:$<${_lute_cxx_lang}:/Gy>>"
@@ -70,9 +55,6 @@ if (LUTE_OPTIMIZE_SIZE AND NOT LUTE_ENABLE_SANITIZERS)
         )
     endif()
 
-    # Enable LTO/IPO for size-relevant configs if the toolchain supports it.
-    # Setting the per-config variable here means every target created in
-    # subsequent add_subdirectory() calls inherits it.
     include(CheckIPOSupported)
     check_ipo_supported(RESULT LUTE_IPO_SUPPORTED OUTPUT LUTE_IPO_ERROR)
     if (LUTE_IPO_SUPPORTED)
@@ -133,17 +115,8 @@ if (LUTE_ENABLE_SANITIZERS AND NOT MSVC)
     target_compile_options(crypto PRIVATE -Wno-frame-larger-than)
 endif()
 
-# BoringSSL's Windows build defines `_HAS_EXCEPTIONS=0`, which changes the
-# layout of several MSVC STL types (e.g. the vtable of std::bad_optional_access)
-# compared to the default `_HAS_EXCEPTIONS=1` used by the rest of lute and its
-# other dependencies (notably Luau). Without LTO this is a latent ODR violation
-# that is harmless in practice because BoringSSL never actually throws. With
-# `/LTCG` enabled, however, the MSVC linker performs cross-TU ABI checks during
-# code generation and emits C4743 for the mismatching vtable sizes. BoringSSL
-# also sets `/WX`, which promotes that warning to an error and fails the link
-# with LNK1257. Disabling IPO on BoringSSL's C++ targets keeps their objects as
-# regular COFF so they don't participate in LTCG's cross-TU merging, while the
-# rest of the binary still benefits from LTO.
+# BoringSSL's _HAS_EXCEPTIONS=0 changes MSVC STL vtables; under /LTCG this
+# trips C4743, which BoringSSL's /WX escalates to LNK1257. Keep it out of LTCG.
 if (MSVC AND LUTE_OPTIMIZE_SIZE AND NOT LUTE_ENABLE_SANITIZERS AND LUTE_IPO_SUPPORTED)
     foreach(_bssl_target crypto ssl fipsmodule decrepit pki)
         if (TARGET ${_bssl_target})
@@ -171,14 +144,7 @@ set(BUILD_CURL_EXE OFF)
 set(BUILD_SHARED_LIBS OFF)
 set(BUILD_STATIC_LIBS ON)
 
-# Disable curl protocols that lute/net never uses. The net client in
-# `lute/net/src/client.cpp` only speaks HTTP/HTTPS, and the websocket client
-# in `lute/net/src/client_websocket.cpp` uses CURLOPT_CONNECT_ONLY=2 (curl's
-# WebSocket mode), so HTTP and WebSockets must remain enabled.
-#
-# We intentionally leave the following enabled since they affect user-visible
-# behavior for HTTP: cookies, auth (basic/bearer/digest/kerberos/negotiate/
-# NTLM), proxy, netrc, HSTS, alt-svc, DoH, verbose error strings.
+# lute/net only speaks HTTP/HTTPS/WebSocket.
 set(CURL_DISABLE_FTP    ON CACHE BOOL "" FORCE)
 set(CURL_DISABLE_TFTP   ON CACHE BOOL "" FORCE)
 set(CURL_DISABLE_FILE   ON CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,28 @@ if (LUTE_ENABLE_SANITIZERS AND NOT MSVC)
     target_compile_options(crypto PRIVATE -Wno-frame-larger-than)
 endif()
 
+# BoringSSL's Windows build defines `_HAS_EXCEPTIONS=0`, which changes the
+# layout of several MSVC STL types (e.g. the vtable of std::bad_optional_access)
+# compared to the default `_HAS_EXCEPTIONS=1` used by the rest of lute and its
+# other dependencies (notably Luau). Without LTO this is a latent ODR violation
+# that is harmless in practice because BoringSSL never actually throws. With
+# `/LTCG` enabled, however, the MSVC linker performs cross-TU ABI checks during
+# code generation and emits C4743 for the mismatching vtable sizes. BoringSSL
+# also sets `/WX`, which promotes that warning to an error and fails the link
+# with LNK1257. Disabling IPO on BoringSSL's C++ targets keeps their objects as
+# regular COFF so they don't participate in LTCG's cross-TU merging, while the
+# rest of the binary still benefits from LTO.
+if (MSVC AND LUTE_OPTIMIZE_SIZE AND NOT LUTE_ENABLE_SANITIZERS AND LUTE_IPO_SUPPORTED)
+    foreach(_bssl_target crypto ssl fipsmodule decrepit pki)
+        if (TARGET ${_bssl_target})
+            set_property(TARGET ${_bssl_target} PROPERTY INTERPROCEDURAL_OPTIMIZATION FALSE)
+            set_property(TARGET ${_bssl_target} PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE FALSE)
+            set_property(TARGET ${_bssl_target} PROPERTY INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL FALSE)
+            set_property(TARGET ${_bssl_target} PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO FALSE)
+        endif()
+    endforeach()
+endif()
+
 # curl setup
 
 set(USE_LIBIDN2 OFF)

--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -64,3 +64,20 @@ set_target_properties(Lute.CLI PROPERTIES OUTPUT_NAME lute)
 target_compile_features(Lute.CLI PUBLIC cxx_std_17)
 target_link_libraries(Lute.CLI PRIVATE Lute.CLI.lib Lute.Common)
 target_compile_options(Lute.CLI PRIVATE ${LUTE_OPTIONS})
+
+# Strip symbols from release builds to reduce binary size. MSVC puts debug
+# information in a separate .pdb file by default, so stripping is a no-op
+# there. On Apple, `strip -x` keeps dynamic symbols (required for backtraces
+# via dladdr) while dropping locals; elsewhere we use the default behavior.
+if (LUTE_OPTIMIZE_SIZE AND NOT LUTE_ENABLE_SANITIZERS AND NOT MSVC AND CMAKE_STRIP)
+    if (APPLE)
+        set(_lute_strip_args -x)
+    else()
+        set(_lute_strip_args "")
+    endif()
+    add_custom_command(TARGET Lute.CLI POST_BUILD
+        COMMAND "$<IF:$<CONFIG:Debug>,true,${CMAKE_STRIP}>" ${_lute_strip_args} "$<TARGET_FILE:Lute.CLI>"
+        COMMENT "Stripping symbols from $<TARGET_FILE_NAME:Lute.CLI> (skipped in Debug)"
+        VERBATIM
+    )
+endif()

--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -65,12 +65,9 @@ target_compile_features(Lute.CLI PUBLIC cxx_std_17)
 target_link_libraries(Lute.CLI PRIVATE Lute.CLI.lib Lute.Common)
 target_compile_options(Lute.CLI PRIVATE ${LUTE_OPTIONS})
 
-# Strip symbols from release builds to reduce binary size. MSVC puts debug
-# information in a separate .pdb file by default, so stripping is a no-op
-# there. On Apple, `strip -x` keeps dynamic symbols (required for backtraces
-# via dladdr) while dropping locals; elsewhere we use the default behavior.
 if (LUTE_OPTIMIZE_SIZE AND NOT LUTE_ENABLE_SANITIZERS AND NOT MSVC AND CMAKE_STRIP)
     if (APPLE)
+        # -x keeps dynamic symbols so dladdr backtraces still work.
         set(_lute_strip_args -x)
     else()
         set(_lute_strip_args "")


### PR DESCRIPTION
| Platform | Before | After | Δ |
|---|---:|---:|---:|
| macOS aarch64 | 12.1 MB | 7.0 MB | −42% |
| Linux x86_64 | 20.5 MB | 8.7 MB | −58% |
| Linux aarch64 | 31.2 MB | 13.0 MB | −58% |
| Windows x86_64 | 7.1 MB | 6.9 MB | −3% |

Shrinks release binary with changes gated behind a new `LUTE_OPTIMIZE_SIZE` option (default on, off under sanitizers):

- Enable LTO for release builds.
- Dead-strip unreferenced code and data at link time.
- Strip symbols from the final binary on non-MSVC.
- Disable curl protocols lute never uses (keeps HTTP/HTTPS/WebSocket).

Successfully built releases on my branch: https://github.com/Nicell/lute/actions/runs/24588918117