### PR TITLE
Loom: Lockfile aliases + field consistency

### DIFF
--- a/lute/cli/commands/pkg/loom-core/src/commands/install.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/install.luau
@@ -1,19 +1,20 @@
+local lockfile = require("../lockfile")
 local packageresolution = require("../packageresolution")
 local path = require("@std/path")
 local process = require("@std/process")
 
-local function printDiagnostics(graph: packageresolution.ResolvedGraph)
+local function printDiagnostics(lock: lockfile.Lockfile)
 	local depCount = 0
-	for _ in graph.dependencies do
+	for _ in lock.dependencies do
 		depCount += 1
 	end
 	print(`Resolved {depCount} package(s).`)
 
-	for key, pkg in graph.dependencies do
+	for _, key in lock.dependencies do
 		local transitive = 0
-		local deps = graph.graph[key]
-		if deps then
-			for _ in deps do
+		local pkg = lock.packages[key]
+		if pkg then
+			for _ in pkg.dependencies do
 				transitive += 1
 			end
 		end
@@ -23,8 +24,8 @@ end
 
 local function install()
 	local rootDirectory = path.format(process.cwd())
-	local graph = packageresolution.resolve(rootDirectory)
-	printDiagnostics(graph)
+	local lock = packageresolution.resolve(rootDirectory)
+	printDiagnostics(lock)
 end
 
 return install

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -35,7 +35,7 @@ end
 
 local function parseLockfile(t: any): Lockfile
 	assert(t ~= nil and type(t) == "table", "Expected lockfile to be a table")
