### PR TITLE
Fix luthier --clean on Windows

### DIFF
--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -473,6 +473,24 @@ local function call(cmd: { string }, passedCwd: string?): number
 	return process.run(cmd, { cwd = passedCwd or cwd, stdio = "inherit" }).exitcode
 end
 
+local function removePathRecursive(path: string)
+	local pathType = safeFsType(path)
+	if pathType == nil then
+		return
+	end
+
+	if pathType ~= "dir" then
+		fs.remove(path)
+		return
+	end
+
+	for _, entry in fs.listdir(path) do
+		removePathRecursive(joinPath(path, entry.name))
+	end
+
+	fs.rmdir(path)
+end
+
 local function build()
 	local target = args:get("target")
 	assert(target ~= nil)
@@ -499,7 +517,8 @@ local function getConfigureArguments()
 	end
 
 	if args:has("clean") then
-		call({ "rm", "-rf", projectPath })
+		print("> remove-tree " .. projectPath)
+		removePathRecursive(projectPath)
 	end
 
 	local configArgs =

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -179,6 +179,10 @@ local function projectPathExists(): boolean
 	return safeFsType(projectPath) == "dir"
 end
 
+local function buildManifestExists(): boolean
+	return safeFsType(joinPath(getProjectPath(), "build.ninja")) == "file"
+end
+
 local function hexify(digest)
 	local hex = {}
 	for i = 1, buffer.len(digest) do
@@ -774,7 +778,7 @@ elseif subcommand == "build" or subcommand == "craft" then
 
 	generateFilesIfNeeded()
 
-	if not projectPathExists() or not areTuneFilesUpToDate() then
+	if not projectPathExists() or not buildManifestExists() or not areTuneFilesUpToDate() then
 		check(configure())
 	end
 
@@ -786,7 +790,7 @@ elseif subcommand == "run" or subcommand == "play" then
 
 	generateFilesIfNeeded()
 
-	if not projectPathExists() or not areTuneFilesUpToDate() then
+	if not projectPathExists() or not buildManifestExists() or not areTuneFilesUpToDate() then
 		check(configure())
 	end
 


### PR DESCRIPTION
## Summary
Replace the `rm -rf` clean step in `tools/luthier.luau` with a recursive delete implemented through Lute's filesystem API.

## Why
`lute tools/luthier.luau build --clean lute` fails on Windows because `luthier` tries to spawn `rm`, which is a Unix command and may not exist in a normal Windows shell.

## Changes
- add a small recursive delete helper in `tools/luthier.luau`
- use that helper for the `--clean` configure path
- make cleaning a no-op when the build directory does not exist