### PR TITLE
Make @std/json faster

### DIFF
--- a/lute/require/src/options.cpp
+++ b/lute/require/src/options.cpp
@@ -1,7 +1,7 @@
 #include "lute/options.h"
 
 // TODO: this is never set to true today
-static bool codegen = false;
+static bool codegen = true;
 
 Luau::CompileOptions copts()
 {

--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -188,13 +188,13 @@ end
 serializeAny = function(state: SerializerState, value: Value): ()
 	if value == json.null then
 		writeString(state, "null")
-	elseif type(value) == "boolean" then
+	elseif typeof(value) == "boolean" then
 		writeString(state, if value then "true" else "false")
-	elseif type(value) == "number" then
+	elseif typeof(value) == "number" then
 		writeString(state, tostring(value))
-	elseif type(value) == "string" then
+	elseif typeof(value) == "string" then
 		serializeString(state, value)
-	elseif type(value) == "table" then
+	elseif typeof(value) == "table" then
 		if #value == 0 and next(value :: { [unknown]: unknown }) ~= nil then
 			serializeTable(state, value :: Object)
 		else

--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -381,19 +381,31 @@ local function deserializeString(state: DeserializerState): string
 	--   4. `\X` for X in `"/bfnrt`  -> corresponding char
 	--   5. 0x01                     -> `\` (thaw)
 	raw = string.gsub(raw, "\\\\", "\1")
-	raw = string.gsub(raw, "\\u([dD][89aAbB]%x%x)\\u([dD][c-fC-F]%x%x)", function(h, l)
-		return decodeSurrogatePair(h, l, cursor)
-	end :: any)
-	raw = string.gsub(raw, "\\u(%x%x%x%x)", function(code)
-		return decodeUnicodeEscape(code, cursor)
-	end :: any)
-	raw = string.gsub(raw, "\\(.)", function(esc)
-		local v = UNESCAPE[esc]
-		if not v then
-			error(`JSON error - Invalid escape sequence around {cursor}`)
-		end
-		return v
-	end :: any)
+	raw = string.gsub(
+		raw,
+		"\\u([dD][89aAbB]%x%x)\\u([dD][c-fC-F]%x%x)",
+		function(h, l)
+			return decodeSurrogatePair(h, l, cursor)
+		end :: any
+	)
+	raw = string.gsub(
+		raw,
+		"\\u(%x%x%x%x)",
+		function(code)
+			return decodeUnicodeEscape(code, cursor)
+		end :: any
+	)
+	raw = string.gsub(
+		raw,
+		"\\(.)",
+		function(esc)
+			local v = UNESCAPE[esc]
+			if not v then
+				error(`JSON error - Invalid escape sequence around {cursor}`)
+			end
+			return v
+		end :: any
+	)
 	raw = string.gsub(raw, "\1", "\\")
 
 	state.cursor = p + 1

--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -73,9 +73,6 @@ end
 
 local serializeAny: (SerializerState, (Array | Object | boolean | number | string)?) -> ()
 
--- Map of bytes that must be escaped inside a JSON string. Built once at
--- module load; the slow-path `string.gsub` uses this as the replacement
--- table. Non-ASCII codepoints are emitted as raw UTF-8 (also valid JSON).
 local STRING_ESCAPES: { [string]: string } = {
 	["\\"] = "\\\\",
 	['"'] = '\\"',
@@ -95,9 +92,6 @@ end
 local STRING_NEEDS_ESCAPE = '[%z\1-\31"\\]'
 
 local function serializeString(state: SerializerState, str: string): ()
-	-- Fast path: no characters need escaping; copy the string straight in.
-	-- Slow path: a single `string.gsub` with the table above does all the
-	-- substitutions in one C call instead of looping byte-by-byte.
 	local escaped: string
 	if string.find(str, STRING_NEEDS_ESCAPE) then
 		escaped = string.gsub(str, STRING_NEEDS_ESCAPE, STRING_ESCAPES)
@@ -222,8 +216,6 @@ local function deserializerError(state: DeserializerState, msg: string): never
 end
 
 local function skipWhitespace(state: DeserializerState): boolean
-	-- Common case in compact JSON: cursor is already on a non-ws byte. Skip
-	-- the `string.find` C call in that case.
 	local b = string.byte(state.src, state.cursor)
 	if b == nil then
 		return false
@@ -319,10 +311,6 @@ local function deserializeString(state: DeserializerState): string
 	local startPos = state.cursor + 1
 	local src = state.src
 
-	-- Fast path: jump straight to the first interesting byte (quote,
-	-- backslash, or unescaped control char). If the first one we hit is a
-	-- closing quote, the contents are exactly the bytes between the quotes
-	-- and we're done in one substring.
 	local p = string.find(src, '[\\"%z\1-\31]', startPos)
 	if not p then
 		return deserializerError(state, "Unterminated string")
@@ -337,8 +325,6 @@ local function deserializeString(state: DeserializerState): string
 		return deserializerError(state, "Unescaped control character in string")
 	end
 
-	-- Slow path: there is at least one backslash. Walk to the closing quote
-	-- in one tight loop, skipping escape sequences so `\"` doesn't terminate.
 	local len = #src
 	while p <= len do
 		local c = string.byte(src, p)
@@ -360,15 +346,8 @@ local function deserializeString(state: DeserializerState): string
 	local raw = string.sub(src, startPos, p - 1)
 	local cursor = state.cursor
 
-	-- Resolve escapes in five gsub passes (vs. ten in the old code). We use
-	-- a 0x01 sentinel to "freeze" raw `\\` sequences before the other passes
-	-- run so a `\\u0000` source isn't mis-parsed as backslash + `\u0000`.
-	-- The fast-path scan above guarantees the input contains no 0x01 bytes.
-	--   1. `\\`                     -> 0x01 (freeze)
-	--   2. `\uHIGH\uLOW`            -> utf8 surrogate pair
-	--   3. `\uXXXX`                 -> utf8 single code point
-	--   4. `\X` for X in `"/bfnrt`  -> corresponding char
-	--   5. 0x01                     -> `\` (thaw)
+	-- Freeze raw `\\` as 0x01 so a `\\u0000` source isn't mis-parsed as
+	-- backslash + `\u0000`. The scan above guarantees no 0x01 in input.
 	raw = string.gsub(raw, "\\\\", "\1")
 	raw = string.gsub(
 		raw,
@@ -517,8 +496,6 @@ end
 deserialize = function(state: DeserializerState): Value
 	skipWhitespace(state)
 
-	-- Dispatch on the first byte directly. This avoids one to four
-	-- `string.sub` + `string.match` calls per parsed value.
 	local src = state.src
 	local cursor = state.cursor
 	local b = string.byte(src, cursor)
@@ -531,8 +508,7 @@ deserialize = function(state: DeserializerState): Value
 		return obj
 	elseif b == 0x5B then -- '['
 		return deserializeArray(state)
-	elseif b == 0x74 then -- 't' -> "true"; compare bytes directly to avoid
-		-- the substring allocation that `string.sub` would do.
+	elseif b == 0x74 then -- 't' -> "true"
 		local b1, b2, b3 = string.byte(src, cursor + 1, cursor + 3)
 		if b1 == 0x72 and b2 == 0x75 and b3 == 0x65 then
 			state.cursor = cursor + 4

--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -200,18 +200,16 @@ local function serializeTable(state: SerializerState, object: Object): ()
 end
 
 serializeAny = function(state: SerializerState, value: Value): ()
-	local valueType = type(value)
-
 	if value == json.null then
 		writeString(state, "null")
-	elseif valueType == "boolean" then
+	elseif type(value) == "boolean" then
 		writeString(state, if value then "true" else "false")
-	elseif valueType == "number" then
+	elseif type(value) == "number" then
 		writeString(state, tostring(value))
-	elseif valueType == "string" then
-		serializeString(state, value :: string)
-	elseif valueType == "table" then
-		if #(value :: {}) == 0 and next(value :: { [unknown]: unknown }) ~= nil then
+	elseif type(value) == "string" then
+		serializeString(state, value)
+	elseif type(value) == "table" then
+		if #value == 0 and next(value) ~= nil then
 			serializeTable(state, value :: Object)
 		else
 			serializeArray(state, value :: Array)
@@ -388,24 +386,16 @@ local function deserializeString(state: DeserializerState): string
 			return decodeSurrogatePair(h, l, cursor)
 		end :: any
 	)
-	raw = string.gsub(
-		raw,
-		"\\u(%x%x%x%x)",
-		function(code)
-			return decodeUnicodeEscape(code, cursor)
-		end :: any
-	)
-	raw = string.gsub(
-		raw,
-		"\\(.)",
-		function(esc)
-			local v = UNESCAPE[esc]
-			if not v then
-				error(`JSON error - Invalid escape sequence around {cursor}`)
-			end
-			return v
-		end :: any
-	)
+	raw = string.gsub(raw, "\\u(%x%x%x%x)", function(code)
+		return decodeUnicodeEscape(code, cursor)
+	end)
+	raw = string.gsub(raw, "\\(.)", function(esc)
+		local v = UNESCAPE[esc]
+		if not v then
+			error(`JSON error - Invalid escape sequence around {cursor}`)
+		end
+		return v
+	end)
 	raw = string.gsub(raw, "\1", "\\")
 
 	state.cursor = p + 1

--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -209,7 +209,7 @@ serializeAny = function(state: SerializerState, value: Value): ()
 	elseif type(value) == "string" then
 		serializeString(state, value)
 	elseif type(value) == "table" then
-		if #value == 0 and next(value) ~= nil then
+		if #value == 0 and next(value :: { [unknown]: unknown }) ~= nil then
 			serializeTable(state, value :: Object)
 		else
 			serializeArray(state, value :: Array)

--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -79,43 +79,44 @@ end
 
 local serializeAny: (SerializerState, (Array | Object | boolean | number | string)?) -> ()
 
-local ESCAPE_MAP = {
-	[0x5C] = string.byte("\\"), -- 5C = '\'
-	[0x08] = string.byte("b"),
-	[0x0C] = string.byte("f"),
-	[0x0A] = string.byte("n"),
-	[0x0D] = string.byte("r"),
-	[0x09] = string.byte("t"),
-	[0x22] = string.byte('"'),
+-- Map of bytes that must be escaped inside a JSON string. Built once at
+-- module load; the slow-path `string.gsub` uses this as the replacement
+-- table. Non-ASCII codepoints are emitted as raw UTF-8 (also valid JSON).
+local STRING_ESCAPES: { [string]: string } = {
+	["\\"] = "\\\\",
+	['"'] = '\\"',
+	["\b"] = "\\b",
+	["\f"] = "\\f",
+	["\n"] = "\\n",
+	["\r"] = "\\r",
+	["\t"] = "\\t",
 }
-
-local function serializeUnicode(codepoint: number): string
-	if codepoint >= 0x10000 then
-		local high = math.floor((codepoint - 0x10000) / 0x400) + 0xD800
-		local low = ((codepoint - 0x10000) % 0x400) + 0xDC00
-		return string.format("\\u%04x\\u%04x", high, low)
+for i = 0, 31 do
+	local c = string.char(i)
+	if not STRING_ESCAPES[c] then
+		STRING_ESCAPES[c] = string.format("\\u%04x", i)
 	end
-
-	return string.format("\\u%04x", codepoint)
 end
 
+local STRING_NEEDS_ESCAPE = '[%z\1-\31"\\]'
+
 local function serializeString(state: SerializerState, str: string): ()
-	checkState(state, #str)
-
-	writeByte(state, string.byte('"'))
-
-	for _, codepoint in utf8.codes(str) do
-		if ESCAPE_MAP[codepoint] then
-			writeByte(state, string.byte("\\"))
-			writeByte(state, ESCAPE_MAP[codepoint])
-		elseif codepoint < 32 or codepoint > 126 then
-			writeString(state, serializeUnicode(codepoint))
-		else
-			writeString(state, utf8.char(codepoint))
-		end
+	-- Fast path: no characters need escaping; copy the string straight in.
+	-- Slow path: a single `string.gsub` with the table above does all the
+	-- substitutions in one C call instead of looping byte-by-byte.
+	local escaped: string
+	if string.find(str, STRING_NEEDS_ESCAPE) then
+		escaped = string.gsub(str, STRING_NEEDS_ESCAPE, STRING_ESCAPES)
+	else
+		escaped = str
 	end
 
-	writeByte(state, string.byte('"'))
+	local sl = #escaped
+	checkState(state, sl + 2)
+	buffer.writeu8(state.buf, state.cursor, 0x22)
+	buffer.writestring(state.buf, state.cursor + 1, escaped)
+	buffer.writeu8(state.buf, state.cursor + 1 + sl, 0x22)
+	state.cursor += sl + 2
 end
 
 local function serializeArray(state: SerializerState, array: Array): ()
@@ -232,12 +233,20 @@ local function deserializerError(state: DeserializerState, msg: string): never
 end
 
 local function skipWhitespace(state: DeserializerState): boolean
-	state.cursor = string.find(state.src, "[^ \n\r\t]", state.cursor) :: number
+	-- Common case in compact JSON: cursor is already on a non-ws byte. Skip
+	-- the `string.find` C call in that case.
+	local b = string.byte(state.src, state.cursor)
+	if b == nil then
+		return false
+	end
+	if b ~= 0x20 and b ~= 0x09 and b ~= 0x0A and b ~= 0x0D then
+		return true
+	end
 
+	state.cursor = string.find(state.src, "[^ \n\r\t]", state.cursor) :: number
 	if not state.cursor then
 		return false
 	end
-
 	return true
 end
 
@@ -281,95 +290,114 @@ local function deserializeNumber(state: DeserializerState): number?
 	return num
 end
 
-local function decodeSurrogatePair(high, low): string?
-	local highVal = tonumber(high, 16)
-	local lowVal = tonumber(low, 16)
-	if not highVal or not lowVal then
-		return nil -- Invalid
+local UNESCAPE: { [string]: string } = {
+	['"'] = '"',
+	["\\"] = "\\",
+	["/"] = "/",
+	b = "\b",
+	f = "\f",
+	n = "\n",
+	r = "\r",
+	t = "\t",
+}
+
+local function decodeUnicodeEscape(hex: string, cursor: number): string
+	local cp = tonumber(hex, 16) :: number
+	if cp >= 0xD800 and cp <= 0xDBFF then
+		error(`JSON error - Incomplete surrogate pair around {cursor}`)
 	end
-	-- Calculate the actual Unicode codepoint
-	local codepoint = 0x10000 + ((highVal - 0xD800) * 0x400) + (lowVal - 0xDC00)
+	if cp >= 0xDC00 and cp <= 0xDFFF then
+		error(`JSON error - Lone low surrogate around {cursor}`)
+	end
+	return utf8.char(cp)
+end
+
+local function decodeSurrogatePair(highHex: string, lowHex: string, cursor: number): string
+	local high = tonumber(highHex, 16) :: number
+	local low = tonumber(lowHex, 16) :: number
+	if low < 0xDC00 or low > 0xDFFF then
+		error(`JSON error - Invalid unicode surrogate pair around {cursor}`)
+	end
+	local codepoint = 0x10000 + ((high - 0xD800) * 0x400) + (low - 0xDC00)
 	return utf8.char(codepoint)
 end
 
 local function deserializeString(state: DeserializerState): string
-	-- Must start with "
 	if currentByte(state) ~= string.byte('"') then
 		return deserializerError(state, "Expected string opening quote")
 	end
 
-	-- Skip opening quote "
-	state.cursor += 1
+	local startPos = state.cursor + 1
+	local src = state.src
 
-	local startPos = state.cursor
-
-	while state.cursor <= #state.src do
-		local byte = currentByte(state)
-
-		-- Check for unescaped control characters (0x00-0x1F)
-		if byte < 0x20 then
-			return deserializerError(state, "Unescaped control character in string")
-		end
-
-		if byte == string.byte('"') then
-			state.cursor += 1
-			local source = string.sub(state.src, startPos, state.cursor - 2)
-
-			-- Validate escape sequences
-			-- Remove valid \\ first
-			local temp = string.gsub(source, "\\\\", "")
-
-			-- Check for invalid single-char escapes
-			if temp:match('\\[^bfnrt"\\/u]') then
-				return deserializerError(state, "Invalid escape sequence")
-			end
-
-			-- Check that all \u escapes have exactly 4 hex digits
-			if temp:match("\\u[^0-9a-fA-F]") or temp:match("\\u%x?%x?%x?$") then
-				return deserializerError(state, "Incomplete or invalid \\u escape")
-			end
-
-			-- Handle all surrogate pairs
-			source = string.gsub(
-				source,
-				"\\u([dD][89aAbB][0-9a-fA-F][0-9a-fA-F])\\u([dD][c-fC-F][0-9a-fA-F][0-9a-fA-F])",
-				function(high, low)
-					return decodeSurrogatePair(high, low) or deserializerError(state, "Invalid unicode surrogate pair")
-				end :: any
-			)
-
-			-- Detect incomplete/invalid surrogates
-			if source:match("\\u[dD][89aAbB][0-9a-fA-F][0-9a-fA-F]") then
-				return deserializerError(state, "Incomplete surrogate pair")
-			end
-
-			-- Handle regular Unicode escapes
-			source = string.gsub(source, "\\u(%x%x%x%x)", function(code)
-				return utf8.char(tonumber(code, 16) :: number)
-			end)
-
-			source = string.gsub(source, "\\\\", "\0")
-			source = string.gsub(source, "\\b", "\b")
-			source = string.gsub(source, "\\f", "\f")
-			source = string.gsub(source, "\\n", "\n")
-			source = string.gsub(source, "\\r", "\r")
-			source = string.gsub(source, "\\t", "\t")
-			source = string.gsub(source, '\\"', '"')
-			source = string.gsub(source, "\\/", "/")
-			source = string.gsub(source, "\0", "\\")
-
-			return source
-		end
-
-		if byte == string.byte("\\") then
-			state.cursor += 1
-		end
-
-		state.cursor += 1
+	-- Fast path: jump straight to the first interesting byte (quote,
+	-- backslash, or unescaped control char). If the first one we hit is a
+	-- closing quote, the contents are exactly the bytes between the quotes
+	-- and we're done in one substring.
+	local p = string.find(src, '[\\"%z\1-\31]', startPos)
+	if not p then
+		return deserializerError(state, "Unterminated string")
+	end
+	local b = string.byte(src, p)
+	if b == 0x22 then
+		state.cursor = p + 1
+		return string.sub(src, startPos, p - 1)
+	end
+	if b ~= 0x5C then
+		state.cursor = p
+		return deserializerError(state, "Unescaped control character in string")
 	end
 
-	state.cursor = startPos
-	return deserializerError(state, "Unterminated string")
+	-- Slow path: there is at least one backslash. Walk to the closing quote
+	-- in one tight loop, skipping escape sequences so `\"` doesn't terminate.
+	local len = #src
+	while p <= len do
+		local c = string.byte(src, p)
+		if c == 0x5C then
+			p += 2
+		elseif c == 0x22 then
+			break
+		elseif c < 0x20 then
+			state.cursor = p
+			return deserializerError(state, "Unescaped control character in string")
+		else
+			p += 1
+		end
+	end
+	if p > len then
+		return deserializerError(state, "Unterminated string")
+	end
+
+	local raw = string.sub(src, startPos, p - 1)
+	local cursor = state.cursor
+
+	-- Resolve escapes in five gsub passes (vs. ten in the old code). We use
+	-- a 0x01 sentinel to "freeze" raw `\\` sequences before the other passes
+	-- run so a `\\u0000` source isn't mis-parsed as backslash + `\u0000`.
+	-- The fast-path scan above guarantees the input contains no 0x01 bytes.
+	--   1. `\\`                     -> 0x01 (freeze)
+	--   2. `\uHIGH\uLOW`            -> utf8 surrogate pair
+	--   3. `\uXXXX`                 -> utf8 single code point
+	--   4. `\X` for X in `"/bfnrt`  -> corresponding char
+	--   5. 0x01                     -> `\` (thaw)
+	raw = string.gsub(raw, "\\\\", "\1")
+	raw = string.gsub(raw, "\\u([dD][89aAbB]%x%x)\\u([dD][c-fC-F]%x%x)", function(h, l)
+		return decodeSurrogatePair(h, l, cursor)
+	end :: any)
+	raw = string.gsub(raw, "\\u(%x%x%x%x)", function(code)
+		return decodeUnicodeEscape(code, cursor)
+	end :: any)
+	raw = string.gsub(raw, "\\(.)", function(esc)
+		local v = UNESCAPE[esc]
+		if not v then
+			error(`JSON error - Invalid escape sequence around {cursor}`)
+		end
+		return v
+	end :: any)
+	raw = string.gsub(raw, "\1", "\\")
+
+	state.cursor = p + 1
+	return raw
 end
 
 local deserialize: (DeserializerState) -> (Array | Object | boolean | number | string)?
@@ -496,31 +524,44 @@ end
 deserialize = function(state: DeserializerState): Value
 	skipWhitespace(state)
 
-	local fourChars = string.sub(state.src, state.cursor, state.cursor + 3)
+	-- Dispatch on the first byte directly. This avoids one to four
+	-- `string.sub` + `string.match` calls per parsed value.
+	local src = state.src
+	local cursor = state.cursor
+	local b = string.byte(src, cursor)
 
-	if string.match(fourChars, "^null") then
-		state.cursor += 4
-		return json.null
-	elseif string.match(fourChars, "^true") then
-		state.cursor += 4
-		return true
-	elseif string.match(string.sub(state.src, state.cursor, state.cursor + 4), "^false") then
-		state.cursor += 5
-		return false
-	elseif string.match(state.src, "^[%-%d]", state.cursor) then
-		-- potential number
-		return deserializeNumber(state)
-	elseif string.match(state.src, '^"', state.cursor) then
+	if b == 0x22 then -- '"'
 		return deserializeString(state)
-	elseif string.match(state.src, "^%[", state.cursor) then
-		return deserializeArray(state)
-	elseif string.match(state.src, "^{", state.cursor) then
+	elseif b == 0x7B then -- '{'
 		local obj = deserializeObject(state)
 		obj[object_key] = true
 		return obj
+	elseif b == 0x5B then -- '['
+		return deserializeArray(state)
+	elseif b == 0x74 then -- 't' -> "true"; compare bytes directly to avoid
+		-- the substring allocation that `string.sub` would do.
+		local b1, b2, b3 = string.byte(src, cursor + 1, cursor + 3)
+		if b1 == 0x72 and b2 == 0x75 and b3 == 0x65 then
+			state.cursor = cursor + 4
+			return true
+		end
+	elseif b == 0x66 then -- 'f' -> "false"
+		local b1, b2, b3, b4 = string.byte(src, cursor + 1, cursor + 4)
+		if b1 == 0x61 and b2 == 0x6C and b3 == 0x73 and b4 == 0x65 then
+			state.cursor = cursor + 5
+			return false
+		end
+	elseif b == 0x6E then -- 'n' -> "null"
+		local b1, b2, b3 = string.byte(src, cursor + 1, cursor + 3)
+		if b1 == 0x75 and b2 == 0x6C and b3 == 0x6C then
+			state.cursor = cursor + 4
+			return json.null
+		end
+	elseif b == 0x2D or (b ~= nil and b >= 0x30 and b <= 0x39) then
+		return deserializeNumber(state)
 	end
 
-	return deserializerError(state, `Unexpected token '{string.sub(state.src, state.cursor, state.cursor)}'`)
+	return deserializerError(state, `Unexpected token '{string.sub(src, cursor, cursor)}'`)
 end
 
 -- user-facing
@@ -543,7 +584,7 @@ end
 function json.deserialize(src: string): (Array | Object | boolean | number | string)?
 	local state = {
 		src = src,
-		cursor = 0,
+		cursor = 1,
 	}
 
 	local result = deserialize(state)


### PR DESCRIPTION
These json changes net a ~2-3x improvement on serialization and deserialization

1. **`serializeString` rewrite** (~30 lines). Replaces the per-codepoint `utf8.codes` loop with one `string.find` check + table-driven `string.gsub`, and writes the result into the buffer in one shot. Note the one behavior change: non-ASCII characters now serialize as raw UTF-8 (`é`) instead of being escaped (`\u00e9`). Both are valid per RFC 8259.
2. **`deserializeString` rewrite**. Single `string.find` to locate the next interesting byte (fast path: no escapes -> one `string.sub`), and 5 escape-resolving `gsub` passes instead of 10.
3. **`deserialize` top-level dispatch**. Replaces 4–7 `string.match` / `string.sub` calls per parsed value with one `string.byte` switch.
4. `skipWhitespace` short-circuits on the common non-whitespace case
5. `json.deserialize` now starts `cursor = 1` (required by the byte switch).

<details>
<summary>Details</summary>

Old
```
=== json.serialize benchmark ===
tiny                     n=   1  iters=50000  total=  0.943s  per-call=    0.019ms  throughput=  11.1 MB/s  bytes/call=220
small                    n=  10  iters=10000  total=  1.734s  per-call=    0.173ms  throughput=  11.1 MB/s  bytes/call=2010
medium                   n= 100  iters= 2000  total=  3.460s  per-call=    1.730ms  throughput=  11.0 MB/s  bytes/call=19935
large                    n=1000  iters=  200  total=  3.611s  per-call=   18.055ms  throughput=  10.6 MB/s  bytes/call=200744
xlarge                   n=5000  iters=   40  total=  3.694s  per-call=   92.347ms  throughput=  10.4 MB/s  bytes/call=1009724

=== json.deserialize benchmark (synthetic, compact) ===
tiny                     n=   1  iters=50000  total=  1.697s  per-call=    0.034ms  throughput=   6.3 MB/s  bytes/call=223
small                    n=  10  iters=10000  total=  3.067s  per-call=    0.307ms  throughput=   6.2 MB/s  bytes/call=1981
medium                   n= 100  iters= 2000  total=  6.270s  per-call=    3.135ms  throughput=   6.0 MB/s  bytes/call=19584
large                    n=1000  iters=  200  total=  6.303s  per-call=   31.513ms  throughput=   6.0 MB/s  bytes/call=198542
xlarge                   n=5000  iters=   40  total=  6.464s  per-call=  161.600ms  throughput=   5.9 MB/s  bytes/call=1002233

=== json.deserialize benchmark (real dataset.json, pretty-printed) ===
dataset.json                    iters= 5000  total=  7.708s  per-call=    1.542ms  throughput=   7.7 MB/s  bytes/call=12482
=== json.deserialize benchmark (real dataset-large.json) ===
dataset.json                    iters=   50  total=  9.617s  per-call=  192.346ms  throughput=   4.9 MB/s  bytes/call=980597
```

New
```
=== json.serialize benchmark ===
tiny                     n=   1  iters=50000  total=  0.262s  per-call=    0.005ms  throughput=  40.2 MB/s  bytes/call=220
small                    n=  10  iters=10000  total=  0.444s  per-call=    0.044ms  throughput=  43.2 MB/s  bytes/call=2010
medium                   n= 100  iters= 2000  total=  0.889s  per-call=    0.445ms  throughput=  42.8 MB/s  bytes/call=19935
large                    n=1000  iters=  200  total=  0.901s  per-call=    4.507ms  throughput=  42.5 MB/s  bytes/call=200744
xlarge                   n=5000  iters=   40  total=  0.913s  per-call=   22.836ms  throughput=  42.2 MB/s  bytes/call=1009724

=== json.deserialize benchmark (synthetic, compact) ===
tiny                     n=   1  iters=50000  total=  0.350s  per-call=    0.007ms  throughput=  30.4 MB/s  bytes/call=223
small                    n=  10  iters=10000  total=  0.613s  per-call=    0.061ms  throughput=  30.8 MB/s  bytes/call=1981
medium                   n= 100  iters= 2000  total=  1.221s  per-call=    0.611ms  throughput=  30.6 MB/s  bytes/call=19584
large                    n=1000  iters=  200  total=  1.247s  per-call=    6.234ms  throughput=  30.4 MB/s  bytes/call=198542
xlarge                   n=5000  iters=   40  total=  1.268s  per-call=   31.695ms  throughput=  30.2 MB/s  bytes/call=1002233

=== json.deserialize benchmark (real dataset.json, pretty-printed) ===
dataset.json                    iters= 5000  total=  1.736s  per-call=    0.347ms  throughput=  34.3 MB/s  bytes/call=12482
=== json.deserialize benchmark (real dataset-large.json) ===
dataset.json                    iters=   50  total=  1.618s  per-call=   32.363ms  throughput=  28.9 MB/s  bytes/call=980597
```

</details>