### PR TITLE
Fix @std/json compact output

### DIFF
--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -51,21 +51,15 @@ local function writeByte(state: SerializerState, byte: number): ()
 end
 
 local function writeSpaces(state: SerializerState): ()
-	if state.depth == 0 then
+	if not state.prettyPrint or state.depth == 0 then
 		return
 	end
 
-	if state.prettyPrint then
-		checkState(state, state.depth * 4)
+	checkState(state, state.depth * 4)
 
-		for _ = 1, state.depth do
-			buffer.writeu32(state.buf, state.cursor, 0x_20_20_20_20)
-			state.cursor += 4
-		end
-	else
-		buffer.writeu8(state.buf, state.cursor, (string.byte(" ")))
-
-		state.cursor += 1
+	for _ = 1, state.depth do
+		buffer.writeu32(state.buf, state.cursor, 0x_20_20_20_20)
+		state.cursor += 4
 	end
 end
 
@@ -136,9 +130,7 @@ local function serializeArray(state: SerializerState, array: Array): ()
 			end
 		end
 
-		if i ~= 1 or state.prettyPrint then
-			writeSpaces(state)
-		end
+		writeSpaces(state)
 
 		serializeAny(state, value)
 	end
@@ -170,7 +162,6 @@ local function serializeTable(state: SerializerState, object: Object): ()
 
 		if not first then
 			writeByte(state, string.byte(","))
-			writeByte(state, string.byte(" "))
 
 			if state.prettyPrint then
 				writeByte(state, string.byte("\n"))
@@ -182,7 +173,7 @@ local function serializeTable(state: SerializerState, object: Object): ()
 		writeSpaces(state)
 
 		serializeString(state, key)
-		writeString(state, ": ")
+		writeString(state, if state.prettyPrint then ": " else ":")
 
 		serializeAny(state, value)
 	end

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -904,56 +904,56 @@ local x = 1 / 0
         {
             "items": [
                 {
-                    "message": "Unused variable detected. Prefix this variable with '_' to indicate that it's intentionally unused.", 
-                    "codeDescription": "https://lute.luau.org/cli/lint/unused_variable.html", 
-                    "source": "lute lint", 
-                    "code": "unused_variable", 
-                    "severity": 2, 
+                    "message": "Unused variable detected. Prefix this variable with '_' to indicate that it's intentionally unused.",
+                    "codeDescription": "https://lute.luau.org/cli/lint/unused_variable.html",
+                    "source": "lute lint",
+                    "code": "unused_variable",
+                    "severity": 2,
                     "tags": [
                         1
-                    ], 
+                    ],
                     "range": {
                         "start": {
-                            "character": 6, 
+                            "character": 6,
                             "line": 0
-                        }, 
+                        },
                         "end": {
-                            "character": 7, 
+                            "character": 7,
                             "line": 0
                         }
                     }
                 },
                 {
-                    "message": "Division by zero detected.", 
-                    "codeDescription": "https://lute.luau.org/cli/lint/divide_by_zero.html", 
-                    "source": "lute lint", 
-                    "code": "divide_by_zero", 
-                    "severity": 2, 
+                    "message": "Division by zero detected.",
+                    "codeDescription": "https://lute.luau.org/cli/lint/divide_by_zero.html",
+                    "source": "lute lint",
+                    "code": "divide_by_zero",
+                    "severity": 2,
                     "range": {
                         "start": {
-                            "character": 10, 
+                            "character": 10,
                             "line": 0
-                        }, 
+                        },
                         "end": {
-                            "character": 15, 
+                            "character": 15,
                             "line": 0
                         }
-                    }, 
+                    },
                     "suggestedfix": {
                         "range": {
                             "start": {
-                                "character": 10, 
+                                "character": 10,
                                 "line": 0
-                            }, 
+                            },
                             "end": {
-                                "character": 15, 
+                                "character": 15,
                                 "line": 0
                             }
-                        }, 
+                        },
                         "fix": "math.huge"
                     }
                 }
-            ], 
+            ],
             "uri":]], -- URI has absolute tmpdir path, so we cut off here
 					count = 1,
 				},
