### PR TITLE
Run tests faster

### DIFF
--- a/lute/cli/commands/test/finder.luau
+++ b/lute/cli/commands/test/finder.luau
@@ -3,6 +3,10 @@ local fs = require("@std/fs")
 local path = require("@std/path")
 local stringext = require("@std/stringext")
 
+export type WalkStats = {
+	entriesVisited: number,
+}
+
 local function istestfile(filename: string): boolean
 	return stringext.hasSuffix(filename, ".test.luau") or stringext.hasSuffix(filename, ".spec.luau")
 end
@@ -11,13 +15,18 @@ local function issnapfile(filename: string): boolean
 	return stringext.hasSuffix(filename, ".snap.luau")
 end
 
-local function findfiles(paths: { string }, predicate: (string) -> boolean): { path.Path }
+local function findfiles(paths: { string }, predicate: (string) -> boolean): ({ path.Path }, WalkStats)
 	local files = {}
+	local stats: WalkStats = { entriesVisited = 0 }
+
 	local function walk(p: path.Pathlike)
 		local it = fs.walk(path.normalize(p), { recursive = true })
 		local file = it()
 		while file do
-			if fs.type(file) ~= "dir" and predicate(path.format(file)) then
+			stats.entriesVisited += 1
+			-- fs.walk returns both files and directories; only add matches to results.
+			-- predicate rejects dir paths because they lack the test-file suffix.
+			if predicate(path.format(file)) then
 				table.insert(files, path.normalize(file))
 			end
 			file = it()