-	assert(t.version == 2, `Unsupported lockfile version: {t.version}`)
+	assert(t.version == 3, `Unsupported lockfile version: {t.version}`)
 	assert(type(t.packages) == "table", "Expected 'packages' field in lockfile")
 	assert(type(t.dependencies) == "table", "Expected 'dependencies' field in lockfile")
 

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -11,8 +11,8 @@ export type LockfileDependency = {
 
 export type Lockfile = {
 	read version: number,
-	read packages: { string },
-	read dependencies: { [string]: LockfileDependency },
+	read packages: { [string]: LockfileDependency },
+	read dependencies: { [string]: string },
 }
 
 local function validatePackageEntry(key: string, entry: any)
@@ -39,15 +39,16 @@ local function parseLockfile(t: any): Lockfile
 	assert(type(t.packages) == "table", "Expected 'packages' field in lockfile")
 	assert(type(t.dependencies) == "table", "Expected 'dependencies' field in lockfile")
 
-	for _, key in t.packages do
+	for key, entry in t.packages do
 		assert(type(key) == "string", "Expected package key to be a string")
-		assert((t.dependencies :: { [unknown]: unknown })[key] ~= nil, `Package '{key}' not found in dependencies`)
+		validatePackageEntry(key, entry)
 	end
 	table.freeze(t.packages)
 
-	for key, entry in t.dependencies do
-		assert(type(key) == "string", "Expected package key to be a string")
-		validatePackageEntry(key, entry)
+	for alias, key in t.dependencies do
+		assert(type(alias) == "string", "Expected dependency alias to be a string")
+		assert(type(key) == "string", "Expected dependency key to be a string")
+		assert(t.packages[key] ~= nil, `Dependency '{alias}' references package '{key}' which is not in packages`)
 	end
 	table.freeze(t.dependencies)
 

--- a/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
@@ -151,15 +151,15 @@ local function resolve(rootDirectory: string): lockfile.Lockfile
 
 	table.freeze(packages)
 
-	local lf: lockfile.Lockfile = table.freeze({
+	local lock: lockfile.Lockfile = table.freeze({
 		version = 3,
 		packages = packages,
 		dependencies = dependencies,
 	})
 
-	fs.writeStringToFile(lockfilePath, `return {pp(lf)}\n`)
+	fs.writeStringToFile(lockfilePath, `return {pp(lock)}\n`)
 
-	return lf
+	return lock
 end
 
 return {

--- a/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
@@ -5,12 +5,6 @@ local path = require("@std/path")
 local pp = require("@batteries/pp")
 local projectmanifest = require("./projectmanifest")
 
-export type ResolvedGraph = {
-	read packages: { string },
-	read dependencies: { [string]: projectmanifest.DependencySpec },
-	read graph: { [string]: { [string]: string } },
-}
-
 local function getManifestPath(directory: string): string
 	return `{directory}/loom.config.luau`
 end
@@ -24,13 +18,6 @@ local function getKey(spec: projectmanifest.DependencySpec): string
 		return `{spec.name}@{spec.rev}`
 	end
 	return spec.name
-end
-
-local function getInstallPath(spec: projectmanifest.DependencySpec): string
-	if spec.sourceKind == "path" then
-		return spec.source
-	end
-	return `Packages/{getKey(spec)}`
 end
 
 local function hasConflict(specA: projectmanifest.DependencySpec, specB: projectmanifest.DependencySpec): boolean
@@ -66,7 +53,7 @@ local function fetchSource(spec: projectmanifest.DependencySpec, rootDirectory: 
 		return sourcePath
 	elseif spec.sourceKind == "github" then
 		assert(spec.rev ~= nil, `Expected rev to be non-nil for GitHub package '{spec.name}'`)
-		local sourcePath = `{rootDirectory}/{getInstallPath(spec)}`
+		local sourcePath = `{rootDirectory}/Packages/{getKey(spec)}`
 		github.installPackage(spec.source, spec.rev, sourcePath)
 		return sourcePath
 	else
@@ -74,28 +61,7 @@ local function fetchSource(spec: projectmanifest.DependencySpec, rootDirectory: 
 	end
 end
 
-local function createLockfile(resolved: ResolvedGraph): lockfile.Lockfile
-	local deps: { [string]: lockfile.LockfileDependency } = {}
-
-	for key, pkg in resolved.dependencies do
-		deps[key] = {
-			name = pkg.name,
-			rev = pkg.rev,
-			source = pkg.source,
-			sourceKind = pkg.sourceKind,
-			installPath = getInstallPath(pkg),
-			dependencies = resolved.graph[key] or {},
-		}
-	end
-
-	return {
-		version = 2,
-		packages = resolved.packages,
-		dependencies = deps,
-	}
-end
-
-local function resolve(rootDirectory: string): ResolvedGraph
+local function resolve(rootDirectory: string): lockfile.Lockfile
 	local rootManifestPath = getManifestPath(rootDirectory)
 	if not fs.exists(rootManifestPath) then
 		error(`Manifest file not found: {rootManifestPath}`)
@@ -112,28 +78,27 @@ local function resolve(rootDirectory: string): ResolvedGraph
 
 	local queue: { projectmanifest.DependencySpec } = {}
 
-	local packages: { string } = {}
-	local dependencies: { [string]: projectmanifest.DependencySpec } = {}
-	local graph: { [string]: { [string]: string } } = {}
+	local dependencies: { [string]: string } = {}
+	local packages: { [string]: lockfile.LockfileDependency } = {}
 
 	local rootManifest = projectmanifest.parseFile(rootManifestPath)
-	for _, spec in rootManifest.package.dependencies do
-		table.insert(packages, getKey(spec))
-		table.insert(queue, spec)
+	for depAlias, depSpec in rootManifest.package.dependencies do
+		dependencies[depAlias] = getKey(depSpec)
+		table.insert(queue, depSpec)
 	end
 
-	table.freeze(packages)
+	table.freeze(dependencies)
 
 	local nameIndex: { [string]: string } = {}
 
 	for _, spec in queue do
 		local key = getKey(spec)
 
-		if dependencies[key] then
-			if hasConflict(dependencies[key], spec) then
+		if packages[key] then
+			if hasConflict(packages[key], spec) then
 				error(
 					`Source mismatch for package '{spec.name}':\n`
-						.. `  resolved: {dependencies[key].source} ({dependencies[key].sourceKind})\n`
+						.. `  resolved: {packages[key].source} ({packages[key].sourceKind})\n`
 						.. `  incoming: {spec.source} ({spec.sourceKind})\n`
 						.. `Both resolve to '{key}' but from different sources.`
 				)
@@ -155,8 +120,7 @@ local function resolve(rootDirectory: string): ResolvedGraph
 
 		-- New package — resolve it
 		nameIndex[spec.name] = key
-		dependencies[key] = spec
-		graph[key] = {}
+		local transitiveDependencies: { [string]: string } = {}
 
 		-- Download and install
 		local installPath = fetchSource(spec, rootDirectory)
@@ -168,27 +132,34 @@ local function resolve(rootDirectory: string): ResolvedGraph
 			for depAlias, depSpec in depManifest.package.dependencies do
 				-- Normalize transitive path dep sources to be rootDirectory-relative
 				local normalizedSpec = normalizePathDependency(depSpec, installPath, rootDirectory)
-				graph[key][depAlias] = getKey(normalizedSpec)
+				transitiveDependencies[depAlias] = getKey(normalizedSpec)
 				table.insert(queue, normalizedSpec)
 			end
 		end
 
-		table.freeze(graph[key])
+		table.freeze(transitiveDependencies)
+
+		packages[key] = table.freeze({
+			name = spec.name,
+			rev = spec.rev,
+			source = spec.source,
+			sourceKind = spec.sourceKind,
+			installPath = path.format(path.relative(rootDirectory, installPath)),
+			dependencies = transitiveDependencies,
+		})
 	end
 
-	table.freeze(dependencies)
-	table.freeze(graph)
+	table.freeze(packages)
 
-	local resolved = table.freeze({
+	local lf: lockfile.Lockfile = table.freeze({
+		version = 2,
 		packages = packages,
 		dependencies = dependencies,
-		graph = graph,
 	})
 
-	local lf = createLockfile(resolved)
 	fs.writeStringToFile(lockfilePath, `return {pp(lf)}\n`)
 
-	return resolved
+	return lf
 end
 
 return {

--- a/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
@@ -152,7 +152,7 @@ local function resolve(rootDirectory: string): lockfile.Lockfile
 	table.freeze(packages)
 
 	local lf: lockfile.Lockfile = table.freeze({
-		version = 2,
+		version = 3,
 		packages = packages,
 		dependencies = dependencies,
 	})

--- a/lute/cli/src/packagerun.cpp
+++ b/lute/cli/src/packagerun.cpp
@@ -75,27 +75,6 @@ static std::string getEntryPoint(const std::string& packageRoot)
     return joinPaths(packageRoot, "src/init.luau");
 }
 
-// Extract a Luau array (numeric-keyed ConfigTable) as ordered strings.
-static std::vector<std::string> extractStringArray(const Luau::ConfigTable& table)
-{
-    std::vector<std::pair<size_t, std::string>> indexed;
-    for (const auto& [k, v] : table)
-    {
-        const double* key = k.get_if<double>();
-        const std::string* val = v.get_if<std::string>();
-        if (!key || !val)
-            continue;
-        indexed.emplace_back(static_cast<size_t>(*key), *val);
-    }
-    std::sort(indexed.begin(), indexed.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
-
-    std::vector<std::string> result;
-    result.reserve(indexed.size());
-    for (auto& [_, val] : indexed)
-        result.push_back(std::move(val));
-    return result;
-}
-
 std::pair<std::vector<Package::Identifier>, std::vector<std::pair<Package::Identifier, Package::Info>>> getDependenciesFromLockfile(
     const std::string& lockfilePath
 )

--- a/lute/cli/src/packagerun.cpp
+++ b/lute/cli/src/packagerun.cpp
@@ -124,12 +124,12 @@ std::pair<std::vector<Package::Identifier>, std::vector<std::pair<Package::Ident
     if (!lockfileParentDir)
         return {};
 
-    // First pass: parse all dependency entries
+    // First pass: parse all package entries
     std::unordered_map<std::string, Package::Identifier> keyToIdentifier;
     std::unordered_map<std::string, Package::Info> keyToInfo;
     std::unordered_map<std::string, std::unordered_map<std::string, std::string>> keyToDepAliases;
 
-    for (const auto& [k, v] : *depsTable)
+    for (const auto& [k, v] : *packagesTable)
     {
         const std::string* packageKey = k.get_if<std::string>();
         if (!packageKey)
@@ -207,12 +207,14 @@ std::pair<std::vector<Package::Identifier>, std::vector<std::pair<Package::Ident
         }
     }
 
-    // Build direct dependencies from packages array
-    std::vector<std::string> packageKeys = extractStringArray(*packagesTable);
+    // Build direct dependencies from dependencies table (alias -> key map)
     std::vector<Package::Identifier> directDependencies;
-    for (const std::string& key : packageKeys)
+    for (const auto& [ak, av] : *depsTable)
     {
-        auto it = keyToIdentifier.find(key);
+        const std::string* depKey = av.get_if<std::string>();
+        if (!depKey)
+            continue;
+        auto it = keyToIdentifier.find(*depKey);
         if (it != keyToIdentifier.end())
             directDependencies.push_back(it->second);
     }

--- a/tests/src/packages/pkgrun_deep_path_deps/loom.lock.luau
+++ b/tests/src/packages/pkgrun_deep_path_deps/loom.lock.luau
@@ -1,7 +1,9 @@
 return {
-	version = 2,
-	packages = { "app" },
+	version = 3,
 	dependencies = {
+		app = "app",
+	},
+	packages = {
 		["app"] = {
 			name = "app",
 			source = "packages/app",

--- a/tests/src/packages/pkgrun_transitive_deps/loom.lock.luau
+++ b/tests/src/packages/pkgrun_transitive_deps/loom.lock.luau
@@ -1,7 +1,9 @@
 return {
-	version = 2,
-	packages = { "dep@v1.2.3" },
+	version = 3,
 	dependencies = {
+		dep = "dep@v1.2.3",
+	},
+	packages = {
 		["dep@v1.2.3"] = {
 			name = "dep",
 			rev = "v1.2.3",

--- a/tests/src/packages/pkgrun_with_lockfile/loom.lock.luau
+++ b/tests/src/packages/pkgrun_with_lockfile/loom.lock.luau
@@ -1,7 +1,9 @@
 return {
-	version = 2,
-	packages = { "dep@v1.2.3" },
+	version = 3,
 	dependencies = {
+		dep = "dep@v1.2.3",
+	},
+	packages = {
 		["dep@v1.2.3"] = {
 			name = "dep",
 			rev = "v1.2.3",


### PR DESCRIPTION
Adds the root package's dependency aliases to the lockfile (so it has complete information about the dependency graph), and renames the top-level lockfile fields so that naming is consistent across all levels:

- `packages: { [key]: LockfileDependency }` — all resolved packages (dependencies + transitive dependencies), keyed by package key
- `dependencies: { [alias]: key }` — the root project's direct dependency aliases
- The new naming matches how transitive dependencies are already represented inside each `LockfileDependency` (`dependencies: { [alias]: key }`), making the structure self-similar at every level
- Lockfile version bumped to 3 to reflect the structural change