### PR TITLE
Support lookup for system ca certs on linux

### DIFF
--- a/lute/net/CMakeLists.txt
+++ b/lute/net/CMakeLists.txt
@@ -7,6 +7,8 @@ target_sources(Lute.Net PRIVATE
     src/client_websocket.cpp
     src/net.cpp
     src/server.cpp
+    src/system_ca.cpp
+    src/system_ca.h
 )
 
 target_compile_features(Lute.Net PUBLIC cxx_std_17)

--- a/lute/net/src/client.cpp
+++ b/lute/net/src/client.cpp
@@ -4,6 +4,8 @@
 #include "lute/runtime.h"
 #include "lute/userdatas.h"
 
+#include "system_ca.h"
+
 #include "Luau/DenseHash.h"
 
 #include "lua.h"
@@ -143,7 +145,7 @@ static CurlResponse requestData(
 
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writeFunction);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &data);
-    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+    applySystemCA(curl);
 
     if (method != "GET")
         curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, method.c_str());

--- a/lute/net/src/client_websocket.cpp
+++ b/lute/net/src/client_websocket.cpp
@@ -1,6 +1,8 @@
 #include "lute/runtime.h"
 #include "lute/userdatas.h"
 
+#include "system_ca.h"
+
 #include "Luau/VecDeque.h"
 
 #include "lua.h"
@@ -708,7 +710,7 @@ int websocket(lua_State* L)
             curl_slist* headerList = nullptr;
 
             curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-            curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+            net::applySystemCA(curl);
             curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L);
 
             for (const auto& headerPair : headers)

--- a/lute/net/src/system_ca.cpp
+++ b/lute/net/src/system_ca.cpp
@@ -1,0 +1,64 @@
+#include "system_ca.h"
+
+#include "curl/curl.h"
+
+#if defined(__linux__)
+#include <sys/stat.h>
+#endif
+
+namespace net
+{
+
+#if defined(__linux__)
+namespace
+{
+
+// Mirrors the lists in Go's crypto/x509/root_linux.go.
+constexpr const char* kCAFiles[] = {
+    "/etc/ssl/certs/ca-certificates.crt",                // Debian/Ubuntu/Gentoo etc.
+    "/etc/pki/tls/certs/ca-bundle.crt",                  // Fedora/RHEL 6
+    "/etc/ssl/ca-bundle.pem",                            // OpenSUSE
+    "/etc/pki/tls/cacert.pem",                           // OpenELEC
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", // CentOS/RHEL 7
+    "/etc/ssl/cert.pem",                                 // Alpine Linux
+};
+
+constexpr const char* kCADirs[] = {
+    "/etc/ssl/certs",     // SLES10/SLES11
+    "/etc/pki/tls/certs", // Fedora/RHEL
+};
+
+const char* findPath(const char* const* paths, size_t count, bool wantDir)
+{
+    struct stat st;
+    for (size_t i = 0; i < count; ++i)
+    {
+        if (::stat(paths[i], &st) != 0)
+            continue;
+        if (wantDir ? S_ISDIR(st.st_mode) : S_ISREG(st.st_mode))
+            return paths[i];
+    }
+    return nullptr;
+}
+
+} // namespace
+#endif
+
+void applySystemCA(CURL* curl)
+{
+#if defined(_WIN32)
+    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_NATIVE_CA);
+#elif defined(__APPLE__)
+    // macOS 12+ always ships /etc/ssl/cert.pem
+    curl_easy_setopt(curl, CURLOPT_CAINFO, "/etc/ssl/cert.pem");
+#elif defined(__linux__)
+    static const char* cafile = findPath(kCAFiles, sizeof(kCAFiles) / sizeof(kCAFiles[0]), false);
+    static const char* capath = findPath(kCADirs, sizeof(kCADirs) / sizeof(kCADirs[0]), true);
+    if (cafile)
+        curl_easy_setopt(curl, CURLOPT_CAINFO, cafile);
+    if (capath)
+        curl_easy_setopt(curl, CURLOPT_CAPATH, capath);
+#endif
+}
+
+} // namespace net

--- a/lute/net/src/system_ca.h
+++ b/lute/net/src/system_ca.h
@@ -1,0 +1,11 @@
+#pragma once
+
+typedef void CURL;
+
+namespace net
+{
+
+// Configures `curl` to use the operating system's trusted CA store.
+void applySystemCA(CURL* curl);
+
+} // namespace net


### PR DESCRIPTION
Right now we hardcode whatever is available at build time, which means other distros don't work. This lookup makes our net requests work on most standard linux distros.