### PR TITLE
Set macOS target version to 12.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.13)
 
+if(APPLE AND NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "12.0" CACHE STRING "Minimum macOS version")
+endif()
+
 # Make sure 'set' for variables is respected by options in nested files
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 


### PR DESCRIPTION
There's nothing in Lute that requires 15.0+ macOS, but our released 1.0.0 will not run on any Mac running a version older than 15.0:

```
> otool -l lute
Load command 11
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 15.0
      sdk 15.5
   ntools 1
     tool 3
  version 1167.5
```

I tested building all the way back to 11.0 (when Apple silicon was introduced), and found that going all the way back to 12.0, the binary is basically identical. In 12.0 the Mach-O format changed, so figured we should stay there.