### PR TITLE
Targeted enablement of native

### DIFF
--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -1,4 +1,5 @@
 --!strict
+--!native
 -- @std/json
 -- JSON serialization and deserialization library
 

--- a/lute/std/libs/syntax/printer.luau
+++ b/lute/std/libs/syntax/printer.luau
@@ -1,4 +1,5 @@
 --!strict
+--!native
 -- @std/syntax/printer
 
 local triviaUtils = require("./utils/trivia")

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -1,4 +1,5 @@
 --!strict
+--!native
 -- @std/syntax/visitor
 -- Visitor pattern implementation for traversing Luau AST nodes
 

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -55,6 +55,7 @@ end
 -- Functions on array-like tables
 
 --- Converts an array into a set-like table where each element maps to `true`.
+@native
 function tableext.toSet<T>(tbl: { T }): { [T]: true }
 	local set: { [T]: true } = {}
 	for _, v in tbl do

--- a/lute/std/libs/test/assert.luau
+++ b/lute/std/libs/test/assert.luau
@@ -1,4 +1,5 @@
 --!strict
+--!native
 -- @std/test/assert
 -- Standard assertion library for Luau
 


### PR DESCRIPTION
Did some local benchmarks and these pieces had the biggest improvement. There's definitely a tradeoff on existing very fast programs, but overall this shaves a lot of time in some workflows I tested internally too.

<details>
<summary>Details</summary>

| Workload | Baseline | `--!native` | Speedup | Decision |
|---|---:|---:|---:|---|
| `json.serialize` 100 rows | 7.45 ms | 3.77 ms | **1.97x** | mark |
| `json.serialize` 1000 rows | 72.49 ms | 36.01 ms | **2.01x** | mark |
| `json.deserialize` 100 rows | 13.68 ms | 8.22 ms | **1.66x** | mark |
| `json.deserialize` 1000 rows | 138.21 ms | 84.44 ms | **1.64x** | mark |
| `visitor.visitBlock` (AST walk) | 1.34 ms | 0.34 ms | **3.93x** | mark |
| `printer.printFile` | 4.40 ms | 1.83 ms | **2.40x** | mark |
| `tableext.map` 10k | 0.75 ms | 0.58 ms | 1.30x | leave |
| `tableext.filter` 10k | 2.00 ms | 1.79 ms | 1.12x | leave |
| `tableext.reverse` 10k | 1.37 ms | 1.04 ms | 1.32x | leave |
| `tableext.toSet` 10k | 0.34 ms | 0.13 ms | **2.71x** | mark |
| `tableext.any` 10k | 0.80 ms | 0.63 ms | 1.27x | leave |
| `assert.eq` deep table (625 leaves) | 1.12 ms | 0.58 ms | **1.93x** | mark |
| `syntax.parse` (control: parser is in C) | 22.48 ms | 22.00 ms | 1.02x | leave |

</details>