### PR TITLE
Improve test discovery speed

### DIFF
--- a/lute/cli/commands/test/finder.luau
+++ b/lute/cli/commands/test/finder.luau
@@ -1,7 +1,7 @@
-local ps = require("@std/process")
 local fs = require("@std/fs")
 local path = require("@std/path")
 local stringext = require("@std/stringext")
+local ignore = require("../lib/ignore")
 
 local function istestfile(filename: string): boolean
 	return stringext.hasSuffix(filename, ".test.luau") or stringext.hasSuffix(filename, ".spec.luau")
@@ -13,23 +13,27 @@ end
 
 local function findfiles(paths: { string }, predicate: (string) -> boolean): { path.Path }
 	local files = {}
-	local function walk(p: path.Pathlike)
-		local it = fs.walk(path.normalize(p), { recursive = true })
-		local file = it()
-		while file do
-			if fs.type(file) ~= "dir" and predicate(path.format(file)) then
-				table.insert(files, path.normalize(file))
+	local resolver = ignore.new()
+
+	local function walk(directory: path.Path)
+		for _, entry in fs.listDirectory(directory) do
+			local fullPath = path.join(directory, entry.name)
+			if entry.type == "dir" then
+				if not resolver:isIgnoredDirectory(fullPath) then
+					walk(fullPath)
+				end
+			elseif predicate(entry.name) and not resolver:isIgnoredFile(fullPath) then
+				table.insert(files, fullPath)
 			end
-			file = it()
 		end
 	end
 
-	local cwd = ps.cwd()
 	for _, p in paths do
-		if path.isAbsolute(p) then
-			walk(p)
-		else
-			walk(path.join(cwd, p))
+		local rooted = path.resolve(p)
+		if fs.type(rooted) == "dir" then
+			walk(rooted)
+		elseif predicate(path.format(rooted)) then
+			table.insert(files, rooted)
 		end
 	end
 

--- a/lute/std/libs/fs.luau
+++ b/lute/std/libs/fs.luau
@@ -226,28 +226,24 @@ end
 --- Returns an iterator over all paths under `path`. If `options.recursive` is `true`, descends into subdirectories.
 --- See example/walk_directory.luau for usage.
 function fslib.walk(path: Pathlike, options: WalkOptions?): () -> Path?
-	local queue: { Path } = { pathlib.parse(path) }
+	local queue = deque.new(pathlib.parse(path))
 	local recursive = if options then options.recursive else false
 
 	return function()
-		while #queue > 0 do
-			local current = table.remove(queue, 1)
-			if not current then
-				return nil
-			end
-
-			if fslib.type(current) == "dir" and recursive then
-				local entries = fslib.listDirectory(current)
-				for _, entry in entries do
-					local fullPath = pathlib.join(current, entry.name)
-					table.insert(queue, fullPath)
-				end
-			end
-
-			return current
+		if #queue == 0 then
+			return nil
 		end
 
-		return nil
+		local current = queue:popfront()
+
+		if fslib.type(current) == "dir" and recursive then
+			local entries = fslib.listDirectory(current)
+			for _, entry in entries do
+				queue:pushback(pathlib.join(current, entry.name))
+			end
+		end
+
+		return current
 	end
 end
 


### PR DESCRIPTION
Test discovery in the lute repository takes around 9s. There's a couple of improvements to be made here:

1. Use gitignore like lute lint/transform does to not waste time walking these directories
2. Use a deque for fs walk instead of an table-array queue

The gitignore fixes the slowdown on its own, but the deque change is a good fix anyways. From my testing in #1000, the deque fix without the gitignore change reduces discovery from 9s to 3s. The gitignore change on top of that reduces down to 30ms.

We probably should have been using ignore from the beginning. This does change behavior, so maybe we should add a CLI option to turn off ignore?