### PR TITLE
Create Docker container release system

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,147 @@
+name: Docker
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Lute version to publish (e.g. 1.0.0). Must match an existing GitHub release tag."
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: "Lute version to publish."
+        required: true
+        type: string
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+
+    env:
+      IMAGE: ghcr.io/${{ github.repository }}
+      VERSION: ${{ inputs.version }}
+
+    steps:
+      - name: Validate version
+        run: |
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version: $VERSION. Expected semver like 1.0.0 (no nightly suffix)."
+            exit 1
+          fi
+
+      - name: Verify release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release view "v$VERSION" --repo "${{ github.repository }}" > /dev/null
+
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: docker
+
+      - name: Compute version tags
+        id: tags
+        run: |
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push bin image
+        id: build_bin
+        uses: docker/build-push-action@v7
+        with:
+          context: docker
+          file: docker/bin.dockerfile
+          platforms: linux/amd64,linux/arm64
+          provenance: false # SLSA provenance is attached separately via actions/attest
+          push: true
+          build-args: |
+            LUTE_VERSION=${{ env.VERSION }}
+          tags: |
+            ${{ env.IMAGE }}:bin
+            ${{ env.IMAGE }}:bin-${{ steps.tags.outputs.major }}
+            ${{ env.IMAGE }}:bin-${{ steps.tags.outputs.minor }}
+            ${{ env.IMAGE }}:bin-${{ env.VERSION }}
+
+      - name: Attest bin image
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build_bin.outputs.digest }}
+          push-to-registry: true
+
+      - name: Build and push debian image
+        id: build_debian
+        uses: docker/build-push-action@v7
+        with:
+          context: docker
+          file: docker/debian.dockerfile
+          platforms: linux/amd64,linux/arm64
+          provenance: false # SLSA provenance is attached separately via actions/attest
+          push: true
+          build-args: |
+            LUTE_VERSION=${{ env.VERSION }}
+            BIN_IMAGE=${{ env.IMAGE }}:bin-${{ env.VERSION }}
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ steps.tags.outputs.major }}
+            ${{ env.IMAGE }}:${{ steps.tags.outputs.minor }}
+            ${{ env.IMAGE }}:${{ env.VERSION }}
+            ${{ env.IMAGE }}:debian
+            ${{ env.IMAGE }}:debian-${{ steps.tags.outputs.major }}
+            ${{ env.IMAGE }}:debian-${{ steps.tags.outputs.minor }}
+            ${{ env.IMAGE }}:debian-${{ env.VERSION }}
+
+      - name: Attest debian image
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build_debian.outputs.digest }}
+          push-to-registry: true
+
+      - name: Build and push distroless image
+        id: build_distroless
+        uses: docker/build-push-action@v7
+        with:
+          context: docker
+          file: docker/distroless.dockerfile
+          platforms: linux/amd64,linux/arm64
+          provenance: false # SLSA provenance is attached separately via actions/attest
+          push: true
+          build-args: |
+            LUTE_VERSION=${{ env.VERSION }}
+            BIN_IMAGE=${{ env.IMAGE }}:bin-${{ env.VERSION }}
+          tags: |
+            ${{ env.IMAGE }}:distroless
+            ${{ env.IMAGE }}:distroless-${{ steps.tags.outputs.major }}
+            ${{ env.IMAGE }}:distroless-${{ steps.tags.outputs.minor }}
+            ${{ env.IMAGE }}:distroless-${{ env.VERSION }}
+
+      - name: Attest distroless image
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.build_distroless.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: "primary"
         type: string
+    outputs:
+      version:
+        description: "The resolved Lute version that was released."
+        value: ${{ jobs.release.outputs.version }}
 
 env:
   IS_NIGHTLY: ${{ inputs.branch == 'primary' }}
@@ -82,6 +86,9 @@ jobs:
 
     permissions:
       contents: write
+
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,16 @@ jobs:
     with:
       branch: ${{ github.ref_name }}
     secrets: inherit
