### PR TITLE
Build Linux release with glibc 2.28

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: "Whether to use the bootstrap script to build the Lute used to run luthier"
     required: false
     default: "false"
+  install-system-deps:
+    description: "Whether to install system build dependencies (compiler, ninja, etc.) via the host package manager. Set to 'false' when the caller has already provisioned a toolchain (e.g. inside a custom container)."
+    required: false
+    default: "true"
 
 outputs:
   exe_path:
@@ -37,7 +41,7 @@ runs:
         allow-external-github-orgs: true
 
     - name: Install dependencies (Linux)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && inputs.install-system-deps == 'true'
       shell: bash
       run: |
         sudo apt-get update

--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -21,7 +21,7 @@ inputs:
     required: false
     default: "false"
   install-system-deps:
-    description: "Whether to install system build dependencies (compiler, ninja, etc.) via the host package manager. Set to 'false' when the caller has already provisioned a toolchain (e.g. inside a custom container)."
+    description: "Whether to install system build dependencies via apt-get. Set to 'false' when the caller provisions its own toolchain (e.g. inside a custom container)."
     required: false
     default: "true"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,5 +57,5 @@ jobs:
       contents: write
     uses: ./.github/workflows/release-common.yml
     with:
-      branch: primary
+      branch: 2.28-test
     secrets: inherit

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,5 +57,5 @@ jobs:
       contents: write
     uses: ./.github/workflows/release-common.yml
     with:
-      branch: 2.28-test
+      branch: primary
     secrets: inherit

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -11,10 +11,6 @@ on:
 
 env:
   IS_NIGHTLY: ${{ inputs.branch == 'primary' }}
-  # Pinned LLVM 18 release used for the Linux release builds. The prebuilt
-  # tarballs are linked against glibc <= 2.28 so they run inside the
-  # manylinux_2_28 container we use as the build sysroot.
-  LLVM_VERSION: "18.1.8"
 
 jobs:
   check:
@@ -34,21 +30,22 @@ jobs:
         include:
           # Linux release binaries are built inside the manylinux_2_28
           # container so the resulting executables only require glibc 2.28
-          # (RHEL 8 / Debian 10 / Ubuntu 20.04 era) while still being
-          # compiled with a modern LLVM 18 toolchain.
+          # (RHEL 8 / Debian 10 / Ubuntu 20.04 era). The container provides a
+          # modern toolchain (clang/lld from `llvm-toolset` on top of
+          # `gcc-toolset-14`'s libstdc++), all linked against glibc 2.28.
+          # We use `use-bootstrap: true` on both Linux arches because the
+          # foreman binary distributed by `Roblox/setup-foreman` is built
+          # against glibc >= 2.29 and won't run inside the container.
           - os: ubuntu-latest
             artifact_name: lute-linux-x86_64
             options: --c-compiler clang --cxx-compiler clang++
+            use-bootstrap: true
             container: quay.io/pypa/manylinux_2_28_x86_64
-            llvm_arch: x86_64
-            llvm_asset: x86_64-linux-gnu-ubuntu-18.04
           - os: ubuntu-24.04-arm
             artifact_name: lute-linux-aarch64
             options: --c-compiler clang --cxx-compiler clang++
             use-bootstrap: true
             container: quay.io/pypa/manylinux_2_28_aarch64
-            llvm_arch: aarch64
-            llvm_asset: aarch64-linux-gnu
           - os: macos-latest
             artifact_name: lute-macos-aarch64
           - os: windows-latest
@@ -70,44 +67,31 @@ jobs:
         shell: bash
         run: echo "LUTE_VERSION_SUFFIX=nightly.$(date +%Y%m%d)" >> "$GITHUB_ENV"
 
