### PR TITLE
runtime: implement serialization for `const` bindings

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -441,6 +441,17 @@ export type AstStatLocal = {
 	read values: Punctuated<AstExpr>,
 }
 
+--- A `const` variable declaration statement node.
+export type AstStatConst = {
+	read location: Span,
+	read kind: "stat",
+	read tag: "const",
+	read constKeyword: Token<"const">,
+	read variables: Punctuated<AstLocal>,
+	read equals: Token<"=">?,
+	read values: Punctuated<AstExpr>,
+}
+
 --- A numeric `for` loop statement node.
 export type AstStatFor = {
 	read location: Span,
@@ -559,6 +570,7 @@ export type AstStat =
 	| AstStatReturn
 	| AstStatExpr
 	| AstStatLocal
+	| AstStatConst
 	| AstStatFor
 	| AstStatForIn
 	| AstStatAssign

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -1607,10 +1607,13 @@ struct AstSerialize : public Luau::AstVisitor
         lua_rawcheckstack(L, 2);
         lua_createtable(L, 0, preambleSize + 4);
 
-        serializeNodePreamble(node, "local", "stat");
+        const char* keyword = node->isConst ? "const" : "local";
+        const char* keywordField = node->isConst ? "constKeyword" : "localKeyword";
 
-        serializeToken(node->location.begin, "local");
-        lua_setfield(L, -2, "localKeyword");
+        serializeNodePreamble(node, keyword, "stat");
+
+        serializeToken(node->location.begin, keyword);
+        lua_setfield(L, -2, keywordField);
 
         const auto cstNode = lookupCstNode<Luau::CstStatLocal>(node);
         serializePunctuated(node->vars, cstNode->varsCommaPositions, ",", cstNode->varsAnnotationColonPositions);

--- a/lute/std/libs/syntax/types.luau
+++ b/lute/std/libs/syntax/types.luau
@@ -89,6 +89,8 @@ export type AstStatExpr = luau.AstStatExpr
 
 export type AstStatLocal = luau.AstStatLocal
 
+export type AstStatConst = luau.AstStatConst
+
 export type AstStatFor = luau.AstStatFor
 
 export type AstStatForIn = luau.AstStatForIn

--- a/lute/std/libs/syntax/utils/init.luau
+++ b/lute/std/libs/syntax/utils/init.luau
@@ -159,6 +159,11 @@ function utils.isStatLocal(n: types.AstNode): types.AstStatLocal?
 	return if n.kind == "stat" and n.tag == "local" then n else nil
 end
 
+--- Returns `n` narrowed to `AstStatConst` if it is a const variable declaration, or `nil` otherwise.
+function utils.isStatConst(n: types.AstNode): types.AstStatConst?
+	return if n.kind == "stat" and n.tag == "const" then n else nil
+end
+
 --- Returns `n` narrowed to `AstStatFor` if it is a numeric for statement, or `nil` otherwise.
 function utils.isStatFor(n: types.AstNode): types.AstStatFor?
 	return if n.kind == "stat" and n.tag == "for" then n else nil

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -22,6 +22,8 @@ export type Visitor = {
 	visitStatReturn: (types.AstStatReturn) -> boolean,
 	visitStatLocalDeclaration: (types.AstStatLocal) -> boolean,
 	visitStatLocalDeclarationEnd: (types.AstStatLocal) -> (),
+	visitStatConstDeclaration: (types.AstStatConst) -> boolean,
+	visitStatConstDeclarationEnd: (types.AstStatConst) -> (),
 	visitStatFor: (types.AstStatFor) -> boolean,
 	visitStatForEnd: (types.AstStatFor) -> (),
 	visitStatForIn: (types.AstStatForIn) -> boolean,
@@ -97,6 +99,8 @@ local defaultVisitor: Visitor = {
 	visitStatReturn = alwaysVisit,
 	visitStatLocalDeclaration = alwaysVisit,
 	visitStatLocalDeclarationEnd = alwaysVisit :: (types.AstNode) -> (),
+	visitStatConstDeclaration = alwaysVisit,
+	visitStatConstDeclarationEnd = alwaysVisit :: (types.AstNode) -> (),
 	visitStatFor = alwaysVisit,
 	visitStatForEnd = alwaysVisit :: (types.AstNode) -> (),
 	visitStatForIn = alwaysVisit,
@@ -281,6 +285,19 @@ local function visitLocalStatement(node: types.AstStatLocal, visitor: Visitor)
 		visitPunctuated(node.values, visitor, visitExpr)
 
 		visitor.visitStatLocalDeclarationEnd(node)
+	end
+end
+
+local function visitConstStatement(node: types.AstStatConst, visitor: Visitor)
+	if visitor.visitStatConstDeclaration(node) then
+		visitToken(node.constKeyword, visitor)
+		visitPunctuated(node.variables, visitor, visitLocal)
+		if node.equals then
+			visitToken(node.equals, visitor)
+		end
+		visitPunctuated(node.values, visitor, visitExpr)
+
+		visitor.visitStatConstDeclarationEnd(node)
 	end
 end
 
@@ -900,6 +917,8 @@ function visitStatement(statement: types.AstStat, visitor: Visitor)
 		visitStatExpr(statement, visitor)
 	elseif statement.tag == "local" then
 		visitLocalStatement(statement, visitor)
+	elseif statement.tag == "const" then
+		visitConstStatement(statement, visitor)
 	elseif statement.tag == "return" then
 		visitStatReturn(statement, visitor)
 	elseif statement.tag == "while" then
@@ -988,6 +1007,10 @@ local function create(visit: ((types.AstNode) -> boolean)?): Visitor
 			visitStatReturn = visit,
 			visitStatLocalDeclaration = visit,
 			visitStatLocalDeclarationEnd = function(s)
+				visit(s)
+			end,
+			visitStatConstDeclaration = visit,
+			visitStatConstDeclarationEnd = function(s)
 				visit(s)
 			end,
 			visitStatFor = visit,

--- a/tests/std/syntax/printer.test.luau
+++ b/tests/std/syntax/printer.test.luau
@@ -519,6 +519,13 @@ local x = 1
 		end, assert)
 	end)
 
+	suite:case("constDeclarationRoundTrip", function(assert)
+		local source = "const a = 'hello'"
+		local ast = syntax.parse(source)
+		local result = printer.printFile(ast)
+		assert.eq(result, source)
+	end)
+
 	suite:case("statForTrivia", function(assert)
 		local source = [[-- hello
 for i = 1, 10 do


### PR DESCRIPTION
The version update PR for Luau didn't catch this because `const` was added using the same AST node as `local`, but we don't currently support `const` per #1050. We can fix this pretty easily by by tweaking the serialization code to look at the `isConst` field. This PR fixes that and adds the downstream `const` AST node to `@std/syntax`.