### PR TITLE
`@lute/io`: fix a possible hang in `io.read` when reading returns no bytes read

### DIFF
--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -63,6 +63,9 @@ static void onTtyRead(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
 {
     IOHandle* handle = static_cast<IOHandle*>(stream->data);
 
+    if (nread == 0)
+        return;
+
     if (nread > 0)
     {
         handle->resumeToken->complete(
@@ -73,7 +76,7 @@ static void onTtyRead(uv_stream_t* stream, ssize_t nread, const uv_buf_t* buf)
             }
         );
     }
-    else if (nread < 0)
+    else
     {
         handle->resumeToken->fail(uv_strerror(nread));
     }


### PR DESCRIPTION
I'm not sure what conditions would cause libuv to give us no bytes read (if I did, I'd try to add a regression test for it), but in that situation, we'll leave the resume token in neither a completed nor failed state, but otherwise close the stream. This means that the runtime would ultimately fail to ever close correctly since the number of active tokens would always be non-zero.