### PR TITLE
Use port 0 for net tests

### DIFF
--- a/tests/lute/net.test.luau
+++ b/tests/lute/net.test.luau
@@ -15,6 +15,7 @@ test.suite("LuteNetSuite", function(suite)
 		local firstServerSendResult: number? = nil
 
 		local instance = server.serve({
+			port = 0,
 			handler = function(req: server.ReceivedRequest, current: server.Server): server.ServerResponse?
 				if current:upgrade(req) then
 					return nil
@@ -175,6 +176,7 @@ test.suite("LuteNetSuite", function(suite)
 		local opened = false
 
 		local instance = server.serve({
+			port = 0,
 			handler = function(req: server.ReceivedRequest, current: server.Server): server.ServerResponse?
 				if current:upgrade(req) then
 					return nil
@@ -223,6 +225,7 @@ test.suite("LuteNetSuite", function(suite)
 		local closeReason: string? = nil
 
 		local instance = server.serve({
+			port = 0,
 			handler = function(req: server.ReceivedRequest, current: server.Server): server.ServerResponse?
 				if current:upgrade(req) then
 					return nil

--- a/tests/std/net.test.luau
+++ b/tests/std/net.test.luau
@@ -6,6 +6,7 @@ local test = require("@std/test")
 test.suite("NetTestSuite", function(suite)
 	suite:case("serveHandlerCanYield", function(assert)
 		local instance = server.serve({
+			port = 0,
 			handler = function(_req: server.ReceivedRequest): server.ServerResponse
 				task.wait(0.01)
 				task.wait(0.01)
@@ -28,6 +29,7 @@ test.suite("NetTestSuite", function(suite)
 
 	suite:case("serveLocallyAndRequest", function(assert)
 		local instance = server.serve({
+			port = 0,
 			handler = function(_req: server.ReceivedRequest): server.ServerResponse
 				return {
 					status = 200,


### PR DESCRIPTION
Port 0 is reserved and will get you an open port on the machine. This should be used for tests to avoid address in use errors.