@@ -1146,52 +1146,52 @@ b = a
 		local expected = [=[
 [
     {
-        "message": "Unused variable detected. Prefix this variable with '_' to indicate that it's intentionally unused.", 
-        "codeDescription": "https://lute.luau.org/cli/lint/unused_variable.html", 
-        "source": "lute lint", 
-        "code": "unused_variable", 
-        "severity": 2, 
+        "message": "Unused variable detected. Prefix this variable with '_' to indicate that it's intentionally unused.",
+        "codeDescription": "https://lute.luau.org/cli/lint/unused_variable.html",
+        "source": "lute lint",
+        "code": "unused_variable",
+        "severity": 2,
         "tags": [
             1
-        ], 
+        ],
         "range": {
             "start": {
-                "character": 6, 
+                "character": 6,
                 "line": 0
-            }, 
+            },
             "end": {
-                "character": 7, 
+                "character": 7,
                 "line": 0
             }
         }
     },
     {
-        "message": "Division by zero detected.", 
-        "codeDescription": "https://lute.luau.org/cli/lint/divide_by_zero.html", 
-        "source": "lute lint", 
-        "code": "divide_by_zero", 
-        "severity": 2, 
+        "message": "Division by zero detected.",
+        "codeDescription": "https://lute.luau.org/cli/lint/divide_by_zero.html",
+        "source": "lute lint",
+        "code": "divide_by_zero",
+        "severity": 2,
         "range": {
             "start": {
-                "character": 10, 
+                "character": 10,
                 "line": 0
-            }, 
+            },
             "end": {
-                "character": 15, 
+                "character": 15,
                 "line": 0
             }
-        }, 
+        },
         "suggestedfix": {
             "range": {
                 "start": {
-                    "character": 10, 
+                    "character": 10,
                     "line": 0
-                }, 
+                },
                 "end": {
-                    "character": 15, 
+                    "character": 15,
                     "line": 0
                 }
-            }, 
+            },
             "fix": "math.huge"
         }
     }
@@ -1489,32 +1489,32 @@ local e = next(t) ~= nil
 		local expected = [=[
 [
     {
-        "message": "This looks like a failed attempt to swap.", 
-        "codeDescription": "https://lute.luau.org/cli/lint/almost_swapped.html", 
-        "source": "lute lint", 
-        "code": "almost_swapped", 
-        "severity": 2, 
+        "message": "This looks like a failed attempt to swap.",
+        "codeDescription": "https://lute.luau.org/cli/lint/almost_swapped.html",
+        "source": "lute lint",
+        "code": "almost_swapped",
+        "severity": 2,
         "range": {
             "start": {
-                "character": 3, 
+                "character": 3,
                 "line": 0
-            }, 
+            },
             "end": {
-                "character": 8, 
+                "character": 8,
                 "line": 1
             }
-        }, 
+        },
         "suggestedfix": {
             "range": {
                 "start": {
-                    "character": 3, 
+                    "character": 3,
                     "line": 0
-                }, 
+                },
                 "end": {
-                    "character": 8, 
+                    "character": 8,
                     "line": 1
                 }
-            }, 
+            },
             "fix": "a, b = b, a"
         }
     }

--- a/tests/std/json.test.luau
+++ b/tests/std/json.test.luau
@@ -48,6 +48,23 @@ test.suite("JSONParsingTestSuite", function(suite)
 		end)
 	end
 
+	suite:case("compactSerializeHasNoSpaces", function(assert)
+		assert.eq(json.serialize({ 1, 2, 3 }), "[1,2,3]")
+		assert.eq(json.serialize({}), "[]")
+		assert.eq(json.serialize(json.object({})), "{}")
+		assert.eq(json.serialize({ nested = { 1, 2 } }), '{"nested":[1,2]}')
+		local mixed: json.Array = { "a", { 1, 2 }, "b" }
+		assert.eq(json.serialize(mixed), '["a",[1,2],"b"]')
+
+		local out = json.serialize({ a = 1, b = 2 })
+		assert.that(out == '{"a":1,"b":2}' or out == '{"b":2,"a":1}')
+	end)
+
+	suite:case("prettySerializeStillIndents", function(assert)
+		local out = json.serialize({ 1, 2, 3 }, true)
+		assert.eq(out, "[\n    1,\n    2,\n    3\n]")
+	end)
+
 	suite:case("jsonObjectAndasObject", function(assert)
 		local obj = json.object({
 			name = "Alice",

--- a/tests/std/json.test.luau
+++ b/tests/std/json.test.luau
@@ -49,11 +49,11 @@ test.suite("JSONParsingTestSuite", function(suite)
 	end
 
 	suite:case("compactSerializeHasNoSpaces", function(assert)
-		assert.eq(json.serialize({ 1, 2, 3 }), "[1,2,3]")
+		assert.eq(json.serialize({ 1, 2, 3 } :: json.Array), "[1,2,3]")
 		assert.eq(json.serialize({}), "[]")
 		assert.eq(json.serialize(json.object({})), "{}")
 		assert.eq(json.serialize({ nested = { 1, 2 } }), '{"nested":[1,2]}')
-		local mixed: json.Array = { "a", { 1, 2 }, "b" }
+		local mixed: json.Array = { "a", { 1, 2 } :: json.Array, "b" }
 		assert.eq(json.serialize(mixed), '["a",[1,2],"b"]')
 
 		local out = json.serialize({ a = 1, b = 2 })
@@ -61,7 +61,7 @@ test.suite("JSONParsingTestSuite", function(suite)
 	end)
 
 	suite:case("prettySerializeStillIndents", function(assert)
-		local out = json.serialize({ 1, 2, 3 }, true)
+		local out = json.serialize({ 1, 2, 3 } :: json.Array, true)
 		assert.eq(out, "[\n    1,\n    2,\n    3\n]")
 	end)
 


### PR DESCRIPTION
`json.serialize` was outputting unnecessary spaces in compact mode. Also fixes extra space after `,` on pretty print, too. Fixed and added a couple of tests