@@ -33,14 +42,14 @@ local function findfiles(paths: { string }, predicate: (string) -> boolean): { p
 		end
 	end
 
-	return files
+	return files, stats
 end
 
-local function findtestfiles(paths: { string }): { path.Path }
+local function findtestfiles(paths: { string }): ({ path.Path }, WalkStats)
 	return findfiles(paths, istestfile)
 end
 
-local function findsnapfiles(paths: { string }): { path.Path }
+local function findsnapfiles(paths: { string }): ({ path.Path }, WalkStats)
 	return findfiles(paths, issnapfile)
 end
 

--- a/lute/cli/commands/test/finder.luau
+++ b/lute/cli/commands/test/finder.luau
@@ -1,7 +1,8 @@
-local ps = require("@std/process")
 local fs = require("@std/fs")
+local ps = require("@std/process")
 local path = require("@std/path")
 local stringext = require("@std/stringext")
+local ignore = require("../lib/ignore")
 
 export type WalkStats = {
 	entriesVisited: number,
@@ -18,27 +19,41 @@ end
 local function findfiles(paths: { string }, predicate: (string) -> boolean): ({ path.Path }, WalkStats)
 	local files = {}
 	local stats: WalkStats = { entriesVisited = 0 }
+	local ignoreResolver = ignore.new()
 
-	local function walk(p: path.Pathlike)
-		local it = fs.walk(path.normalize(p), { recursive = true })
-		local file = it()
-		while file do
+	local function walk(directory: path.Path)
+		local entries = fs.listDirectory(directory)
+		for _, entry in entries do
 			stats.entriesVisited += 1
-			-- fs.walk returns both files and directories; only add matches to results.
-			-- predicate rejects dir paths because they lack the test-file suffix.
-			if predicate(path.format(file)) then
-				table.insert(files, path.normalize(file))
+			local fullPath = path.join(directory, entry.name)
+
+			if entry.type == "dir" then
+				if ignoreResolver:isIgnoredDirectory(fullPath) then
+					continue
+				end
+				walk(fullPath)
+			elseif predicate(entry.name) then
+				if ignoreResolver:isIgnoredFile(fullPath) then
+					continue
+				end
+				table.insert(files, fullPath)
 			end
-			file = it()
 		end
 	end
 
 	local cwd = ps.cwd()
 	for _, p in paths do
-		if path.isAbsolute(p) then
-			walk(p)
-		else
-			walk(path.join(cwd, p))
+		local rooted = if path.isAbsolute(p) then path.normalize(p) else path.normalize(path.join(cwd, p))
+		local ok, ftype = pcall(fs.type, path.format(rooted))
+		if ok and ftype == "dir" then
+			walk(rooted)
+		elseif ok and ftype == "file" then
+			-- explicit file path: include it if it matches, no ignore check
+			-- (user asked for it directly).
+			local basename = path.basename(rooted)
+			if basename and predicate(basename) then
+				table.insert(files, rooted)
+			end
 		end
 	end
 

--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -191,7 +191,7 @@ local function main(...: string)
 		local setupSeconds = time.since(phaseStart)
 
 		local parallelSuitesArg = args:get("parallel-suites")
-		local parallelSuites = if parallelSuitesArg then tonumber(parallelSuitesArg) else nil
+		local parallelSuites = if parallelSuitesArg then tonumber(parallelSuitesArg) else 8
 		if parallelSuitesArg and not parallelSuites then
 			print(`Invalid --parallel-suites value: '{parallelSuitesArg}' (expected a number)`)
 			ps.exit(1)

--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -8,17 +8,79 @@ local testtypes = require("@std/test/types")
 local runner = require("@std/test/runner")
 local reporter = require("@self/reporter")
 local test = require("@std/test")
+local time = require("@std/time")
 local snaprunner = require("@self/snap/runner")
 local updater = require("@self/snap/updater")
 
-local function loadtests(testfiles: { path.Path })
+local SLOW_LOAD_LIMIT = 10
+local SLOW_LOAD_THRESHOLD_SECONDS = 0.05
+
+local function formatSeconds(seconds: number): string
+	if seconds >= 1 then
+		return string.format("%.2fs", seconds)
+	elseif seconds >= 0.001 then
+		return string.format("%.1fms", seconds * 1000)
+	else
+		return string.format("%.0fµs", seconds * 1_000_000)
+	end
+end
+
+type LoadStats = {
+	totalseconds: number,
+	count: number,
+	perfile: { { file: string, seconds: number } },
+}
+
+local function loadtests(testfiles: { path.Path }): LoadStats
+	local loadstart = time.now()
+	local perfile: { { file: string, seconds: number } } = {}
 	-- Load all test files first
 	for _, p in testfiles do
+		local fstart = time.now()
 		local success, err = pcall(luau.loadModule, p, nil)
+		local elapsed = time.since(fstart)
 
 		if not success then
 			print(`Error loading {path.format(p)}: {err}`)
 			ps.exit(1)
+		end
+
+		table.insert(perfile, { file = path.format(p), seconds = elapsed })
+	end
+
+	return {
+		totalseconds = time.since(loadstart),
+		count = #testfiles,
+		perfile = perfile,
+	}
+end
+
+local function printLoadSummary(stats: LoadStats, discoverSeconds: number, discoveredCount: number)
+	print(
+		`Discovered {discoveredCount} test files in {formatSeconds(discoverSeconds)}; `
+			.. `loaded {stats.count} in {formatSeconds(stats.totalseconds)}`
+	)
+
+	local perfile = table.clone(stats.perfile)
+	table.sort(perfile, function(a, b)
+		return a.seconds > b.seconds
+	end)
+
+	local slow = {}
+	for _, entry in perfile do
+		if entry.seconds < SLOW_LOAD_THRESHOLD_SECONDS then
+			break
+		end
+		table.insert(slow, entry)
+		if #slow >= SLOW_LOAD_LIMIT then
+			break
+		end
+	end
+
+	if #slow > 0 then
+		print("Slowest test file loads:")
+		for _, entry in slow do
+			print(`  {formatSeconds(entry.seconds)}  {entry.file}`)
 		end
 	end
 end
@@ -40,10 +102,18 @@ local function listtests()
 	end
 end
 
-local function runtests(env: testtypes.TestEnvironment, runner: testtypes.TestRunner, reporter: testtypes.TestReporter)
-	local result = runner(env)
+local function runtests(
+	env: testtypes.TestEnvironment,
+	runFn: (testtypes.TestEnvironment) -> testtypes.TestRunResult,
+	reporter: testtypes.TestReporter,
+	afterRun: (() -> ())?
+)
+	local result = runFn(env)
 
 	reporter(result)
+	if afterRun then
+		afterRun()
+	end
 	if result.failed ~= 0 then
 		ps.exit(1)
 	end
@@ -73,6 +143,10 @@ local function main(...: string)
 	args:add("case", "option", { help = "Run only test cases matching the specified name", aliases = { "c" } })
 	args:add("interactive", "flag", { help = "Interactively accept/reject snapshot changes", aliases = { "i" } })
 	args:add("update", "flag", { help = "Auto-accept all snapshot changes", aliases = { "u" } })
+	args:add("parallel-suites", "option", {
+		help = "Run up to N suites concurrently (default 1, sequential).",
+		aliases = { "p" },
+	})
 
 	args:parse({ ... })
 
@@ -96,14 +170,44 @@ local function main(...: string)
 	end
 
 	local searchpath = if forwarded and #forwarded > 0 then forwarded else { "./" }
-	loadtests(finder.findtestfiles(searchpath))
+	local isList = args:has("list")
 
-	if args:has("list") then
+	local phaseStart = time.now()
+
+	local discoverstart = time.now()
+	local testfiles, walkStats = finder.findtestfiles(searchpath)
+	local discoverSeconds = time.since(discoverstart)
+
+	local stats = loadtests(testfiles)
+
+	if isList then
+		-- --list output is consumed by other tests verbatim; keep stdout clean.
 		listtests()
 	else
+		printLoadSummary(stats, discoverSeconds, #testfiles)
+		print(`Discovery walk: {walkStats.entriesVisited} filesystem entries visited`)
 		local env = test._registered() :: testtypes.TestEnvironment
 		local filteredEnv = filter.filtertests(env, args:get("suite"), args:get("case"))
-		runtests(filteredEnv, runner.run, reporter.color)
+		local setupSeconds = time.since(phaseStart)
+
+		local parallelSuitesArg = args:get("parallel-suites")
+		local parallelSuites = if parallelSuitesArg then tonumber(parallelSuitesArg) else nil
+		if parallelSuitesArg and not parallelSuites then
+			print(`Invalid --parallel-suites value: '{parallelSuitesArg}' (expected a number)`)
+			ps.exit(1)
+		end
+
+		local function runFn(e: testtypes.TestEnvironment): testtypes.TestRunResult
+			return runner.run(e, { parallelSuites = parallelSuites })
+		end
+
+		runtests(filteredEnv, runFn, reporter.color, function()
+			print(
+				`Phase timings: discover={formatSeconds(discoverSeconds)}, `
+					.. `load={formatSeconds(stats.totalseconds)}, `
+					.. `cli-setup(total before runner)={formatSeconds(setupSeconds)}`
+			)
+		end)
 	end
 end
 

--- a/lute/cli/commands/test/reporter.luau
+++ b/lute/cli/commands/test/reporter.luau
@@ -40,15 +40,110 @@ local function printFailure(failed: tys.FailedTest)
 	end
 end
 
+local function formatSeconds(seconds: number): string
+	if seconds >= 1 then
+		return string.format("%.2fs", seconds)
+	elseif seconds >= 0.001 then
+		return string.format("%.1fms", seconds * 1000)
+	else
+		return string.format("%.0fµs", seconds * 1_000_000)
+	end
+end
+
+local SLOW_LIMIT = 15
+local SLOW_THRESHOLD_SECONDS = 0.01 -- only report entries >= 10ms
+
+local function printTimings(result: tys.TestRunResult)
+	local timings = result.timings
+	if not timings or #timings == 0 then
+		return
+	end
+
+	local suiteTotals: { [string]: number } = {}
+	local suiteOrder: { string } = {}
+
+	local sortable = table.clone(timings)
+	table.sort(sortable, function(a, b)
+		return a.seconds > b.seconds
+	end)
+
+	for _, t in timings do
+		if t.kind == "case" then
+			local suite = string.match(t.name, "^(.-)%.") or "(anonymous)"
+			if suiteTotals[suite] == nil then
+				suiteTotals[suite] = 0
+				table.insert(suiteOrder, suite)
+			end
+			suiteTotals[suite] += t.seconds
+		elseif t.kind == "beforeAll" or t.kind == "afterAll" then
+			local suite = t.name
+			if suiteTotals[suite] == nil then
+				suiteTotals[suite] = 0
+				table.insert(suiteOrder, suite)
+			end
+			suiteTotals[suite] += t.seconds
+		elseif t.kind == "beforeEach" or t.kind == "afterEach" then
+			local suite = string.match(t.name, "^(.-)%.") or "(anonymous)"
+			if suiteTotals[suite] == nil then
+				suiteTotals[suite] = 0
+				table.insert(suiteOrder, suite)
+			end
+			suiteTotals[suite] += t.seconds
+		end
+	end
+
+	table.sort(suiteOrder, function(a, b)
+		return (suiteTotals[a] or 0) > (suiteTotals[b] or 0)
+	end)
+
+	print("")
+	print(rt.bold("Slowest tests:"))
+	local shown = 0
+	for _, t in sortable do
+		if t.seconds < SLOW_THRESHOLD_SECONDS then
+			break
+		end
+		if shown >= SLOW_LIMIT then
+			break
+		end
+		shown += 1
+		local kindLabel = if t.kind == "case" then "" else ` [{t.kind}]`
+		print(`  {location(formatSeconds(t.seconds))}  {testname(t.name)}{dim(kindLabel)}`)
+	end
+	if shown == 0 then
+		print(dim(`  (no individual entries exceeded {formatSeconds(SLOW_THRESHOLD_SECONDS)})`))
+	end
+
+	print("")
+	print(rt.bold("Slowest suites (sum of cases + hooks):"))
+	local suiteShown = 0
+	for _, suite in suiteOrder do
+		if suiteShown >= SLOW_LIMIT then
+			break
+		end
+		local secs = suiteTotals[suite] or 0
+		if secs < SLOW_THRESHOLD_SECONDS then
+			break
+		end
+		suiteShown += 1
+		print(`  {location(formatSeconds(secs))}  {testname(suite)}`)
+	end
+	if suiteShown == 0 then
+		print(dim(`  (no suites exceeded {formatSeconds(SLOW_THRESHOLD_SECONDS)})`))
+	end
+end
+
 local function printSummary(result: tys.TestRunResult)
 	print(separator(string.rep("─", 50)))
-	print(
-		rt.bold("Results: ")
-			.. pass(`{result.passed} passed`)
-			.. dim(", ")
-			.. fail(`{result.failed} failed`)
-			.. dim(` of {result.total}`)
-	)
+	local line = rt.bold("Results: ")
+		.. pass(`{result.passed} passed`)
+		.. dim(", ")
+		.. fail(`{result.failed} failed`)
+		.. dim(` of {result.total}`)
+	if result.totalseconds then
+		line ..= dim(` in {formatSeconds(result.totalseconds)}`)
+	end
+	print(line)
 end
 
 local function colorReporter(result: tys.TestRunResult)
@@ -62,6 +157,7 @@ local function colorReporter(result: tys.TestRunResult)
 		end
 	end
 
+	printTimings(result)
 	printSummary(result)
 end
 

--- a/lute/std/libs/fs.luau
+++ b/lute/std/libs/fs.luau
@@ -226,28 +226,24 @@ end
 --- Returns an iterator over all paths under `path`. If `options.recursive` is `true`, descends into subdirectories.
 --- See example/walk_directory.luau for usage.
 function fslib.walk(path: Pathlike, options: WalkOptions?): () -> Path?
-	local queue: { Path } = { pathlib.parse(path) }
+	local queue = deque.new(pathlib.parse(path))
 	local recursive = if options then options.recursive else false
 
 	return function()
-		while #queue > 0 do
-			local current = table.remove(queue, 1)
-			if not current then
-				return nil
-			end
-
-			if fslib.type(current) == "dir" and recursive then
-				local entries = fslib.listDirectory(current)
-				for _, entry in entries do
-					local fullPath = pathlib.join(current, entry.name)
-					table.insert(queue, fullPath)
-				end
-			end
-
-			return current
+		if #queue == 0 then
+			return nil
 		end
 
-		return nil
+		local current = queue:popfront()
+
+		if fslib.type(current) == "dir" and recursive then
+			local entries = fslib.listDirectory(current)
+			for _, entry in entries do
+				queue:pushback(pathlib.join(current, entry.name))
+			end
+		end
+
+		return current
 	end
 end
 

--- a/lute/std/libs/test/init.luau
+++ b/lute/std/libs/test/init.luau
@@ -22,6 +22,8 @@ function TestSuite.new(name: string): TestSuite
 		_beforeAll = nil,
 		_afterEach = nil,
 		_afterAll = nil,
+		_parallel = false,
+		_maxConcurrency = nil,
 	}, TestSuite)
 	return self :: TestSuite
 end
@@ -49,6 +51,19 @@ end
 --- Registers a hook to run once after all test cases in this suite.
 function TestSuite:afterAll(hook: () -> ())
 	self._afterAll = hook
+end
+
+--- Marks this suite to run its test cases concurrently. Each case is launched on its
+--- own coroutine, so yielding calls (e.g. `process.run`, `fs.*`, `net.*`) overlap via
+--- the event loop. `beforeAll`/`afterAll` still run sequentially around the batch.
+---
+--- `maxConcurrency` caps in-flight cases (default 8). Keep it modest on suites that
+--- spawn subprocesses to avoid running out of file descriptors.
+---
+--- Cases in a parallel suite must not share mutable state (tmp file paths, cwd, etc.).
+function TestSuite:parallel(maxConcurrency: number?)
+	self._parallel = true
+	self._maxConcurrency = maxConcurrency
 end
 
 -- Test library export surface

--- a/lute/std/libs/test/runner.luau
+++ b/lute/std/libs/test/runner.luau
@@ -2,6 +2,8 @@
 -- @std/test/runner
 -- Standard test runner library for Luau
 local ps = require("@std/process")
+local task = require("@std/task")
+local time = require("@std/time")
 
 local asserts = require("./assert")
 local failure = require("./failure")
@@ -16,15 +18,42 @@ type TestEnvironment = types.TestEnvironment
 type TestReporter = types.TestReporter
 type FailedTest = types.FailedTest
 type TestRunResult = types.TestRunResult
+type TestTiming = types.TestTiming
 
 local runner = {}
 
+--- Options controlling how `runner.run` schedules work.
+---
+--- `parallelSuites` runs whole suites concurrently as coroutines, with at most
+--- `parallelSuites` suites in flight at once. `nil` or `<= 1` keeps the existing
+--- sequential behavior. Suite-level concurrency composes with `suite:parallel()`:
+--- a suite that opted into parallel cases runs its cases concurrently within the
+--- coroutine slot it occupies in the suite-parallel pool.
+---
+--- Tests in suites that run concurrently must not share mutable state (tmp file
+--- paths, cwd, env vars, global tables). The lute lint suite is a worked example:
+--- each case calls `freshScratchDir()` for its filesystem state.
+export type RunOptions = {
+	parallelSuites: number?,
+}
+
 --- Runs all test cases and suites in `env`, executing lifecycle hooks around each case. Returns the aggregate results.
-function runner.run(env: TestEnvironment): TestRunResult
+function runner.run(env: TestEnvironment, options: RunOptions?): TestRunResult
+	local maxSuiteConcurrency = if options and options.parallelSuites and options.parallelSuites > 1
+		then options.parallelSuites
+		else 1
+
 	local failures: { FailedTest } = {}
+	local timings: { TestTiming } = {}
 	local total = 0
 	local failed = 0
 	local passed = 0
+
+	local runstart = time.now()
+
+	local function record(name: string, kind: "case" | "beforeAll" | "beforeEach" | "afterEach" | "afterAll", start)
+		table.insert(timings, { name = name, kind = kind, seconds = time.since(start) })
+	end
 
 	-- Error handler for beforeAll hook
 	local function beforeAllErrorHandler(suite: TestSuite)
@@ -94,63 +123,149 @@ function runner.run(env: TestEnvironment): TestRunResult
 			failed += 1
 		end
 
+		local casestart = time.now()
 		local success = xpcall(tc.case, handlefailure, asserts)
+		record(tc.name, "case", casestart)
 		if success then
 			passed += 1
 		end
 	end
 
-	-- Run tests from suites
-	for _, suite in env.suites do
-		-- Run beforeAll hook once per suite
+	-- Runs a single case with its beforeEach/afterEach hooks and updates shared
+	-- counters. The `beforeEach` error handler increments `failed` on its own if it
+	-- fires, so this function leaves counters alone in that path and otherwise
+	-- decides pass/fail based on the case + afterEach outcome.
+	--
+	-- Safe to call from multiple coroutines: Luau is cooperatively scheduled, so
+	-- `+=` on the shared counters and `table.insert` into `failures` never race.
+	local function runcase(suite: TestSuite, tc: TestCase)
+		local testFullName = `{suite.name}.{tc.name}`
+		local function handlefailure(err)
+			local wasruntimefailure = not (typeof(err) == "table" and err.__tag and err.__tag == "assertion")
+			local failedtest: FailedTest = {
+				test = testFullName,
+				failure = if wasruntimefailure then failure.runtimeerror(err) else err,
+			}
+			table.insert(failures, failedtest)
+		end
+
+		if suite._beforeEach then
+			local hookstart = time.now()
+			local beforeSuccess = xpcall(suite._beforeEach, beforeEachErrorHandler(testFullName))
+			record(testFullName, "beforeEach", hookstart)
+			if not beforeSuccess then
+				-- beforeEachErrorHandler already bumped `failed`.
+				return
+			end
+		end
+
+		local casestart = time.now()
+		local success = xpcall(tc.case, handlefailure, asserts)
+		record(testFullName, "case", casestart)
+
+		if suite._afterEach then
+			local hookstart = time.now()
+			local afterSuccess = xpcall(suite._afterEach, afterEachErrorHandler(testFullName))
+			record(testFullName, "afterEach", hookstart)
+			if not afterSuccess then
+				success = false
+			end
+		end
+
+		if success then
+			passed += 1
+		else
+			failed += 1
+		end
+	end
+
+	-- Runs a single suite end-to-end: beforeAll, all cases (sequential or parallel
+	-- depending on `suite:parallel()`), then afterAll. Designed to be safe to call
+	-- from a coroutine when running suites concurrently.
+	local function runSuite(suite: TestSuite)
 		if suite._beforeAll then
+			local hookstart = time.now()
 			local beforeAllSuccess = xpcall(suite._beforeAll, beforeAllErrorHandler(suite))
+			record(suite.name, "beforeAll", hookstart)
 			if not beforeAllSuccess then
-				-- If beforeAll fails, skip all tests in the suite
-				continue
+				-- beforeAllErrorHandler already recorded total/failed for the skipped cases.
+				return
 			end
 		end
 
-		for _, tc in suite.cases do
-			total += 1
-			local testFullName = `{suite.name}.{tc.name}`
-			local function handlefailure(err)
-				local wasruntimefailure = not (typeof(err) == "table" and err.__tag and err.__tag == "assertion")
-				local failedtest: FailedTest = {
-					test = testFullName,
-					failure = if wasruntimefailure then failure.runtimeerror(err) else err,
-				}
-				table.insert(failures, failedtest)
-			end
+		if suite._parallel then
+			-- Parallel cases: launch each as a coroutine, capped at maxConcurrency
+			-- in-flight. Yielding calls (process.run, net.*, fs.*) overlap via libuv.
+			local maxConcurrency = suite._maxConcurrency or 8
+			local numCases = #suite.cases
+			total += numCases
 
-			-- Run beforeEach hook if it exists
-			if suite._beforeEach then
-				local beforeSuccess = xpcall(suite._beforeEach, beforeEachErrorHandler(testFullName))
-				if not beforeSuccess then
-					continue
+			local pending = 0
+			local completed = 0
+			local launched = 0
+
+			local function launchMore()
+				while launched < numCases and pending < maxConcurrency do
+					launched += 1
+					local tc = suite.cases[launched]
+					pending += 1
+					task.spawn(function()
+						runcase(suite, tc)
+						pending -= 1
+						completed += 1
+					end)
 				end
 			end
 
-			local success = xpcall(tc.case, handlefailure, asserts)
-			-- Run afterEach hook if it exists (runs even if test failed)
-			if suite._afterEach then
-				local afterSuccess = xpcall(suite._afterEach, afterEachErrorHandler(testFullName))
-				if not afterSuccess then
-					-- If test passed but afterEach failed, mark as failed
-					success = false
-				end
+			launchMore()
+			while completed < numCases do
+				task.wait()
+				launchMore()
 			end
-			-- if the test and the teardown method passed, the test passes
-			if success then
-				passed += 1
-			else
-				failed += 1
+		else
+			for _, tc in suite.cases do
+				total += 1
+				runcase(suite, tc)
 			end
 		end
 
-		-- Run afterAll hook once per suite (runs even if tests failed)
 		if suite._afterAll then
+			local hookstart = time.now()
 			xpcall(suite._afterAll, afterAllErrorHandler(suite.name))
+			record(suite.name, "afterAll", hookstart)
+		end
+	end
+
+	if maxSuiteConcurrency <= 1 then
+		for _, suite in env.suites do
+			runSuite(suite)
+		end
+	else
+		-- Suite-parallel mode: launch each suite as its own coroutine, with a cap on
+		-- in-flight suites. A suite that opted into `:parallel()` will further fan
+		-- out its cases inside its coroutine slot, giving two-level concurrency.
+		local numSuites = #env.suites
+		local pending = 0
+		local completed = 0
+		local launched = 0
+
+		local function launchMore()
+			while launched < numSuites and pending < maxSuiteConcurrency do
+				launched += 1
+				local suite = env.suites[launched]
+				pending += 1
+				task.spawn(function()
+					runSuite(suite)
+					pending -= 1
+					completed += 1
+				end)
+			end
+		end
+
+		launchMore()
+		while completed < numSuites do
+			task.wait()
+			launchMore()
 		end
 	end
 
@@ -159,6 +274,8 @@ function runner.run(env: TestEnvironment): TestRunResult
 		total = total,
 		failed = failed,
 		passed = passed,
+		timings = timings,
+		totalseconds = time.since(runstart),
 	}
 end
 

