### PR TITLE
runtime: clean up a few instances of memory leaks and other undefined behavior

### DIFF
--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -257,11 +257,10 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
         uv_env_item_t* currentEnvItems;
         int currentEnvCount;
         int err = uv_os_environ(&currentEnvItems, &currentEnvCount);
+        // if error is non-zero, no allocation happened
         if (err != 0)
-        {
-            uv_os_free_environ(currentEnvItems, currentEnvCount);
             luaL_error(L, "Failed to get current environment: %s", uv_strerror(err));
-        }
+
         for (int i = 0; i < currentEnvCount; i++)
         {
             if (currentEnvItems[i].name && currentEnvItems[i].value && opts.env.find(currentEnvItems[i].name) == opts.env.end())
@@ -269,20 +268,25 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
                 opts.env[currentEnvItems[i].name] = currentEnvItems[i].value;
             }
         }
+
+        // Free the environment items allocated by uv_os_environ
         uv_os_free_environ(currentEnvItems, currentEnvCount);
 
         // Turn the new environment into a char** array
         envStrings.reserve(opts.env.size());
         envPtr.reserve(opts.env.size() + 1);
+
         for (const auto& pair : opts.env)
         {
             envStrings.push_back(pair.first + "=" + pair.second);
         }
+
         for (auto& str : envStrings)
         {
             envPtr.push_back(&str[0]);
         }
         envPtr.push_back(nullptr);
+
         options.env = envPtr.data();
     }
 
@@ -539,6 +543,9 @@ static int envIndex(lua_State* L)
     if (err == UV_ENOBUFS)
     {
         char* buffer = (char*)malloc(size);
+        if (!buffer)
+            luaL_error(L, "out of memory");
+
         err = uv_os_getenv(key, buffer, &size);
         if (err == 0)
         {

--- a/lute/system/src/system.cpp
+++ b/lute/system/src/system.cpp
@@ -68,6 +68,9 @@ int lua_cpus(lua_State* L)
         lua_settable(L, -3);
     };
 
+    // free the cpu info array allocated by libuv
+    uv_free_cpu_info(cpus, count);
+
     return 1;
 }
 

--- a/lute/time/src/time.cpp
+++ b/lute/time/src/time.cpp
@@ -59,7 +59,7 @@ uv_timespec64_t getTimespecFromSeconds(double seconds)
 
 uint64_t getNanosecondsFromTimespec(uv_timespec64_t timespec)
 {
-	return timespec.tv_sec * NANOSECONDS_PER_SECOND + timespec.tv_nsec;
+	return static_cast<uint64_t>(timespec.tv_sec) * static_cast<uint64_t>(NANOSECONDS_PER_SECOND) + static_cast<uint64_t>(timespec.tv_nsec);
 }
 
 uv_timespec64_t getTimespecFromNanoseconds(int64_t nanoseconds)
@@ -98,7 +98,7 @@ int createDurationFromSeconds(lua_State* L, double seconds)
 static int duration_tonanoseconds(lua_State* L)
 {
     uv_timespec64_t timespec = getTimespecFromDuration(L, 1);
-    lua_pushnumber(L, static_cast<double>(timespec.tv_sec * NANOSECONDS_PER_SECOND) + timespec.tv_nsec);
+    lua_pushnumber(L, static_cast<double>(timespec.tv_sec) * static_cast<double>(NANOSECONDS_PER_SECOND) + timespec.tv_nsec);
     return 1;
 }
 
@@ -217,7 +217,10 @@ static int duration__mul(lua_State* L)
     uv_timespec64_t left = getTimespecFromDuration(L, 1);
     double factor = luaL_checknumber(L, 2);
 
-    uv_timespec64_t result = getTimespecFromNanoseconds(getNanosecondsFromTimespec(left) * factor);
+    if (!std::isfinite(factor) || factor < 0)
+        luaL_error(L, "factor must be a finite non-negative number");
+
+    uv_timespec64_t result = getTimespecFromNanoseconds(static_cast<int64_t>(getNanosecondsFromTimespec(left) * factor));
     return createDurationFromTimespec(L, {result.tv_sec >= 0 ? result.tv_sec : 0, result.tv_nsec >= 0 ? result.tv_nsec : 0});
 }
 
@@ -226,7 +229,10 @@ static int duration__div(lua_State* L)
     uv_timespec64_t left = getTimespecFromDuration(L, 1);
     double factor = luaL_checknumber(L, 2);
 
-    uv_timespec64_t result = getTimespecFromNanoseconds(getNanosecondsFromTimespec(left) / factor);
+    if (!std::isfinite(factor) || factor <= 0)
+        luaL_error(L, "factor must be a finite positive number");
+
+    uv_timespec64_t result = getTimespecFromNanoseconds(static_cast<int64_t>(getNanosecondsFromTimespec(left) / factor));
     return createDurationFromTimespec(L, {result.tv_sec >= 0 ? result.tv_sec : 0, result.tv_nsec >= 0 ? result.tv_nsec : 0});
 }
 


### PR DESCRIPTION
There's some outstanding undefined behavior in a few of the runtime libraries that I was able to identify. There's a double-free in some of the error-path code for the process library, some missing clean up calls leaking memory, and two remaining instances of possible integer overflows for timespec code in durations (with very large durations, they're something like ~290 years). All of these are pretty easy to fix: remove the offending code, add the missing clean up calls, and cast to the larger type _earlier_ in the computation respectively.