+
+  docker:
+    needs: release-common
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+    uses: ./.github/workflows/docker.yml
+    with:
+      version: ${{ needs.release-common.outputs.version }}
+    secrets: inherit

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,22 @@
+# Lute Docker Sources
+
+Source Dockerfiles for the official Lute container images. The images are built and published to `ghcr.io/luau-lang/lute` by the `release` workflow on every stable (non-nightly) release.
+
+See the [Docker guide](../docs/guide/docker.md) for the list of image variants, tags, and usage examples.
+
+## Building locally
+
+The Dockerfiles fetch the `lute` binary from the GitHub Releases page for the requested version, so any released version can be built locally:
+
+```bash
+docker buildx build \
+    --build-arg LUTE_VERSION=1.0.0 \
+    -f docker/bin.dockerfile \
+    -t lute:bin docker
+
+docker buildx build \
+    --build-arg LUTE_VERSION=1.0.0 \
+    --build-arg BIN_IMAGE=lute:bin \
+    -f docker/debian.dockerfile \
+    -t lute:debian docker
+```

--- a/docker/bin.dockerfile
+++ b/docker/bin.dockerfile
@@ -1,0 +1,21 @@
+ARG LUTE_VERSION
+
+FROM buildpack-deps:curl AS download
+
+RUN apt-get update && apt-get install -y --no-install-recommends unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG LUTE_VERSION
+ARG TARGETARCH
+
+RUN ARCH=$(echo "$TARGETARCH" | sed -e 's/arm64/aarch64/' -e 's/amd64/x86_64/') \
+    && curl -fsSL "https://github.com/luau-lang/lute/releases/download/v${LUTE_VERSION}/lute-linux-${ARCH}.zip" --output lute.zip \
+    && unzip lute.zip \
+    && chmod +x lute
+
+FROM scratch
+
+ARG LUTE_VERSION
+ENV LUTE_VERSION=${LUTE_VERSION}
+
+COPY --from=download /lute /lute

--- a/docker/debian.dockerfile
+++ b/docker/debian.dockerfile
@@ -1,0 +1,16 @@
+ARG LUTE_VERSION
+ARG BIN_IMAGE=ghcr.io/luau-lang/lute:bin-${LUTE_VERSION}
+
+FROM ${BIN_IMAGE} AS bin
+
+FROM debian:stable-slim
+
+ARG LUTE_VERSION
+ENV LUTE_VERSION=${LUTE_VERSION}
+
+COPY --from=bin /lute /usr/local/bin/lute
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["--help"]

--- a/docker/debian.dockerfile
+++ b/docker/debian.dockerfile
@@ -8,6 +8,10 @@ FROM debian:stable-slim
 ARG LUTE_VERSION
 ENV LUTE_VERSION=${LUTE_VERSION}
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=bin /lute /usr/local/bin/lute
 
 COPY docker-entrypoint.sh /usr/local/bin/

