### PR TITLE
Enable codegen

### DIFF
--- a/lute/require/src/options.cpp
+++ b/lute/require/src/options.cpp
@@ -1,7 +1,6 @@
 #include "lute/options.h"
 
-// TODO: this is never set to true today
-static bool codegen = false;
+static bool codegen = true;
 
 Luau::CompileOptions copts()
 {


### PR DESCRIPTION
Experimenting. Finding large regressions in running `lute test` on the lute repo with this PR.