### PR TITLE
Parallel test runners

### DIFF
--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -66,15 +66,16 @@ local function runtests(
 		local done = 0
 		for _ = 1, nworkers do
 			task.spawn(function()
+				local current: path.Path? = nil
 				xpcall(function()
 					local worker = vm.create("@self/worker")
 					while true do
-						local p = takenext()
-						if not p then
+						current = takenext()
+						if not current then
 							break
 						end
 						local r = worker.runfile({
-							file = path.format(p),
+							file = path.format(current),
 							suite = suiteName,
 							case = caseName,
 							verbose = runOptions.verbose,
@@ -87,18 +88,18 @@ local function runtests(
 						end
 					end
 				end, function(err: any)
+					local where = if current then path.format(current) else "<worker setup>"
 					result.total += 1
 					result.failed += 1
 					table.insert(result.failures, {
-						test = "<worker>",
+						test = where,
 						failure = {
 							__tag = "runtime_error",
-							msg = `worker errored: {tostring(err)}`,
+							msg = `worker errored on {where}: {tostring(err)}`,
 							stacktrace = debug.traceback(nil, 2),
 						},
 					})
 				end)
-
 				done += 1
 			end)
 		end

--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -1,11 +1,12 @@
 local cli = require("@batteries/cli")
 local finder = require("@self/finder")
-local filter = require("@self/filter")
 local luau = require("@std/luau")
 local path = require("@std/path")
 local ps = require("@std/process")
+local system = require("@std/system")
+local task = require("@std/task")
+local vm = require("@lute/vm")
 local testtypes = require("@std/test/types")
-local runner = require("@std/test/runner")
 local reporter = require("@self/reporter")
 local test = require("@std/test")
 local snaprunner = require("@self/snap/runner")
@@ -41,14 +42,59 @@ local function listtests()
 end
 
 local function runtests(
-	env: testtypes.TestEnvironment,
-	runner: testtypes.TestRunner,
-	reporter: testtypes.TestReporter,
+	testfiles: { path.Path },
+	suiteName: string?,
+	caseName: string?,
 	runOptions: testtypes.TestRunnerOptions
 )
-	local result = runner(env, runOptions)
+	local result = { failures = {}, total = 0, failed = 0, passed = 0 }
+	local nfiles = #testfiles
 
-	reporter(result)
+	if nfiles > 0 then
+		local nworkers = math.max(1, math.min(system.threadCount(), nfiles))
+
+		local cursor = 1
+		local function takenext(): path.Path?
+			if cursor > nfiles then
+				return nil
+			end
+			local p = testfiles[cursor]
+			cursor += 1
+			return p
+		end
+
+		local done = 0
+		for _ = 1, nworkers do
+			task.spawn(function()
+				local worker = vm.create("@self/worker")
+				while true do
+					local p = takenext()
+					if not p then
+						break
+					end
+					local r = worker.runfile({
+						file = path.format(p),
+						suite = suiteName,
+						case = caseName,
+						verbose = runOptions.verbose,
+					})
+					result.total += r.total
+					result.passed += r.passed
+					result.failed += r.failed
+					for _, f in r.failures do
+						table.insert(result.failures, f)
+					end
+				end
+				done += 1
+			end)
+		end
+
+		while done < nworkers do
+			task.wait()
+		end
+	end
+
+	reporter.color(result)
 	if result.failed ~= 0 then
 		ps.exit(1)
 	end
@@ -106,15 +152,14 @@ local function main(...: string)
 	end
 
 	local searchpath = if forwarded and #forwarded > 0 then forwarded else { "./" }
-	loadtests(finder.findtestfiles(searchpath))
+	local testfiles = finder.findtestfiles(searchpath)
 
 	if args:has("list") then
+		loadtests(testfiles)
 		listtests()
 	else
-		local env = test._registered() :: testtypes.TestEnvironment
 		local runOpts: testtypes.TestRunnerOptions = { verbose = args:has("verbose") }
-		local filteredEnv = filter.filtertests(env, args:get("suite"), args:get("case"))
-		runtests(filteredEnv, runner.run, reporter.color, runOpts)
+		runtests(testfiles, args:get("suite"), args:get("case"), runOpts)
 	end
 end
 

--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -66,25 +66,39 @@ local function runtests(
 		local done = 0
 		for _ = 1, nworkers do
 			task.spawn(function()
-				local worker = vm.create("@self/worker")
-				while true do
-					local p = takenext()
-					if not p then
-						break
+				xpcall(function()
+					local worker = vm.create("@self/worker")
+					while true do
+						local p = takenext()
+						if not p then
+							break
+						end
+						local r = worker.runfile({
+							file = path.format(p),
+							suite = suiteName,
+							case = caseName,
+							verbose = runOptions.verbose,
+						})
+						result.total += r.total
+						result.passed += r.passed
+						result.failed += r.failed
+						for _, f in r.failures do
+							table.insert(result.failures, f)
+						end
 					end
-					local r = worker.runfile({
-						file = path.format(p),
-						suite = suiteName,
-						case = caseName,
-						verbose = runOptions.verbose,
+				end, function(err: any)
+					result.total += 1
+					result.failed += 1
+					table.insert(result.failures, {
+						test = "<worker>",
+						failure = {
+							__tag = "runtime_error",
+							msg = `worker errored: {tostring(err)}`,
+							stacktrace = debug.traceback(nil, 2),
+						},
 					})
-					result.total += r.total
-					result.passed += r.passed
-					result.failed += r.failed
-					for _, f in r.failures do
-						table.insert(result.failures, f)
-					end
-				end
+				end)
+
 				done += 1
 			end)
 		end

--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -48,10 +48,15 @@ local function runtests(
 	runOptions: testtypes.TestRunnerOptions
 )
 	local result = { failures = {}, total = 0, failed = 0, passed = 0 }
+	local workerFailures: { string } = {}
 	local nfiles = #testfiles
 
 	if nfiles > 0 then
 		local nworkers = math.max(1, math.min(system.threadCount(), nfiles))
+
+		if runOptions.verbose then
+			print(`Running tests on {nworkers} worker{if nworkers == 1 then "" else "s"}...`)
+		end
 
 		local cursor = 1
 		local function takenext(): path.Path?
@@ -74,31 +79,27 @@ local function runtests(
 						if not current then
 							break
 						end
-						local r = worker.runfile({
+						local res = worker.runfile({
 							file = path.format(current),
 							suite = suiteName,
 							case = caseName,
 							verbose = runOptions.verbose,
 						})
-						result.total += r.total
-						result.passed += r.passed
-						result.failed += r.failed
-						for _, f in r.failures do
-							table.insert(result.failures, f)
+						if res.__tag == "err" then
+							table.insert(workerFailures, res.error)
+						else
+							local r = res.value
+							result.total += r.total
+							result.passed += r.passed
+							result.failed += r.failed
+							for _, f in r.failures do
+								table.insert(result.failures, f)
+							end
 						end
 					end
 				end, function(err: any)
 					local where = if current then path.format(current) else "<worker setup>"
-					result.total += 1
-					result.failed += 1
-					table.insert(result.failures, {
-						test = where,
-						failure = {
-							__tag = "runtime_error",
-							msg = `worker errored on {where}: {tostring(err)}`,
-							stacktrace = debug.traceback(nil, 2),
-						},
-					})
+					table.insert(workerFailures, `worker errored while running {where}: {tostring(err)}`)
 				end)
 				done += 1
 			end)
@@ -110,7 +111,8 @@ local function runtests(
 	end
 
 	reporter.color(result)
-	if result.failed ~= 0 then
+	reporter.workerFailures(workerFailures)
+	if result.failed ~= 0 or #workerFailures > 0 then
 		ps.exit(1)
 	end
 	ps.exit(0)

--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -66,7 +66,7 @@ local function runtests(
 		local done = 0
 		for _ = 1, nworkers do
 			task.spawn(function()
-				local current: path.Path? = nil
+				local current = nil
 				xpcall(function()
 					local worker = vm.create("@self/worker")
 					while true do

--- a/lute/cli/commands/test/reporter.luau
+++ b/lute/cli/commands/test/reporter.luau
@@ -65,6 +65,19 @@ local function colorReporter(result: tys.TestRunResult)
 	printSummary(result)
 end
 
+local function workerFailuresReporter(failures: { string })
+	if #failures == 0 then
+		return
+	end
+
+	print("")
+	print(fail("Worker failures:"))
+	print("")
+	for _, msg in failures do
+		print(errlabel("  WORKER ") .. msg)
+	end
+end
+
 local function snapReporter(result: snapty.snapresult)
 	local total = #result.passed + #result.failed + #result.new
 
@@ -105,4 +118,4 @@ local function snapReporter(result: snapty.snapresult)
 	print(snapsty.bold("Snapshots: ") .. table.concat(parts, snapsty.dim(", ")) .. snapsty.dim(` of {total}`))
 end
 
-return table.freeze({ color = colorReporter, snap = snapReporter })
+return table.freeze({ color = colorReporter, snap = snapReporter, workerFailures = workerFailuresReporter })

--- a/lute/cli/commands/test/worker.luau
+++ b/lute/cli/commands/test/worker.luau
@@ -11,26 +11,22 @@ local function reset()
 	table.clear(env.caseindex)
 end
 
-local function loadFailure(filepath: string, err: any): types.FailedTest
-	return {
-		test = filepath,
-		failure = {
-			msg = `failed to load test file: {tostring(err)}`,
-			stacktrace = "",
-			__tag = "runtime_error",
-		},
-	}
-end
-
-local function runfile(
-	args: { file: string, suite: string?, case: string?, verbose: boolean? }
-): types.TestRunResult
+local function runfile(args: { file: string, suite: string?, case: string?, verbose: boolean? }): types.TestRunResult
 	reset()
 
 	local ok, err = pcall(luau.loadModule, args.file, nil)
 	if not ok then
 		return {
-			failures = { loadFailure(args.file, err) },
+			failures = {
+				{
+					test = args.file,
+					failure = {
+						__tag = "runtime_error",
+						msg = `failed to load test file: {tostring(err)}`,
+						stacktrace = "",
+					},
+				},
+			},
 			total = 1,
 			passed = 0,
 			failed = 1,

--- a/lute/cli/commands/test/worker.luau
+++ b/lute/cli/commands/test/worker.luau
@@ -4,6 +4,8 @@ local runner = require("@std/test/runner")
 local types = require("@std/test/types")
 local filter = require("./filter")
 
+export type Result<T, E> = { __tag: "ok", value: T } | { __tag: "err", error: E }
+
 local function reset()
 	table.clear(env.anonymous)
 	table.clear(env.suites)
@@ -11,30 +13,18 @@ local function reset()
 	table.clear(env.caseindex)
 end
 
-local function runfile(args: { file: string, suite: string?, case: string?, verbose: boolean? }): types.TestRunResult
+local function runfile(
+	args: { file: string, suite: string?, case: string?, verbose: boolean? }
+): Result<types.TestRunResult, string>
 	reset()
 
 	local ok, err = pcall(luau.loadModule, args.file, nil)
 	if not ok then
-		return {
-			failures = {
-				{
-					test = args.file,
-					failure = {
-						__tag = "runtime_error",
-						msg = `failed to load test file: {tostring(err)}`,
-						stacktrace = debug.traceback(nil, 2),
-					},
-				},
-			},
-			total = 1,
-			passed = 0,
-			failed = 1,
-		}
+		return { __tag = "err", error = tostring(err) }
 	end
 
 	local filtered = filter.filtertests(env, args.suite, args.case)
-	return runner.run(filtered, { verbose = args.verbose == true })
+	return { __tag = "ok", value = runner.run(filtered, { verbose = args.verbose == true }) }
 end
 
 return table.freeze({ runfile = runfile })

--- a/lute/cli/commands/test/worker.luau
+++ b/lute/cli/commands/test/worker.luau
@@ -1,0 +1,44 @@
+local luau = require("@std/luau")
+local env = require("@std/test/env")
+local runner = require("@std/test/runner")
+local types = require("@std/test/types")
+local filter = require("./filter")
+
+local function reset()
+	table.clear(env.anonymous)
+	table.clear(env.suites)
+	table.clear(env.suiteindex)
+	table.clear(env.caseindex)
+end
+
+local function loadFailure(filepath: string, err: any): types.FailedTest
+	return {
+		test = filepath,
+		failure = {
+			msg = `failed to load test file: {tostring(err)}`,
+			stacktrace = "",
+			__tag = "runtime_error",
+		},
+	}
+end
+
+local function runfile(
+	args: { file: string, suite: string?, case: string?, verbose: boolean? }
+): types.TestRunResult
+	reset()
+
+	local ok, err = pcall(luau.loadModule, args.file, nil)
+	if not ok then
+		return {
+			failures = { loadFailure(args.file, err) },
+			total = 1,
+			passed = 0,
+			failed = 1,
+		}
+	end
+
+	local filtered = filter.filtertests(env, args.suite, args.case)
+	return runner.run(filtered, { verbose = args.verbose == true })
+end
+
+return table.freeze({ runfile = runfile })

--- a/lute/cli/commands/test/worker.luau
+++ b/lute/cli/commands/test/worker.luau
@@ -23,7 +23,7 @@ local function runfile(args: { file: string, suite: string?, case: string?, verb
 					failure = {
 						__tag = "runtime_error",
 						msg = `failed to load test file: {tostring(err)}`,
-						stacktrace = "",
+						stacktrace = debug.traceback(nil, 2),
 					},
 				},
 			},

--- a/lute/vm/src/spawn.cpp
+++ b/lute/vm/src/spawn.cpp
@@ -1,5 +1,6 @@
 #include "lute/vm.h"
 
+#include "lute/clivfs.h"
 #include "lute/ref.h"
 #include "lute/require.h"
 #include "lute/requirevfs.h"
@@ -188,7 +189,8 @@ static void* createChildVmRequireContext(lua_State* L)
     if (!ctx)
         luaL_error(L, "unable to allocate RequireCtx");
 
-    ctx = new (ctx) RequireCtx{std::make_unique<RequireVfs>()};
+    // Explicit CliVfs should be removed with https://github.com/luau-lang/lute/issues/1027
+    ctx = new (ctx) RequireCtx{std::make_unique<RequireVfs>(CliVfs{})};
 
     // Store RequireCtx in the registry to keep it alive for the lifetime of
     // this lua_State. Memory address is used as a key to avoid collisions.
@@ -216,8 +218,9 @@ int VM::lua_spawn(lua_State* L)
     lua_Debug ar;
     lua_getinfo(L, 1, "s", &ar);
 
-    // Require the target module
-    RequireCtx ctx{std::make_unique<RequireVfs>()};
+    // Require the target module.
+    // Explicit CliVfs should be removed with https://github.com/luau-lang/lute/issues/1027
+    RequireCtx ctx{std::make_unique<RequireVfs>(CliVfs{})};
     luarequire_pushproxyrequire(child->GL, requireConfigInit, &ctx);
     lua_pushstring(child->GL, file);
     lua_pushstring(child->GL, ar.source);


### PR DESCRIPTION
Creates a worker for each system thread using the VM lib and then workers pull test files as they become free to distribute test load.

Tests ran in ~8.0s on 1.0.0. With #1001, we got down to ~5.4s. With parallel execution, we reach ~2.8s. 🎉 

<details>
<summary>Details</summary>

```
Benchmark 1: lute test (1.0.0)
  Time (mean ± σ):      7.967 s ±  0.084 s    [User: 3.547 s, System: 2.175 s]
  Range (min … max):    7.813 s …  8.093 s    10 runs
 
Benchmark 2: lute test (primary, has discovery fixes)
  Time (mean ± σ):      5.386 s ±  0.052 s    [User: 2.281 s, System: 0.690 s]
  Range (min … max):    5.312 s …  5.473 s    10 runs
 
Benchmark 3: lute test (parallel execution)
  Time (mean ± σ):      2.807 s ±  0.050 s    [User: 2.608 s, System: 1.104 s]
  Range (min … max):    2.750 s …  2.909 s    10 runs
```

</details>