-      - name: Cache LLVM ${{ env.LLVM_VERSION }} toolchain
-        if: ${{ matrix.container }}
-        id: cache-llvm
-        uses: actions/cache@v4
-        with:
-          path: /opt/llvm
-          key: llvm-${{ env.LLVM_VERSION }}-${{ matrix.llvm_arch }}
-
-      - name: Install LLVM ${{ env.LLVM_VERSION }} toolchain
-        if: ${{ matrix.container && steps.cache-llvm.outputs.cache-hit != 'true' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          url="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-${{ matrix.llvm_asset }}.tar.xz"
-          echo "Downloading $url"
-          mkdir -p /opt/llvm
-          curl -fL --retry 3 --retry-delay 5 "$url" -o /tmp/llvm.tar.xz
-          tar -xf /tmp/llvm.tar.xz -C /opt/llvm --strip-components=1
-          rm -f /tmp/llvm.tar.xz
-
-      - name: Configure LLVM ${{ env.LLVM_VERSION }} environment
+      - name: Set up Linux release toolchain
         if: ${{ matrix.container }}
         shell: bash
         run: |
           set -euo pipefail
-          # Make sure the manylinux container has the build tools we rely on
-          # outside of LLVM itself (cmake/ninja/git ship with the image, but
-          # ninja-build is not always on PATH under that exact name).
-          dnf install -y --allowerasing ninja-build perl-IPC-Cmd which
+          # `llvm-toolset` brings in clang/lld; `ninja-build`, `perl-IPC-Cmd`
+          # and `which` are required by the build (boringssl needs perl
+          # IPC::Cmd; foreman-style tooling occasionally calls `which`).
+          dnf install -y --allowerasing \
+            llvm-toolset \
+            ninja-build \
+            perl-IPC-Cmd \
+            which
 
-          echo "/opt/llvm/bin" >> "$GITHUB_PATH"
-          echo "CC=/opt/llvm/bin/clang" >> "$GITHUB_ENV"
-          echo "CXX=/opt/llvm/bin/clang++" >> "$GITHUB_ENV"
-          # Build C++ against LLVM's libc++ and statically link both libc++
-          # and libc++abi so the resulting binary does not require an
-          # external libc++.so on user machines.
-          echo "CXXFLAGS=-stdlib=libc++" >> "$GITHUB_ENV"
-          echo "LDFLAGS=-stdlib=libc++ -static-libstdc++ -L/opt/llvm/lib" >> "$GITHUB_ENV"
+          # Force clang to use the SYSTEM gcc 8.5 install (under /usr) for
+          # libstdc++ headers and runtime, instead of the newer
+          # gcc-toolset-14 that manylinux_2_28 puts on PATH. gcc 8.5's
+          # libstdc++ only references symbols up through GLIBCXX_3.4.25 /
+          # CXXABI_1.3.11, which matches what ships on every distro that
+          # already has glibc 2.28 (RHEL 8, Debian 10, Ubuntu 20.04, etc.).
+          # This lets us dynamically link libstdc++ without raising the
+          # runtime floor above glibc 2.28.
+          echo "CFLAGS=--gcc-toolchain=/usr" >> "$GITHUB_ENV"
+          echo "CXXFLAGS=--gcc-toolchain=/usr" >> "$GITHUB_ENV"
+          echo "LDFLAGS=--gcc-toolchain=/usr" >> "$GITHUB_ENV"
 
       - name: Setup and Build Lute
         id: build_lute
@@ -120,7 +104,7 @@ jobs:
           use-bootstrap: ${{ matrix.use-bootstrap || 'false' }}
           install-system-deps: ${{ matrix.container && 'false' || 'true' }}
 
-      - name: Verify Linux binary glibc requirement
+      - name: Verify Linux binary symbol versions
         if: ${{ matrix.container }}
         shell: bash
         run: |
@@ -128,23 +112,42 @@ jobs:
           exe="${{ steps.build_lute.outputs.exe_path }}"
           echo "Dynamic dependencies of $exe:"
           ldd "$exe" || true
-          echo "GLIBC version references:"
-          # Fail the build if anything in the binary needs glibc > 2.28.
-          max_ver=$(objdump -T "$exe" 2>/dev/null \
-            | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' \
-            | sort -uV \
-            | tail -n 1 || true)
-          echo "Max referenced glibc symbol: ${max_ver:-<none>}"
-          if [[ -n "${max_ver:-}" ]]; then
-            ver="${max_ver#GLIBC_}"
-            major="${ver%%.*}"
-            rest="${ver#*.}"
-            minor="${rest%%.*}"
-            if (( major > 2 || (major == 2 && minor > 28) )); then
-              echo "ERROR: binary requires ${max_ver}, which is newer than the targeted glibc 2.28" >&2
-              exit 1
+          echo
+
+          # Helper: compare two dotted versions ("3.4.25" vs "3.4.30") and
+          # exit non-zero if $1 > $2.
+          ver_gt() {
+            [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" == "$1" \
+              && "$1" != "$2" ]]
+          }
+
+          check_max() {
+            local label="$1" prefix="$2" max_allowed="$3"
+            local found
+            found=$(objdump -T "$exe" 2>/dev/null \
+              | grep -oE "${prefix}_[0-9]+(\.[0-9]+)+" \
+              | sort -uV || true)
+            local max
+            max=$(echo "$found" | tail -n 1)
+            echo "${label} symbols referenced:"
+            echo "${found:-  <none>}" | sed 's/^/  /'
+            echo "  -> max: ${max:-<none>} (limit: ${prefix}_${max_allowed})"
+            if [[ -n "${max:-}" ]]; then
+              local cur="${max#${prefix}_}"
+              if ver_gt "$cur" "$max_allowed"; then
+                echo "ERROR: binary requires ${max}, which exceeds the floor of ${prefix}_${max_allowed}" >&2
+                return 1
+              fi
             fi
-          fi
+          }
+
+          # Targeted floors:
+          #   glibc      2.28        (manylinux_2_28 / RHEL 8 / Debian 10)
+          #   libstdc++  3.4.25      (gcc 8.5, ships on every glibc-2.28 distro)
+          #   libstdc++  CXXABI 1.3.11
+          check_max "GLIBC"   "GLIBC"   "2.28"
+          check_max "GLIBCXX" "GLIBCXX" "3.4.25"
+          check_max "CXXABI"  "CXXABI"  "1.3.11"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -26,13 +26,7 @@ jobs:
       - name: Validate CI status
         id: check
         run: |
-          LAST_STATUS=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            "https://api.github.com/repos/luau-lang/lute/actions/workflows/ci.yml/runs?branch=${{ inputs.branch }}&status=completed&per_page=1" \
-            | jq -r '.workflow_runs[0].conclusion')
-          if [[ "$LAST_STATUS" != "success" ]]; then
-            echo "The latest CI run on '${{ inputs.branch }}' branch did not succeed. Aborting release."
-            exit 1
-          fi
+          echo "hi"
 
   build:
     strategy:

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -72,11 +72,26 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # `llvm-toolset` brings in clang/lld; `ninja-build`, `perl-IPC-Cmd`
-          # and `which` are required by the build (boringssl needs perl
-          # IPC::Cmd; foreman-style tooling occasionally calls `which`).
+          # Install:
+          #   * llvm-toolset      - clang/lld (the compiler we'll actually use)
+          #   * gcc, gcc-c++,
+          #     libstdc++-devel,
+          #     glibc-devel       - the SYSTEM gcc 8.5 install, including
+          #                         crt files, libgcc, and libstdc++ headers
+          #                         that clang will be redirected to
+          #   * ninja-build,
+          #     perl-IPC-Cmd,
+          #     which             - required by the build
+          # manylinux_2_28 only ships gcc-toolset-14 by default; the system
+          # gcc 8.5 package is needed so `/usr/lib/gcc/<triple>/8/` actually
+          # exists with a complete install (crtbegin.o, libgcc.a, etc.) for
+          # clang to point at.
           dnf install -y --allowerasing \
             llvm-toolset \
+            gcc \
+            gcc-c++ \
+            libstdc++-devel \
+            glibc-devel \
             ninja-build \
             perl-IPC-Cmd \
             which
@@ -90,19 +105,46 @@ jobs:
           echo "CC=clang" >> "$GITHUB_ENV"
           echo "CXX=clang++" >> "$GITHUB_ENV"
 
-          # Direct clang at the SYSTEM gcc 8.5 install (under /usr) for
-          # libstdc++ headers and runtime, instead of the newer
-          # gcc-toolset-14 that manylinux_2_28 puts on PATH. gcc 8.5's
-          # libstdc++ only references symbols up through GLIBCXX_3.4.25 /
-          # CXXABI_1.3.11, which matches what ships on every distro that
-          # already has glibc 2.28 (RHEL 8, Debian 10, Ubuntu 20.04, etc.).
-          # This lets us dynamically link libstdc++ without raising the
-          # runtime floor above glibc 2.28. `--gcc-toolchain=` is a clang
-          # driver flag, so this only works once CC/CXX above are set to
-          # clang.
-          echo "CFLAGS=--gcc-toolchain=/usr" >> "$GITHUB_ENV"
-          echo "CXXFLAGS=--gcc-toolchain=/usr" >> "$GITHUB_ENV"
-          echo "LDFLAGS=--gcc-toolchain=/usr" >> "$GITHUB_ENV"
+          # Direct clang at exactly the SYSTEM gcc 8.5 install for libstdc++
+          # headers, runtime, and crt files, instead of the newer
+          # gcc-toolset-14 install that manylinux_2_28 puts on PATH. gcc
+          # 8.5's libstdc++ only references symbols up through GLIBCXX_3.4.25
+          # / CXXABI_1.3.11, which matches what ships on every distro that
+          # already has glibc 2.28 (RHEL 8, Debian 10, Ubuntu 20.04, etc.),
+          # so dynamically linking libstdc++ doesn't raise the runtime floor
+          # above glibc 2.28.
+          #
+          # `--gcc-install-dir=` (clang 16+) is more surgical than
+          # `--gcc-toolchain=`: it points clang at a single specific install
+          # rather than letting it scan a root (and accidentally pick up
+          # gcc-toolset-14 anyway, or falsely "succeed" against an absent
+          # install).
+          GCC_INSTALL_DIR="/usr/lib/gcc/$(uname -m)-redhat-linux/8"
+          if [[ ! -d "${GCC_INSTALL_DIR}" ]]; then
+            echo "ERROR: expected system gcc 8.5 install at ${GCC_INSTALL_DIR} not found" >&2
+            ls /usr/lib/gcc/ || true
+            exit 1
+          fi
+          echo "Using gcc install dir: ${GCC_INSTALL_DIR}"
+          ls -la "${GCC_INSTALL_DIR}" | head -n 20
+
+          GCC_FLAG="--gcc-install-dir=${GCC_INSTALL_DIR}"
+          echo "CFLAGS=${GCC_FLAG}" >> "$GITHUB_ENV"
+          echo "CXXFLAGS=${GCC_FLAG}" >> "$GITHUB_ENV"
+          echo "LDFLAGS=${GCC_FLAG}" >> "$GITHUB_ENV"
+
+          # Diagnostic: show which gcc install clang resolves and which
+          # libraries it would link against. Useful breadcrumb if things go
+          # sideways later.
+          echo "::group::clang -v sanity check"
+          clang++ ${GCC_FLAG} -v -E -x c++ - </dev/null
+          echo "::endgroup::"
+          echo "::group::clang pthread link check"
+          printf '#include <pthread.h>\nint main(void){pthread_create(0,0,0,0);return 0;}\n' \
+            > /tmp/pthread_check.c
+          clang ${GCC_FLAG} -v -pthread /tmp/pthread_check.c -o /tmp/pthread_check
+          rm -f /tmp/pthread_check.c /tmp/pthread_check
+          echo "::endgroup::"
 
       - name: Setup and Build Lute
         id: build_lute

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -97,29 +97,6 @@ jobs:
           use-bootstrap: ${{ matrix.use-bootstrap || 'false' }}
           install-system-deps: ${{ matrix.container && 'false' || 'true' }}
 
-      - name: Verify Linux binary symbol versions
-        if: ${{ matrix.container }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          exe="${{ steps.build_lute.outputs.exe_path }}"
-          ldd "$exe" || true
-          check() {
-            local prefix=$1 limit=$2 max
-            max=$(objdump -T "$exe" 2>/dev/null \
-              | grep -oE "${prefix}_[0-9]+(\.[0-9]+)+" \
-              | sort -uV | tail -n1)
-            echo "${prefix} max: ${max:-<none>} (limit: ${prefix}_${limit})"
-            if [[ -n "$max" && "$(printf '%s\n%s\n' "${max#${prefix}_}" "$limit" \
-              | sort -V | tail -n1)" != "$limit" ]]; then
-              echo "ERROR: $max exceeds ${prefix}_${limit}" >&2
-              exit 1
-            fi
-          }
-          check GLIBC   2.28
-          check GLIBCXX 3.4.25
-          check CXXABI  1.3.11
-
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -11,6 +11,10 @@ on:
 
 env:
   IS_NIGHTLY: ${{ inputs.branch == 'primary' }}
+  # Pinned LLVM 18 release used for the Linux release builds. The prebuilt
+  # tarballs are linked against glibc <= 2.28 so they run inside the
+  # manylinux_2_28 container we use as the build sysroot.
+  LLVM_VERSION: "18.1.8"
 
 jobs:
   check:
@@ -34,13 +38,23 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-22.04
+          # Linux release binaries are built inside the manylinux_2_28
+          # container so the resulting executables only require glibc 2.28
+          # (RHEL 8 / Debian 10 / Ubuntu 20.04 era) while still being
+          # compiled with a modern LLVM 18 toolchain.
+          - os: ubuntu-latest
             artifact_name: lute-linux-x86_64
             options: --c-compiler clang --cxx-compiler clang++
-          - os: ubuntu-22.04-arm
+            container: quay.io/pypa/manylinux_2_28_x86_64
+            llvm_arch: x86_64
+            llvm_asset: x86_64-linux-gnu-ubuntu-18.04
+          - os: ubuntu-24.04-arm
             artifact_name: lute-linux-aarch64
             options: --c-compiler clang --cxx-compiler clang++
             use-bootstrap: true
+            container: quay.io/pypa/manylinux_2_28_aarch64
+            llvm_arch: aarch64
+            llvm_asset: aarch64-linux-gnu
           - os: macos-latest
             artifact_name: lute-macos-aarch64
           - os: windows-latest
@@ -49,6 +63,7 @@ jobs:
 
     needs: check
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
 
     steps:
       - name: Checkout code
@@ -58,7 +73,47 @@ jobs:
 
       - name: Set nightly version suffix
         if: ${{ env.IS_NIGHTLY == 'true' }}
+        shell: bash
         run: echo "LUTE_VERSION_SUFFIX=nightly.$(date +%Y%m%d)" >> "$GITHUB_ENV"
+
+      - name: Cache LLVM ${{ env.LLVM_VERSION }} toolchain
+        if: ${{ matrix.container }}
+        id: cache-llvm
+        uses: actions/cache@v4
+        with:
+          path: /opt/llvm
+          key: llvm-${{ env.LLVM_VERSION }}-${{ matrix.llvm_arch }}
+
+      - name: Install LLVM ${{ env.LLVM_VERSION }} toolchain
+        if: ${{ matrix.container && steps.cache-llvm.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/clang+llvm-${LLVM_VERSION}-${{ matrix.llvm_asset }}.tar.xz"
+          echo "Downloading $url"
+          mkdir -p /opt/llvm
+          curl -fL --retry 3 --retry-delay 5 "$url" -o /tmp/llvm.tar.xz
+          tar -xf /tmp/llvm.tar.xz -C /opt/llvm --strip-components=1
+          rm -f /tmp/llvm.tar.xz
+
+      - name: Configure LLVM ${{ env.LLVM_VERSION }} environment
+        if: ${{ matrix.container }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Make sure the manylinux container has the build tools we rely on
+          # outside of LLVM itself (cmake/ninja/git ship with the image, but
+          # ninja-build is not always on PATH under that exact name).
+          dnf install -y --allowerasing ninja-build perl-IPC-Cmd which
+
+          echo "/opt/llvm/bin" >> "$GITHUB_PATH"
+          echo "CC=/opt/llvm/bin/clang" >> "$GITHUB_ENV"
+          echo "CXX=/opt/llvm/bin/clang++" >> "$GITHUB_ENV"
+          # Build C++ against LLVM's libc++ and statically link both libc++
+          # and libc++abi so the resulting binary does not require an
+          # external libc++.so on user machines.
+          echo "CXXFLAGS=-stdlib=libc++" >> "$GITHUB_ENV"
+          echo "LDFLAGS=-stdlib=libc++ -static-libstdc++ -L/opt/llvm/lib" >> "$GITHUB_ENV"
 
       - name: Setup and Build Lute
         id: build_lute
@@ -69,6 +124,33 @@ jobs:
           options: ${{ matrix.options }}
           token: ${{ secrets.GITHUB_TOKEN }}
           use-bootstrap: ${{ matrix.use-bootstrap || 'false' }}
+          install-system-deps: ${{ matrix.container && 'false' || 'true' }}
+
+      - name: Verify Linux binary glibc requirement
+        if: ${{ matrix.container }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          exe="${{ steps.build_lute.outputs.exe_path }}"
+          echo "Dynamic dependencies of $exe:"
+          ldd "$exe" || true
+          echo "GLIBC version references:"
+          # Fail the build if anything in the binary needs glibc > 2.28.
+          max_ver=$(objdump -T "$exe" 2>/dev/null \
+            | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' \
+            | sort -uV \
+            | tail -n 1 || true)
+          echo "Max referenced glibc symbol: ${max_ver:-<none>}"
+          if [[ -n "${max_ver:-}" ]]; then
+            ver="${max_ver#GLIBC_}"
+            major="${ver%%.*}"
+            rest="${ver#*.}"
+            minor="${rest%%.*}"
+            if (( major > 2 || (major == 2 && minor > 28) )); then
+              echo "ERROR: binary requires ${max_ver}, which is newer than the targeted glibc 2.28" >&2
+              exit 1
+            fi
+          fi
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -22,20 +22,18 @@ jobs:
       - name: Validate CI status
         id: check
         run: |
-          echo "hi"
+          LAST_STATUS=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/luau-lang/lute/actions/workflows/ci.yml/runs?branch=${{ inputs.branch }}&status=completed&per_page=1" \
+            | jq -r '.workflow_runs[0].conclusion')
+          if [[ "$LAST_STATUS" != "success" ]]; then
+            echo "The latest CI run on '${{ inputs.branch }}' branch did not succeed. Aborting release."
+            exit 1
+          fi
 
   build:
     strategy:
       matrix:
         include:
-          # Linux release binaries are built inside the manylinux_2_28
-          # container so the resulting executables only require glibc 2.28
-          # (RHEL 8 / Debian 10 / Ubuntu 20.04 era). The container provides a
-          # modern toolchain (clang/lld from `llvm-toolset` on top of
-          # `gcc-toolset-14`'s libstdc++), all linked against glibc 2.28.
-          # We use `use-bootstrap: true` on both Linux arches because the
-          # foreman binary distributed by `Roblox/setup-foreman` is built
-          # against glibc >= 2.29 and won't run inside the container.
           - os: ubuntu-latest
             artifact_name: lute-linux-x86_64
             options: --c-compiler clang --cxx-compiler clang++
@@ -64,7 +62,6 @@ jobs:
 
       - name: Set nightly version suffix
         if: ${{ env.IS_NIGHTLY == 'true' }}
-        shell: bash
         run: echo "LUTE_VERSION_SUFFIX=nightly.$(date +%Y%m%d)" >> "$GITHUB_ENV"
 
       - name: Set up Linux release toolchain
@@ -72,79 +69,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Install:
-          #   * llvm-toolset      - clang/lld (the compiler we'll actually use)
-          #   * gcc, gcc-c++,
-          #     libstdc++-devel,
-          #     glibc-devel       - the SYSTEM gcc 8.5 install, including
-          #                         crt files, libgcc, and libstdc++ headers
-          #                         that clang will be redirected to
-          #   * ninja-build,
-          #     perl-IPC-Cmd,
-          #     which             - required by the build
-          # manylinux_2_28 only ships gcc-toolset-14 by default; the system
-          # gcc 8.5 package is needed so `/usr/lib/gcc/<triple>/8/` actually
-          # exists with a complete install (crtbegin.o, libgcc.a, etc.) for
-          # clang to point at.
           dnf install -y --allowerasing \
-            llvm-toolset \
-            gcc \
-            gcc-c++ \
-            libstdc++-devel \
-            glibc-devel \
-            ninja-build \
-            perl-IPC-Cmd \
-            which
+            llvm-toolset gcc gcc-c++ libstdc++-devel glibc-devel \
+            ninja-build perl-IPC-Cmd which
 
-          # Force clang for the WHOLE build, including the bootstrap stage.
-          # Without this, `bootstrap.sh` runs `cmake` with no explicit
-          # compiler arg and CMake auto-detects the gcc-toolset-14 g++ that
-          # manylinux_2_28 puts at the front of PATH (the matrix's
-          # `--c-compiler clang` option only affects the post-bootstrap
-          # luthier invocations).
-          echo "CC=clang" >> "$GITHUB_ENV"
-          echo "CXX=clang++" >> "$GITHUB_ENV"
-
-          # Direct clang at exactly the SYSTEM gcc 8.5 install for libstdc++
-          # headers, runtime, and crt files, instead of the newer
-          # gcc-toolset-14 install that manylinux_2_28 puts on PATH. gcc
-          # 8.5's libstdc++ only references symbols up through GLIBCXX_3.4.25
-          # / CXXABI_1.3.11, which matches what ships on every distro that
-          # already has glibc 2.28 (RHEL 8, Debian 10, Ubuntu 20.04, etc.),
-          # so dynamically linking libstdc++ doesn't raise the runtime floor
-          # above glibc 2.28.
-          #
-          # `--gcc-install-dir=` (clang 16+) is more surgical than
-          # `--gcc-toolchain=`: it points clang at a single specific install
-          # rather than letting it scan a root (and accidentally pick up
-          # gcc-toolset-14 anyway, or falsely "succeed" against an absent
-          # install).
-          GCC_INSTALL_DIR="/usr/lib/gcc/$(uname -m)-redhat-linux/8"
-          if [[ ! -d "${GCC_INSTALL_DIR}" ]]; then
-            echo "ERROR: expected system gcc 8.5 install at ${GCC_INSTALL_DIR} not found" >&2
-            ls /usr/lib/gcc/ || true
-            exit 1
-          fi
-          echo "Using gcc install dir: ${GCC_INSTALL_DIR}"
-          ls -la "${GCC_INSTALL_DIR}" | head -n 20
-
-          GCC_FLAG="--gcc-install-dir=${GCC_INSTALL_DIR}"
-          echo "CFLAGS=${GCC_FLAG}" >> "$GITHUB_ENV"
-          echo "CXXFLAGS=${GCC_FLAG}" >> "$GITHUB_ENV"
-          echo "LDFLAGS=${GCC_FLAG}" >> "$GITHUB_ENV"
-
-          # Diagnostic: show which gcc install clang resolves and which
-          # libraries it would link against. Useful breadcrumb if things go
-          # sideways later.
-          echo "::group::clang -v sanity check"
-          clang++ ${GCC_FLAG} -v -E -x c++ - </dev/null
-          echo "::endgroup::"
-          echo "::group::clang pthread link check"
-          printf '#include <pthread.h>\nint main(void){pthread_create(0,0,0,0);return 0;}\n' \
-            > /tmp/pthread_check.c
-          clang ${GCC_FLAG} -v -pthread /tmp/pthread_check.c -o /tmp/pthread_check
-          rm -f /tmp/pthread_check.c /tmp/pthread_check
-          echo "::endgroup::"
+          # Force clang for the whole build (incl. bootstrap, where CMake
+          # would otherwise auto-pick gcc-toolset-14's g++ from PATH) and
+          # point it at the system gcc 8.5 install so libstdc++ stays at
+          # GLIBCXX_3.4.25 / CXXABI_1.3.11 (compatible with glibc 2.28).
+          GCC_FLAG="--gcc-install-dir=/usr/lib/gcc/$(uname -m)-redhat-linux/8"
+          {
+            echo "CC=clang"
+            echo "CXX=clang++"
+            echo "CFLAGS=${GCC_FLAG}"
+            echo "CXXFLAGS=${GCC_FLAG}"
+            echo "LDFLAGS=${GCC_FLAG}"
+          } >> "$GITHUB_ENV"
 
       - name: Setup and Build Lute
         id: build_lute
@@ -163,44 +103,22 @@ jobs:
         run: |
           set -euo pipefail
           exe="${{ steps.build_lute.outputs.exe_path }}"
-          echo "Dynamic dependencies of $exe:"
           ldd "$exe" || true
-          echo
-
-          # Helper: compare two dotted versions ("3.4.25" vs "3.4.30") and
-          # exit non-zero if $1 > $2.
-          ver_gt() {
-            [[ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" == "$1" \
-              && "$1" != "$2" ]]
-          }
-
-          check_max() {
-            local label="$1" prefix="$2" max_allowed="$3"
-            local found
-            found=$(objdump -T "$exe" 2>/dev/null \
+          check() {
+            local prefix=$1 limit=$2 max
+            max=$(objdump -T "$exe" 2>/dev/null \
               | grep -oE "${prefix}_[0-9]+(\.[0-9]+)+" \
-              | sort -uV || true)
-            local max
-            max=$(echo "$found" | tail -n 1)
-            echo "${label} symbols referenced:"
-            echo "${found:-  <none>}" | sed 's/^/  /'
-            echo "  -> max: ${max:-<none>} (limit: ${prefix}_${max_allowed})"
-            if [[ -n "${max:-}" ]]; then
-              local cur="${max#${prefix}_}"
-              if ver_gt "$cur" "$max_allowed"; then
-                echo "ERROR: binary requires ${max}, which exceeds the floor of ${prefix}_${max_allowed}" >&2
-                return 1
-              fi
+              | sort -uV | tail -n1)
+            echo "${prefix} max: ${max:-<none>} (limit: ${prefix}_${limit})"
+            if [[ -n "$max" && "$(printf '%s\n%s\n' "${max#${prefix}_}" "$limit" \
+              | sort -V | tail -n1)" != "$limit" ]]; then
+              echo "ERROR: $max exceeds ${prefix}_${limit}" >&2
+              exit 1
             fi
           }
-
-          # Targeted floors:
-          #   glibc      2.28        (manylinux_2_28 / RHEL 8 / Debian 10)
-          #   libstdc++  3.4.25      (gcc 8.5, ships on every glibc-2.28 distro)
-          #   libstdc++  CXXABI 1.3.11
-          check_max "GLIBC"   "GLIBC"   "2.28"
-          check_max "GLIBCXX" "GLIBCXX" "3.4.25"
-          check_max "CXXABI"  "CXXABI"  "1.3.11"
+          check GLIBC   2.28
+          check GLIBCXX 3.4.25
+          check CXXABI  1.3.11
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -81,14 +81,25 @@ jobs:
             perl-IPC-Cmd \
             which
 
-          # Force clang to use the SYSTEM gcc 8.5 install (under /usr) for
+          # Force clang for the WHOLE build, including the bootstrap stage.
+          # Without this, `bootstrap.sh` runs `cmake` with no explicit
+          # compiler arg and CMake auto-detects the gcc-toolset-14 g++ that
+          # manylinux_2_28 puts at the front of PATH (the matrix's
+          # `--c-compiler clang` option only affects the post-bootstrap
+          # luthier invocations).
+          echo "CC=clang" >> "$GITHUB_ENV"
+          echo "CXX=clang++" >> "$GITHUB_ENV"
+
+          # Direct clang at the SYSTEM gcc 8.5 install (under /usr) for
           # libstdc++ headers and runtime, instead of the newer
           # gcc-toolset-14 that manylinux_2_28 puts on PATH. gcc 8.5's
           # libstdc++ only references symbols up through GLIBCXX_3.4.25 /
           # CXXABI_1.3.11, which matches what ships on every distro that
           # already has glibc 2.28 (RHEL 8, Debian 10, Ubuntu 20.04, etc.).
           # This lets us dynamically link libstdc++ without raising the
-          # runtime floor above glibc 2.28.
+          # runtime floor above glibc 2.28. `--gcc-toolchain=` is a clang
+          # driver flag, so this only works once CC/CXX above are set to
+          # clang.
           echo "CFLAGS=--gcc-toolchain=/usr" >> "$GITHUB_ENV"
           echo "CXXFLAGS=--gcc-toolchain=/usr" >> "$GITHUB_ENV"
           echo "LDFLAGS=--gcc-toolchain=/usr" >> "$GITHUB_ENV"


### PR DESCRIPTION
Increase our Linux compatibility by building with glibc 2.28 instead of Ubuntu 22.04's 2.35. This also builds with llvm 20 instead of 14 that came with Ubuntu 22.04. Closes #1014 

Validated again after merging primary: https://github.com/Nicell/lute/actions/runs/24686780137