### PR TITLE
Adds a dotenv battery with tests and example usage

### DIFF
--- a/batteries/env.luau
+++ b/batteries/env.luau
@@ -1,0 +1,515 @@
+local fs = require("@std/fs")
+local path = require("@std/path")
+local process = require("@std/process")
+
+local env = {}
+
+export type Environment = { [string]: string }
+export type Pathlike = path.Pathlike
+
+export type ParseOptions = {
+	expand: boolean?,
+	strict: boolean?,
+	env: Environment?,
+}
+
+export type ApplyOptions = {
+	target: Environment?,
+	override: boolean?,
+}
+
+export type LoadOptions = ParseOptions
+
+export type ConfigOptions = ParseOptions & ApplyOptions & {
+	path: Pathlike?,
+}
+
+export type SerializeOptions = {
+	export: boolean?,
+	newline: string?,
+}
+
+type QuoteKind = "none" | "single" | "double"
+
+type Entry = {
+	line: number,
+	value: string,
+	quote: QuoteKind,
+}
+
+local UTF8_BOM = string.char(239, 187, 191)
+local DOLLAR_SENTINEL = "\0"
+
+local function trim(value: string): string
+	return (string.match(value, "^%s*(.-)%s*$") or "")
+end
+
+local function normalizeInput(input: string): string
+	local normalized = string.gsub(input, "\r\n", "\n")
+	normalized = string.gsub(normalized, "\r", "\n")
+
+	if string.sub(normalized, 1, #UTF8_BOM) == UTF8_BOM then
+		normalized = string.sub(normalized, #UTF8_BOM + 1)
+	end
+
+	return normalized
+end
+
+local function splitLines(input: string): { string }
+	local lines = {}
+	for line in string.gmatch(input .. "\n", "(.-)\n") do
+		table.insert(lines, line)
+	end
+	return lines
+end
+
+local function decodeDoubleQuoted(contents: string): string
+	local out = {}
+	local index = 1
+
+	while index <= #contents do
+		local ch = string.sub(contents, index, index)
+		if ch ~= "\\" then
+			table.insert(out, ch)
+			index += 1
+			continue
+		end
+
+		if index == #contents then
+			table.insert(out, "\\")
+			break
+		end
+
+		local nextCh = string.sub(contents, index + 1, index + 1)
+		if nextCh == "n" then
+			table.insert(out, "\n")
+		elseif nextCh == "r" then
+			table.insert(out, "\r")
+		elseif nextCh == "t" then
+			table.insert(out, "\t")
+		elseif nextCh == '"' then
+			table.insert(out, '"')
+		elseif nextCh == "\\" then
+			table.insert(out, "\\")
+		elseif nextCh == "$" then
+			table.insert(out, DOLLAR_SENTINEL)
+		else
+			table.insert(out, "\\")
+			table.insert(out, nextCh)
+		end
+
+		index += 2
+	end
+
+	return table.concat(out)
+end
+
+local function decodeSingleQuoted(contents: string): string
+	local out = {}
+	local index = 1
+
+	while index <= #contents do
+		local ch = string.sub(contents, index, index)
+		if ch == "\\" and index < #contents then
+			local nextCh = string.sub(contents, index + 1, index + 1)
+			if nextCh == "'" or nextCh == "\\" then
+				table.insert(out, nextCh)
+				index += 2
+				continue
+			end
+		end
+
+		table.insert(out, ch)
+		index += 1
+	end
+
+	return table.concat(out)
+end
+
+local function parseUnquoted(rawValue: string): string
+	local value = {}
+	local index = 1
+
+	while index <= #rawValue do
+		local ch = string.sub(rawValue, index, index)
+		if ch == "#" then
+			local prev = if index > 1 then string.sub(rawValue, index - 1, index - 1) else ""
+			if index == 1 or prev == " " or prev == "\t" then
+				break
+			end
+		elseif ch == "\\" and index < #rawValue then
+			local nextCh = string.sub(rawValue, index + 1, index + 1)
+			if nextCh == "#" then
+				table.insert(value, "#")
+				index += 2
+				continue
+			elseif nextCh == "$" then
+				table.insert(value, DOLLAR_SENTINEL)
+				index += 2
+				continue
+			end
+		end
+
+		table.insert(value, ch)
+		index += 1
+	end
+
+	return trim(table.concat(value))
+end
+
+local function isEscaped(value: string, index: number): boolean
+	local backslashes = 0
+	local scan = index - 1
+	while scan >= 1 and string.sub(value, scan, scan) == "\\" do
+		backslashes += 1
+		scan -= 1
+	end
+	return backslashes % 2 == 1
+end
+
+local function parseQuotedValue(
+	lines: { string },
+	lineIndex: number,
+	rawValue: string,
+	quote: QuoteKind
+): (string, number)
+	local segments = {}
+	local currentLineIndex = lineIndex
+	local current = string.sub(rawValue, 2)
+
+	while true do
+		local index = 1
+		while index <= #current do
+			local ch = string.sub(current, index, index)
+			local escaped = isEscaped(current, index)
+			if ch == (if quote == "single" then "'" else '"') and not escaped then
+				table.insert(segments, string.sub(current, 1, index - 1))
+
+				local trailing = string.sub(current, index + 1)
+				if trailing ~= "" and not string.match(trailing, "^%s*$") and not string.match(trailing, "^%s*#") then
+					error(`invalid trailing characters after quoted value on line {lineIndex}`)
+				end
+
+				local joined = table.concat(segments, "\n")
+				if quote == "single" then
+					return decodeSingleQuoted(joined), currentLineIndex
+				else
+					return decodeDoubleQuoted(joined), currentLineIndex
+				end
+			end
+
+			index += 1
+		end
+
+		table.insert(segments, current)
+		currentLineIndex += 1
+		if currentLineIndex > #lines then
+			error(`unterminated quoted value starting on line {lineIndex}`)
+		end
+		current = lines[currentLineIndex]
+	end
+end
+
+local function parseEntries(input: string, options: ParseOptions?): { [string]: Entry }
+	local strict = if options and options.strict ~= nil then options.strict else true
+	local normalized = normalizeInput(input)
+	local lines = splitLines(normalized)
+	local entries: { [string]: Entry } = {}
+
+	local lineIndex = 1
+	while lineIndex <= #lines do
+		local line = lines[lineIndex]
+		local stripped = string.match(line, "^%s*(.-)%s*$") or ""
+
+		if stripped == "" or string.sub(stripped, 1, 1) == "#" then
+			lineIndex += 1
+			continue
+		end
+
+		local content = line
+		if string.match(content, "^%s*export%s+") then
+			content = string.gsub(content, "^(%s*)export%s+", "%1", 1)
+		end
+
+		local key, rawValue = string.match(content, "^%s*([%a_][%w_]*)%s*=%s*(.*)$")
+		if not key then
+			if strict then
+				error(`invalid .env assignment on line {lineIndex}`)
+			end
+			lineIndex += 1
+			continue
+		end
+		assert(rawValue ~= nil)
+
+		local value: string
+		local quote: QuoteKind = "none"
+		local firstChar = string.sub(rawValue, 1, 1)
+		if firstChar == '"' then
+			quote = "double"
+			value, lineIndex = parseQuotedValue(lines, lineIndex, rawValue, quote)
+		elseif firstChar == "'" then
+			quote = "single"
+			value, lineIndex = parseQuotedValue(lines, lineIndex, rawValue, quote)
+		else
+			value = parseUnquoted(rawValue)
+		end
+
+		entries[key] = {
+			line = lineIndex,
+			value = value,
+			quote = quote,
+		}
+
+		lineIndex += 1
+	end
+
+	return entries
+end
+
+local function parseExpansionExpression(expression: string): (string, string?, string?)
+	local name, operator, rest = string.match(expression, "^([%a_][%w_]*)(:?[-+])(.*)$")
+	if name then
+		assert(operator ~= nil)
+		assert(rest ~= nil)
+		return name, operator, rest
+	end
+
+	local plainName = string.match(expression, "^([%a_][%w_]*)$")
+	if plainName then
+		return plainName, nil, nil
+	end
+
+	error("invalid expansion expression: ${" .. expression .. "}")
+end
+
+local function expandEntries(entries: { [string]: Entry }, baseEnv: Environment): Environment
+	local resolved: Environment = {}
+	local resolving: { [string]: number } = {}
+	local stack = {}
+
+	local expandValue
+	local resolveReference
+
+	local function resolveName(name: string): string
+		if resolved[name] ~= nil then
+			return resolved[name]
+		end
+
+		local entry = entries[name]
+		if not entry then
+			return baseEnv[name] or ""
+		end
+
+		if resolving[name] then
+			local cycle = {}
+			for _, stackName in stack do
+				table.insert(cycle, stackName)
+			end
+			table.insert(cycle, name)
+			error(`circular env expansion detected: {table.concat(cycle, " -> ")}`)
+		end
+
+		resolving[name] = #stack + 1
+		table.insert(stack, name)
+
+		local value = entry.value
+		if entry.quote ~= "single" then
+			value = expandValue(value)
+		end
+
+		resolved[name] = value
+		resolving[name] = nil
+		table.remove(stack)
+
+		return value
+	end
+
+	function resolveReference(name: string): (string, boolean)
+		if entries[name] ~= nil then
+			return resolveName(name), true
+		end
+
+		local external = baseEnv[name]
+		if external ~= nil then
+			return external, true
+		end
+
+		return "", false
+	end
+
+	function expandValue(value: string): string
+		local out = {}
+		local index = 1
+
+		while index <= #value do
+			local ch = string.sub(value, index, index)
+
+			if ch == DOLLAR_SENTINEL then
+				table.insert(out, "$")
+				index += 1
+				continue
+			end
+
+			if ch == "\\" and index < #value and string.sub(value, index + 1, index + 1) == "$" then
+				table.insert(out, "$")
+				index += 2
+				continue
+			end
+
+			if ch ~= "$" then
+				table.insert(out, ch)
+				index += 1
+				continue
+			end
+
+			local nextCh = if index < #value then string.sub(value, index + 1, index + 1) else ""
+			if nextCh == "{" then
+				local closeIndex = string.find(value, "}", index + 2, true)
+				if not closeIndex then
+					error("unterminated expansion expression")
+				end
+
+				local expression = string.sub(value, index + 2, closeIndex - 1)
+				local name, operator, rest = parseExpansionExpression(expression)
+				local referenced, exists = resolveReference(name)
+				local shouldUseRest = false
+				local expandedRest = ""
+
+				if rest ~= nil then
+					expandedRest = expandValue(rest)
+					if operator == "-" then
+						shouldUseRest = not exists
+					elseif operator == ":-" then
+						shouldUseRest = (not exists) or referenced == ""
+					elseif operator == "+" then
+						shouldUseRest = exists
+					elseif operator == ":+" then
+						shouldUseRest = exists and referenced ~= ""
+					end
+				end
+
+				table.insert(out, if shouldUseRest then expandedRest else referenced)
+				index = closeIndex + 1
+				continue
+			end
+
+			local name = string.match(string.sub(value, index + 1), "^([%a_][%w_]*)")
+			if name then
+				local referenced = resolveReference(name)
+				table.insert(out, referenced)
+				index += 1 + #name
+				continue
+			end
+
+			table.insert(out, "$")
+			index += 1
+		end
+
+		return table.concat(out)
+	end
+
+	for name in entries do
+		resolveName(name)
+	end
+
+	return resolved
+end
+
+local function rawEntriesToEnvironment(entries: { [string]: Entry }): Environment
+	local values = {}
+	for name, entry in entries do
+		values[name] = string.gsub(entry.value, DOLLAR_SENTINEL, "$")
+	end
+	return values
+end
+
+local function encodeDoubleQuoted(value: string): string
+	value = string.gsub(value, "\\", "\\\\")
+	value = string.gsub(value, "\n", "\\n")
+	value = string.gsub(value, "\r", "\\r")
+	value = string.gsub(value, "\t", "\\t")
+	value = string.gsub(value, '"', '\\"')
+	value = string.gsub(value, "%$", "\\$")
+	return value
+end
+
+local function serializeValue(value: string): string
+	if value == "" then
+		return ""
+	end
+
+	if string.match(value, [[^[^%s#"'=$]+$]]) then
+		return value
+	end
+
+	return '"' .. encodeDoubleQuoted(value) .. '"'
+end
+
+function env.parse(input: string, options: ParseOptions?): Environment
+	local entries = parseEntries(input, options)
+	local shouldExpand = if options and options.expand ~= nil then options.expand else false
+	if not shouldExpand then
+		return rawEntriesToEnvironment(entries)
+	end
+
+	local baseEnv = if options and options.env then options.env else process.env
+	return expandEntries(entries, baseEnv)
+end
+
+function env.serialize(values: Environment, options: SerializeOptions?): string
+	local keys = {}
+	for name in values do
+		assert(string.match(name, "^[%a_][%w_]*$"), `invalid environment variable name: {name}`)
+		table.insert(keys, name)
+	end
+
+	table.sort(keys)
+
+	local lines = {}
+	local prefix = if options and options.export then "export " else ""
+	for _, name in keys do
+		table.insert(lines, prefix .. name .. "=" .. serializeValue(values[name]))
+	end
+
+	local newline = if options and options.newline then options.newline else "\n"
+	return table.concat(lines, newline)
+end
+
+function env.load(filepath: Pathlike, options: LoadOptions?): Environment
+	local contents = fs.readFileToString(filepath)
+	return env.parse(contents, options)
+end
+
+function env.apply(values: Environment, options: ApplyOptions?): Environment
+	local target = if options and options.target then options.target else process.env
+	local override = if options and options.override ~= nil then options.override else false
+
+	for name, value in values do
+		if override or target[name] == nil then
+			target[name] = value
+		end
+	end
+
+	return target
+end
+
+function env.config(options: ConfigOptions?): Environment
+	local filepath = if options and options.path then options.path else ".env"
+	local baseEnv = if options and options.env
+		then options.env
+		else if options and options.target then options.target else process.env
+	local values = env.load(filepath, {
+		expand = if options then options.expand else nil,
+		strict = if options then options.strict else nil,
+		env = baseEnv,
+	})
+
+	env.apply(values, {
+		target = if options then options.target else nil,
+		override = if options then options.override else nil,
+	})
+
+	return values
+end
+
+return table.freeze(env)

--- a/batteries/env.luau
+++ b/batteries/env.luau
@@ -287,8 +287,8 @@ local function expandEntries(entries: { [string]: Entry }, baseEnv: Environment)
 	local resolving: { [string]: number } = {}
 	local stack = {}
 
-	local expandValue
-	local resolveReference
+	local resolveReference: ((string) -> (string, boolean))? = nil
+	local expandValue: ((string) -> string)? = nil
 
 	local function resolveName(name: string): string
 		if resolved[name] ~= nil then
@@ -314,6 +314,7 @@ local function expandEntries(entries: { [string]: Entry }, baseEnv: Environment)
 
 		local value = entry.value
 		if entry.quote ~= "single" then
+			assert(expandValue ~= nil)
 			value = expandValue(value)
 		end
 
@@ -324,7 +325,7 @@ local function expandEntries(entries: { [string]: Entry }, baseEnv: Environment)
 		return value
 	end
 
-	function resolveReference(name: string): (string, boolean)
+	resolveReference = function(name: string): (string, boolean)
 		if entries[name] ~= nil then
 			return resolveName(name), true
 		end
@@ -337,7 +338,7 @@ local function expandEntries(entries: { [string]: Entry }, baseEnv: Environment)
 		return "", false
 	end
 
-	function expandValue(value: string): string
+	expandValue = function(value: string): string
 		local out = {}
 		local index = 1
 
@@ -371,11 +372,13 @@ local function expandEntries(entries: { [string]: Entry }, baseEnv: Environment)
 
 				local expression = string.sub(value, index + 2, closeIndex - 1)
 				local name, operator, rest = parseExpansionExpression(expression)
+				assert(resolveReference ~= nil)
 				local referenced, exists = resolveReference(name)
 				local shouldUseRest = false
 				local expandedRest = ""
 
 				if rest ~= nil then
+					assert(expandValue ~= nil)
 					expandedRest = expandValue(rest)
 					if operator == "-" then
 						shouldUseRest = not exists
@@ -395,6 +398,7 @@ local function expandEntries(entries: { [string]: Entry }, baseEnv: Environment)
 
 			local name = string.match(string.sub(value, index + 1), "^([%a_][%w_]*)")
 			if name then
+				assert(resolveReference ~= nil)
 				local referenced = resolveReference(name)
 				table.insert(out, referenced)
 				index += 1 + #name

--- a/batteries/env.luau
+++ b/batteries/env.luau
@@ -504,8 +504,9 @@ function env.config(options: ConfigOptions?): Environment
 		env = baseEnv,
 	})
 
+	local target = if options and options.target then options.target else process.env
 	env.apply(values, {
-		target = if options then options.target else nil,
+		target = target,
 		override = if options then options.override else nil,
 	})
 

--- a/examples/env/.env
+++ b/examples/env/.env
@@ -1,0 +1,6 @@
+APP_NAME=Lute
+APP_ENV=development
+APP_PORT=3000
+APP_HOST=127.0.0.1
+APP_URL=http://${APP_HOST}:${APP_PORT}
+WELCOME_MESSAGE="Hello from ${APP_NAME} running in ${APP_ENV}"

--- a/examples/env/.luaurc
+++ b/examples/env/.luaurc
@@ -1,0 +1,6 @@
+{
+    "languageMode": "strict",
+    "aliases": {
+        "batteries": "../../batteries"
+    }
+}

--- a/examples/env/main.luau
+++ b/examples/env/main.luau
@@ -1,0 +1,30 @@
+local env = require("@batteries/env")
+local path = require("@std/path")
+local process = require("@std/process")
+
+local source = debug.info(1, "s")
+assert(source, "unable to determine the example source path")
+
+local exampleDir = path.dirname(source)
+local envFile = path.join(exampleDir, ".env")
+
+local values = env.config({
+	path = envFile,
+	expand = true,
+	override = true,
+})
+
+local keys = {}
+for key in values do
+	table.insert(keys, key)
+end
+table.sort(keys)
+
+print("Loaded values:")
+for _, key in keys do
+	print(`{key}={values[key]}`)
+end
+
+print("")
+print("From process.env:")
+print("WELCOME_MESSAGE=", process.env.WELCOME_MESSAGE)

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,3 +1,3 @@
 [tools]
 stylua = "JohnnyMorganz/StyLua@2.4.0"
-lute = "luau-lang/lute@1.0.0"
+lute = "luau-lang/lute@0.1.0-nightly.20260415"

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,3 +1,3 @@
 [tools]
 stylua = "JohnnyMorganz/StyLua@2.4.0"
-lute = "luau-lang/lute@0.1.0-nightly.20260415"
+lute = "luau-lang/lute@1.0.0"

--- a/tests/batteries/env.test.luau
+++ b/tests/batteries/env.test.luau
@@ -1,0 +1,151 @@
+local env = require("@batteries/env")
+local fs = require("@std/fs")
+local path = require("@std/path")
+local system = require("@std/system")
+local test = require("@std/test")
+
+local root = path.format(path.join(system.tmpdir(), "lute-env-battery"))
+local envFile = path.join(root, ".env")
+
+test.suite(".env parsing", function(suite)
+	suite:case("parsesCommonAssignments", function(assert)
+		local parsed = env.parse([[
+# comment
+FOO=bar
+BAR = baz # inline comment
+EMPTY=
+export BEEP=boop
+HASH=literal\#hash
+]])
+
+		assert.eq(parsed.FOO, "bar")
+		assert.eq(parsed.BAR, "baz")
+		assert.eq(parsed.EMPTY, "")
+		assert.eq(parsed.BEEP, "boop")
+		assert.eq(parsed.HASH, "literal#hash")
+	end)
+
+	suite:case("parsesQuotedAndMultilineValues", function(assert)
+		local parsed = env.parse([[
+SINGLE='hello # world'
+DOUBLE="hello\nworld"
+MULTI="line 1
+line 2"
+ESCAPED="cost: \$5"
+]])
+
+		assert.eq(parsed.SINGLE, "hello # world")
+		assert.eq(parsed.DOUBLE, "hello\nworld")
+		assert.eq(parsed.MULTI, "line 1\nline 2")
+		assert.eq(parsed.ESCAPED, "cost: $5")
+	end)
+
+	suite:case("expandsVariablesWithFallbackOperators", function(assert)
+		local parsed = env.parse(
+			[[
+ROOT=/workspace
+BIN=${ROOT}/bin
+HOME_DIR=$HOME
+DEFAULTED=${MISSING:-fallback}
+EMPTY_FALLBACK=${EMPTY:-fallback}
+SET_ALT=${ROOT:+yes}
+UNSET_ALT=${MISSING:+no}
+]],
+			{
+				expand = true,
+				env = {
+					HOME = "/users/lute",
+					EMPTY = "",
+				},
+			}
+		)
+
+		assert.eq(parsed.ROOT, "/workspace")
+		assert.eq(parsed.BIN, "/workspace/bin")
+		assert.eq(parsed.HOME_DIR, "/users/lute")
+		assert.eq(parsed.DEFAULTED, "fallback")
+		assert.eq(parsed.EMPTY_FALLBACK, "fallback")
+		assert.eq(parsed.SET_ALT, "yes")
+		assert.eq(parsed.UNSET_ALT, "")
+	end)
+
+	suite:case("rejectsCircularExpansion", function(assert)
+		assert.throwsWith("circular env expansion detected: A -> B -> A", function()
+			env.parse("A=$B\nB=$A\n", {
+				expand = true,
+			})
+		end)
+	end)
+end)
+
+test.suite(".env serialization", function(suite)
+	suite:case("roundTripsSpecialValues", function(assert)
+		local serialized = env.serialize({
+			EMPTY = "",
+			MULTI = "line 1\nline 2",
+			HASH = "a#b",
+			MONEY = "$5",
+			SIMPLE = "value",
+			SPACED = "hello world",
+		})
+
+		local parsed = env.parse(serialized, { expand = true })
+		assert.eq(parsed.EMPTY, "")
+		assert.eq(parsed.MULTI, "line 1\nline 2")
+		assert.eq(parsed.HASH, "a#b")
+		assert.eq(parsed.MONEY, "$5")
+		assert.eq(parsed.SIMPLE, "value")
+		assert.eq(parsed.SPACED, "hello world")
+	end)
+end)
+
+test.suite(".env file helpers", function(suite)
+	suite:beforeEach(function()
+		if fs.exists(root) then
+			fs.removeDirectory(root, { recursive = true })
+		end
+		fs.createDirectory(root)
+	end)
+
+	suite:case("loadReadsAndExpandsFromDisk", function(assert)
+		fs.writeStringToFile(envFile, "ROOT=/app\nBIN=${ROOT}/bin\n")
+		local parsed = env.load(envFile, { expand = true })
+
+		assert.eq(parsed.ROOT, "/app")
+		assert.eq(parsed.BIN, "/app/bin")
+	end)
+
+	suite:case("configAppliesWithoutOverridingByDefault", function(assert)
+		fs.writeStringToFile(envFile, "EXISTING=from-file\nNEW=value\n")
+
+		local target: env.Environment = {
+			EXISTING = "keep-me",
+		}
+
+		local parsed = env.config({
+			path = envFile,
+			target = target,
+		})
+
+		assert.eq(parsed.EXISTING, "from-file")
+		assert.eq(parsed.NEW, "value")
+		assert.eq(target.EXISTING, "keep-me")
+		assert.eq(target.NEW, "value")
+	end)
+
+	suite:case("configCanOverrideExistingValues", function(assert)
+		fs.writeStringToFile(envFile, "EXISTING=from-file\n")
+
+		local target: env.Environment = {
+			EXISTING = "keep-me",
+		}
+
+		env.config({
+			path = envFile,
+			target = target,
+			override = true,
+		})
+
+		assert.eq(target.EXISTING, "from-file")
+	end)
+end)


### PR DESCRIPTION
## Summary

Adds a new `@batteries/env` module for dotenv-style `.env` loading.

## Included

- parsing for common `.env` syntax
- variable expansion support
- `parse`, `load`, `apply`, `serialize`, and `config` helpers
- tests covering parsing, expansion, serialization, and file loading
- an example under `examples/env`

## Usage

`env.config()` loads `.env` from the current working directory, applies values to `process.env`, and returns the parsed table.