--- a/lute/std/libs/test/types.luau
+++ b/lute/std/libs/test/types.luau
@@ -51,6 +51,16 @@ export type Test = (Asserts) -> ()
 export type TestCase = { name: string, case: Test }
 
 --- A named collection of test cases with optional lifecycle hooks.
+---
+--- Parallel suites:
+--- - Call `suite:parallel(n?)` to run this suite's cases concurrently using `task.spawn`.
+---   Each case (plus its `beforeEach`/`afterEach`) runs in its own coroutine, so yielding
+---   library calls like `process.run` overlap via libuv. `beforeAll` still runs once
+---   before all cases and `afterAll` once after. `n` caps the number of cases in flight
+---   at once (default 8); pass a larger value to allow more concurrency.
+--- - Cases in a parallel suite must be independent: no shared file paths, no shared
+---   global state mutated across cases. Each case should create and clean up its own
+---   scratch resources.
 export type TestSuite = {
 	name: string,
 	cases: { TestCase },
@@ -58,11 +68,14 @@ export type TestSuite = {
 	_beforeAll: (() -> ())?,
 	_afterEach: (() -> ())?,
 	_afterAll: (() -> ())?,
+	_parallel: boolean?,
+	_maxConcurrency: number?,
 	case: (self: TestSuite, string, Test) -> (),
 	beforeEach: (self: TestSuite, () -> ()) -> (),
 	beforeAll: (self: TestSuite, () -> ()) -> (),
 	afterEach: (self: TestSuite, () -> ()) -> (),
 	afterAll: (self: TestSuite, () -> ()) -> (),
+	parallel: (self: TestSuite, maxConcurrency: number?) -> (),
 }
 
 --- A test case that failed, paired with the failure that caused it.
@@ -71,12 +84,21 @@ export type FailedTest = {
 	failure: Failure,
 }
 
+--- A measured duration for a single test case or lifecycle hook, in seconds.
+export type TestTiming = {
+	name: string, -- fully-qualified test or hook name
+	kind: "case" | "beforeAll" | "beforeEach" | "afterEach" | "afterAll",
+	seconds: number,
+}
+
 --- The aggregate results of a test run: total, passed, failed counts and the list of failures.
 export type TestRunResult = {
 	failures: { FailedTest },
 	total: number,
 	failed: number,
 	passed: number,
+	timings: { TestTiming }?, -- optional per-test/hook timings when the runner captures them
+	totalseconds: number?, -- optional total elapsed seconds for the whole run
 }
 
 --- A function that receives a `TestRunResult` and reports it (e.g. prints to stdout).

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -8,7 +8,34 @@ local testTypes = require("@std/test/types")
 
 local lutePath = path.format(process.execPath())
 local tmpDir = system.tmpdir()
-local rulesDir = path.format(path.join(".", "lints"))
+
+-- Tests that copy rule files out of `examples/lints/` (or `lute/cli/commands/lint/rules/`)
+-- need the project's `@commands` and `@std` aliases to resolve from the scratch dir.
+-- We seed each scratch dir with a `.luaurc` pointing at the project's lib dirs.
+local projectRoot = path.format(process.cwd())
+local luaurcContents = string.format(
+	[[{"aliases": {"std": %q, "commands": %q, "batteries": %q}}]],
+	path.format(path.join(projectRoot, "lute", "std", "libs")),
+	path.format(path.join(projectRoot, "lute", "cli", "commands")),
+	path.format(path.join(projectRoot, "batteries"))
+)
+
+-- Each test that touches the filesystem must use its own scratch directory so the
+-- suite can run with `suite:parallel()`. `freshScratchDir()` returns a fresh path
+-- under `tmpDir` per call. The counter is process-local; we clean any leftover
+-- directory from a previous run before reusing the slot.
+local scratchCounter = 0
+local function freshScratchDir(): string
+	scratchCounter += 1
+	local dir = path.format(path.join(tmpDir, `lint_test_{scratchCounter}`))
+	if fs.exists(dir) then
+		fs.removeDirectory(dir, { recursive = true })
+	end
+	fs.createDirectory(dir)
+	fs.writeStringToFile(path.format(path.join(dir, ".luaurc")), luaurcContents)
+	return dir
+end
+
 local defaultRulesFolder = path.format(path.join("lute", "cli", "commands", "lint", "rules"))
 local defaultRulesPaths = {
 	almost_swapped = path.format(path.join(defaultRulesFolder, "almost_swapped.luau")),
@@ -49,9 +76,9 @@ type lintTestParams = {
 }
 
 local function lintTestHelper(assert: testTypes.Asserts, params: lintTestParams): string
-	-- Setup
-	-- Create a file that violates the rule
-	local violatorPath = path.format(path.join(tmpDir, "violator.luau"))
+	-- Each invocation gets its own scratch dir so concurrent tests don't share files.
+	local scratch = freshScratchDir()
+	local violatorPath = path.format(path.join(scratch, "violator.luau"))
 	fs.writeStringToFile(violatorPath, params.content)
 
 	-- Do
@@ -63,7 +90,7 @@ local function lintTestHelper(assert: testTypes.Asserts, params: lintTestParams)
 		table.insert(lintArgs, "-r")
 		table.insert(lintArgs, params.rulePath)
 	elseif params.customRuleContents then
-		local customRulePath = path.format(path.join(tmpDir, "custom_rule.luau"))
+		local customRulePath = path.format(path.join(scratch, "custom_rule.luau"))
 		fs.writeStringToFile(customRulePath, params.customRuleContents)
 		table.insert(lintArgs, "-r")
 		table.insert(lintArgs, customRulePath)
@@ -79,7 +106,7 @@ local function lintTestHelper(assert: testTypes.Asserts, params: lintTestParams)
 
 	-- Create a config file if specified
 	if params.configContents then
-		local configPath = path.format(path.join(tmpDir, ".config.luau"))
+		local configPath = path.format(path.join(scratch, ".config.luau"))
 		fs.writeStringToFile(configPath, params.configContents)
 		table.insert(lintArgs, "-c")
 		table.insert(lintArgs, configPath)
@@ -115,17 +142,9 @@ local function lintTestHelper(assert: testTypes.Asserts, params: lintTestParams)
 end
 
 test.suite("lute lint", function(suite)
-	suite:beforeEach(function()
-		-- A test that creates rulesDir which fails won't cleanup after itself
-		if fs.exists(rulesDir) then
-			fs.removeDirectory(rulesDir, { recursive = true })
-		end
-
-		local modulePath = path.join(tmpDir, "module")
-		if fs.exists(modulePath) then
-			fs.removeDirectory(modulePath, { recursive = true })
-		end
-	end)
+	-- Run cases concurrently. Each test must use `freshScratchDir()` (or call
+	-- `lintTestHelper`, which does) for any filesystem state.
+	suite:parallel()
 
 	suite:case("luteLintHelpMessage", function(assert)
 		local result = process.run({ lutePath, "lint", "-h" })
@@ -329,7 +348,8 @@ end
 	end)
 
 	suite:case("luteLintCustomRulesDir", function(assert)
-		-- Setup
+		-- Use a per-test rules dir so parallel cases don't collide on `./lints`.
+		local rulesDir = path.format(path.join(freshScratchDir(), "lints"))
 		fs.createDirectory(rulesDir)
 		-- Copy almostSwapped.luau to rulesDir/almostSwapped.luau
 		-- Because the default rules require types using a relative path, we copy from examples, which uses an absolute require path
@@ -381,12 +401,10 @@ violator.luau:3:1-4:6 ──
 				{ expectedOutput = LINT_RULE_MESSAGES.almost_swapped, count = 1 },
 			},
 		})
-
-		fs.removeDirectory(rulesDir, { recursive = true })
 	end)
 
 	suite:case("luteLintMultipleRulesButOneErrors", function(assert)
-		-- Setup
+		local rulesDir = path.format(path.join(freshScratchDir(), "lints"))
 		fs.createDirectory(rulesDir)
 		-- Copy almostSwapped.luau to rulesDir/almostSwapped.luau
 		fs.copy(path.join("examples", "lints", "almost_swapped.luau"), path.join(rulesDir, "almost_swapped.luau"))
@@ -427,20 +445,16 @@ b = a
 
 		assert.neq(
 			output:find(
-				"Error applying lint rule 'AlwaysErrors': %.[/\\]lints[/\\]erroring_rule%.luau:4: This rule always errors",
+				"Error applying lint rule 'AlwaysErrors': .+[/\\]lints[/\\]erroring_rule%.luau:4: This rule always errors",
 				1
 			),
 			nil
 		)
-
-		-- Teardown
-		fs.removeDirectory(rulesDir, { recursive = true })
 	end)
 
 	suite:case("luteLintMultipleInputFiles", function(assert)
-		-- Setup
-		-- Create multiple files that violate the rule
-		local violatorPath1 = path.format(path.join(tmpDir, "violator1.luau"))
+		local scratch = freshScratchDir()
+		local violatorPath1 = path.format(path.join(scratch, "violator1.luau"))
 		fs.writeStringToFile(
 			violatorPath1,
 			[[
@@ -451,7 +465,7 @@ b = a
     ]]
 		)
 
-		local modulePath = path.join(tmpDir, "module")
+		local modulePath = path.join(scratch, "module")
 		fs.createDirectory(modulePath)
 		local violatorPath2 = path.format(path.join(modulePath, "violator2.lua"))
 		fs.writeStringToFile(
@@ -515,19 +529,14 @@ violator2.lua:5:1-6:6 ──
 		assert.strContains(result.stdout, expected)
 		expected = "Skipping non%-Luau file '.+[/\\]module[/\\]not_luau%.txt'"
 		assert.neq(result.stdout:find(expected, 1, false), nil)
-
-		-- Teardown
-		fs.remove(violatorPath1)
-		fs.removeDirectory(modulePath, { recursive = true })
 	end)
 
 	suite:case("luteLintMultipleFilesWithErrorsRecovers", function(assert)
-		-- Setup
-		-- Create multiple files that violate the rule
-		local lintee = path.format(path.join(tmpDir, "lintee.luau"))
+		local scratch = freshScratchDir()
+		local lintee = path.format(path.join(scratch, "lintee.luau"))
 		fs.writeStringToFile(lintee, "bogus")
 
-		local violatorPath = path.format(path.join(tmpDir, "violator1.luau"))
+		local violatorPath = path.format(path.join(scratch, "violator1.luau"))
 		fs.writeStringToFile(
 			violatorPath,
 			[[
@@ -538,11 +547,8 @@ b = a
     ]]
 		)
 
-		-- Do
-		-- Run the transformer on the transformee
 		local result = process.run({ lutePath, "lint", lintee, violatorPath })
 
-		-- Check
 		assert.eq(result.exitcode, 1)
 
 		local expected = [[
@@ -553,10 +559,6 @@ lintee.luau': @std/syntax/parser.luau:12: parsing failed:
 
 		assert.strContains(result.stdout, LINT_RULE_MESSAGES.divide_by_zero)
 		assert.strContains(result.stdout, LINT_RULE_MESSAGES.almost_swapped)
-
-		-- Teardown
-		fs.remove(lintee)
-		fs.remove(violatorPath)
 	end)
 
 	suite:case("luteLintDefaultRules", function(assert)
@@ -962,9 +964,7 @@ local x = 1 / 0
 	end)
 
 	suite:case("luteLintRespectsGitignore", function(assert)
-		-- Setup
-		-- Create a module directory with a .gitignore that ignores one file
-		local modulePath = path.join(tmpDir, "module")
+		local modulePath = path.join(freshScratchDir(), "module")
 		fs.createDirectory(modulePath)
 		local violatorPath1 = path.format(path.join(modulePath, "violator1.luau"))
 		fs.writeStringToFile(
@@ -982,11 +982,8 @@ local y = 10 / 0
 		)
 		fs.writeStringToFile(path.format(path.join(modulePath, ".gitignore")), "violator2.luau\n")
 
-		-- Do
-		-- Run the transformer on the transformee
 		local result = process.run({ lutePath, "lint", path.format(modulePath) })
 
-		-- Check
 		assert.eq(result.exitcode, 1)
 
 		assert.strContains(result.stdout, LINT_RULE_MESSAGES.divide_by_zero, 1)
@@ -1007,9 +1004,6 @@ violator2.lua:1:11-17 ──
    │
 ]]
 		assert.strNotContains(result.stdout, expected)
-
-		-- Teardown
-		fs.removeDirectory(modulePath, { recursive = true })
 	end)
 
 	suite:case("luteLintReportDirective", function(assert)
@@ -2540,7 +2534,7 @@ return {
 	end)
 
 	suite:case("luteLintAccountsForConfiguredIgnoresConfigPassedAsArg", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		fs.createDirectory(testSubDir)
 
 		local ignoredFile = path.join(testSubDir, "ignored.luau")
@@ -2572,7 +2566,7 @@ return {
 	end)
 
 	suite:case("luteLintAccountsForConfiguredIgnoresConfigAutoDetected", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		fs.createDirectory(testSubDir)
 
 		local ignoredFile = path.join(testSubDir, "ignored.luau")
@@ -2605,7 +2599,7 @@ return {
 	end)
 
 	suite:case("luteLintConfiguredIgnoresSupplementNotOverrideExistingGitignores", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		fs.createDirectory(testSubDir)
 
 		local ignoredFile = path.join(testSubDir, "ignored.luau")
@@ -2799,7 +2793,7 @@ local t = { [0] = 1 }
 	end)
 
 	suite:case("luteLintSupportsConfiguredDirectoryIgnores", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		fs.createDirectory(testSubDir)
 
 		-- Create a nested directory structure with violating files
@@ -2845,7 +2839,7 @@ local t = { [0] = 1 }
 	end)
 
 	suite:case("luteLintHandlesIgnoresWithRelativeConfigPath", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		fs.createDirectory(testSubDir)
 
 		local ignoredFile = path.join(testSubDir, "ignored.luau")
@@ -2880,7 +2874,7 @@ local t = { [0] = 1 }
 	end)
 
 	suite:case("luteLintHandlesIgnoresWithAbsoluteConfigPath", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		fs.createDirectory(testSubDir)
 
 		local ignoredFile = path.join(testSubDir, "ignored.luau")
@@ -2960,7 +2954,7 @@ local t = { [0] = 1 }
 	end)
 
 	suite:case("luteLintAccountsForRuleSpecificIgnores", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		fs.createDirectory(testSubDir)
 
 		local violatorFile = path.join(testSubDir, "violator.luau")
@@ -3009,7 +3003,7 @@ return {
 	end)
 
 	suite:case("luteLintAccountsForRuleSpecificDirectoryIgnores", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		fs.createDirectory(testSubDir)
 
 		local ignoredDir = path.join(testSubDir, "ignoredDir")
@@ -3160,6 +3154,9 @@ return {
 	end)
 
 	suite:case("rulesGivenByConfigRulepathsAreLoadedInAdditionToCliPassedRulesAndRan", function(assert)
+		-- Inlined (not using lintTestHelper) so the config file, the relative-path
+		-- rule, and the violator all live in the same scratch dir. Lute resolves
+		-- `./configuredRelativeRule.luau` relative to the config file's directory.
 		local ruleTemplate = [[
 return {
 	name = %q,
@@ -3174,9 +3171,10 @@ return {
 		}
 	end
 }
-		]]
-		-- Create the config-provided rules (loaded via config.rulepaths, NOT via -r)
-		local configuredAbsoluteRulePath = path.format(path.join(tmpDir, "configuredAbsRule.luau"))
+]]
+		local scratch = freshScratchDir()
+
+		local configuredAbsoluteRulePath = path.format(path.join(scratch, "configuredAbsRule.luau"))
 		fs.writeStringToFile(
 			configuredAbsoluteRulePath,
 			(ruleTemplate :: any):format(
@@ -3185,7 +3183,7 @@ return {
 				"configuredAbsoluteRule ran."
 			)
 		)
-		local configuredRelativePath = path.format(path.join(tmpDir, "configuredRelativeRule.luau"))
+		local configuredRelativePath = path.format(path.join(scratch, "configuredRelativeRule.luau"))
 		fs.writeStringToFile(
 			configuredRelativePath,
 			(ruleTemplate :: any):format(
@@ -3195,12 +3193,10 @@ return {
 			)
 		)
 
-		-- The CLI-provided rule is passed via customRuleContents (which uses -r),
-		-- while the config-provided rules are referenced via config.rulepaths
-		lintTestHelper(assert, {
-			content = "local x = 1",
-			expectedExitCode = 1,
-			customRuleContents = [[
+		local cliRulePath = path.format(path.join(scratch, "custom_rule.luau"))
+		fs.writeStringToFile(
+			cliRulePath,
+			[[
 return {
 	name = "cliRule",
 	lint = function(ast, sourcepath, context)
@@ -3214,8 +3210,13 @@ return {
 		}
 	end
 }
-]],
-			configContents = ([[
+]]
+		)
+
+		local configPath = path.format(path.join(scratch, ".config.luau"))
+		fs.writeStringToFile(
+			configPath,
+			([[
 return {
 	lute = {
 		lint = {
@@ -3223,24 +3224,33 @@ return {
 		}
 	}
 }
-]]):format(configuredAbsoluteRulePath),
-			disableDefaultLints = true,
-			outputExpectations = {
-				-- both config-given and CLI-given rules should have ran
-				{ expectedOutput = "configuredAbsoluteRule ran.", count = 1 },
-				{ expectedOutput = "configuredRelativeRule ran.", count = 1 },
-				{ expectedOutput = "CLI Rule Ran.", count = 1 },
-			},
-			processOptions = {
-				cwd = path.format(tmpDir),
-			},
-		})
+]]):format(configuredAbsoluteRulePath)
+		)
+
+		local violatorPath = path.format(path.join(scratch, "violator.luau"))
+		fs.writeStringToFile(violatorPath, "local x = 1")
+
+		local result = process.run({
+			lutePath,
+			"lint",
+			"-r",
+			cliRulePath,
+			"--no-default-lints",
+			"-c",
+			configPath,
+			violatorPath,
+		}, { cwd = scratch })
+
+		assert.eq(result.exitcode, 1)
+		assert.strContains(result.stdout, "configuredAbsoluteRule ran.", 1)
+		assert.strContains(result.stdout, "configuredRelativeRule ran.", 1)
+		assert.strContains(result.stdout, "CLI Rule Ran.", 1)
 	end)
 
 	suite:case(
 		"lute lint properly loads rule-specific configuration for rules provided by config.rulepaths",
 		function(assert)
-			local testSubDir = path.join(tmpDir, "module")
+			local testSubDir = path.join(freshScratchDir(), "module")
 			fs.createDirectory(testSubDir)
 
 			local configuredRulePath = path.join(testSubDir, "configuredRule.luau")
@@ -3592,7 +3602,7 @@ end
 	end)
 
 	suite:case("luteLintCurrentDirFindsLuauFiles", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		fs.createDirectory(testSubDir)
 
 		local violatorPath = path.format(path.join(testSubDir, "violator.luau"))
@@ -3607,7 +3617,7 @@ end
 	end)
 
 	suite:case("luteLintCurrentDirFindsLuaFiles", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		fs.createDirectory(testSubDir)
 
 		local violatorPath = path.format(path.join(testSubDir, "violator.lua"))
@@ -3622,7 +3632,7 @@ end
 	end)
 
 	suite:case("luteLintCurrentDirRecursive", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		local nestedDir = path.join(testSubDir, "nested")
 		fs.createDirectory(testSubDir)
 		fs.createDirectory(nestedDir)
@@ -3639,7 +3649,7 @@ end
 	end)
 
 	suite:case("luteLintCurrentDirNoLuauFiles", function(assert)
-		local testSubDir = path.join(tmpDir, "module")
+		local testSubDir = path.join(freshScratchDir(), "module")
 		fs.createDirectory(testSubDir)
 
 		local result = process.run({ lutePath, "lint" }, {


### PR DESCRIPTION
Locally makes tests run in ~3s instead of ~30s.

- Discovery improvements (~9s -> 30ms):
  - Use a deque instead of an table-array queue for fs walk (~6s)
  - Use gitignore to skip over directories that tests shouldn't run on anyways (~3s)
- Make tests run in parallel (~20s -> ~3s):
  - Run the lute lint suite cases in parallel (~10s)
  - Run the suites in parallel (~7s)