--- a/docker/distroless.dockerfile
+++ b/docker/distroless.dockerfile
@@ -1,0 +1,15 @@
+ARG LUTE_VERSION
+ARG BIN_IMAGE=ghcr.io/luau-lang/lute:bin-${LUTE_VERSION}
+
+FROM ${BIN_IMAGE} AS bin
+
+FROM gcr.io/distroless/cc-debian13
+
+ARG LUTE_VERSION
+ENV LUTE_VERSION=${LUTE_VERSION}
+
+COPY --from=bin /lute /usr/local/bin/lute
+
+ENTRYPOINT ["lute"]
+
+CMD ["--help"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# If the first argument starts with `-` or is not a system command, prepend
+# `lute` so users can run e.g. `docker run lute run script.luau` directly.
+if [ "$1" != "${1#-}" ] || [ -z "$(command -v "${1}")" ]; then
+    set -- lute "$@"
+fi
+
+exec "$@"

--- a/docs/guide/docker.md
+++ b/docs/guide/docker.md
@@ -1,0 +1,70 @@
+---
+order: 8
+---
+
+# Docker
+
+Lute publishes official container images to the [GitHub Container Registry](https://github.com/luau-lang/lute/pkgs/container/lute) on every stable (non-nightly) release. They cover both `linux/amd64` and `linux/arm64`.
+
+## Available images
+
+| Image | Base | When to use it |
+| --- | --- | --- |
+| `ghcr.io/luau-lang/lute` | `debian:stable-slim` | The default. Includes a shell and common utilities, suitable for most use cases. |
+| `ghcr.io/luau-lang/lute:distroless` | `gcr.io/distroless/cc-debian13` | Minimal runtime image. No shell or package manager. Smallest attack surface. |
+| `ghcr.io/luau-lang/lute:bin` | `scratch` | Just the `lute` binary, intended for use as a build stage in your own Dockerfiles. |
+
+## Tags
+
+For a release of version `X.Y.Z`, the workflow publishes the following tags:
+
+- Default (debian) variant: `latest`, `X`, `X.Y`, `X.Y.Z`, plus the same set prefixed with `debian-` (e.g. `debian`, `debian-X`, `debian-X.Y`, `debian-X.Y.Z`).
+- Distroless variant: `distroless`, `distroless-X`, `distroless-X.Y`, `distroless-X.Y.Z`.
+- Binary-only variant: `bin`, `bin-X`, `bin-X.Y`, `bin-X.Y.Z`.
+
+Pin to `X.Y.Z` for reproducible builds, `X.Y` to receive patch updates, or `X` to receive minor and patch updates within a major version.
+
+## Running Lute
+
+Print the Lute CLI help (the default `CMD`):
+
+```bash
+docker run --rm ghcr.io/luau-lang/lute
+```
+
+Run a `script.luau` file from your current directory:
+
+```bash
+docker run --init --rm -it -v "$PWD:/app" -w /app ghcr.io/luau-lang/lute run script.luau
+```
+
+Open a shell inside the container (debian variant only):
+
+```bash
+docker run --rm -it ghcr.io/luau-lang/lute sh
+```
+
+The `--init` flag is recommended so signals like `Ctrl+C` are forwarded to `lute` correctly. `-v "$PWD:/app"` mounts the current directory into the container, and `-w /app` makes it the working directory.
+
+## Using Lute in your own Dockerfile
+
+You can extend the default image directly:
+
+```dockerfile
+FROM ghcr.io/luau-lang/lute:1
+
+WORKDIR /app
+COPY . .
+
+CMD ["run", "server.luau"]
+```
+
+Or use the binary-only image to install Lute into any base image you want:
+
+```dockerfile
+FROM ubuntu:24.04
+
+COPY --from=ghcr.io/luau-lang/lute:bin /lute /usr/local/bin/
+
+CMD ["lute", "--help"]
+```

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -10,3 +10,4 @@ order: 1
 - [Writing Tests](./writing-tests/index)
 - [Code Transforms](./code-transforms)
 - [Developer Tooling](./dev-tooling/index)
+- [Docker](./docker)

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -31,6 +31,16 @@ After creating the `foreman.toml` file, run the following command to install the
 foreman install
 ```
 
+## Docker
+
+Official container images are published to the GitHub Container Registry on every stable release. The default image is based on `debian:stable-slim`:
+
+```bash
+docker run --rm -it -v "$PWD:/app" -w /app ghcr.io/luau-lang/lute run script.luau
+```
+
+See the [Docker guide](./docker) for the full list of image variants and tags.
+
 ## Nightly Builds
 
 Unstable versions of Lute are available as a nightly build. You can find and download the latest build on [releases page](https://github.com/luau-lang/lute/releases).


### PR DESCRIPTION
Closes #1013.

Adds a new workflow (that can be dispatched ad-hoc if necessary, will use to backfill 1.0.0) that produces Docker containers defined in the `docker/` folder.

Three containers are defined, `debian`, `distroless`, and `bin`. See the `docker.md` doc in the PR for details on which is for what.

Also added some documentation about docker to our docs site (happy to rename to generic "containers", but figured docker was more recognizable).