### PR TITLE
runtime: extract environment variable reading into a helper function

### DIFF
--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -27,6 +27,26 @@
 namespace process
 {
 
+// Loads the current process environment into `map`. Returns the libuv error
+// code on failure, or an empty optional on success.
+static std::optional<int> getEnvironmentVariables(std::map<std::string, std::string>& map)
+{
+    uv_env_item_t* items;
+    int count;
+    int err = uv_os_environ(&items, &count);
+    if (err != 0)
+        return err;
+
+    for (int i = 0; i < count; i++)
+    {
+        if (items[i].name && items[i].value)
+            map[items[i].name] = items[i].value;
+    }
+
+    uv_os_free_environ(items, count);
+    return std::nullopt;
+}
+
 void convertCRLFtoLF(std::string& str)
 {
     size_t writePos = 0;
@@ -254,23 +274,15 @@ int executionHelper(lua_State* L, std::vector<std::string> args, ProcessOptions 
     if (!opts.env.empty())
     {
         // Copy current environment into the new environment
-        uv_env_item_t* currentEnvItems;
-        int currentEnvCount;
-        int err = uv_os_environ(&currentEnvItems, &currentEnvCount);
-        // if error is non-zero, no allocation happened
-        if (err != 0)
-            luaL_error(L, "Failed to get current environment: %s", uv_strerror(err));
+        std::map<std::string, std::string> currentEnv;
+        if (std::optional<int> err = getEnvironmentVariables(currentEnv))
+            luaL_error(L, "Failed to get current environment: %s", uv_strerror(*err));
 
-        for (int i = 0; i < currentEnvCount; i++)
+        for (const auto& [name, value] : currentEnv)
         {
-            if (currentEnvItems[i].name && currentEnvItems[i].value && opts.env.find(currentEnvItems[i].name) == opts.env.end())
-            {
-                opts.env[currentEnvItems[i].name] = currentEnvItems[i].value;
-            }
+            if (opts.env.find(name) == opts.env.end())
+                opts.env[name] = value;
         }
-
-        // Free the environment items allocated by uv_os_environ
-        uv_os_free_environ(currentEnvItems, currentEnvCount);
 
         // Turn the new environment into a char** array
         envStrings.reserve(opts.env.size());

--- a/tests/std/time.test.luau
+++ b/tests/std/time.test.luau
@@ -1,3 +1,4 @@
+-- lute-lint-global-ignore(divide_by_zero)
 local test = require("@std/test")
 local time = require("@std/time")
 

--- a/tests/std/time.test.luau
+++ b/tests/std/time.test.luau
@@ -137,6 +137,37 @@ test.suite("TimeSuite", function(suite)
 		assert.eq(a < b, false)
 	end)
 
+	suite:case("largeSecondsDurationToNanoseconds", function(assert)
+		-- 10 billion seconds (~317 years) exceeds the ~292-year threshold at which
+		-- tv_sec * NANOSECONDS_PER_SECOND overflows int64. Before the fix, the
+		-- multiplication would overflow before being cast to double, yielding a large
+		-- negative value (~-8.45e18) instead of the correct 1e19.
+		local d = duration.seconds(10_000_000_000)
+		assert.eq(d:toNanoseconds(), 1e19)
+	end)
+
+	suite:case("mulDivInvalidFactorErrors", function(assert)
+		local d = duration.seconds(1)
+
+		-- infinite factor
+		assert.throws(function()
+			return d * math.huge
+		end)
+		assert.throws(function()
+			return d / math.huge
+		end)
+
+		-- negative factor
+		assert.throws(function()
+			return d * -1
+		end)
+
+		-- zero divisor
+		assert.throws(function()
+			return d / 0
+		end)
+	end)
+
 	suite:case("tostringFormat", function(assert)
 		local a = duration.seconds(1)
 		assert.eq(tostring(a), "1.000000000")


### PR DESCRIPTION
Following up on #1028 with some additional tests for duration behavior in the face of overflows and "exceptional" parts of`number` as well as refactoring reading environment variables into helper functions per @Vighnesh-V's ask.