### PR TITLE
Fix heap use after free in process.run

### DIFF
--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -348,7 +348,10 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
         luaL_error(L, "Failed to spawn process: %s", uv_strerror(spawnResult));
     }
 
-    // Close our end of the child's stdin so it sees EOF instead of blocking.
+    // In the default stdio mode we create a pipe for the child's stdin so that
+    // future APIs can feed data to it, but there is no API to write to it yet.
+    // Close our write end immediately so the child sees EOF on stdin instead
+    // of blocking forever on a read.
     if (opts.stdioKind == kStdioKindDefault || opts.stdioKind.empty())
     {
         handle->pendingCloses++;

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -316,8 +316,7 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
     }
     else if (opts.stdioKind == kStdioKindDefault || opts.stdioKind.empty())
     {
-        stdio[0].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_READABLE_PIPE);
-        stdio[0].data.stream = (uv_stream_t*)&handle->stdinPipe;
+        stdio[0].flags = UV_IGNORE;
         stdio[1].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
         stdio[1].data.stream = (uv_stream_t*)&handle->stdoutPipe;
         stdio[2].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
@@ -348,15 +347,6 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
         handle->closeHandles();
 
         luaL_error(L, "Failed to spawn process: %s", uv_strerror(spawnResult));
-    }
-
-    // In the default stdio mode we create a pipe for the child's stdin so that
-    // future APIs can feed data to it, but there is no API to write to it yet.
-    // Close our write end immediately so the child sees EOF on stdin instead
-    // of blocking forever on a read.
-    if (opts.stdioKind == kStdioKindDefault || opts.stdioKind.empty())
-    {
-        uv_close((uv_handle_t*)&handle->stdinPipe, nullptr);
     }
 
     uv_read_start((uv_stream_t*)&handle->stdoutPipe, allocBuffer, onPipeRead);

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -53,46 +53,44 @@ struct ProcessHandle
     bool completed = false;
     ResumeToken resumeToken;
     std::shared_ptr<ProcessHandle> self;
-    std::atomic<int> pendingCloses{0};
+    std::atomic<int> pendingCloses{1};
+
+    static void onHandleClose(uv_handle_t* handle)
+    {
+        ProcessHandle* ph = static_cast<ProcessHandle*>(handle->data);
+        if (--ph->pendingCloses == 0)
+            ph->self.reset();
+    }
 
     void closeHandles()
     {
-        auto closeCb = [](uv_handle_t* handle)
-        {
-            ProcessHandle* ph = static_cast<ProcessHandle*>(handle->data);
-            if (--ph->pendingCloses == 0)
-            {
-                ph->self.reset();
-            }
-        };
-
         if (!uv_is_closing((uv_handle_t*)&stdinPipe))
         {
             pendingCloses++;
             uv_read_stop((uv_stream_t*)&stdinPipe);
-            uv_close((uv_handle_t*)&stdinPipe, closeCb);
+            uv_close((uv_handle_t*)&stdinPipe, onHandleClose);
         }
 
         if (!uv_is_closing((uv_handle_t*)&stdoutPipe))
         {
             pendingCloses++;
             uv_read_stop((uv_stream_t*)&stdoutPipe);
-            uv_close((uv_handle_t*)&stdoutPipe, closeCb);
+            uv_close((uv_handle_t*)&stdoutPipe, onHandleClose);
         }
 
         if (!uv_is_closing((uv_handle_t*)&stderrPipe))
         {
             pendingCloses++;
             uv_read_stop((uv_stream_t*)&stderrPipe);
-            uv_close((uv_handle_t*)&stderrPipe, closeCb);
+            uv_close((uv_handle_t*)&stderrPipe, onHandleClose);
         }
         if (!uv_is_closing((uv_handle_t*)&process))
         {
             pendingCloses++;
-            uv_close((uv_handle_t*)&process, closeCb);
+            uv_close((uv_handle_t*)&process, onHandleClose);
         }
 
-        if (pendingCloses == 0)
+        if (--pendingCloses == 0)
         {
             self.reset();
         }
@@ -316,7 +314,8 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
     }
     else if (opts.stdioKind == kStdioKindDefault || opts.stdioKind.empty())
     {
-        stdio[0].flags = UV_IGNORE;
+        stdio[0].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_READABLE_PIPE);
+        stdio[0].data.stream = (uv_stream_t*)&handle->stdinPipe;
         stdio[1].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
         stdio[1].data.stream = (uv_stream_t*)&handle->stdoutPipe;
         stdio[2].flags = static_cast<uv_stdio_flags>(UV_CREATE_PIPE | UV_WRITABLE_PIPE);
@@ -347,6 +346,13 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
         handle->closeHandles();
 
         luaL_error(L, "Failed to spawn process: %s", uv_strerror(spawnResult));
+    }
+
+    // Close our end of the child's stdin so it sees EOF instead of blocking.
+    if (opts.stdioKind == kStdioKindDefault || opts.stdioKind.empty())
+    {
+        handle->pendingCloses++;
+        uv_close((uv_handle_t*)&handle->stdinPipe, ProcessHandle::onHandleClose);
     }
 
     uv_read_start((uv_stream_t*)&handle->stdoutPipe, allocBuffer, onPipeRead);


### PR DESCRIPTION
#996 introduced a heap use after free from closing the stdin pipe right away without tracking it against the ProcessHandle's lifetime. Updated to track stdin close through `pendingCloses` like the other handles.