### PR TITLE
@batteries/toml: implement the TOML 1.1 specification

### DIFF
--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -166,6 +166,7 @@ local function deserialize(input: string): { [string]: unknown }
 	local src = input
 	local pos = 1
 	local len = #src
+	local srcBuf = buffer.fromstring(src)
 
 	-- Table metadata: maps table reference -> { kind, keys }
 	-- kind values:
@@ -194,7 +195,7 @@ local function deserialize(input: string): { [string]: unknown }
 
 	local function cb(offset: number?): number? -- byte at pos+offset
 		local p = pos + (offset or 0)
-		return if p <= len then string.byte(src, p) else nil
+		return if p <= len then buffer.readu8(srcBuf, p - 1) else nil
 	end
 
 	local function isDigit(c: number?): boolean
@@ -233,7 +234,9 @@ local function deserialize(input: string): { [string]: unknown }
 	-- whitespace skipping
 
 	local function skipWS()
-		while pos <= len and isWS(cb()) do
+		while pos <= len do
+			local c = buffer.readu8(srcBuf, pos - 1)
+			if c ~= 32 and c ~= 9 then break end
 			pos += 1
 		end
 	end
@@ -243,9 +246,11 @@ local function deserialize(input: string): { [string]: unknown }
 		if cb() ~= 35 then return end -- '#'
 		pos += 1
 		while pos <= len do
-			local c = cb()
+			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 10 then break end
-			if isCtrl(c) then err("control character in comment") end
+			if c <= 8 or c == 11 or c == 12 or (c >= 14 and c <= 31) or c == 127 then
+				err("control character in comment")
+			end
 			pos += 1
 		end
 	end
@@ -253,8 +258,8 @@ local function deserialize(input: string): { [string]: unknown }
 	-- skip horizontal whitespace, newlines, and comments
 	local function skipWSNL()
 		while pos <= len do
-			local c = cb()
-			if isWS(c) or c == 10 then
+			local c = buffer.readu8(srcBuf, pos - 1)
+			if c == 32 or c == 9 or c == 10 then
 				pos += 1
 			elseif c == 35 then
 				skipComment()
@@ -328,7 +333,19 @@ local function deserialize(input: string): { [string]: unknown }
 	local function parseBasicString(): string
 		local parts = {}
 		while pos <= len do
-			local c = cb() :: number
+			-- Fast path: scan forward over plain characters in one go
+			local runStart = pos
+			while pos <= len do
+				local c2 = buffer.readu8(srcBuf, pos - 1)
+				-- break on: " (34), \ (92), DEL (127), ctrl chars except tab (9)
+				if c2 == 34 or c2 == 92 or c2 == 127 or (c2 < 32 and c2 ~= 9) then break end
+				pos += 1
+			end
+			if pos > runStart then
+				table.insert(parts, string.sub(src, runStart, pos - 1))
+			end
+			if pos > len then break end
+			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 34 then -- closing "
 				pos += 1
 				return table.concat(parts)
@@ -337,11 +354,8 @@ local function deserialize(input: string): { [string]: unknown }
 				table.insert(parts, parseEscape())
 			elseif c == 10 then
 				err("unescaped newline in basic string")
-			elseif isCtrl(c) then
-				err("unescaped control character in basic string")
 			else
-				table.insert(parts, string.char(c))
-				pos += 1
+				err("unescaped control character in basic string")
 			end
 		end
 		err("unterminated basic string")
@@ -352,28 +366,49 @@ local function deserialize(input: string): { [string]: unknown }
 		if cb() == 10 then pos += 1 end
 		local parts = {}
 		while pos <= len do
-			local c = cb() :: number
-			if c == 34 and string.sub(src, pos, pos + 2) == '"""' then
-				pos += 3
-				-- up to two extra quotes are part of the string
-				local extra = 0
-				while pos <= len and cb() == 34 and extra < 2 do
+			-- Fast path: scan over plain chars (LF and tab are literal content too)
+			local runStart = pos
+			while pos <= len do
+				local c2 = buffer.readu8(srcBuf, pos - 1)
+				-- break on: " (34), \ (92), DEL (127), ctrl except tab (9) and LF (10)
+				if c2 == 34 or c2 == 92 or c2 == 127 or (c2 < 32 and c2 ~= 9 and c2 ~= 10) then break end
+				pos += 1
+			end
+			if pos > runStart then
+				table.insert(parts, string.sub(src, runStart, pos - 1))
+			end
+			if pos > len then break end
+			local c = buffer.readu8(srcBuf, pos - 1)
+			if c == 34 then
+				if string.sub(src, pos, pos + 2) == '"""' then
+					pos += 3
+					local extra = 0
+					while pos <= len and buffer.readu8(srcBuf, pos - 1) == 34 and extra < 2 do
+						table.insert(parts, '"')
+						pos += 1
+						extra += 1
+					end
+					return table.concat(parts)
+				else
+					-- lone " is valid content in a multiline basic string
 					table.insert(parts, '"')
 					pos += 1
-					extra += 1
 				end
-				return table.concat(parts)
 			elseif c == 92 then -- backslash
 				pos += 1
-				-- peek past any trailing horizontal whitespace to detect line-ending backslash
+				-- peek past trailing horizontal whitespace to detect line-ending backslash
 				local peek = pos
-				while peek <= len and isWS(string.byte(src, peek)) do
+				while peek <= len do
+					local pc = buffer.readu8(srcBuf, peek - 1)
+					if pc ~= 32 and pc ~= 9 then break end
 					peek += 1
 				end
-				if peek <= len and string.byte(src, peek) == 10 then
+				if peek <= len and buffer.readu8(srcBuf, peek - 1) == 10 then
 					-- line-ending backslash: skip newline and all following WS/NL
 					pos = peek + 1
-					while pos <= len and (isWS(cb()) or cb() == 10) do
+					while pos <= len do
+						local c3 = buffer.readu8(srcBuf, pos - 1)
+						if c3 ~= 32 and c3 ~= 9 and c3 ~= 10 then break end
 						pos += 1
 					end
 				elseif peek > len then
@@ -381,17 +416,8 @@ local function deserialize(input: string): { [string]: unknown }
 				else
 					table.insert(parts, parseEscape())
 				end
-			elseif c == 10 then
-				table.insert(parts, "\n")
-				pos += 1
-			elseif c == 9 then -- tab is allowed
-				table.insert(parts, "\t")
-				pos += 1
-			elseif isCtrl(c) then
+			else -- ctrl char or DEL
 				err("unescaped control character in multiline basic string")
-			else
-				table.insert(parts, string.char(c))
-				pos += 1
 			end
 		end
 		err("unterminated multiline basic string")
@@ -400,19 +426,17 @@ local function deserialize(input: string): { [string]: unknown }
 	local function parseLiteralString(): string
 		local start = pos
 		while pos <= len do
-			local c = cb() :: number
+			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 39 then -- closing '
 				local result = string.sub(src, start, pos - 1)
 				pos += 1
 				return result
+			elseif c == 9 or (c >= 32 and c ~= 127) or c >= 128 then
+				pos += 1 -- plain char (tab, printable ASCII, or multibyte UTF-8)
 			elseif c == 10 then
 				err("unescaped newline in literal string")
-			elseif c == 9 then
-				pos += 1 -- tab is allowed
-			elseif isCtrl(c) then
-				err("unescaped control character in literal string")
 			else
-				pos += 1
+				err("unescaped control character in literal string")
 			end
 		end
 		err("unterminated literal string")
@@ -422,27 +446,36 @@ local function deserialize(input: string): { [string]: unknown }
 		if cb() == 10 then pos += 1 end -- trim leading newline
 		local parts = {}
 		while pos <= len do
-			local c = cb() :: number
-			if c == 39 and string.sub(src, pos, pos + 2) == "'''" then
-				pos += 3
-				local extra = 0
-				while pos <= len and cb() == 39 and extra < 2 do
+			-- Fast path: scan over plain chars (LF and tab are literal content)
+			local runStart = pos
+			while pos <= len do
+				local c2 = buffer.readu8(srcBuf, pos - 1)
+				-- break on: ' (39), DEL (127), ctrl except tab (9) and LF (10)
+				if c2 == 39 or c2 == 127 or (c2 < 32 and c2 ~= 9 and c2 ~= 10) then break end
+				pos += 1
+			end
+			if pos > runStart then
+				table.insert(parts, string.sub(src, runStart, pos - 1))
+			end
+			if pos > len then break end
+			local c = buffer.readu8(srcBuf, pos - 1)
+			if c == 39 then
+				if string.sub(src, pos, pos + 2) == "'''" then
+					pos += 3
+					local extra = 0
+					while pos <= len and buffer.readu8(srcBuf, pos - 1) == 39 and extra < 2 do
+						table.insert(parts, "'")
+						pos += 1
+						extra += 1
+					end
+					return table.concat(parts)
+				else
+					-- lone ' is valid content in a multiline literal string
 					table.insert(parts, "'")
 					pos += 1
-					extra += 1
 				end
-				return table.concat(parts)
-			elseif c == 10 then
-				table.insert(parts, "\n")
-				pos += 1
-			elseif c == 9 then
-				table.insert(parts, "\t")
-				pos += 1
-			elseif isCtrl(c) then
+			else -- ctrl char or DEL
 				err("unescaped control character in multiline literal string")
-			else
-				table.insert(parts, string.char(c))
-				pos += 1
 			end
 		end
 		err("unterminated multiline literal string")
@@ -781,7 +814,13 @@ local function deserialize(input: string): { [string]: unknown }
 				part = parseLiteralString()
 			elseif isBareKey(c) then
 				local start = pos
-				while pos <= len and isBareKey(cb()) do pos += 1 end
+				while pos <= len do
+					local c2 = buffer.readu8(srcBuf, pos - 1)
+					if not ((c2 >= 97 and c2 <= 122) or (c2 >= 65 and c2 <= 90) or (c2 >= 48 and c2 <= 57) or c2 == 95 or c2 == 45) then
+						break
+					end
+					pos += 1
+				end
 				part = string.sub(src, start, pos - 1)
 			else
 				if #parts == 0 then

--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -80,7 +80,9 @@ end
 
 -- deserialization
 
-local function deserialize(input: string): { [string]: unknown }
+export type TomlValue = string | number | boolean | { TomlValue } | { [string]: TomlValue }
+
+local function deserialize(input: string): { [string]: TomlValue }
 	-- Reject bare CR (only CRLF → LF is allowed)
 	if input:find("\r\n", 1, true) then
 		input = input:gsub("\r\n", "\n")
@@ -191,7 +193,7 @@ local function deserialize(input: string): { [string]: unknown }
 		return tableMeta[tbl]
 	end
 
-	local function err(msg: string): never
+	local function tomlParseError(msg: string): never
 		error(`TOML parse error at position {pos}: {msg}`)
 	end
 
@@ -249,7 +251,7 @@ local function deserialize(input: string): { [string]: unknown }
 			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 10 then break end
 			if isCtrl(c) then
-				err("control character in comment")
+				tomlParseError("control character in comment")
 			end
 			pos += 1
 		end
@@ -278,7 +280,7 @@ local function deserialize(input: string): { [string]: unknown }
 		if c == 10 then
 			pos += 1
 		else
-			err(`expected newline or EOF, got '${string.char(c :: number)}'`)
+			tomlParseError(`expected newline or EOF, got '${string.char(c :: number)}'`)
 		end
 	end
 
@@ -287,16 +289,16 @@ local function deserialize(input: string): { [string]: unknown }
 	local function parseUnicodeEscape(long: boolean): string
 		local n = if long then 8 else 4
 		local hexStr = string.sub(src, pos, pos + n - 1)
-		if #hexStr < n then err("incomplete unicode escape") end
+		if #hexStr < n then tomlParseError("incomplete unicode escape") end
 		for i = 1, n do
 			if not isHexDigit(string.byte(hexStr, i)) then
-				err("invalid hex digit in unicode escape")
+				tomlParseError("invalid hex digit in unicode escape")
 			end
 		end
 		pos += n
 		local cp = tonumber(hexStr, 16) :: number
-		if cp >= 0xD800 and cp <= 0xDFFF then err("surrogate codepoint in unicode escape") end
-		if cp > 0x10FFFF then err("unicode codepoint out of range") end
+		if cp >= 0xD800 and cp <= 0xDFFF then tomlParseError("surrogate codepoint in unicode escape") end
+		if cp > 0x10FFFF then tomlParseError("unicode codepoint out of range") end
 		return utf8.char(cp)
 	end
 
@@ -304,14 +306,14 @@ local function deserialize(input: string): { [string]: unknown }
 	local function parseHexEscape(): string
 		local hexStr = string.sub(src, pos, pos + 1)
 		if #hexStr < 2 or not isHexDigit(string.byte(hexStr, 1)) or not isHexDigit(string.byte(hexStr, 2)) then
-			err("invalid \\x escape")
+			tomlParseError("invalid \\x escape")
 		end
 		pos += 2
 		return utf8.char(tonumber(hexStr, 16) :: number)
 	end
 
 	local function parseEscape(): string
-		if pos > len then err("incomplete escape sequence") end
+		if pos > len then tomlParseError("incomplete escape sequence") end
 		local c = cb() :: number
 		pos += 1
 		if c == 98 then return "\b"
@@ -325,7 +327,7 @@ local function deserialize(input: string): { [string]: unknown }
 		elseif c == 117 then return parseUnicodeEscape(false) -- \uXXXX
 		elseif c == 85 then return parseUnicodeEscape(true) -- \UXXXXXXXX
 		elseif c == 120 then return parseHexEscape() -- \xXX  (TOML 1.1)
-		else err(`invalid escape sequence \\${string.char(c)}`) end
+		else tomlParseError(`invalid escape sequence \\${string.char(c)}`) end
 	end
 
 	-- string parsers (pos is always past the opening delimiter on entry)
@@ -353,12 +355,12 @@ local function deserialize(input: string): { [string]: unknown }
 				pos += 1
 				table.insert(parts, parseEscape())
 			elseif c == 10 then
-				err("unescaped newline in basic string")
+				tomlParseError("unescaped newline in basic string")
 			else
-				err("unescaped control character in basic string")
+				tomlParseError("unescaped control character in basic string")
 			end
 		end
-		err("unterminated basic string")
+		tomlParseError("unterminated basic string")
 	end
 
 	local function parseMLBasicString(): string
@@ -412,15 +414,15 @@ local function deserialize(input: string): { [string]: unknown }
 						pos += 1
 					end
 				elseif peek > len then
-					err("incomplete escape at end of file")
+					tomlParseError("incomplete escape at end of file")
 				else
 					table.insert(parts, parseEscape())
 				end
 			else -- ctrl char or DEL
-				err("unescaped control character in multiline basic string")
+				tomlParseError("unescaped control character in multiline basic string")
 			end
 		end
-		err("unterminated multiline basic string")
+		tomlParseError("unterminated multiline basic string")
 	end
 
 	local function parseLiteralString(): string
@@ -434,12 +436,12 @@ local function deserialize(input: string): { [string]: unknown }
 			elseif c == 9 or (c >= 32 and c ~= 127) or c >= 128 then
 				pos += 1 -- plain char (tab, printable ASCII, or multibyte UTF-8)
 			elseif c == 10 then
-				err("unescaped newline in literal string")
+				tomlParseError("unescaped newline in literal string")
 			else
-				err("unescaped control character in literal string")
+				tomlParseError("unescaped control character in literal string")
 			end
 		end
-		err("unterminated literal string")
+		tomlParseError("unterminated literal string")
 	end
 
 	local function parseMLLiteralString(): string
@@ -475,17 +477,17 @@ local function deserialize(input: string): { [string]: unknown }
 					pos += 1
 				end
 			else -- ctrl char or DEL
-				err("unescaped control character in multiline literal string")
+				tomlParseError("unescaped control character in multiline literal string")
 			end
 		end
-		err("unterminated multiline literal string")
+		tomlParseError("unterminated multiline literal string")
 	end
 
 	-- number / datetime helpers
 
 	-- parse a run of digits (with internal underscores allowed), return digits-only string
 	local function parseDigits(digitCheck: (number?) -> boolean): string
-		if not digitCheck(cb()) then err("expected digit") end
+		if not digitCheck(cb()) then tomlParseError("expected digit") end
 		local result = ""
 		local runStart = pos
 		while pos <= len do
@@ -495,10 +497,10 @@ local function deserialize(input: string): { [string]: unknown }
 			elseif c == 95 then -- underscore
 				result ..= string.sub(src, runStart, pos - 1)
 				pos += 1
-				if pos > len then err("trailing underscore in number") end
+				if pos > len then tomlParseError("trailing underscore in number") end
 				local nc = buffer.readu8(srcBuf, pos - 1)
-				if nc == 95 then err("consecutive underscores in number") end
-				if not digitCheck(nc) then err("trailing underscore in number") end
+				if nc == 95 then tomlParseError("consecutive underscores in number") end
+				if not digitCheck(nc) then tomlParseError("trailing underscore in number") end
 				runStart = pos
 			else
 				break
@@ -542,21 +544,21 @@ local function deserialize(input: string): { [string]: unknown }
 			-- Parse YYYY-MM-DD
 			local yearStr = string.sub(src, pos, pos + 3)
 			pos += 4
-			if cb() ~= 45 then err("expected '-' in date") end
+			if cb() ~= 45 then tomlParseError("expected '-' in date") end
 			pos += 1
-			if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit month") end
+			if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit month") end
 			local monthStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local month = tonumber(monthStr) :: number
-			if month < 1 or month > 12 then err(`invalid month: {month}`) end
-			if cb() ~= 45 then err("expected '-' in date") end
+			if month < 1 or month > 12 then tomlParseError(`invalid month: {month}`) end
+			if cb() ~= 45 then tomlParseError("expected '-' in date") end
 			pos += 1
-			if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit day") end
+			if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit day") end
 			local dayStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local day = tonumber(dayStr) :: number
 			local year = tonumber(yearStr) :: number
-			if day < 1 or day > daysInMonth(year, month) then err(`invalid day {day} for month {month}`) end
+			if day < 1 or day > daysInMonth(year, month) then tomlParseError(`invalid day {day} for month {month}`) end
 			result = `{yearStr}-{monthStr}-{dayStr}`
 
 			-- Optional datetime separator: T, t, or space followed by digit
@@ -572,36 +574,36 @@ local function deserialize(input: string): { [string]: unknown }
 		end
 
 		-- Parse HH:MM[:SS[.frac]]
-		if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit hour") end
+		if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit hour") end
 		local hourStr = string.sub(src, pos, pos + 1)
 		pos += 2
 		local hour = tonumber(hourStr) :: number
-		if hour > 23 then err(`invalid hour: {hour}`) end
-		if cb() ~= 58 then err("expected ':' in time") end
+		if hour > 23 then tomlParseError(`invalid hour: {hour}`) end
+		if cb() ~= 58 then tomlParseError("expected ':' in time") end
 		pos += 1
-		if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit minute") end
+		if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit minute") end
 		local minStr = string.sub(src, pos, pos + 1)
 		pos += 2
 		local minute = tonumber(minStr) :: number
-		if minute > 59 then err(`invalid minute: {minute}`) end
+		if minute > 59 then tomlParseError(`invalid minute: {minute}`) end
 		result ..= `{hourStr}:{minStr}`
 
 		-- Optional seconds (TOML 1.1)
 		local secStr = "00"
 		if cb() == 58 then
 			pos += 1
-			if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit second") end
+			if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit second") end
 			secStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local sec = tonumber(secStr) :: number
-			if sec > 59 then err(`invalid second: {sec}`) end
+			if sec > 59 then tomlParseError(`invalid second: {sec}`) end
 		end
 		result ..= `:{secStr}`
 
 		-- Optional fractional seconds
 		if cb() == 46 then
 			pos += 1
-			if not isDigit(cb()) then err("expected digit after '.' in time") end
+			if not isDigit(cb()) then tomlParseError("expected digit after '.' in time") end
 			local fracStart = pos
 			while isDigit(cb()) do pos += 1 end
 			local fracPart = string.sub(src, fracStart, pos - 1)
@@ -611,34 +613,34 @@ local function deserialize(input: string): { [string]: unknown }
 		-- Optional offset: Z, +HH:MM, -HH:MM
 		local oc = cb()
 		if oc == 90 or oc == 122 then
-			if not hasDate then err("offset not allowed in time-local") end
+			if not hasDate then tomlParseError("offset not allowed in time-local") end
 			pos += 1
 			result ..= "Z"
 		elseif oc == 43 or oc == 45 then
-			if not hasDate then err("offset not allowed in time-local") end
-			local sign = string.char(oc)
+			if not hasDate then tomlParseError("offset not allowed in time-local") end
+			local sign = string.char(oc :: number)
 			pos += 1
-			if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit offset hour") end
+			if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit offset hour") end
 			local ohStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local oh = tonumber(ohStr) :: number
-			if oh > 23 then err(`invalid offset hour: {oh}`) end
-			if cb() ~= 58 then err("expected ':' in offset") end
+			if oh > 23 then tomlParseError(`invalid offset hour: {oh}`) end
+			if cb() ~= 58 then tomlParseError("expected ':' in offset") end
 			pos += 1
-			if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit offset minute") end
+			if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit offset minute") end
 			local omStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local om = tonumber(omStr) :: number
-			if om > 59 then err(`invalid offset minute: {om}`) end
+			if om > 59 then tomlParseError(`invalid offset minute: {om}`) end
 			result ..= `{sign}{ohStr}:{omStr}`
 		end
 
 		return result
 	end
 
-	local parseValue -- forward declaration
+	local parseValue: () -> TomlValue
 
-	local function parseNumOrDatetime(sign: string?): any
+	local function parseNumOrDatetime(sign: string?): string | number
 		local signStr = sign or ""
 		local c = cb()
 
@@ -652,7 +654,7 @@ local function deserialize(input: string): { [string]: unknown }
 			return 0 / 0
 		end
 
-		if not isDigit(c) then err(`expected digit, got '${string.char(c :: number)}'`) end
+		if not isDigit(c) then tomlParseError(`expected digit, got '${string.char(c :: number)}'`) end
 
 		-- prefixed integer bases (no sign allowed)
 		if sign == nil and c == 48 then
@@ -673,7 +675,7 @@ local function deserialize(input: string): { [string]: unknown }
 		local intDigits: string
 		if isZero then
 			pos += 1
-			if isDigit(cb()) then err("leading zero in integer") end
+			if isDigit(cb()) then tomlParseError("leading zero in integer") end
 			intDigits = "0"
 		else
 			intDigits = parseDigits(isDigit)
@@ -686,7 +688,7 @@ local function deserialize(input: string): { [string]: unknown }
 		if nc == 46 then -- '.'
 			isFloat = true
 			pos += 1
-			if not isDigit(cb()) then err("expected digit after decimal point") end
+			if not isDigit(cb()) then tomlParseError("expected digit after decimal point") end
 			result ..= "." .. parseDigits(isDigit)
 			nc = cb()
 		end
@@ -700,7 +702,7 @@ local function deserialize(input: string): { [string]: unknown }
 				expSign = string.char(ec :: number)
 				pos += 1
 			end
-			if not isDigit(cb()) then err("expected digit in exponent") end
+			if not isDigit(cb()) then tomlParseError("expected digit in exponent") end
 			result ..= "e" .. expSign .. parseDigits(isDigit)
 		end
 
@@ -708,14 +710,14 @@ local function deserialize(input: string): { [string]: unknown }
 	end
 
 	-- array and inline-table parsers (forward declared for mutual recursion)
-	local parseArray: () -> { any }
-	local parseInlineTable: () -> { [string]: any }
+	local parseArray: () -> { TomlValue }
+	local parseInlineTable: () -> { [string]: TomlValue }
 	local parseKey: () -> { string }
-	local setNestedKey: (tbl: any, parts: { string }, value: any, fromDottedKey: boolean) -> ()
+	local setNestedKey: (tbl: { [string]: TomlValue }, parts: { string }, value: TomlValue, fromDottedKey: boolean) -> ()
 
-	parseValue = function(): any
+	parseValue = function(): TomlValue
 		skipWS()
-		if pos > len then err("expected value") end
+		if pos > len then tomlParseError("expected value") end
 		local c = cb() :: number
 
 		if c == 34 then -- "
@@ -741,29 +743,29 @@ local function deserialize(input: string): { [string]: unknown }
 		elseif c == 116 then -- t
 			if string.sub(src, pos, pos + 3) == "true" then
 				pos += 4
-				if isBareKey(cb()) then err("invalid value") end
+				if isBareKey(cb()) then tomlParseError("invalid value") end
 				return true
 			end
-			err("invalid value starting with 't'")
+			tomlParseError("invalid value starting with 't'")
 		elseif c == 102 then -- f
 			if string.sub(src, pos, pos + 4) == "false" then
 				pos += 5
-				if isBareKey(cb()) then err("invalid value") end
+				if isBareKey(cb()) then tomlParseError("invalid value") end
 				return false
 			end
-			err("invalid value starting with 'f'")
+			tomlParseError("invalid value starting with 'f'")
 		elseif c == 105 then -- i
 			if string.sub(src, pos, pos + 2) == "inf" then
 				pos += 3
 				return math.huge
 			end
-			err("invalid value starting with 'i'")
+			tomlParseError("invalid value starting with 'i'")
 		elseif c == 110 then -- n
 			if string.sub(src, pos, pos + 2) == "nan" then
 				pos += 3
 				return 0 / 0
 			end
-			err("invalid value starting with 'n'")
+			tomlParseError("invalid value starting with 'n'")
 		elseif c == 43 then -- +
 			pos += 1
 			return parseNumOrDatetime("+")
@@ -773,22 +775,22 @@ local function deserialize(input: string): { [string]: unknown }
 		elseif isDigit(c) then
 			return parseNumOrDatetime(nil)
 		else
-			err(`unexpected character '${string.char(c)}' in value`)
+			tomlParseError(`unexpected character '${string.char(c)}' in value`)
 		end
 	end
 
-	parseArray = function(): { any }
-		local result: { any } = {}
+	parseArray = function(): { TomlValue }
+		local result: { TomlValue } = {}
 		tableMeta[result] = { kind = "array-value", keys = {} } -- mark as static array
 		skipWSNL()
 		if cb() == 93 then pos += 1; return result end -- empty []
 		while true do
 			skipWSNL()
-			if pos > len then err("unterminated array") end
+			if pos > len then tomlParseError("unterminated array") end
 			if cb() == 93 then pos += 1; break end -- trailing comma case
 			table.insert(result, parseValue())
 			skipWSNL()
-			if pos > len then err("unterminated array") end
+			if pos > len then tomlParseError("unterminated array") end
 			local c = cb()
 			if c == 44 then -- ','
 				pos += 1
@@ -796,7 +798,7 @@ local function deserialize(input: string): { [string]: unknown }
 				pos += 1
 				break
 			else
-				err(`expected ',' or ']' in array, got '${string.char(c :: number)}'`)
+				tomlParseError(`expected ',' or ']' in array, got '${string.char(c :: number)}'`)
 			end
 		end
 		return result
@@ -824,9 +826,9 @@ local function deserialize(input: string): { [string]: unknown }
 				part = string.sub(src, start, pos - 1)
 			else
 				if #parts == 0 then
-					err(`expected key, got '${string.char(c :: number or 0)}'`)
+					tomlParseError(`expected key, got '${string.char(c :: number or 0)}'`)
 				else
-					err("expected key segment after '.'")
+					tomlParseError("expected key segment after '.'")
 				end
 			end
 			table.insert(parts, part)
@@ -843,71 +845,71 @@ local function deserialize(input: string): { [string]: unknown }
 
 	-- navigate through dotted intermediate keys, creating tables as needed;
 	-- returns (leaf_table, leaf_key_string)
-	local function navigateDotted(tbl: any, parts: { string }, newKind: TableKind): (any, string)
-		local current = tbl
+	local function navigateDotted(tbl: { [string]: TomlValue }, parts: { string }, newKind: TableKind): ({ [string]: TomlValue }, string)
+		local current: { [string]: TomlValue } = tbl
 		for i = 1, #parts - 1 do
 			local k = parts[i]
 			local child = current[k]
 			if child == nil then
-				local newTbl: any = {}
+				local newTbl: { [string]: TomlValue } = {}
 				tableMeta[newTbl] = { kind = newKind, keys = {} }
 				current[k] = newTbl
 				getMeta(current).keys[k] = true
 				current = newTbl
-			elseif type(child) == "table" then
+			elseif typeof(child) == "table" then
 				if arrayTableSets[child] then
-					err(`cannot extend array-of-tables '${k}' via dotted key`)
+					tomlParseError(`cannot extend array-of-tables '${k}' via dotted key`)
 				end
 				local m = getMeta(child)
 				if m.kind == "array-value" then
-					err(`cannot navigate through static array value '${k}'`)
+					tomlParseError(`cannot navigate through static array value '${k}'`)
 				end
 				if m.kind == "inline" then
-					err(`cannot extend inline table via key '${k}'`)
+					tomlParseError(`cannot extend inline table via key '${k}'`)
 				end
 				if m.kind == "defined" or m.kind == "array-element" then
-					err(`cannot extend explicitly-defined table '${k}' via dotted key`)
+					tomlParseError(`cannot extend explicitly-defined table '${k}' via dotted key`)
 				end
-				current = child
+				current = child :: { [string]: TomlValue }
 			else
-				err(`key '${k}' is not a table`)
+				tomlParseError(`key '${k}' is not a table`)
 			end
 		end
 		return current, parts[#parts]
 	end
 
-	setNestedKey = function(tbl: any, parts: { string }, value: any, fromDottedKey: boolean)
+	setNestedKey = function(tbl: { [string]: TomlValue }, parts: { string }, value: TomlValue, fromDottedKey: boolean)
 		local newKind = if fromDottedKey then "implicit-dotted" else "implicit-header"
 		local leafTbl, leafKey = navigateDotted(tbl, parts, newKind)
 		local m = getMeta(leafTbl)
 		if m.keys[leafKey] then
-			err(`duplicate key '${leafKey}'`)
+			tomlParseError(`duplicate key '${leafKey}'`)
 		end
 		m.keys[leafKey] = true
 		leafTbl[leafKey] = value
 		-- tag any freshly assigned table value
-		if type(value) == "table" and not tableMeta[value] then
+		if typeof(value) == "table" and not tableMeta[value] then
 			tableMeta[value] = { kind = newKind, keys = {} }
 		end
 	end
 
-	parseInlineTable = function(): { [string]: any }
-		local result: any = {}
+	parseInlineTable = function(): { [string]: TomlValue }
+		local result: { [string]: TomlValue } = {}
 		tableMeta[result] = { kind = "inline", keys = {} }
 		skipWSNL() -- TOML 1.1: newlines allowed inside inline tables
 		if cb() == 125 then pos += 1; return result end -- empty {}
 		while true do
 			skipWSNL()
-			if pos > len then err("unterminated inline table") end
+			if pos > len then tomlParseError("unterminated inline table") end
 			if cb() == 125 then pos += 1; break end -- '}' (trailing comma support)
 			local keys = parseKey()
 			skipWS()
-			if cb() ~= 61 then err("expected '=' in inline table") end -- '='
+			if cb() ~= 61 then tomlParseError("expected '=' in inline table") end -- '='
 			pos += 1
 			local value = parseValue()
 			setNestedKey(result, keys, value, false)
 			skipWSNL()
-			if pos > len then err("unterminated inline table") end
+			if pos > len then tomlParseError("unterminated inline table") end
 			local c = cb()
 			if c == 44 then -- ','
 				pos += 1
@@ -915,39 +917,39 @@ local function deserialize(input: string): { [string]: unknown }
 				pos += 1
 				break
 			else
-				err(`expected ',' or '}}' in inline table, got '${string.char(c :: number)}'`)
+				tomlParseError(`expected ',' or '}}' in inline table, got '${string.char(c :: number)}'`)
 			end
 		end
 		return result
 	end
 
 	-- navigate to the table referenced by a [key] or [[key]] header
-	local function navigateToHeader(root: any, parts: { string }, isArrayTable: boolean): any
-		local current = root
+	local function navigateToHeader(root: { [string]: TomlValue }, parts: { string }, isArrayTable: boolean): { [string]: TomlValue }
+		local current: { [string]: TomlValue } = root
 		for i = 1, #parts - 1 do
 			local k = parts[i]
 			local child = current[k]
 			if child == nil then
-				local newTbl: any = {}
+				local newTbl: { [string]: TomlValue } = {}
 				tableMeta[newTbl] = { kind = "implicit-header", keys = {} }
 				current[k] = newTbl
 				getMeta(current).keys[k] = true
 				current = newTbl
-			elseif type(child) == "table" then
+			elseif typeof(child) == "table" then
 				if arrayTableSets[child] then
-					current = child[#child]
+					current = (child :: { TomlValue })[#(child :: { TomlValue })] :: { [string]: TomlValue }
 				else
 					local m = getMeta(child)
 					if m.kind == "array-value" then
-						err(`key '${k}' is a static array, cannot navigate through it`)
+						tomlParseError(`key '${k}' is a static array, cannot navigate through it`)
 					end
 					if m.kind == "inline" then
-						err("cannot extend inline table")
+						tomlParseError("cannot extend inline table")
 					end
-					current = child
+					current = child :: { [string]: TomlValue }
 				end
 			else
-				err(`key '${k}' is not a table`)
+				tomlParseError(`key '${k}' is not a table`)
 			end
 		end
 
@@ -956,63 +958,63 @@ local function deserialize(input: string): { [string]: unknown }
 
 		if isArrayTable then
 			if existing == nil then
-				local arr: any = {}
+				local arr: { { [string]: TomlValue } } = {}
 				arrayTableSets[arr] = true
-				current[leafKey] = arr
+				current[leafKey] = arr :: { TomlValue }
 				getMeta(current).keys[leafKey] = true
-				local entry: any = {}
+				local entry: { [string]: TomlValue } = {}
 				tableMeta[entry] = { kind = "array-element", keys = {} }
 				table.insert(arr, entry)
 				return entry
-			elseif type(existing) == "table" and arrayTableSets[existing] then
-				local entry: any = {}
+			elseif typeof(existing) == "table" and arrayTableSets[existing] then
+				local entry: { [string]: TomlValue } = {}
 				tableMeta[entry] = { kind = "array-element", keys = {} }
-				table.insert(existing, entry)
+				table.insert(existing :: { { [string]: TomlValue } }, entry)
 				return entry
 			else
-				err(`cannot define [[${leafKey}]]: key already exists as a different type`)
+				tomlParseError(`cannot define [[${leafKey}]]: key already exists as a different type`)
 			end
 		else
 			if existing == nil then
-				local newTbl: any = {}
+				local newTbl: { [string]: TomlValue } = {}
 				tableMeta[newTbl] = { kind = "defined", keys = {} }
 				current[leafKey] = newTbl
 				getMeta(current).keys[leafKey] = true
 				return newTbl
-			elseif type(existing) == "table" then
+			elseif typeof(existing) == "table" then
 				-- Check arrayTableSets BEFORE getMeta to avoid creating spurious meta
 				if arrayTableSets[existing] then
-					err(`cannot define [${leafKey}]: already an array-of-tables`)
+					tomlParseError(`cannot define [${leafKey}]: already an array-of-tables`)
 				end
 				local m = getMeta(existing)
 				if m.kind == "array-value" then
-					err(`cannot define [${leafKey}]: key is a static array value`)
+					tomlParseError(`cannot define [${leafKey}]: key is a static array value`)
 				end
 				if m.kind == "implicit-header" then
 					m.kind = "defined"
-					return existing
+					return existing :: { [string]: TomlValue }
 				elseif m.kind == "defined" then
-					err(`duplicate table header [${leafKey}]`)
+					tomlParseError(`duplicate table header [${leafKey}]`)
 				elseif m.kind == "inline" then
-					err("cannot extend inline table with a table header")
+					tomlParseError("cannot extend inline table with a table header")
 				elseif m.kind == "implicit-dotted" then
-					err(`table [${leafKey}] was already defined via a dotted key`)
+					tomlParseError(`table [${leafKey}] was already defined via a dotted key`)
 				elseif m.kind == "array-element" then
-					err(`cannot define [${leafKey}]: already an array-of-tables element`)
+					tomlParseError(`cannot define [${leafKey}]: already an array-of-tables element`)
 				else
-					err(`cannot redefine [${leafKey}]`)
+					tomlParseError(`cannot redefine [${leafKey}]`)
 				end
 			else
-				err(`key '${leafKey}' is not a table`)
+				tomlParseError(`key '${leafKey}' is not a table`)
 			end
 		end
 	end
 
 	-- main parse loop
 
-	local root: any = {}
+	local root: { [string]: TomlValue } = {}
 	tableMeta[root] = { kind = "root", keys = {} }
-	local currentTable = root
+	local currentTable: { [string]: TomlValue } = root
 
 	while pos <= len do
 		skipWSNL()
@@ -1026,7 +1028,7 @@ local function deserialize(input: string): { [string]: unknown }
 				skipWS()
 				local parts = parseKey()
 				skipWS()
-				if string.sub(src, pos, pos + 1) ~= "]]" then err("expected ']]'") end
+				if string.sub(src, pos, pos + 1) ~= "]]" then tomlParseError("expected ']]'") end
 				pos += 2
 				expectLineEnd()
 				currentTable = navigateToHeader(root, parts, true)
@@ -1035,7 +1037,7 @@ local function deserialize(input: string): { [string]: unknown }
 				skipWS()
 				local parts = parseKey()
 				skipWS()
-				if cb() ~= 93 then err("expected ']'") end -- ']'
+				if cb() ~= 93 then tomlParseError("expected ']'") end -- ']'
 				pos += 1
 				expectLineEnd()
 				currentTable = navigateToHeader(root, parts, false)
@@ -1043,7 +1045,7 @@ local function deserialize(input: string): { [string]: unknown }
 		else
 			local parts = parseKey()
 			skipWS()
-			if cb() ~= 61 then err("expected '='") end -- '='
+			if cb() ~= 61 then tomlParseError("expected '='") end -- '='
 			pos += 1
 			local value = parseValue()
 			setNestedKey(currentTable, parts, value, true)

--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -199,7 +199,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	-- character helpers (all operate on the shared pos/src/len upvalues)
 
-	local function cb(offset: number?): number? -- byte at pos+offset
+	local function byteAt(offset: number?): number? -- byte at pos+offset
 		local p = pos + (offset or 0)
 		return if p <= len then buffer.readu8(srcBuf, p - 1) else nil
 	end
@@ -228,14 +228,14 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	-- control characters that are forbidden unescaped (everything < 0x20 except tab,
 	-- plus DEL 0x7F; LF 0x0A is handled separately per context)
-	local function isCtrl(c: number?): boolean
+	local function isControlCharacter(c: number?): boolean
 		if c == nil then return false end
 		return c <= 8 or c == 11 or c == 12 or (c >= 14 and c <= 31) or c == 127
 	end
 
 	-- whitespace skipping
 
-	local function skipWS()
+	local function skipWhitespace()
 		while pos <= len do
 			local c = buffer.readu8(srcBuf, pos - 1)
 			if c ~= 32 and c ~= 9 then break end
@@ -245,12 +245,12 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	-- skip a # comment up to (but not including) the newline
 	local function skipComment()
-		if cb() ~= 35 then return end -- '#'
+		if byteAt() ~= 35 then return end -- '#'
 		pos += 1
 		while pos <= len do
 			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 10 then break end
-			if isCtrl(c) then
+			if isControlCharacter(c) then
 				tomlParseError("control character in comment")
 			end
 			pos += 1
@@ -258,7 +258,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 	end
 
 	-- skip horizontal whitespace, newlines, and comments
-	local function skipWSNL()
+	local function skipWhitespaceNewlinesAndComments()
 		while pos <= len do
 			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 32 or c == 9 or c == 10 then
@@ -271,12 +271,12 @@ local function deserialize(input: string): { [string]: TomlValue }
 		end
 	end
 
-	-- after a value: consume trailing WS + optional comment, then require newline or EOF
+	-- after a value: consume trailing whitespace + optional comment, then require newline or EOF
 	local function expectLineEnd()
-		skipWS()
+		skipWhitespace()
 		skipComment()
 		if pos > len then return end
-		local c = cb()
+		local c = byteAt()
 		if c == 10 then
 			pos += 1
 		else
@@ -314,7 +314,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	local function parseEscape(): string
 		if pos > len then tomlParseError("incomplete escape sequence") end
-		local c = cb() :: number
+		local c = byteAt() :: number
 		pos += 1
 		if c == 98 then return "\b"
 		elseif c == 116 then return "\t"
@@ -367,9 +367,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 		error("unreachable")
 	end
 
-	local function parseMLBasicString(): string
+	local function parseMultilineBasicString(): string
 		-- trim a single leading newline
-		if cb() == 10 then pos += 1 end
+		if byteAt() == 10 then pos += 1 end
 		local parts = {}
 		while pos <= len do
 			-- Fast path: scan over plain chars (LF and tab are literal content too)
@@ -410,7 +410,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 					peek += 1
 				end
 				if peek <= len and buffer.readu8(srcBuf, peek - 1) == 10 then
-					-- line-ending backslash: skip newline and all following WS/NL
+					-- line-ending backslash: skip newline and all following whitespace and newlines
 					pos = peek + 1
 					while pos <= len do
 						local c3 = buffer.readu8(srcBuf, pos - 1)
@@ -452,8 +452,8 @@ local function deserialize(input: string): { [string]: TomlValue }
 		error("unreachable")
 	end
 
-	local function parseMLLiteralString(): string
-		if cb() == 10 then pos += 1 end -- trim leading newline
+	local function parseMultilineLiteralString(): string
+		if byteAt() == 10 then pos += 1 end -- trim leading newline
 		local parts = {}
 		while pos <= len do
 			-- Fast path: scan over plain chars (LF and tab are literal content)
@@ -497,7 +497,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	-- parse a run of digits (with internal underscores allowed), return digits-only string
 	local function parseDigits(digitCheck: (number?) -> boolean): string
-		if not digitCheck(cb()) then tomlParseError("expected digit") end
+		if not digitCheck(byteAt()) then tomlParseError("expected digit") end
 		local result = ""
 		local runStart = pos
 		while pos <= len do
@@ -531,7 +531,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	local function looksLikeTime(): boolean
 		-- HH: : exactly 2 decimal digits followed by ':'
-		return isDigit(cb(0)) and isDigit(cb(1)) and cb(2) == 58
+		return isDigit(byteAt(0)) and isDigit(byteAt(1)) and byteAt(2) == 58
 	end
 
 	-- Returns days in month for given year and month (1-12)
@@ -554,16 +554,16 @@ local function deserialize(input: string): { [string]: TomlValue }
 			-- Parse YYYY-MM-DD
 			local yearStr = string.sub(src, pos, pos + 3)
 			pos += 4
-			if cb() ~= 45 then tomlParseError("expected '-' in date") end
+			if byteAt() ~= 45 then tomlParseError("expected '-' in date") end
 			pos += 1
-			if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit month") end
+			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit month") end
 			local monthStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local month = tonumber(monthStr) :: number
 			if month < 1 or month > 12 then tomlParseError(`invalid month: {month}`) end
-			if cb() ~= 45 then tomlParseError("expected '-' in date") end
+			if byteAt() ~= 45 then tomlParseError("expected '-' in date") end
 			pos += 1
-			if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit day") end
+			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit day") end
 			local dayStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local day = tonumber(dayStr) :: number
@@ -572,10 +572,10 @@ local function deserialize(input: string): { [string]: TomlValue }
 			result = `{yearStr}-{monthStr}-{dayStr}`
 
 			-- Optional datetime separator: T, t, or space followed by digit
-			local sep = cb()
+			local sep = byteAt()
 			if sep == 84 or sep == 116 then
 				pos += 1
-			elseif sep == 32 and isDigit(cb(1)) then
+			elseif sep == 32 and isDigit(byteAt(1)) then
 				pos += 1
 			else
 				return result -- date-local
@@ -584,14 +584,14 @@ local function deserialize(input: string): { [string]: TomlValue }
 		end
 
 		-- Parse HH:MM[:SS[.frac]]
-		if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit hour") end
+		if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit hour") end
 		local hourStr = string.sub(src, pos, pos + 1)
 		pos += 2
 		local hour = tonumber(hourStr) :: number
 		if hour > 23 then tomlParseError(`invalid hour: {hour}`) end
-		if cb() ~= 58 then tomlParseError("expected ':' in time") end
+		if byteAt() ~= 58 then tomlParseError("expected ':' in time") end
 		pos += 1
-		if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit minute") end
+		if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit minute") end
 		local minStr = string.sub(src, pos, pos + 1)
 		pos += 2
 		local minute = tonumber(minStr) :: number
@@ -600,9 +600,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 		-- Optional seconds (TOML 1.1)
 		local secStr = "00"
-		if cb() == 58 then
+		if byteAt() == 58 then
 			pos += 1
-			if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit second") end
+			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit second") end
 			secStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local sec = tonumber(secStr) :: number
@@ -611,17 +611,17 @@ local function deserialize(input: string): { [string]: TomlValue }
 		result ..= `:{secStr}`
 
 		-- Optional fractional seconds
-		if cb() == 46 then
+		if byteAt() == 46 then
 			pos += 1
-			if not isDigit(cb()) then tomlParseError("expected digit after '.' in time") end
+			if not isDigit(byteAt()) then tomlParseError("expected digit after '.' in time") end
 			local fracStart = pos
-			while isDigit(cb()) do pos += 1 end
+			while isDigit(byteAt()) do pos += 1 end
 			local fracPart = string.sub(src, fracStart, pos - 1)
 			result ..= `.{fracPart}`
 		end
 
 		-- Optional offset: Z, +HH:MM, -HH:MM
-		local oc = cb()
+		local oc = byteAt()
 		if oc == 90 or oc == 122 then
 			if not hasDate then tomlParseError("offset not allowed in time-local") end
 			pos += 1
@@ -630,14 +630,14 @@ local function deserialize(input: string): { [string]: TomlValue }
 			if not hasDate then tomlParseError("offset not allowed in time-local") end
 			local sign = string.char(oc :: number)
 			pos += 1
-			if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit offset hour") end
+			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit offset hour") end
 			local ohStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local oh = tonumber(ohStr) :: number
 			if oh > 23 then tomlParseError(`invalid offset hour: {oh}`) end
-			if cb() ~= 58 then tomlParseError("expected ':' in offset") end
+			if byteAt() ~= 58 then tomlParseError("expected ':' in offset") end
 			pos += 1
-			if not (isDigit(cb(0)) and isDigit(cb(1))) then tomlParseError("expected 2-digit offset minute") end
+			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit offset minute") end
 			local omStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local om = tonumber(omStr) :: number
@@ -652,7 +652,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	local function parseNumOrDatetime(sign: string?): string | number
 		local signStr = sign or ""
-		local c = cb()
+		local c = byteAt()
 
 		-- bare inf / nan
 		if string.sub(src, pos, pos + 2) == "inf" then
@@ -668,7 +668,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 		-- prefixed integer bases (no sign allowed)
 		if sign == nil and c == 48 then
-			local nc = cb(1)
+			local nc = byteAt(1)
 			if nc == 120 then pos += 2; return tonumber(parseDigits(isHexDigit), 16) :: number end -- 0x
 			if nc == 111 then pos += 2; return tonumber(parseDigits(isOctDigit), 8) :: number end -- 0o
 			if nc == 98 then pos += 2; return tonumber(parseDigits(isBinDigit), 2) :: number end -- 0b
@@ -685,34 +685,34 @@ local function deserialize(input: string): { [string]: TomlValue }
 		local intDigits: string
 		if isZero then
 			pos += 1
-			if isDigit(cb()) then tomlParseError("leading zero in integer") end
+			if isDigit(byteAt()) then tomlParseError("leading zero in integer") end
 			intDigits = "0"
 		else
 			intDigits = parseDigits(isDigit)
 		end
 
-		local nc = cb()
+		local nc = byteAt()
 		local isFloat = false
 		local result = signStr .. intDigits
 
 		if nc == 46 then -- '.'
 			isFloat = true
 			pos += 1
-			if not isDigit(cb()) then tomlParseError("expected digit after decimal point") end
+			if not isDigit(byteAt()) then tomlParseError("expected digit after decimal point") end
 			result ..= "." .. parseDigits(isDigit)
-			nc = cb()
+			nc = byteAt()
 		end
 
 		if nc == 101 or nc == 69 then -- e / E
 			isFloat = true
 			pos += 1
 			local expSign = ""
-			local ec = cb()
+			local ec = byteAt()
 			if ec == 43 or ec == 45 then
 				expSign = string.char(ec :: number)
 				pos += 1
 			end
-			if not isDigit(cb()) then tomlParseError("expected digit in exponent") end
+			if not isDigit(byteAt()) then tomlParseError("expected digit in exponent") end
 			result ..= "e" .. expSign .. parseDigits(isDigit)
 		end
 
@@ -726,22 +726,22 @@ local function deserialize(input: string): { [string]: TomlValue }
 	local setNestedKey: (tbl: { [string]: TomlValue }, parts: { string }, value: TomlValue, fromDottedKey: boolean) -> ()
 
 	parseValue = function(): TomlValue
-		skipWS()
+		skipWhitespace()
 		if pos > len then tomlParseError("expected value") end
-		local c = cb() :: number
+		local c = byteAt() :: number
 
 		if c == 34 then -- "
 			pos += 1
 			if string.sub(src, pos, pos + 1) == '""' then
 				pos += 2
-				return parseMLBasicString()
+				return parseMultilineBasicString()
 			end
 			return parseBasicString()
 		elseif c == 39 then -- '
 			pos += 1
 			if string.sub(src, pos, pos + 1) == "''" then
 				pos += 2
-				return parseMLLiteralString()
+				return parseMultilineLiteralString()
 			end
 			return parseLiteralString()
 		elseif c == 91 then -- [
@@ -753,14 +753,14 @@ local function deserialize(input: string): { [string]: TomlValue }
 		elseif c == 116 then -- t
 			if string.sub(src, pos, pos + 3) == "true" then
 				pos += 4
-				if isBareKey(cb()) then tomlParseError("invalid value") end
+				if isBareKey(byteAt()) then tomlParseError("invalid value") end
 				return true
 			end
 			tomlParseError("invalid value starting with 't'")
 		elseif c == 102 then -- f
 			if string.sub(src, pos, pos + 4) == "false" then
 				pos += 5
-				if isBareKey(cb()) then tomlParseError("invalid value") end
+				if isBareKey(byteAt()) then tomlParseError("invalid value") end
 				return false
 			end
 			tomlParseError("invalid value starting with 'f'")
@@ -794,16 +794,16 @@ local function deserialize(input: string): { [string]: TomlValue }
 	parseArray = function(): { TomlValue }
 		local result: { TomlValue } = {}
 		tableMeta[result] = { kind = "array-value", keys = {} } -- mark as static array
-		skipWSNL()
-		if cb() == 93 then pos += 1; return result end -- empty []
+		skipWhitespaceNewlinesAndComments()
+		if byteAt() == 93 then pos += 1; return result end -- empty []
 		while true do
-			skipWSNL()
+			skipWhitespaceNewlinesAndComments()
 			if pos > len then tomlParseError("unterminated array") end
-			if cb() == 93 then pos += 1; break end -- trailing comma case
+			if byteAt() == 93 then pos += 1; break end -- trailing comma case
 			table.insert(result, parseValue())
-			skipWSNL()
+			skipWhitespaceNewlinesAndComments()
 			if pos > len then tomlParseError("unterminated array") end
-			local c = cb()
+			local c = byteAt()
 			if c == 44 then -- ','
 				pos += 1
 			elseif c == 93 then -- ']'
@@ -817,10 +817,10 @@ local function deserialize(input: string): { [string]: TomlValue }
 	end
 
 	parseKey = function(): { string }
-		skipWS()
+		skipWhitespace()
 		local parts: { string } = {}
 		while true do
-			local c = cb()
+			local c = byteAt()
 			local part: string
 			if c == 34 then -- "
 				pos += 1
@@ -844,10 +844,10 @@ local function deserialize(input: string): { [string]: TomlValue }
 				end
 			end
 			table.insert(parts, part)
-			skipWS()
-			if cb() == 46 then -- '.'
+			skipWhitespace()
+			if byteAt() == 46 then -- '.'
 				pos += 1
-				skipWS()
+				skipWhitespace()
 			else
 				break
 			end
@@ -908,21 +908,21 @@ local function deserialize(input: string): { [string]: TomlValue }
 	parseInlineTable = function(): { [string]: TomlValue }
 		local result: { [string]: TomlValue } = {}
 		tableMeta[result] = { kind = "inline", keys = {} }
-		skipWSNL() -- TOML 1.1: newlines allowed inside inline tables
-		if cb() == 125 then pos += 1; return result end -- empty {}
+		skipWhitespaceNewlinesAndComments() -- TOML 1.1: newlines allowed inside inline tables
+		if byteAt() == 125 then pos += 1; return result end -- empty {}
 		while true do
-			skipWSNL()
+			skipWhitespaceNewlinesAndComments()
 			if pos > len then tomlParseError("unterminated inline table") end
-			if cb() == 125 then pos += 1; break end -- '}' (trailing comma support)
+			if byteAt() == 125 then pos += 1; break end -- '}' (trailing comma support)
 			local keys = parseKey()
-			skipWS()
-			if cb() ~= 61 then tomlParseError("expected '=' in inline table") end -- '='
+			skipWhitespace()
+			if byteAt() ~= 61 then tomlParseError("expected '=' in inline table") end -- '='
 			pos += 1
 			local value = parseValue()
 			setNestedKey(result, keys, value, false)
-			skipWSNL()
+			skipWhitespaceNewlinesAndComments()
 			if pos > len then tomlParseError("unterminated inline table") end
-			local c = cb()
+			local c = byteAt()
 			if c == 44 then -- ','
 				pos += 1
 			elseif c == 125 then -- '}'
@@ -1031,35 +1031,35 @@ local function deserialize(input: string): { [string]: TomlValue }
 	local currentTable: { [string]: TomlValue } = root
 
 	while pos <= len do
-		skipWSNL()
+		skipWhitespaceNewlinesAndComments()
 		if pos > len then break end
 
-		local c = cb() :: number
+		local c = byteAt() :: number
 
 		if c == 91 then -- '['
-			if cb(1) == 91 then -- '[['
+			if byteAt(1) == 91 then -- '[['
 				pos += 2
-				skipWS()
+				skipWhitespace()
 				local parts = parseKey()
-				skipWS()
+				skipWhitespace()
 				if string.sub(src, pos, pos + 1) ~= "]]" then tomlParseError("expected ']]'") end
 				pos += 2
 				expectLineEnd()
 				currentTable = navigateToHeader(root, parts, true)
 			else
 				pos += 1
-				skipWS()
+				skipWhitespace()
 				local parts = parseKey()
-				skipWS()
-				if cb() ~= 93 then tomlParseError("expected ']'") end -- ']'
+				skipWhitespace()
+				if byteAt() ~= 93 then tomlParseError("expected ']'") end -- ']'
 				pos += 1
 				expectLineEnd()
 				currentTable = navigateToHeader(root, parts, false)
 			end
 		else
 			local parts = parseKey()
-			skipWS()
-			if cb() ~= 61 then tomlParseError("expected '='") end -- '='
+			skipWhitespace()
+			if byteAt() ~= 61 then tomlParseError("expected '='") end -- '='
 			pos += 1
 			local value = parseValue()
 			setNestedKey(currentTable, parts, value, true)

--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -108,6 +108,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 		while i <= n do
 			local b = string.byte(input, i)
 			local seqLen: number
+
 			if b < 0x80 then
 				seqLen = 1
 			elseif b < 0xC2 then
@@ -121,9 +122,11 @@ local function deserialize(input: string): { [string]: TomlValue }
 			else
 				error("TOML parse error: invalid UTF-8 byte at position " .. i)
 			end
+
 			if i + seqLen - 1 > n then
 				error("TOML parse error: truncated UTF-8 sequence at position " .. i)
 			end
+
 			-- Validate continuation bytes and overlong/surrogate checks
 			if seqLen == 2 then
 				local b2 = string.byte(input, i + 1)
@@ -153,6 +156,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 				local b2 = string.byte(input, i + 1)
 				local b3 = string.byte(input, i + 2)
 				local b4 = string.byte(input, i + 3)
+
 				if b == 0xF0 then
 					if b2 < 0x90 or b2 > 0xBF then
 						error("TOML parse error: overlong UTF-8 sequence at position " .. i)
@@ -166,9 +170,11 @@ local function deserialize(input: string): { [string]: TomlValue }
 						error("TOML parse error: invalid UTF-8 continuation at position " .. (i + 1))
 					end
 				end
+
 				if b3 < 0x80 or b3 > 0xBF then
 					error("TOML parse error: invalid UTF-8 continuation at position " .. (i + 2))
 				end
+
 				if b4 < 0x80 or b4 > 0xBF then
 					error("TOML parse error: invalid UTF-8 continuation at position " .. (i + 3))
 				end
@@ -193,7 +199,8 @@ local function deserialize(input: string): { [string]: TomlValue }
 		| "array-value" -- a static array literal (cannot be navigated into)
 	type TableMeta = { kind: TableKind, keys: { [string]: boolean } }
 	local tableMeta: { [any]: TableMeta } = {}
-	-- tracks which Lua arrays are array-of-tables (vs regular array values)
+
+	-- tracks which Luau arrays are array-of-tables (vs regular array values)
 	local arrayTableSets: { [any]: boolean } = {}
 
 	local function getMeta(tbl: any): TableMeta

--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -232,14 +232,18 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	-- bare key chars: A-Z a-z 0-9 _ -
 	local function isBareKey(c: number?): boolean
-		if c == nil then return false end
+		if c == nil then
+			return false
+		end
 		return (c >= 97 and c <= 122) or (c >= 65 and c <= 90) or (c >= 48 and c <= 57) or c == 95 or c == 45
 	end
 
 	-- control characters that are forbidden unescaped (everything < 0x20 except tab,
 	-- plus DEL 0x7F; LF 0x0A is handled separately per context)
 	local function isControlCharacter(c: number?): boolean
-		if c == nil then return false end
+		if c == nil then
+			return false
+		end
 		return c <= 8 or c == 11 or c == 12 or (c >= 14 and c <= 31) or c == 127
 	end
 
@@ -248,18 +252,24 @@ local function deserialize(input: string): { [string]: TomlValue }
 	local function skipWhitespace()
 		while pos <= len do
 			local c = buffer.readu8(srcBuf, pos - 1)
-			if c ~= 32 and c ~= 9 then break end
+			if c ~= 32 and c ~= 9 then
+				break
+			end
 			pos += 1
 		end
 	end
 
 	-- skip a # comment up to (but not including) the newline
 	local function skipComment()
-		if byteAt() ~= 35 then return end -- '#'
+		if byteAt() ~= 35 then
+			return
+		end -- '#'
 		pos += 1
 		while pos <= len do
 			local c = buffer.readu8(srcBuf, pos - 1)
-			if c == 10 then break end
+			if c == 10 then
+				break
+			end
 			if isControlCharacter(c) then
 				tomlParseError("control character in comment")
 			end
@@ -285,7 +295,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 	local function expectLineEnd()
 		skipWhitespace()
 		skipComment()
-		if pos > len then return end
+		if pos > len then
+			return
+		end
 		local c = byteAt()
 		if c == 10 then
 			pos += 1
@@ -299,7 +311,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 	local function parseUnicodeEscape(long: boolean): string
 		local n = if long then 8 else 4
 		local hexStr = string.sub(src, pos, pos + n - 1)
-		if #hexStr < n then tomlParseError("incomplete unicode escape") end
+		if #hexStr < n then
+			tomlParseError("incomplete unicode escape")
+		end
 		for i = 1, n do
 			if not isHexDigit(string.byte(hexStr, i)) then
 				tomlParseError("invalid hex digit in unicode escape")
@@ -307,8 +321,12 @@ local function deserialize(input: string): { [string]: TomlValue }
 		end
 		pos += n
 		local cp = tonumber(hexStr, 16) :: number
-		if cp >= 0xD800 and cp <= 0xDFFF then tomlParseError("surrogate codepoint in unicode escape") end
-		if cp > 0x10FFFF then tomlParseError("unicode codepoint out of range") end
+		if cp >= 0xD800 and cp <= 0xDFFF then
+			tomlParseError("surrogate codepoint in unicode escape")
+		end
+		if cp > 0x10FFFF then
+			tomlParseError("unicode codepoint out of range")
+		end
 		return utf8.char(cp)
 	end
 
@@ -323,21 +341,36 @@ local function deserialize(input: string): { [string]: TomlValue }
 	end
 
 	local function parseEscape(): string
-		if pos > len then tomlParseError("incomplete escape sequence") end
+		if pos > len then
+			tomlParseError("incomplete escape sequence")
+		end
 		local c = byteAt() :: number
 		pos += 1
-		if c == 98 then return "\b"
-		elseif c == 116 then return "\t"
-		elseif c == 110 then return "\n"
-		elseif c == 102 then return "\f"
-		elseif c == 114 then return "\r"
-		elseif c == 34 then return '"'
-		elseif c == 92 then return "\\"
-		elseif c == 101 then return "\x1B" -- \e  (TOML 1.1)
-		elseif c == 117 then return parseUnicodeEscape(false) -- \uXXXX
-		elseif c == 85 then return parseUnicodeEscape(true) -- \UXXXXXXXX
-		elseif c == 120 then return parseHexEscape() -- \xXX  (TOML 1.1)
-		else tomlParseError(`invalid escape sequence \\${string.char(c)}`) end
+		if c == 98 then
+			return "\b"
+		elseif c == 116 then
+			return "\t"
+		elseif c == 110 then
+			return "\n"
+		elseif c == 102 then
+			return "\f"
+		elseif c == 114 then
+			return "\r"
+		elseif c == 34 then
+			return '"'
+		elseif c == 92 then
+			return "\\"
+		elseif c == 101 then
+			return "\x1B" -- \e  (TOML 1.1)
+		elseif c == 117 then
+			return parseUnicodeEscape(false) -- \uXXXX
+		elseif c == 85 then
+			return parseUnicodeEscape(true) -- \UXXXXXXXX
+		elseif c == 120 then
+			return parseHexEscape() -- \xXX  (TOML 1.1)
+		else
+			tomlParseError(`invalid escape sequence \\${string.char(c)}`)
+		end
 		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
 		error("unreachable")
 	end
@@ -352,13 +385,17 @@ local function deserialize(input: string): { [string]: TomlValue }
 			while pos <= len do
 				local c2 = buffer.readu8(srcBuf, pos - 1)
 				-- break on: " (34), \ (92), DEL (127), ctrl chars except tab (9)
-				if c2 == 34 or c2 == 92 or c2 == 127 or (c2 < 32 and c2 ~= 9) then break end
+				if c2 == 34 or c2 == 92 or c2 == 127 or (c2 < 32 and c2 ~= 9) then
+					break
+				end
 				pos += 1
 			end
 			if pos > runStart then
 				table.insert(parts, string.sub(src, runStart, pos - 1))
 			end
-			if pos > len then break end
+			if pos > len then
+				break
+			end
 			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 34 then -- closing "
 				pos += 1
@@ -381,7 +418,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	local function parseMultilineBasicString(): string
 		-- trim a single leading newline
-		if byteAt() == 10 then pos += 1 end
+		if byteAt() == 10 then
+			pos += 1
+		end
 
 		local parts = {}
 		while pos <= len do
@@ -390,13 +429,17 @@ local function deserialize(input: string): { [string]: TomlValue }
 			while pos <= len do
 				local c2 = buffer.readu8(srcBuf, pos - 1)
 				-- break on: " (34), \ (92), DEL (127), ctrl except tab (9) and LF (10)
-				if c2 == 34 or c2 == 92 or c2 == 127 or (c2 < 32 and c2 ~= 9 and c2 ~= 10) then break end
+				if c2 == 34 or c2 == 92 or c2 == 127 or (c2 < 32 and c2 ~= 9 and c2 ~= 10) then
+					break
+				end
 				pos += 1
 			end
 			if pos > runStart then
 				table.insert(parts, string.sub(src, runStart, pos - 1))
 			end
-			if pos > len then break end
+			if pos > len then
+				break
+			end
 			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 34 then
 				if string.sub(src, pos, pos + 2) == '"""' then
@@ -419,7 +462,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 				local peek = pos
 				while peek <= len do
 					local pc = buffer.readu8(srcBuf, peek - 1)
-					if pc ~= 32 and pc ~= 9 then break end
+					if pc ~= 32 and pc ~= 9 then
+						break
+					end
 					peek += 1
 				end
 				if peek <= len and buffer.readu8(srcBuf, peek - 1) == 10 then
@@ -427,7 +472,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 					pos = peek + 1
 					while pos <= len do
 						local c3 = buffer.readu8(srcBuf, pos - 1)
-						if c3 ~= 32 and c3 ~= 9 and c3 ~= 10 then break end
+						if c3 ~= 32 and c3 ~= 9 and c3 ~= 10 then
+							break
+						end
 						pos += 1
 					end
 				elseif peek > len then
@@ -470,7 +517,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 	end
 
 	local function parseMultilineLiteralString(): string
-		if byteAt() == 10 then pos += 1 end -- trim leading newline
+		if byteAt() == 10 then
+			pos += 1
+		end -- trim leading newline
 		local parts = {}
 		while pos <= len do
 			-- Fast path: scan over plain chars (LF and tab are literal content)
@@ -478,13 +527,17 @@ local function deserialize(input: string): { [string]: TomlValue }
 			while pos <= len do
 				local c2 = buffer.readu8(srcBuf, pos - 1)
 				-- break on: ' (39), DEL (127), ctrl except tab (9) and LF (10)
-				if c2 == 39 or c2 == 127 or (c2 < 32 and c2 ~= 9 and c2 ~= 10) then break end
+				if c2 == 39 or c2 == 127 or (c2 < 32 and c2 ~= 9 and c2 ~= 10) then
+					break
+				end
 				pos += 1
 			end
 			if pos > runStart then
 				table.insert(parts, string.sub(src, runStart, pos - 1))
 			end
-			if pos > len then break end
+			if pos > len then
+				break
+			end
 			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 39 then
 				if string.sub(src, pos, pos + 2) == "'''" then
@@ -516,7 +569,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	-- parse a run of digits (with internal underscores allowed), return digits-only string
 	local function parseDigits(digitCheck: (number?) -> boolean): string
-		if not digitCheck(byteAt()) then tomlParseError("expected digit") end
+		if not digitCheck(byteAt()) then
+			tomlParseError("expected digit")
+		end
 		local result = ""
 		local runStart = pos
 		while pos <= len do
@@ -526,10 +581,16 @@ local function deserialize(input: string): { [string]: TomlValue }
 			elseif c == 95 then -- underscore
 				result ..= string.sub(src, runStart, pos - 1)
 				pos += 1
-				if pos > len then tomlParseError("trailing underscore in number") end
+				if pos > len then
+					tomlParseError("trailing underscore in number")
+				end
 				local nc = buffer.readu8(srcBuf, pos - 1)
-				if nc == 95 then tomlParseError("consecutive underscores in number") end
-				if not digitCheck(nc) then tomlParseError("trailing underscore in number") end
+				if nc == 95 then
+					tomlParseError("consecutive underscores in number")
+				end
+				if not digitCheck(nc) then
+					tomlParseError("trailing underscore in number")
+				end
 				runStart = pos
 			else
 				break
@@ -541,9 +602,13 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	local function looksLikeDate(): boolean
 		-- YYYY- : 4 decimal digits followed by '-'
-		if pos + 4 > len then return false end
+		if pos + 4 > len then
+			return false
+		end
 		for i = 0, 3 do
-			if not isDigit(buffer.readu8(srcBuf, pos + i - 1)) then return false end
+			if not isDigit(buffer.readu8(srcBuf, pos + i - 1)) then
+				return false
+			end
 		end
 		return buffer.readu8(srcBuf, pos + 3) == 45
 	end
@@ -573,21 +638,33 @@ local function deserialize(input: string): { [string]: TomlValue }
 			-- Parse YYYY-MM-DD
 			local yearStr = string.sub(src, pos, pos + 3)
 			pos += 4
-			if byteAt() ~= 45 then tomlParseError("expected '-' in date") end
+			if byteAt() ~= 45 then
+				tomlParseError("expected '-' in date")
+			end
 			pos += 1
-			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit month") end
+			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
+				tomlParseError("expected 2-digit month")
+			end
 			local monthStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local month = tonumber(monthStr) :: number
-			if month < 1 or month > 12 then tomlParseError(`invalid month: {month}`) end
-			if byteAt() ~= 45 then tomlParseError("expected '-' in date") end
+			if month < 1 or month > 12 then
+				tomlParseError(`invalid month: {month}`)
+			end
+			if byteAt() ~= 45 then
+				tomlParseError("expected '-' in date")
+			end
 			pos += 1
-			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit day") end
+			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
+				tomlParseError("expected 2-digit day")
+			end
 			local dayStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local day = tonumber(dayStr) :: number
 			local year = tonumber(yearStr) :: number
-			if day < 1 or day > daysInMonth(year, month) then tomlParseError(`invalid day {day} for month {month}`) end
+			if day < 1 or day > daysInMonth(year, month) then
+				tomlParseError(`invalid day {day} for month {month}`)
+			end
 			result = `{yearStr}-{monthStr}-{dayStr}`
 
 			-- Optional datetime separator: T, t, or space followed by digit
@@ -603,38 +680,56 @@ local function deserialize(input: string): { [string]: TomlValue }
 		end
 
 		-- Parse HH:MM[:SS[.frac]]
-		if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit hour") end
+		if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
+			tomlParseError("expected 2-digit hour")
+		end
 		local hourStr = string.sub(src, pos, pos + 1)
 		pos += 2
 		local hour = tonumber(hourStr) :: number
-		if hour > 23 then tomlParseError(`invalid hour: {hour}`) end
-		if byteAt() ~= 58 then tomlParseError("expected ':' in time") end
+		if hour > 23 then
+			tomlParseError(`invalid hour: {hour}`)
+		end
+		if byteAt() ~= 58 then
+			tomlParseError("expected ':' in time")
+		end
 		pos += 1
-		if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit minute") end
+		if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
+			tomlParseError("expected 2-digit minute")
+		end
 		local minStr = string.sub(src, pos, pos + 1)
 		pos += 2
 		local minute = tonumber(minStr) :: number
-		if minute > 59 then tomlParseError(`invalid minute: {minute}`) end
+		if minute > 59 then
+			tomlParseError(`invalid minute: {minute}`)
+		end
 		result ..= `{hourStr}:{minStr}`
 
 		-- Optional seconds (TOML 1.1)
 		local secStr = "00"
 		if byteAt() == 58 then
 			pos += 1
-			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit second") end
+			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
+				tomlParseError("expected 2-digit second")
+			end
 			secStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local sec = tonumber(secStr) :: number
-			if sec > 59 then tomlParseError(`invalid second: {sec}`) end
+			if sec > 59 then
+				tomlParseError(`invalid second: {sec}`)
+			end
 		end
 		result ..= `:{secStr}`
 
 		-- Optional fractional seconds
 		if byteAt() == 46 then
 			pos += 1
-			if not isDigit(byteAt()) then tomlParseError("expected digit after '.' in time") end
+			if not isDigit(byteAt()) then
+				tomlParseError("expected digit after '.' in time")
+			end
 			local fracStart = pos
-			while isDigit(byteAt()) do pos += 1 end
+			while isDigit(byteAt()) do
+				pos += 1
+			end
 			local fracPart = string.sub(src, fracStart, pos - 1)
 			result ..= `.{fracPart}`
 		end
@@ -642,25 +737,39 @@ local function deserialize(input: string): { [string]: TomlValue }
 		-- Optional offset: Z, +HH:MM, -HH:MM
 		local oc = byteAt()
 		if oc == 90 or oc == 122 then
-			if not hasDate then tomlParseError("offset not allowed in time-local") end
+			if not hasDate then
+				tomlParseError("offset not allowed in time-local")
+			end
 			pos += 1
 			result ..= "Z"
 		elseif oc == 43 or oc == 45 then
-			if not hasDate then tomlParseError("offset not allowed in time-local") end
+			if not hasDate then
+				tomlParseError("offset not allowed in time-local")
+			end
 			local sign = string.char(oc :: number)
 			pos += 1
-			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit offset hour") end
+			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
+				tomlParseError("expected 2-digit offset hour")
+			end
 			local ohStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local oh = tonumber(ohStr) :: number
-			if oh > 23 then tomlParseError(`invalid offset hour: {oh}`) end
-			if byteAt() ~= 58 then tomlParseError("expected ':' in offset") end
+			if oh > 23 then
+				tomlParseError(`invalid offset hour: {oh}`)
+			end
+			if byteAt() ~= 58 then
+				tomlParseError("expected ':' in offset")
+			end
 			pos += 1
-			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then tomlParseError("expected 2-digit offset minute") end
+			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
+				tomlParseError("expected 2-digit offset minute")
+			end
 			local omStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local om = tonumber(omStr) :: number
-			if om > 59 then tomlParseError(`invalid offset minute: {om}`) end
+			if om > 59 then
+				tomlParseError(`invalid offset minute: {om}`)
+			end
 			result ..= `{sign}{ohStr}:{omStr}`
 		end
 
@@ -683,20 +792,35 @@ local function deserialize(input: string): { [string]: TomlValue }
 			return 0 / 0
 		end
 
-		if not isDigit(c) then tomlParseError(`expected digit, got '${string.char(c :: number)}'`) end
+		if not isDigit(c) then
+			tomlParseError(`expected digit, got '${string.char(c :: number)}'`)
+		end
 
 		-- prefixed integer bases (no sign allowed)
 		if sign == nil and c == 48 then
 			local nc = byteAt(1)
-			if nc == 120 then pos += 2; return tonumber(parseDigits(isHexDigit), 16) :: number end -- 0x
-			if nc == 111 then pos += 2; return tonumber(parseDigits(isOctDigit), 8) :: number end -- 0o
-			if nc == 98 then pos += 2; return tonumber(parseDigits(isBinDigit), 2) :: number end -- 0b
+			if nc == 120 then
+				pos += 2
+				return tonumber(parseDigits(isHexDigit), 16) :: number
+			end -- 0x
+			if nc == 111 then
+				pos += 2
+				return tonumber(parseDigits(isOctDigit), 8) :: number
+			end -- 0o
+			if nc == 98 then
+				pos += 2
+				return tonumber(parseDigits(isBinDigit), 2) :: number
+			end -- 0b
 		end
 
 		-- datetime / time detection (no sign)
 		if sign == nil then
-			if looksLikeDate() then return parseDatetime() end
-			if looksLikeTime() then return parseDatetime() end
+			if looksLikeDate() then
+				return parseDatetime()
+			end
+			if looksLikeTime() then
+				return parseDatetime()
+			end
 		end
 
 		-- decimal integer or float
@@ -704,7 +828,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 		local intDigits: string
 		if isZero then
 			pos += 1
-			if isDigit(byteAt()) then tomlParseError("leading zero in integer") end
+			if isDigit(byteAt()) then
+				tomlParseError("leading zero in integer")
+			end
 			intDigits = "0"
 		else
 			intDigits = parseDigits(isDigit)
@@ -717,7 +843,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if nc == 46 then -- '.'
 			isFloat = true
 			pos += 1
-			if not isDigit(byteAt()) then tomlParseError("expected digit after decimal point") end
+			if not isDigit(byteAt()) then
+				tomlParseError("expected digit after decimal point")
+			end
 			result ..= "." .. parseDigits(isDigit)
 			nc = byteAt()
 		end
@@ -731,7 +859,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 				expSign = string.char(ec :: number)
 				pos += 1
 			end
-			if not isDigit(byteAt()) then tomlParseError("expected digit in exponent") end
+			if not isDigit(byteAt()) then
+				tomlParseError("expected digit in exponent")
+			end
 			result ..= "e" .. expSign .. parseDigits(isDigit)
 		end
 
@@ -746,7 +876,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	parseValue = function(): TomlValue
 		skipWhitespace()
-		if pos > len then tomlParseError("expected value") end
+		if pos > len then
+			tomlParseError("expected value")
+		end
 		local c = byteAt() :: number
 
 		if c == 34 then -- "
@@ -774,7 +906,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 		elseif c == 116 then -- t
 			if string.sub(src, pos, pos + 3) == "true" then
 				pos += 4
-				if isBareKey(byteAt()) then tomlParseError("invalid value") end
+				if isBareKey(byteAt()) then
+					tomlParseError("invalid value")
+				end
 				return true
 			end
 
@@ -782,7 +916,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 		elseif c == 102 then -- f
 			if string.sub(src, pos, pos + 4) == "false" then
 				pos += 5
-				if isBareKey(byteAt()) then tomlParseError("invalid value") end
+				if isBareKey(byteAt()) then
+					tomlParseError("invalid value")
+				end
 				return false
 			end
 
@@ -821,15 +957,25 @@ local function deserialize(input: string): { [string]: TomlValue }
 		local result: { TomlValue } = {}
 		tableMeta[result] = { kind = "array-value", keys = {} } -- mark as static array
 		skipWhitespaceNewlinesAndComments()
-		if byteAt() == 93 then pos += 1; return result end -- empty []
+		if byteAt() == 93 then
+			pos += 1
+			return result
+		end -- empty []
 
 		while true do
 			skipWhitespaceNewlinesAndComments()
-			if pos > len then tomlParseError("unterminated array") end
-			if byteAt() == 93 then pos += 1; break end -- trailing comma case
+			if pos > len then
+				tomlParseError("unterminated array")
+			end
+			if byteAt() == 93 then
+				pos += 1
+				break
+			end -- trailing comma case
 			table.insert(result, parseValue())
 			skipWhitespaceNewlinesAndComments()
-			if pos > len then tomlParseError("unterminated array") end
+			if pos > len then
+				tomlParseError("unterminated array")
+			end
 			local c = byteAt()
 			if c == 44 then -- ','
 				pos += 1
@@ -860,7 +1006,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 				local start = pos
 				while pos <= len do
 					local c2 = buffer.readu8(srcBuf, pos - 1)
-					if not isBareKey(c2) then break end
+					if not isBareKey(c2) then
+						break
+					end
 					pos += 1
 				end
 				part = string.sub(src, start, pos - 1)
@@ -886,7 +1034,11 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	-- navigate through dotted intermediate keys, creating tables as needed;
 	-- returns (leaf_table, leaf_key_string)
-	local function navigateDotted(tbl: { [string]: TomlValue }, parts: { string }, newKind: TableKind): ({ [string]: TomlValue }, string)
+	local function navigateDotted(
+		tbl: { [string]: TomlValue },
+		parts: { string },
+		newKind: TableKind
+	): ({ [string]: TomlValue }, string)
 		local current: { [string]: TomlValue } = tbl
 		for i = 1, #parts - 1 do
 			local k = parts[i]
@@ -938,19 +1090,31 @@ local function deserialize(input: string): { [string]: TomlValue }
 		local result: { [string]: TomlValue } = {}
 		tableMeta[result] = { kind = "inline", keys = {} }
 		skipWhitespaceNewlinesAndComments() -- TOML 1.1: newlines allowed inside inline tables
-		if byteAt() == 125 then pos += 1; return result end -- empty {}
+		if byteAt() == 125 then
+			pos += 1
+			return result
+		end -- empty {}
 		while true do
 			skipWhitespaceNewlinesAndComments()
-			if pos > len then tomlParseError("unterminated inline table") end
-			if byteAt() == 125 then pos += 1; break end -- '}' (trailing comma support)
+			if pos > len then
+				tomlParseError("unterminated inline table")
+			end
+			if byteAt() == 125 then
+				pos += 1
+				break
+			end -- '}' (trailing comma support)
 			local keys = parseKey()
 			skipWhitespace()
-			if byteAt() ~= 61 then tomlParseError("expected '=' in inline table") end -- '='
+			if byteAt() ~= 61 then
+				tomlParseError("expected '=' in inline table")
+			end -- '='
 			pos += 1
 			local value = parseValue()
 			setNestedKey(result, keys, value, false)
 			skipWhitespaceNewlinesAndComments()
-			if pos > len then tomlParseError("unterminated inline table") end
+			if pos > len then
+				tomlParseError("unterminated inline table")
+			end
 			local c = byteAt()
 			if c == 44 then -- ','
 				pos += 1
@@ -966,7 +1130,11 @@ local function deserialize(input: string): { [string]: TomlValue }
 	end
 
 	-- navigate to the table referenced by a [key] or [[key]] header
-	local function navigateToHeader(root: { [string]: TomlValue }, parts: { string }, isArrayTable: boolean): { [string]: TomlValue }
+	local function navigateToHeader(
+		root: { [string]: TomlValue },
+		parts: { string },
+		isArrayTable: boolean
+	): { [string]: TomlValue }
 		local current: { [string]: TomlValue } = root
 		for i = 1, #parts - 1 do
 			local k = parts[i]
@@ -1063,7 +1231,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	while pos <= len do
 		skipWhitespaceNewlinesAndComments()
-		if pos > len then break end
+		if pos > len then
+			break
+		end
 
 		local c = byteAt() :: number
 
@@ -1073,7 +1243,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 				skipWhitespace()
 				local parts = parseKey()
 				skipWhitespace()
-				if string.sub(src, pos, pos + 1) ~= "]]" then tomlParseError("expected ']]'") end
+				if string.sub(src, pos, pos + 1) ~= "]]" then
+					tomlParseError("expected ']]'")
+				end
 				pos += 2
 				expectLineEnd()
 				currentTable = navigateToHeader(root, parts, true)
@@ -1082,7 +1254,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 				skipWhitespace()
 				local parts = parseKey()
 				skipWhitespace()
-				if byteAt() ~= 93 then tomlParseError("expected ']'") end -- ']'
+				if byteAt() ~= 93 then
+					tomlParseError("expected ']'")
+				end -- ']'
 				pos += 1
 				expectLineEnd()
 				currentTable = navigateToHeader(root, parts, false)
@@ -1090,7 +1264,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 		else
 			local parts = parseKey()
 			skipWhitespace()
-			if byteAt() ~= 61 then tomlParseError("expected '='") end -- '='
+			if byteAt() ~= 61 then
+				tomlParseError("expected '='")
+			end -- '='
 			pos += 1
 			local value = parseValue()
 			setNestedKey(currentTable, parts, value, true)

--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -1,10 +1,6 @@
 local toml = {}
 
 -- serialization
-type SerializerState = {
-	buf: buffer,
-	cursor: number,
-}
 
 local function serializeValue(value: string | number): string
 	if typeof(value) == "string" then
@@ -83,132 +79,940 @@ local function serialize(tbl: { [any]: any }): string
 end
 
 -- deserialization
-type DeserializerState = {
-	buf: string,
-	cursor: number,
-}
-
-local function splitTablePath(path: string): { string }
-	local parts = {}
-	local index = 1
-	local pathLen = string.len(path)
-
-	while index <= pathLen do
-		local symbol = string.sub(path, index, index)
-		if symbol == "." then
-			index += 1
-		elseif symbol == '"' or symbol == "'" then
-			local closePos = string.find(path, symbol, index + 1, true) or pathLen + 1
-			table.insert(parts, string.sub(path, index + 1, closePos - 1))
-			index = closePos + 1
-		else
-			local nextSpecial = string.find(path, "[.\"']", index)
-			local segEnd = if nextSpecial then nextSpecial - 1 else pathLen
-			table.insert(parts, string.sub(path, index, segEnd))
-			index = segEnd + 1
-		end
-	end
-
-	return parts
-end
-
-local function ensurePath(root: { [string]: unknown }, parts: { string }, depth: number?): { [string]: unknown }
-	local current = root
-	for i = 1, depth or #parts do
-		if not current[parts[i]] then
-			current[parts[i]] = {}
-		end
-		current = current[parts[i]] :: { [string]: unknown }
-	end
-	return current
-end
-
-local function skipWhitespace(state: DeserializerState): ()
-	local pos = state.cursor
-	while pos <= string.len(state.buf) and string.match(string.sub(state.buf, pos, pos), "%s") do
-		pos += 1
-	end
-	state.cursor = pos
-end
-
-local function readLine(state: DeserializerState): string
-	local nextLine = string.find(state.buf, "\n", state.cursor) or string.len(state.buf) + 1
-	local line = string.sub(state.buf, state.cursor, nextLine - 1)
-	state.cursor = nextLine + 1
-	return line
-end
 
 local function deserialize(input: string): { [string]: unknown }
-	-- Normalize line endings: Replace Windows (\r\n) and old Mac (\r) with Unix (\n)
-	input = string.gsub(input, "\r\n", "\n")
-	input = string.gsub(input, "\r", "\n")
+	-- Reject bare CR (only CRLF → LF is allowed)
+	input = input:gsub("\r\n", "\n")
+	if input:find("\r") then
+		error("TOML parse error: bare carriage return (\\r) not allowed")
+	end
 
-	local state: DeserializerState = {
-		buf = input,
-		cursor = 1,
-	}
-	local result: { [string]: unknown } = {}
-	local currentTable = result
-	local arrayTables = {}
-
-	while state.cursor <= string.len(state.buf) do
-		skipWhitespace(state)
-		local line = readLine(state)
-
-		if line == "" or string.sub(line, 1, 1) == "#" then
-			continue
-		end
-
-		if string.match(line, "^%[%[(.-)%]%]$") then
-			local tableName = string.match(line, "^%[%[(.-)%]%]$") or ""
-
-			if not arrayTables[tableName] then
-				arrayTables[tableName] = {}
-				local parts = splitTablePath(tableName)
-				local leaf = parts[#parts]
-				local _parent = ensurePath(result, parts, #parts - 1)
-				_parent[leaf] = arrayTables[tableName]
+	-- Validate UTF-8 encoding
+	do
+		local i = 1
+		local n = #input
+		while i <= n do
+			local b = string.byte(input, i)
+			local seqLen: number
+			if b < 0x80 then
+				seqLen = 1
+			elseif b < 0xC2 then
+				error("TOML parse error: invalid UTF-8 byte at position " .. i)
+			elseif b < 0xE0 then
+				seqLen = 2
+			elseif b < 0xF0 then
+				seqLen = 3
+			elseif b <= 0xF4 then
+				seqLen = 4
+			else
+				error("TOML parse error: invalid UTF-8 byte at position " .. i)
 			end
-
-			local newEntry = {}
-			table.insert(arrayTables[tableName], newEntry)
-			currentTable = newEntry
-		elseif string.match(line, "^%[(.-)%]$") then
-			local tablePath = string.match(line, "^%[(.-)%]$")
-			currentTable = ensurePath(result, splitTablePath(tablePath :: string))
-		elseif string.match(line, "^(.-)%s*=%s*(.-)$") then
-			local key, value = string.match(line, "^(.-)%s*=%s*(.-)$")
-			assert(key and value)
-			key = string.match(key, "^%s*(.-)%s*$")
-			value = string.match(value, "^%s*(.-)%s*$")
-			assert(key and value)
-			if string.match(key, '^"(.*)"$') or string.match(key, "^'(.*)'$") then
-				key = string.sub(key, 2, -2)
+			if i + seqLen - 1 > n then
+				error("TOML parse error: truncated UTF-8 sequence at position " .. i)
 			end
-			if string.match(value, '^"(.*)"$') or string.match(value, "^'(.*)'$") then
-				value = string.sub(value, 2, -2)
-				value = string.gsub(value, "\\\\", "\\")
-				value = string.gsub(value, "\\n", "\n")
-				value = string.gsub(value, "\\t", "\t")
-			elseif tonumber(value) then
-				value = tonumber(value)
-			elseif value == "true" then
-				value = true
-			elseif value == "false" then
-				value = false
-			elseif value == "inf" or value == "+inf" then
-				value = math.huge
-			elseif value == "-inf" then
-				value = -math.huge
-			elseif value == "nan" then
-				value = math.nan
+			-- Validate continuation bytes and overlong/surrogate checks
+			if seqLen == 2 then
+				local b2 = string.byte(input, i + 1)
+				if b2 < 0x80 or b2 > 0xBF then
+					error("TOML parse error: invalid UTF-8 continuation at position " .. (i + 1))
+				end
+			elseif seqLen == 3 then
+				local b2 = string.byte(input, i + 1)
+				local b3 = string.byte(input, i + 2)
+				if b == 0xE0 then
+					if b2 < 0xA0 or b2 > 0xBF then
+						error("TOML parse error: overlong UTF-8 sequence at position " .. i)
+					end
+				elseif b == 0xED then
+					if b2 < 0x80 or b2 > 0x9F then
+						error("TOML parse error: UTF-8 surrogate codepoint at position " .. i)
+					end
+				else
+					if b2 < 0x80 or b2 > 0xBF then
+						error("TOML parse error: invalid UTF-8 continuation at position " .. (i + 1))
+					end
+				end
+				if b3 < 0x80 or b3 > 0xBF then
+					error("TOML parse error: invalid UTF-8 continuation at position " .. (i + 2))
+				end
+			elseif seqLen == 4 then
+				local b2 = string.byte(input, i + 1)
+				local b3 = string.byte(input, i + 2)
+				local b4 = string.byte(input, i + 3)
+				if b == 0xF0 then
+					if b2 < 0x90 or b2 > 0xBF then
+						error("TOML parse error: overlong UTF-8 sequence at position " .. i)
+					end
+				elseif b == 0xF4 then
+					if b2 < 0x80 or b2 > 0x8F then
+						error("TOML parse error: UTF-8 codepoint > U+10FFFF at position " .. i)
+					end
+				else
+					if b2 < 0x80 or b2 > 0xBF then
+						error("TOML parse error: invalid UTF-8 continuation at position " .. (i + 1))
+					end
+				end
+				if b3 < 0x80 or b3 > 0xBF then
+					error("TOML parse error: invalid UTF-8 continuation at position " .. (i + 2))
+				end
+				if b4 < 0x80 or b4 > 0xBF then
+					error("TOML parse error: invalid UTF-8 continuation at position " .. (i + 3))
+				end
 			end
-
-			currentTable[key] = value
+			i += seqLen
 		end
 	end
 
-	return result
+	local src = input
+	local pos = 1
+	local len = #src
+
+	-- Table metadata: maps table reference -> { kind, keys }
+	-- kind values:
+	--   "root"             – the document root
+	--   "defined"          – created by an explicit [header]
+	--   "implicit-header"  – implicitly created while navigating a [a.b.c] path
+	--   "implicit-dotted"  – implicitly created by a dotted key assignment (a.b = v)
+	--   "inline"           – an inline table; immutable after creation
+	--   "array-element"    – an element of an [[array-of-tables]]
+	local tableMeta: { [any]: { kind: string, keys: { [string]: boolean } } } = {}
+	-- tracks which Lua arrays are array-of-tables (vs regular array values)
+	local arrayTableSets: { [any]: boolean } = {}
+
+	local function getMeta(tbl: any): { kind: string, keys: { [string]: boolean } }
+		if not tableMeta[tbl] then
+			tableMeta[tbl] = { kind = "implicit-header", keys = {} }
+		end
+		return tableMeta[tbl]
+	end
+
+	local function err(msg: string): never
+		error(`TOML parse error at position {pos}: {msg}`)
+	end
+
+	-- character helpers (all operate on the shared pos/src/len upvalues)
+
+	local function cb(offset: number?): number? -- byte at pos+offset
+		local p = pos + (offset or 0)
+		return if p <= len then string.byte(src, p) else nil
+	end
+
+	local function isDigit(c: number?): boolean
+		return c ~= nil and c >= 48 and c <= 57
+	end
+
+	local function isHexDigit(c: number?): boolean
+		return c ~= nil and ((c >= 48 and c <= 57) or (c >= 65 and c <= 70) or (c >= 97 and c <= 102))
+	end
+
+	local function isOctDigit(c: number?): boolean
+		return c ~= nil and c >= 48 and c <= 55
+	end
+
+	local function isBinDigit(c: number?): boolean
+		return c ~= nil and (c == 48 or c == 49)
+	end
+
+	-- bare key chars: A-Z a-z 0-9 _ -
+	local function isBareKey(c: number?): boolean
+		if c == nil then return false end
+		return (c >= 97 and c <= 122) or (c >= 65 and c <= 90) or (c >= 48 and c <= 57) or c == 95 or c == 45
+	end
+
+	local function isWS(c: number?): boolean
+		return c == 32 or c == 9
+	end
+
+	-- control characters that are forbidden unescaped (everything < 0x20 except tab,
+	-- plus DEL 0x7F; LF 0x0A is handled separately per context)
+	local function isCtrl(c: number?): boolean
+		if c == nil then return false end
+		return c <= 8 or c == 11 or c == 12 or (c >= 14 and c <= 31) or c == 127
+	end
+
+	-- whitespace skipping
+
+	local function skipWS()
+		while pos <= len and isWS(cb()) do
+			pos += 1
+		end
+	end
+
+	-- skip a # comment up to (but not including) the newline
+	local function skipComment()
+		if cb() ~= 35 then return end -- '#'
+		pos += 1
+		while pos <= len do
+			local c = cb()
+			if c == 10 then break end
+			if isCtrl(c) then err("control character in comment") end
+			pos += 1
+		end
+	end
+
+	-- skip horizontal whitespace, newlines, and comments
+	local function skipWSNL()
+		while pos <= len do
+			local c = cb()
+			if isWS(c) or c == 10 then
+				pos += 1
+			elseif c == 35 then
+				skipComment()
+			else
+				break
+			end
+		end
+	end
+
+	-- after a value: consume trailing WS + optional comment, then require newline or EOF
+	local function expectLineEnd()
+		skipWS()
+		skipComment()
+		if pos > len then return end
+		local c = cb()
+		if c == 10 then
+			pos += 1
+		else
+			err(`expected newline or EOF, got '${string.char(c :: number)}'`)
+		end
+	end
+
+	-- string escape helpers
+
+	local function parseUnicodeEscape(long: boolean): string
+		local n = if long then 8 else 4
+		local hexStr = string.sub(src, pos, pos + n - 1)
+		if #hexStr < n then err("incomplete unicode escape") end
+		for i = 1, n do
+			if not isHexDigit(string.byte(hexStr, i)) then
+				err("invalid hex digit in unicode escape")
+			end
+		end
+		pos += n
+		local cp = tonumber(hexStr, 16) :: number
+		if cp >= 0xD800 and cp <= 0xDFFF then err("surrogate codepoint in unicode escape") end
+		if cp > 0x10FFFF then err("unicode codepoint out of range") end
+		return utf8.char(cp)
+	end
+
+	-- \xXX escape (TOML 1.1): unicode codepoint U+0000..U+00FF
+	local function parseHexEscape(): string
+		local hexStr = string.sub(src, pos, pos + 1)
+		if #hexStr < 2 or not isHexDigit(string.byte(hexStr, 1)) or not isHexDigit(string.byte(hexStr, 2)) then
+			err("invalid \\x escape")
+		end
+		pos += 2
+		return utf8.char(tonumber(hexStr, 16) :: number)
+	end
+
+	local function parseEscape(): string
+		if pos > len then err("incomplete escape sequence") end
+		local c = cb() :: number
+		pos += 1
+		if c == 98 then return "\b"
+		elseif c == 116 then return "\t"
+		elseif c == 110 then return "\n"
+		elseif c == 102 then return "\f"
+		elseif c == 114 then return "\r"
+		elseif c == 34 then return '"'
+		elseif c == 92 then return "\\"
+		elseif c == 101 then return "\x1B" -- \e  (TOML 1.1)
+		elseif c == 117 then return parseUnicodeEscape(false) -- \uXXXX
+		elseif c == 85 then return parseUnicodeEscape(true) -- \UXXXXXXXX
+		elseif c == 120 then return parseHexEscape() -- \xXX  (TOML 1.1)
+		else err(`invalid escape sequence \\${string.char(c)}`) end
+	end
+
+	-- string parsers (pos is always past the opening delimiter on entry)
+
+	local function parseBasicString(): string
+		local parts = {}
+		while pos <= len do
+			local c = cb() :: number
+			if c == 34 then -- closing "
+				pos += 1
+				return table.concat(parts)
+			elseif c == 92 then -- backslash
+				pos += 1
+				table.insert(parts, parseEscape())
+			elseif c == 10 then
+				err("unescaped newline in basic string")
+			elseif isCtrl(c) then
+				err("unescaped control character in basic string")
+			else
+				table.insert(parts, string.char(c))
+				pos += 1
+			end
+		end
+		err("unterminated basic string")
+	end
+
+	local function parseMLBasicString(): string
+		-- trim a single leading newline
+		if cb() == 10 then pos += 1 end
+		local parts = {}
+		while pos <= len do
+			local c = cb() :: number
+			if c == 34 and string.sub(src, pos, pos + 2) == '"""' then
+				pos += 3
+				-- up to two extra quotes are part of the string
+				local extra = 0
+				while pos <= len and cb() == 34 and extra < 2 do
+					table.insert(parts, '"')
+					pos += 1
+					extra += 1
+				end
+				return table.concat(parts)
+			elseif c == 92 then -- backslash
+				pos += 1
+				-- peek past any trailing horizontal whitespace to detect line-ending backslash
+				local peek = pos
+				while peek <= len and isWS(string.byte(src, peek)) do
+					peek += 1
+				end
+				if peek <= len and string.byte(src, peek) == 10 then
+					-- line-ending backslash: skip newline and all following WS/NL
+					pos = peek + 1
+					while pos <= len and (isWS(cb()) or cb() == 10) do
+						pos += 1
+					end
+				elseif peek > len then
+					err("incomplete escape at end of file")
+				else
+					table.insert(parts, parseEscape())
+				end
+			elseif c == 10 then
+				table.insert(parts, "\n")
+				pos += 1
+			elseif c == 9 then -- tab is allowed
+				table.insert(parts, "\t")
+				pos += 1
+			elseif isCtrl(c) then
+				err("unescaped control character in multiline basic string")
+			else
+				table.insert(parts, string.char(c))
+				pos += 1
+			end
+		end
+		err("unterminated multiline basic string")
+	end
+
+	local function parseLiteralString(): string
+		local start = pos
+		while pos <= len do
+			local c = cb() :: number
+			if c == 39 then -- closing '
+				local result = string.sub(src, start, pos - 1)
+				pos += 1
+				return result
+			elseif c == 10 then
+				err("unescaped newline in literal string")
+			elseif c == 9 then
+				pos += 1 -- tab is allowed
+			elseif isCtrl(c) then
+				err("unescaped control character in literal string")
+			else
+				pos += 1
+			end
+		end
+		err("unterminated literal string")
+	end
+
+	local function parseMLLiteralString(): string
+		if cb() == 10 then pos += 1 end -- trim leading newline
+		local parts = {}
+		while pos <= len do
+			local c = cb() :: number
+			if c == 39 and string.sub(src, pos, pos + 2) == "'''" then
+				pos += 3
+				local extra = 0
+				while pos <= len and cb() == 39 and extra < 2 do
+					table.insert(parts, "'")
+					pos += 1
+					extra += 1
+				end
+				return table.concat(parts)
+			elseif c == 10 then
+				table.insert(parts, "\n")
+				pos += 1
+			elseif c == 9 then
+				table.insert(parts, "\t")
+				pos += 1
+			elseif isCtrl(c) then
+				err("unescaped control character in multiline literal string")
+			else
+				table.insert(parts, string.char(c))
+				pos += 1
+			end
+		end
+		err("unterminated multiline literal string")
+	end
+
+	-- number / datetime helpers
+
+	-- parse a run of digits (with internal underscores allowed), return digits-only string
+	local function parseDigits(digitCheck: (number?) -> boolean): string
+		if not digitCheck(cb()) then err("expected digit") end
+		local parts = { string.char(cb() :: number) }
+		pos += 1
+		while pos <= len do
+			local c = cb()
+			if c == 95 then -- underscore
+				pos += 1
+				if cb() == 95 then err("consecutive underscores in number") end
+				if not digitCheck(cb()) then err("trailing underscore in number") end
+				table.insert(parts, string.char(cb() :: number))
+				pos += 1
+			elseif digitCheck(c) then
+				table.insert(parts, string.char(c :: number))
+				pos += 1
+			else
+				break
+			end
+		end
+		return table.concat(parts)
+	end
+
+	local function looksLikeDate(): boolean
+		-- YYYY- : 4 decimal digits followed by '-'
+		if pos + 4 > len then return false end
+		for i = 0, 3 do
+			if not isDigit(string.byte(src, pos + i)) then return false end
+		end
+		return string.byte(src, pos + 4) == 45
+	end
+
+	local function looksLikeTime(): boolean
+		-- HH: : exactly 2 decimal digits followed by ':'
+		return isDigit(cb(0)) and isDigit(cb(1)) and cb(2) == 58
+	end
+
+	-- Returns days in month for given year and month (1-12)
+	local function daysInMonth(year: number, month: number): number
+		if month == 2 then
+			local isLeap = (year % 4 == 0 and year % 100 ~= 0) or (year % 400 == 0)
+			return if isLeap then 29 else 28
+		elseif month == 4 or month == 6 or month == 9 or month == 11 then
+			return 30
+		else
+			return 31
+		end
+	end
+
+	local function parseDatetime(): string
+		local hasDate = looksLikeDate()
+		local result = ""
+
+		if hasDate then
+			-- Parse YYYY-MM-DD
+			local yearStr = string.sub(src, pos, pos + 3)
+			pos += 4
+			if cb() ~= 45 then err("expected '-' in date") end
+			pos += 1
+			if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit month") end
+			local monthStr = string.sub(src, pos, pos + 1)
+			pos += 2
+			local month = tonumber(monthStr) :: number
+			if month < 1 or month > 12 then err(`invalid month: {month}`) end
+			if cb() ~= 45 then err("expected '-' in date") end
+			pos += 1
+			if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit day") end
+			local dayStr = string.sub(src, pos, pos + 1)
+			pos += 2
+			local day = tonumber(dayStr) :: number
+			local year = tonumber(yearStr) :: number
+			if day < 1 or day > daysInMonth(year, month) then err(`invalid day {day} for month {month}`) end
+			result = `{yearStr}-{monthStr}-{dayStr}`
+
+			-- Optional datetime separator: T, t, or space followed by digit
+			local sep = cb()
+			if sep == 84 or sep == 116 then
+				pos += 1
+			elseif sep == 32 and isDigit(cb(1)) then
+				pos += 1
+			else
+				return result -- date-local
+			end
+			result ..= "T"
+		end
+
+		-- Parse HH:MM[:SS[.frac]]
+		if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit hour") end
+		local hourStr = string.sub(src, pos, pos + 1)
+		pos += 2
+		local hour = tonumber(hourStr) :: number
+		if hour > 23 then err(`invalid hour: {hour}`) end
+		if cb() ~= 58 then err("expected ':' in time") end
+		pos += 1
+		if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit minute") end
+		local minStr = string.sub(src, pos, pos + 1)
+		pos += 2
+		local minute = tonumber(minStr) :: number
+		if minute > 59 then err(`invalid minute: {minute}`) end
+		result ..= `{hourStr}:{minStr}`
+
+		-- Optional seconds (TOML 1.1)
+		local secStr = "00"
+		if cb() == 58 then
+			pos += 1
+			if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit second") end
+			secStr = string.sub(src, pos, pos + 1)
+			pos += 2
+			local sec = tonumber(secStr) :: number
+			if sec > 59 then err(`invalid second: {sec}`) end
+		end
+		result ..= `:{secStr}`
+
+		-- Optional fractional seconds
+		if cb() == 46 then
+			pos += 1
+			if not isDigit(cb()) then err("expected digit after '.' in time") end
+			local fracStart = pos
+			while isDigit(cb()) do pos += 1 end
+			local fracPart = string.sub(src, fracStart, pos - 1)
+			result ..= `.{fracPart}`
+		end
+
+		-- Optional offset: Z, +HH:MM, -HH:MM
+		local oc = cb()
+		if oc == 90 or oc == 122 then
+			if not hasDate then err("offset not allowed in time-local") end
+			pos += 1
+			result ..= "Z"
+		elseif oc == 43 or oc == 45 then
+			if not hasDate then err("offset not allowed in time-local") end
+			local sign = string.char(oc)
+			pos += 1
+			if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit offset hour") end
+			local ohStr = string.sub(src, pos, pos + 1)
+			pos += 2
+			local oh = tonumber(ohStr) :: number
+			if oh > 23 then err(`invalid offset hour: {oh}`) end
+			if cb() ~= 58 then err("expected ':' in offset") end
+			pos += 1
+			if not (isDigit(cb(0)) and isDigit(cb(1))) then err("expected 2-digit offset minute") end
+			local omStr = string.sub(src, pos, pos + 1)
+			pos += 2
+			local om = tonumber(omStr) :: number
+			if om > 59 then err(`invalid offset minute: {om}`) end
+			result ..= `{sign}{ohStr}:{omStr}`
+		end
+
+		return result
+	end
+
+	local parseValue -- forward declaration
+
+	local function parseNumOrDatetime(sign: string?): any
+		local signStr = sign or ""
+		local c = cb()
+
+		-- bare inf / nan
+		if string.sub(src, pos, pos + 2) == "inf" then
+			pos += 3
+			return if signStr == "-" then -math.huge else math.huge
+		end
+		if string.sub(src, pos, pos + 2) == "nan" then
+			pos += 3
+			return 0 / 0
+		end
+
+		if not isDigit(c) then err(`expected digit, got '${string.char(c :: number)}'`) end
+
+		-- prefixed integer bases (no sign allowed)
+		if sign == nil and c == 48 then
+			local nc = cb(1)
+			if nc == 120 then pos += 2; return tonumber(parseDigits(isHexDigit), 16) :: number end -- 0x
+			if nc == 111 then pos += 2; return tonumber(parseDigits(isOctDigit), 8) :: number end -- 0o
+			if nc == 98 then pos += 2; return tonumber(parseDigits(isBinDigit), 2) :: number end -- 0b
+		end
+
+		-- datetime / time detection (no sign)
+		if sign == nil then
+			if looksLikeDate() then return parseDatetime() end
+			if looksLikeTime() then return parseDatetime() end
+		end
+
+		-- decimal integer or float
+		local isZero = c == 48
+		local intDigits: string
+		if isZero then
+			pos += 1
+			if isDigit(cb()) then err("leading zero in integer") end
+			intDigits = "0"
+		else
+			intDigits = parseDigits(isDigit)
+		end
+
+		local nc = cb()
+		local isFloat = false
+		local result = signStr .. intDigits
+
+		if nc == 46 then -- '.'
+			isFloat = true
+			pos += 1
+			if not isDigit(cb()) then err("expected digit after decimal point") end
+			result ..= "." .. parseDigits(isDigit)
+			nc = cb()
+		end
+
+		if nc == 101 or nc == 69 then -- e / E
+			isFloat = true
+			pos += 1
+			local expSign = ""
+			local ec = cb()
+			if ec == 43 or ec == 45 then
+				expSign = string.char(ec :: number)
+				pos += 1
+			end
+			if not isDigit(cb()) then err("expected digit in exponent") end
+			result ..= "e" .. expSign .. parseDigits(isDigit)
+		end
+
+		return if isFloat then tonumber(result) :: number else tonumber(signStr .. intDigits) :: number
+	end
+
+	-- array and inline-table parsers (forward declared for mutual recursion)
+	local parseArray: () -> { any }
+	local parseInlineTable: () -> { [string]: any }
+	local parseKey: () -> { string }
+	local setNestedKey: (tbl: any, parts: { string }, value: any, dottedImplicit: boolean) -> ()
+
+	parseValue = function(): any
+		skipWS()
+		if pos > len then err("expected value") end
+		local c = cb() :: number
+
+		if c == 34 then -- "
+			pos += 1
+			if string.sub(src, pos, pos + 1) == '""' then
+				pos += 2
+				return parseMLBasicString()
+			end
+			return parseBasicString()
+		elseif c == 39 then -- '
+			pos += 1
+			if string.sub(src, pos, pos + 1) == "''" then
+				pos += 2
+				return parseMLLiteralString()
+			end
+			return parseLiteralString()
+		elseif c == 91 then -- [
+			pos += 1
+			return parseArray()
+		elseif c == 123 then -- {
+			pos += 1
+			return parseInlineTable()
+		elseif c == 116 then -- t
+			if string.sub(src, pos, pos + 3) == "true" then
+				pos += 4
+				if isBareKey(cb()) then err("invalid value") end
+				return true
+			end
+			err("invalid value starting with 't'")
+		elseif c == 102 then -- f
+			if string.sub(src, pos, pos + 4) == "false" then
+				pos += 5
+				if isBareKey(cb()) then err("invalid value") end
+				return false
+			end
+			err("invalid value starting with 'f'")
+		elseif c == 105 then -- i
+			if string.sub(src, pos, pos + 2) == "inf" then
+				pos += 3
+				return math.huge
+			end
+			err("invalid value starting with 'i'")
+		elseif c == 110 then -- n
+			if string.sub(src, pos, pos + 2) == "nan" then
+				pos += 3
+				return 0 / 0
+			end
+			err("invalid value starting with 'n'")
+		elseif c == 43 then -- +
+			pos += 1
+			return parseNumOrDatetime("+")
+		elseif c == 45 then -- -
+			pos += 1
+			return parseNumOrDatetime("-")
+		elseif isDigit(c) then
+			return parseNumOrDatetime(nil)
+		else
+			err(`unexpected character '${string.char(c)}' in value`)
+		end
+	end
+
+	parseArray = function(): { any }
+		local result: { any } = {}
+		tableMeta[result] = { kind = "array-value", keys = {} } -- mark as static array
+		skipWSNL()
+		if cb() == 93 then pos += 1; return result end -- empty []
+		while true do
+			skipWSNL()
+			if pos > len then err("unterminated array") end
+			if cb() == 93 then pos += 1; break end -- trailing comma case
+			table.insert(result, parseValue())
+			skipWSNL()
+			if pos > len then err("unterminated array") end
+			local c = cb()
+			if c == 44 then -- ','
+				pos += 1
+			elseif c == 93 then -- ']'
+				pos += 1
+				break
+			else
+				err(`expected ',' or ']' in array, got '${string.char(c :: number)}'`)
+			end
+		end
+		return result
+	end
+
+	parseKey = function(): { string }
+		skipWS()
+		local parts: { string } = {}
+		while true do
+			local c = cb()
+			local part: string
+			if c == 34 then -- "
+				pos += 1
+				part = parseBasicString()
+			elseif c == 39 then -- '
+				pos += 1
+				part = parseLiteralString()
+			elseif isBareKey(c) then
+				local start = pos
+				while pos <= len and isBareKey(cb()) do pos += 1 end
+				part = string.sub(src, start, pos - 1)
+			else
+				if #parts == 0 then
+					err(`expected key, got '${string.char(c :: number or 0)}'`)
+				else
+					err("expected key segment after '.'")
+				end
+			end
+			table.insert(parts, part)
+			skipWS()
+			if cb() == 46 then -- '.'
+				pos += 1
+				skipWS()
+			else
+				break
+			end
+		end
+		return parts
+	end
+
+	-- navigate through dotted intermediate keys, creating tables as needed;
+	-- returns (leaf_table, leaf_key_string)
+	local function navigateDotted(tbl: any, parts: { string }, newKind: string): (any, string)
+		local current = tbl
+		for i = 1, #parts - 1 do
+			local k = parts[i]
+			local child = current[k]
+			if child == nil then
+				local newTbl: any = {}
+				tableMeta[newTbl] = { kind = newKind, keys = {} }
+				current[k] = newTbl
+				getMeta(current).keys[k] = true
+				current = newTbl
+			elseif type(child) == "table" then
+				if arrayTableSets[child] then
+					err(`cannot extend array-of-tables '${k}' via dotted key`)
+				end
+				local m = getMeta(child)
+				if m.kind == "array-value" then
+					err(`cannot navigate through static array value '${k}'`)
+				end
+				if m.kind == "inline" then
+					err(`cannot extend inline table via key '${k}'`)
+				end
+				if m.kind == "defined" or m.kind == "array-element" then
+					err(`cannot extend explicitly-defined table '${k}' via dotted key`)
+				end
+				current = child
+			else
+				err(`key '${k}' is not a table`)
+			end
+		end
+		return current, parts[#parts]
+	end
+
+	setNestedKey = function(tbl: any, parts: { string }, value: any, dottedImplicit: boolean)
+		local newKind = if dottedImplicit then "implicit-dotted" else "implicit-header"
+		local leafTbl, leafKey = navigateDotted(tbl, parts, newKind)
+		local m = getMeta(leafTbl)
+		if m.keys[leafKey] then
+			err(`duplicate key '${leafKey}'`)
+		end
+		m.keys[leafKey] = true
+		leafTbl[leafKey] = value
+		-- tag any freshly assigned table value
+		if type(value) == "table" and not tableMeta[value] then
+			tableMeta[value] = { kind = newKind, keys = {} }
+		end
+	end
+
+	parseInlineTable = function(): { [string]: any }
+		local result: any = {}
+		tableMeta[result] = { kind = "inline", keys = {} }
+		skipWSNL() -- TOML 1.1: newlines allowed inside inline tables
+		if cb() == 125 then pos += 1; return result end -- empty {}
+		while true do
+			skipWSNL()
+			if pos > len then err("unterminated inline table") end
+			if cb() == 125 then pos += 1; break end -- '}' (trailing comma support)
+			local keys = parseKey()
+			skipWS()
+			if cb() ~= 61 then err("expected '=' in inline table") end -- '='
+			pos += 1
+			local value = parseValue()
+			setNestedKey(result, keys, value, false)
+			skipWSNL()
+			if pos > len then err("unterminated inline table") end
+			local c = cb()
+			if c == 44 then -- ','
+				pos += 1
+			elseif c == 125 then -- '}'
+				pos += 1
+				break
+			else
+				err(`expected ',' or '}}' in inline table, got '${string.char(c :: number)}'`)
+			end
+		end
+		return result
+	end
+
+	-- navigate to the table referenced by a [key] or [[key]] header
+	local function navigateToHeader(root: any, parts: { string }, isArrayTable: boolean): any
+		local current = root
+		for i = 1, #parts - 1 do
+			local k = parts[i]
+			local child = current[k]
+			if child == nil then
+				local newTbl: any = {}
+				tableMeta[newTbl] = { kind = "implicit-header", keys = {} }
+				current[k] = newTbl
+				getMeta(current).keys[k] = true
+				current = newTbl
+			elseif type(child) == "table" then
+				if arrayTableSets[child] then
+					current = child[#child]
+				else
+					local m = getMeta(child)
+					if m.kind == "array-value" then
+						err(`key '${k}' is a static array, cannot navigate through it`)
+					end
+					if m.kind == "inline" then
+						err("cannot extend inline table")
+					end
+					current = child
+				end
+			else
+				err(`key '${k}' is not a table`)
+			end
+		end
+
+		local leafKey = parts[#parts]
+		local existing = current[leafKey]
+
+		if isArrayTable then
+			if existing == nil then
+				local arr: any = {}
+				arrayTableSets[arr] = true
+				current[leafKey] = arr
+				getMeta(current).keys[leafKey] = true
+				local entry: any = {}
+				tableMeta[entry] = { kind = "array-element", keys = {} }
+				table.insert(arr, entry)
+				return entry
+			elseif type(existing) == "table" and arrayTableSets[existing] then
+				local entry: any = {}
+				tableMeta[entry] = { kind = "array-element", keys = {} }
+				table.insert(existing, entry)
+				return entry
+			else
+				err(`cannot define [[${leafKey}]]: key already exists as a different type`)
+			end
+		else
+			if existing == nil then
+				local newTbl: any = {}
+				tableMeta[newTbl] = { kind = "defined", keys = {} }
+				current[leafKey] = newTbl
+				getMeta(current).keys[leafKey] = true
+				return newTbl
+			elseif type(existing) == "table" then
+				-- Check arrayTableSets BEFORE getMeta to avoid creating spurious meta
+				if arrayTableSets[existing] then
+					err(`cannot define [${leafKey}]: already an array-of-tables`)
+				end
+				local m = getMeta(existing)
+				if m.kind == "array-value" then
+					err(`cannot define [${leafKey}]: key is a static array value`)
+				end
+				if m.kind == "implicit-header" then
+					m.kind = "defined"
+					return existing
+				elseif m.kind == "defined" then
+					err(`duplicate table header [${leafKey}]`)
+				elseif m.kind == "inline" then
+					err("cannot extend inline table with a table header")
+				elseif m.kind == "implicit-dotted" then
+					err(`table [${leafKey}] was already defined via a dotted key`)
+				elseif m.kind == "array-element" then
+					err(`cannot define [${leafKey}]: already an array-of-tables element`)
+				else
+					err(`cannot redefine [${leafKey}]`)
+				end
+			else
+				err(`key '${leafKey}' is not a table`)
+			end
+		end
+	end
+
+	-- main parse loop
+
+	local root: any = {}
+	tableMeta[root] = { kind = "root", keys = {} }
+	local currentTable = root
+
+	while pos <= len do
+		skipWSNL()
+		if pos > len then break end
+
+		local c = cb() :: number
+
+		if c == 91 then -- '['
+			if cb(1) == 91 then -- '[['
+				pos += 2
+				skipWS()
+				local parts = parseKey()
+				skipWS()
+				if string.sub(src, pos, pos + 1) ~= "]]" then err("expected ']]'") end
+				pos += 2
+				expectLineEnd()
+				currentTable = navigateToHeader(root, parts, true)
+			else
+				pos += 1
+				skipWS()
+				local parts = parseKey()
+				skipWS()
+				if cb() ~= 93 then err("expected ']'") end -- ']'
+				pos += 1
+				expectLineEnd()
+				currentTable = navigateToHeader(root, parts, false)
+			end
+		else
+			local parts = parseKey()
+			skipWS()
+			if cb() ~= 61 then err("expected '='") end -- '='
+			pos += 1
+			local value = parseValue()
+			setNestedKey(currentTable, parts, value, true)
+			expectLineEnd()
+		end
+	end
+
+	return root
 end
 
 -- user-facing

--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -207,6 +207,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if not tableMeta[tbl] then
 			tableMeta[tbl] = { kind = "implicit-header", keys = {} }
 		end
+
 		return tableMeta[tbl]
 	end
 
@@ -1093,7 +1094,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if c == 110 then -- n
 			if string.sub(src, pos, pos + 2) == "nan" then
 				pos += 3
-				return  math.nan
+				return math.nan
 			end
 
 			tomlParseError("invalid value starting with 'n'")

--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -82,8 +82,10 @@ end
 
 local function deserialize(input: string): { [string]: unknown }
 	-- Reject bare CR (only CRLF → LF is allowed)
-	input = input:gsub("\r\n", "\n")
-	if input:find("\r") then
+	if input:find("\r\n", 1, true) then
+		input = input:gsub("\r\n", "\n")
+	end
+	if input:find("\r", 1, true) then
 		error("TOML parse error: bare carriage return (\\r) not allowed")
 	end
 
@@ -169,18 +171,20 @@ local function deserialize(input: string): { [string]: unknown }
 	local srcBuf = buffer.fromstring(src)
 
 	-- Table metadata: maps table reference -> { kind, keys }
-	-- kind values:
-	--   "root"             – the document root
-	--   "defined"          – created by an explicit [header]
-	--   "implicit-header"  – implicitly created while navigating a [a.b.c] path
-	--   "implicit-dotted"  – implicitly created by a dotted key assignment (a.b = v)
-	--   "inline"           – an inline table; immutable after creation
-	--   "array-element"    – an element of an [[array-of-tables]]
-	local tableMeta: { [any]: { kind: string, keys: { [string]: boolean } } } = {}
+	type TableKind =
+		| "root" -- the document root
+		| "defined" -- created by an explicit [header]
+		| "implicit-header" -- implicitly created while navigating a [a.b.c] path
+		| "implicit-dotted" -- implicitly created by a dotted key assignment (a.b = v)
+		| "inline" -- an inline table; immutable after creation
+		| "array-element" -- an element of an [[array-of-tables]]
+		| "array-value" -- a static array literal (cannot be navigated into)
+	type TableMeta = { kind: TableKind, keys: { [string]: boolean } }
+	local tableMeta: { [any]: TableMeta } = {}
 	-- tracks which Lua arrays are array-of-tables (vs regular array values)
 	local arrayTableSets: { [any]: boolean } = {}
 
-	local function getMeta(tbl: any): { kind: string, keys: { [string]: boolean } }
+	local function getMeta(tbl: any): TableMeta
 		if not tableMeta[tbl] then
 			tableMeta[tbl] = { kind = "implicit-header", keys = {} }
 		end
@@ -220,10 +224,6 @@ local function deserialize(input: string): { [string]: unknown }
 		return (c >= 97 and c <= 122) or (c >= 65 and c <= 90) or (c >= 48 and c <= 57) or c == 95 or c == 45
 	end
 
-	local function isWS(c: number?): boolean
-		return c == 32 or c == 9
-	end
-
 	-- control characters that are forbidden unescaped (everything < 0x20 except tab,
 	-- plus DEL 0x7F; LF 0x0A is handled separately per context)
 	local function isCtrl(c: number?): boolean
@@ -248,7 +248,7 @@ local function deserialize(input: string): { [string]: unknown }
 		while pos <= len do
 			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 10 then break end
-			if c <= 8 or c == 11 or c == 12 or (c >= 14 and c <= 31) or c == 127 then
+			if isCtrl(c) then
 				err("control character in comment")
 			end
 			pos += 1
@@ -486,33 +486,35 @@ local function deserialize(input: string): { [string]: unknown }
 	-- parse a run of digits (with internal underscores allowed), return digits-only string
 	local function parseDigits(digitCheck: (number?) -> boolean): string
 		if not digitCheck(cb()) then err("expected digit") end
-		local parts = { string.char(cb() :: number) }
-		pos += 1
+		local result = ""
+		local runStart = pos
 		while pos <= len do
-			local c = cb()
-			if c == 95 then -- underscore
+			local c = buffer.readu8(srcBuf, pos - 1)
+			if digitCheck(c) then
 				pos += 1
-				if cb() == 95 then err("consecutive underscores in number") end
-				if not digitCheck(cb()) then err("trailing underscore in number") end
-				table.insert(parts, string.char(cb() :: number))
+			elseif c == 95 then -- underscore
+				result ..= string.sub(src, runStart, pos - 1)
 				pos += 1
-			elseif digitCheck(c) then
-				table.insert(parts, string.char(c :: number))
-				pos += 1
+				if pos > len then err("trailing underscore in number") end
+				local nc = buffer.readu8(srcBuf, pos - 1)
+				if nc == 95 then err("consecutive underscores in number") end
+				if not digitCheck(nc) then err("trailing underscore in number") end
+				runStart = pos
 			else
 				break
 			end
 		end
-		return table.concat(parts)
+		result ..= string.sub(src, runStart, pos - 1)
+		return result
 	end
 
 	local function looksLikeDate(): boolean
 		-- YYYY- : 4 decimal digits followed by '-'
 		if pos + 4 > len then return false end
 		for i = 0, 3 do
-			if not isDigit(string.byte(src, pos + i)) then return false end
+			if not isDigit(buffer.readu8(srcBuf, pos + i - 1)) then return false end
 		end
-		return string.byte(src, pos + 4) == 45
+		return buffer.readu8(srcBuf, pos + 3) == 45
 	end
 
 	local function looksLikeTime(): boolean
@@ -709,7 +711,7 @@ local function deserialize(input: string): { [string]: unknown }
 	local parseArray: () -> { any }
 	local parseInlineTable: () -> { [string]: any }
 	local parseKey: () -> { string }
-	local setNestedKey: (tbl: any, parts: { string }, value: any, dottedImplicit: boolean) -> ()
+	local setNestedKey: (tbl: any, parts: { string }, value: any, fromDottedKey: boolean) -> ()
 
 	parseValue = function(): any
 		skipWS()
@@ -816,9 +818,7 @@ local function deserialize(input: string): { [string]: unknown }
 				local start = pos
 				while pos <= len do
 					local c2 = buffer.readu8(srcBuf, pos - 1)
-					if not ((c2 >= 97 and c2 <= 122) or (c2 >= 65 and c2 <= 90) or (c2 >= 48 and c2 <= 57) or c2 == 95 or c2 == 45) then
-						break
-					end
+					if not isBareKey(c2) then break end
 					pos += 1
 				end
 				part = string.sub(src, start, pos - 1)
@@ -843,7 +843,7 @@ local function deserialize(input: string): { [string]: unknown }
 
 	-- navigate through dotted intermediate keys, creating tables as needed;
 	-- returns (leaf_table, leaf_key_string)
-	local function navigateDotted(tbl: any, parts: { string }, newKind: string): (any, string)
+	local function navigateDotted(tbl: any, parts: { string }, newKind: TableKind): (any, string)
 		local current = tbl
 		for i = 1, #parts - 1 do
 			local k = parts[i]
@@ -876,8 +876,8 @@ local function deserialize(input: string): { [string]: unknown }
 		return current, parts[#parts]
 	end
 
-	setNestedKey = function(tbl: any, parts: { string }, value: any, dottedImplicit: boolean)
-		local newKind = if dottedImplicit then "implicit-dotted" else "implicit-header"
+	setNestedKey = function(tbl: any, parts: { string }, value: any, fromDottedKey: boolean)
+		local newKind = if fromDottedKey then "implicit-dotted" else "implicit-header"
 		local leafTbl, leafKey = navigateDotted(tbl, parts, newKind)
 		local m = getMeta(leafTbl)
 		if m.keys[leafKey] then

--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -328,6 +328,8 @@ local function deserialize(input: string): { [string]: TomlValue }
 		elseif c == 85 then return parseUnicodeEscape(true) -- \UXXXXXXXX
 		elseif c == 120 then return parseHexEscape() -- \xXX  (TOML 1.1)
 		else tomlParseError(`invalid escape sequence \\${string.char(c)}`) end
+		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
+		error("unreachable")
 	end
 
 	-- string parsers (pos is always past the opening delimiter on entry)
@@ -361,6 +363,8 @@ local function deserialize(input: string): { [string]: TomlValue }
 			end
 		end
 		tomlParseError("unterminated basic string")
+		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
+		error("unreachable")
 	end
 
 	local function parseMLBasicString(): string
@@ -423,6 +427,8 @@ local function deserialize(input: string): { [string]: TomlValue }
 			end
 		end
 		tomlParseError("unterminated multiline basic string")
+		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
+		error("unreachable")
 	end
 
 	local function parseLiteralString(): string
@@ -442,6 +448,8 @@ local function deserialize(input: string): { [string]: TomlValue }
 			end
 		end
 		tomlParseError("unterminated literal string")
+		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
+		error("unreachable")
 	end
 
 	local function parseMLLiteralString(): string
@@ -481,6 +489,8 @@ local function deserialize(input: string): { [string]: TomlValue }
 			end
 		end
 		tomlParseError("unterminated multiline literal string")
+		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
+		error("unreachable")
 	end
 
 	-- number / datetime helpers
@@ -777,6 +787,8 @@ local function deserialize(input: string): { [string]: TomlValue }
 		else
 			tomlParseError(`unexpected character '${string.char(c)}' in value`)
 		end
+		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
+		error("unreachable")
 	end
 
 	parseArray = function(): { TomlValue }
@@ -1008,6 +1020,8 @@ local function deserialize(input: string): { [string]: TomlValue }
 				tomlParseError(`key '${leafKey}' is not a table`)
 			end
 		end
+		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
+		error("unreachable")
 	end
 
 	-- main parse loop

--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -235,6 +235,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if c == nil then
 			return false
 		end
+
 		return (c >= 97 and c <= 122) or (c >= 65 and c <= 90) or (c >= 48 and c <= 57) or c == 95 or c == 45
 	end
 
@@ -244,6 +245,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if c == nil then
 			return false
 		end
+
 		return c <= 8 or c == 11 or c == 12 or (c >= 14 and c <= 31) or c == 127
 	end
 
@@ -252,9 +254,11 @@ local function deserialize(input: string): { [string]: TomlValue }
 	local function skipWhitespace()
 		while pos <= len do
 			local c = buffer.readu8(srcBuf, pos - 1)
+
 			if c ~= 32 and c ~= 9 then
 				break
 			end
+
 			pos += 1
 		end
 	end
@@ -264,15 +268,20 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if byteAt() ~= 35 then
 			return
 		end -- '#'
+
 		pos += 1
+
 		while pos <= len do
 			local c = buffer.readu8(srcBuf, pos - 1)
+
 			if c == 10 then
 				break
 			end
+
 			if isControlCharacter(c) then
 				tomlParseError("control character in comment")
 			end
+
 			pos += 1
 		end
 	end
@@ -281,6 +290,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 	local function skipWhitespaceNewlinesAndComments()
 		while pos <= len do
 			local c = buffer.readu8(srcBuf, pos - 1)
+
 			if c == 32 or c == 9 or c == 10 then
 				pos += 1
 			elseif c == 35 then
@@ -295,9 +305,11 @@ local function deserialize(input: string): { [string]: TomlValue }
 	local function expectLineEnd()
 		skipWhitespace()
 		skipComment()
+
 		if pos > len then
 			return
 		end
+
 		local c = byteAt()
 		if c == 10 then
 			pos += 1
@@ -311,32 +323,42 @@ local function deserialize(input: string): { [string]: TomlValue }
 	local function parseUnicodeEscape(long: boolean): string
 		local n = if long then 8 else 4
 		local hexStr = string.sub(src, pos, pos + n - 1)
+
 		if #hexStr < n then
 			tomlParseError("incomplete unicode escape")
 		end
+
 		for i = 1, n do
 			if not isHexDigit(string.byte(hexStr, i)) then
 				tomlParseError("invalid hex digit in unicode escape")
 			end
 		end
+
 		pos += n
+
 		local cp = tonumber(hexStr, 16) :: number
+
 		if cp >= 0xD800 and cp <= 0xDFFF then
 			tomlParseError("surrogate codepoint in unicode escape")
 		end
+
 		if cp > 0x10FFFF then
 			tomlParseError("unicode codepoint out of range")
 		end
+
 		return utf8.char(cp)
 	end
 
 	-- \xXX escape (TOML 1.1): unicode codepoint U+0000..U+00FF
 	local function parseHexEscape(): string
 		local hexStr = string.sub(src, pos, pos + 1)
+
 		if #hexStr < 2 or not isHexDigit(string.byte(hexStr, 1)) or not isHexDigit(string.byte(hexStr, 2)) then
 			tomlParseError("invalid \\x escape")
 		end
+
 		pos += 2
+
 		return utf8.char(tonumber(hexStr, 16) :: number)
 	end
 
@@ -344,33 +366,55 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if pos > len then
 			tomlParseError("incomplete escape sequence")
 		end
+
 		local c = byteAt() :: number
 		pos += 1
+
 		if c == 98 then
 			return "\b"
-		elseif c == 116 then
-			return "\t"
-		elseif c == 110 then
-			return "\n"
-		elseif c == 102 then
-			return "\f"
-		elseif c == 114 then
-			return "\r"
-		elseif c == 34 then
-			return '"'
-		elseif c == 92 then
-			return "\\"
-		elseif c == 101 then
-			return "\x1B" -- \e  (TOML 1.1)
-		elseif c == 117 then
-			return parseUnicodeEscape(false) -- \uXXXX
-		elseif c == 85 then
-			return parseUnicodeEscape(true) -- \UXXXXXXXX
-		elseif c == 120 then
-			return parseHexEscape() -- \xXX  (TOML 1.1)
-		else
-			tomlParseError(`invalid escape sequence \\${string.char(c)}`)
 		end
+
+		if c == 116 then
+			return "\t"
+		end
+
+		if c == 110 then
+			return "\n"
+		end
+
+		if c == 102 then
+			return "\f"
+		end
+
+		if c == 114 then
+			return "\r"
+		end
+
+		if c == 34 then
+			return '"'
+		end
+
+		if c == 92 then
+			return "\\"
+		end
+
+		if c == 101 then
+			return "\x1B"
+		end -- \e  (TOML 1.1)
+
+		if c == 117 then
+			return parseUnicodeEscape(false)
+		end -- \uXXXX
+
+		if c == 85 then
+			return parseUnicodeEscape(true)
+		end -- \UXXXXXXXX
+
+		if c == 120 then
+			return parseHexEscape()
+		end -- \xXX  (TOML 1.1)
+
+		tomlParseError(`invalid escape sequence \\${string.char(c)}`)
 		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
 		error("unreachable")
 	end
@@ -379,35 +423,48 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	local function parseBasicString(): string
 		local parts = {}
+
 		while pos <= len do
 			-- Fast path: scan forward over plain characters in one go
 			local runStart = pos
+
 			while pos <= len do
 				local c2 = buffer.readu8(srcBuf, pos - 1)
+
 				-- break on: " (34), \ (92), DEL (127), ctrl chars except tab (9)
 				if c2 == 34 or c2 == 92 or c2 == 127 or (c2 < 32 and c2 ~= 9) then
 					break
 				end
+
 				pos += 1
 			end
+
 			if pos > runStart then
 				table.insert(parts, string.sub(src, runStart, pos - 1))
 			end
+
 			if pos > len then
 				break
 			end
+
 			local c = buffer.readu8(srcBuf, pos - 1)
+
 			if c == 34 then -- closing "
 				pos += 1
 				return table.concat(parts)
-			elseif c == 92 then -- backslash
+			end
+
+			if c == 92 then -- backslash
 				pos += 1
 				table.insert(parts, parseEscape())
-			elseif c == 10 then
-				tomlParseError("unescaped newline in basic string")
-			else
-				tomlParseError("unescaped control character in basic string")
+				continue
 			end
+
+			if c == 10 then
+				tomlParseError("unescaped newline in basic string")
+			end
+
+			tomlParseError("unescaped control character in basic string")
 		end
 
 		tomlParseError("unterminated basic string")
@@ -423,50 +480,69 @@ local function deserialize(input: string): { [string]: TomlValue }
 		end
 
 		local parts = {}
+
 		while pos <= len do
 			-- Fast path: scan over plain chars (LF and tab are literal content too)
 			local runStart = pos
+
 			while pos <= len do
 				local c2 = buffer.readu8(srcBuf, pos - 1)
+
 				-- break on: " (34), \ (92), DEL (127), ctrl except tab (9) and LF (10)
 				if c2 == 34 or c2 == 92 or c2 == 127 or (c2 < 32 and c2 ~= 9 and c2 ~= 10) then
 					break
 				end
+
 				pos += 1
 			end
+
 			if pos > runStart then
 				table.insert(parts, string.sub(src, runStart, pos - 1))
 			end
+
 			if pos > len then
 				break
 			end
+
 			local c = buffer.readu8(srcBuf, pos - 1)
+
 			if c == 34 then
 				if string.sub(src, pos, pos + 2) == '"""' then
 					pos += 3
 					local extra = 0
+
 					while pos <= len and buffer.readu8(srcBuf, pos - 1) == 34 and extra < 2 do
 						table.insert(parts, '"')
 						pos += 1
 						extra += 1
 					end
+
 					return table.concat(parts)
-				else
-					-- lone " is valid content in a multiline basic string
-					table.insert(parts, '"')
-					pos += 1
 				end
-			elseif c == 92 then -- backslash
+
+				-- lone " is valid content in a multiline basic string
+				table.insert(parts, '"')
 				pos += 1
+
+				continue
+			end
+
+			if c == 92 then -- backslash
+				pos += 1
+
 				-- peek past trailing horizontal whitespace to detect line-ending backslash
 				local peek = pos
+
 				while peek <= len do
 					local pc = buffer.readu8(srcBuf, peek - 1)
+
 					if pc ~= 32 and pc ~= 9 then
 						break
 					end
+
 					peek += 1
 				end
+
 				if peek <= len and buffer.readu8(srcBuf, peek - 1) == 10 then
 					-- line-ending backslash: skip newline and all following whitespace and newlines
 					pos = peek + 1
@@ -482,9 +558,12 @@ local function deserialize(input: string): { [string]: TomlValue }
 				else
 					table.insert(parts, parseEscape())
 				end
-			else -- ctrl char or DEL
-				tomlParseError("unescaped control character in multiline basic string")
+
+				continue
 			end
+
+			-- ctrl char or DEL
+			tomlParseError("unescaped control character in multiline basic string")
 		end
 
 		tomlParseError("unterminated multiline basic string")
@@ -495,19 +574,25 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 	local function parseLiteralString(): string
 		local start = pos
+
 		while pos <= len do
 			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 39 then -- closing '
 				local result = string.sub(src, start, pos - 1)
 				pos += 1
 				return result
-			elseif c == 9 or (c >= 32 and c ~= 127) or c >= 128 then
-				pos += 1 -- plain char (tab, printable ASCII, or multibyte UTF-8)
-			elseif c == 10 then
-				tomlParseError("unescaped newline in literal string")
-			else
-				tomlParseError("unescaped control character in literal string")
 			end
+
+			if c == 9 or (c >= 32 and c ~= 127) or c >= 128 then
+				pos += 1 -- plain char (tab, printable ASCII, or multibyte UTF-8)
+				continue
+			end
+
+			if c == 10 then
+				tomlParseError("unescaped newline in literal string")
+			end
+
+			tomlParseError("unescaped control character in literal string")
 		end
 
 		tomlParseError("unterminated literal string")
@@ -520,7 +605,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if byteAt() == 10 then
 			pos += 1
 		end -- trim leading newline
+
 		local parts = {}
+
 		while pos <= len do
 			-- Fast path: scan over plain chars (LF and tab are literal content)
 			local runStart = pos
@@ -532,12 +619,15 @@ local function deserialize(input: string): { [string]: TomlValue }
 				end
 				pos += 1
 			end
+
 			if pos > runStart then
 				table.insert(parts, string.sub(src, runStart, pos - 1))
 			end
+
 			if pos > len then
 				break
 			end
+
 			local c = buffer.readu8(srcBuf, pos - 1)
 			if c == 39 then
 				if string.sub(src, pos, pos + 2) == "'''" then
@@ -549,14 +639,15 @@ local function deserialize(input: string): { [string]: TomlValue }
 						extra += 1
 					end
 					return table.concat(parts)
-				else
-					-- lone ' is valid content in a multiline literal string
-					table.insert(parts, "'")
-					pos += 1
 				end
-			else -- ctrl char or DEL
-				tomlParseError("unescaped control character in multiline literal string")
+				-- lone ' is valid content in a multiline literal string
+				table.insert(parts, "'")
+				pos += 1
+				continue
 			end
+
+			-- ctrl char or DEL
+			tomlParseError("unescaped control character in multiline literal string")
 		end
 
 		tomlParseError("unterminated multiline literal string")
@@ -572,30 +663,38 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if not digitCheck(byteAt()) then
 			tomlParseError("expected digit")
 		end
+
 		local result = ""
 		local runStart = pos
+
 		while pos <= len do
 			local c = buffer.readu8(srcBuf, pos - 1)
+
 			if digitCheck(c) then
 				pos += 1
 			elseif c == 95 then -- underscore
 				result ..= string.sub(src, runStart, pos - 1)
 				pos += 1
+
 				if pos > len then
 					tomlParseError("trailing underscore in number")
 				end
+
 				local nc = buffer.readu8(srcBuf, pos - 1)
 				if nc == 95 then
 					tomlParseError("consecutive underscores in number")
 				end
+
 				if not digitCheck(nc) then
 					tomlParseError("trailing underscore in number")
 				end
+
 				runStart = pos
 			else
 				break
 			end
 		end
+
 		result ..= string.sub(src, runStart, pos - 1)
 		return result
 	end
@@ -605,11 +704,13 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if pos + 4 > len then
 			return false
 		end
+
 		for i = 0, 3 do
 			if not isDigit(buffer.readu8(srcBuf, pos + i - 1)) then
 				return false
 			end
 		end
+
 		return buffer.readu8(srcBuf, pos + 3) == 45
 	end
 
@@ -623,11 +724,13 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if month == 2 then
 			local isLeap = (year % 4 == 0 and year % 100 ~= 0) or (year % 400 == 0)
 			return if isLeap then 29 else 28
-		elseif month == 4 or month == 6 or month == 9 or month == 11 then
-			return 30
-		else
-			return 31
 		end
+
+		if month == 4 or month == 6 or month == 9 or month == 11 then
+			return 30
+		end
+
+		return 31
 	end
 
 	local function parseDatetime(): string
@@ -638,33 +741,44 @@ local function deserialize(input: string): { [string]: TomlValue }
 			-- Parse YYYY-MM-DD
 			local yearStr = string.sub(src, pos, pos + 3)
 			pos += 4
+
 			if byteAt() ~= 45 then
 				tomlParseError("expected '-' in date")
 			end
+
 			pos += 1
+
 			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
 				tomlParseError("expected 2-digit month")
 			end
+
 			local monthStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local month = tonumber(monthStr) :: number
+
 			if month < 1 or month > 12 then
 				tomlParseError(`invalid month: {month}`)
 			end
+
 			if byteAt() ~= 45 then
 				tomlParseError("expected '-' in date")
 			end
+
 			pos += 1
+
 			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
 				tomlParseError("expected 2-digit day")
 			end
+
 			local dayStr = string.sub(src, pos, pos + 1)
 			pos += 2
+
 			local day = tonumber(dayStr) :: number
 			local year = tonumber(yearStr) :: number
 			if day < 1 or day > daysInMonth(year, month) then
 				tomlParseError(`invalid day {day} for month {month}`)
 			end
+
 			result = `{yearStr}-{monthStr}-{dayStr}`
 
 			-- Optional datetime separator: T, t, or space followed by digit
@@ -676,6 +790,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 			else
 				return result -- date-local
 			end
+
 			result ..= "T"
 		end
 
@@ -683,34 +798,41 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
 			tomlParseError("expected 2-digit hour")
 		end
+
 		local hourStr = string.sub(src, pos, pos + 1)
 		pos += 2
 		local hour = tonumber(hourStr) :: number
 		if hour > 23 then
 			tomlParseError(`invalid hour: {hour}`)
 		end
+
 		if byteAt() ~= 58 then
 			tomlParseError("expected ':' in time")
 		end
+
 		pos += 1
 		if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
 			tomlParseError("expected 2-digit minute")
 		end
+
 		local minStr = string.sub(src, pos, pos + 1)
 		pos += 2
 		local minute = tonumber(minStr) :: number
 		if minute > 59 then
 			tomlParseError(`invalid minute: {minute}`)
 		end
+
 		result ..= `{hourStr}:{minStr}`
 
 		-- Optional seconds (TOML 1.1)
 		local secStr = "00"
 		if byteAt() == 58 then
 			pos += 1
+
 			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
 				tomlParseError("expected 2-digit second")
 			end
+
 			secStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local sec = tonumber(secStr) :: number
@@ -723,13 +845,16 @@ local function deserialize(input: string): { [string]: TomlValue }
 		-- Optional fractional seconds
 		if byteAt() == 46 then
 			pos += 1
+
 			if not isDigit(byteAt()) then
 				tomlParseError("expected digit after '.' in time")
 			end
+
 			local fracStart = pos
 			while isDigit(byteAt()) do
 				pos += 1
 			end
+
 			local fracPart = string.sub(src, fracStart, pos - 1)
 			result ..= `.{fracPart}`
 		end
@@ -740,36 +865,46 @@ local function deserialize(input: string): { [string]: TomlValue }
 			if not hasDate then
 				tomlParseError("offset not allowed in time-local")
 			end
+
 			pos += 1
 			result ..= "Z"
 		elseif oc == 43 or oc == 45 then
 			if not hasDate then
 				tomlParseError("offset not allowed in time-local")
 			end
+
 			local sign = string.char(oc :: number)
+
 			pos += 1
+
 			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
 				tomlParseError("expected 2-digit offset hour")
 			end
+
 			local ohStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local oh = tonumber(ohStr) :: number
 			if oh > 23 then
 				tomlParseError(`invalid offset hour: {oh}`)
 			end
+
 			if byteAt() ~= 58 then
 				tomlParseError("expected ':' in offset")
 			end
+
 			pos += 1
+
 			if not (isDigit(byteAt(0)) and isDigit(byteAt(1))) then
 				tomlParseError("expected 2-digit offset minute")
 			end
+
 			local omStr = string.sub(src, pos, pos + 1)
 			pos += 2
 			local om = tonumber(omStr) :: number
 			if om > 59 then
 				tomlParseError(`invalid offset minute: {om}`)
 			end
+
 			result ..= `{sign}{ohStr}:{omStr}`
 		end
 
@@ -787,6 +922,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 			pos += 3
 			return if signStr == "-" then -math.huge else math.huge
 		end
+
 		if string.sub(src, pos, pos + 2) == "nan" then
 			pos += 3
 			return 0 / 0
@@ -803,10 +939,12 @@ local function deserialize(input: string): { [string]: TomlValue }
 				pos += 2
 				return tonumber(parseDigits(isHexDigit), 16) :: number
 			end -- 0x
+
 			if nc == 111 then
 				pos += 2
 				return tonumber(parseDigits(isOctDigit), 8) :: number
 			end -- 0o
+
 			if nc == 98 then
 				pos += 2
 				return tonumber(parseDigits(isBinDigit), 2) :: number
@@ -818,6 +956,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 			if looksLikeDate() then
 				return parseDatetime()
 			end
+
 			if looksLikeTime() then
 				return parseDatetime()
 			end
@@ -828,9 +967,11 @@ local function deserialize(input: string): { [string]: TomlValue }
 		local intDigits: string
 		if isZero then
 			pos += 1
+
 			if isDigit(byteAt()) then
 				tomlParseError("leading zero in integer")
 			end
+
 			intDigits = "0"
 		else
 			intDigits = parseDigits(isDigit)
@@ -887,23 +1028,29 @@ local function deserialize(input: string): { [string]: TomlValue }
 				pos += 2
 				return parseMultilineBasicString()
 			end
-
 			return parseBasicString()
-		elseif c == 39 then -- '
+		end
+
+		if c == 39 then -- '
 			pos += 1
 			if string.sub(src, pos, pos + 1) == "''" then
 				pos += 2
 				return parseMultilineLiteralString()
 			end
-
 			return parseLiteralString()
-		elseif c == 91 then -- [
+		end
+
+		if c == 91 then -- [
 			pos += 1
 			return parseArray()
-		elseif c == 123 then -- {
+		end
+
+		if c == 123 then -- {
 			pos += 1
 			return parseInlineTable()
-		elseif c == 116 then -- t
+		end
+
+		if c == 116 then -- t
 			if string.sub(src, pos, pos + 3) == "true" then
 				pos += 4
 				if isBareKey(byteAt()) then
@@ -911,9 +1058,10 @@ local function deserialize(input: string): { [string]: TomlValue }
 				end
 				return true
 			end
-
 			tomlParseError("invalid value starting with 't'")
-		elseif c == 102 then -- f
+		end
+
+		if c == 102 then -- f
 			if string.sub(src, pos, pos + 4) == "false" then
 				pos += 5
 				if isBareKey(byteAt()) then
@@ -921,34 +1069,40 @@ local function deserialize(input: string): { [string]: TomlValue }
 				end
 				return false
 			end
-
 			tomlParseError("invalid value starting with 'f'")
-		elseif c == 105 then -- i
+		end
+
+		if c == 105 then -- i
 			if string.sub(src, pos, pos + 2) == "inf" then
 				pos += 3
 				return math.huge
 			end
-
 			tomlParseError("invalid value starting with 'i'")
-		elseif c == 110 then -- n
+		end
+
+		if c == 110 then -- n
 			if string.sub(src, pos, pos + 2) == "nan" then
 				pos += 3
 				return 0 / 0
 			end
-
 			tomlParseError("invalid value starting with 'n'")
-		elseif c == 43 then -- +
-			pos += 1
-			return parseNumOrDatetime("+")
-		elseif c == 45 then -- -
-			pos += 1
-			return parseNumOrDatetime("-")
-		elseif isDigit(c) then
-			return parseNumOrDatetime(nil)
-		else
-			tomlParseError(`unexpected character '${string.char(c)}' in value`)
 		end
 
+		if c == 43 then -- +
+			pos += 1
+			return parseNumOrDatetime("+")
+		end
+
+		if c == 45 then -- -
+			pos += 1
+			return parseNumOrDatetime("-")
+		end
+
+		if isDigit(c) then
+			return parseNumOrDatetime(nil)
+		end
+
+		tomlParseError(`unexpected character '${string.char(c)}' in value`)
 		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
 		error("unreachable")
 	end
@@ -956,6 +1110,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 	parseArray = function(): { TomlValue }
 		local result: { TomlValue } = {}
 		tableMeta[result] = { kind = "array-value", keys = {} } -- mark as static array
+
 		skipWhitespaceNewlinesAndComments()
 		if byteAt() == 93 then
 			pos += 1
@@ -967,24 +1122,32 @@ local function deserialize(input: string): { [string]: TomlValue }
 			if pos > len then
 				tomlParseError("unterminated array")
 			end
+
 			if byteAt() == 93 then
 				pos += 1
 				break
 			end -- trailing comma case
+
 			table.insert(result, parseValue())
+
 			skipWhitespaceNewlinesAndComments()
+
 			if pos > len then
 				tomlParseError("unterminated array")
 			end
+
 			local c = byteAt()
 			if c == 44 then -- ','
 				pos += 1
-			elseif c == 93 then -- ']'
+				continue
+			end
+
+			if c == 93 then -- ']'
 				pos += 1
 				break
-			else
-				tomlParseError(`expected ',' or ']' in array, got '${string.char(c :: number)}'`)
 			end
+
+			tomlParseError(`expected ',' or ']' in array, got '${string.char(c :: number)}'`)
 		end
 
 		return result
@@ -993,9 +1156,11 @@ local function deserialize(input: string): { [string]: TomlValue }
 	parseKey = function(): { string }
 		skipWhitespace()
 		local parts: { string } = {}
+
 		while true do
 			local c = byteAt()
 			local part: string
+
 			if c == 34 then -- "
 				pos += 1
 				part = parseBasicString()
@@ -1004,6 +1169,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 				part = parseLiteralString()
 			elseif isBareKey(c) then
 				local start = pos
+
 				while pos <= len do
 					local c2 = buffer.readu8(srcBuf, pos - 1)
 					if not isBareKey(c2) then
@@ -1011,6 +1177,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 					end
 					pos += 1
 				end
+
 				part = string.sub(src, start, pos - 1)
 			else
 				if #parts == 0 then
@@ -1019,7 +1186,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 					tomlParseError("expected key segment after '.'")
 				end
 			end
+
 			table.insert(parts, part)
+
 			skipWhitespace()
 			if byteAt() == 46 then -- '.'
 				pos += 1
@@ -1040,9 +1209,11 @@ local function deserialize(input: string): { [string]: TomlValue }
 		newKind: TableKind
 	): ({ [string]: TomlValue }, string)
 		local current: { [string]: TomlValue } = tbl
+
 		for i = 1, #parts - 1 do
 			local k = parts[i]
 			local child = current[k]
+
 			if child == nil then
 				local newTbl: { [string]: TomlValue } = {}
 				tableMeta[newTbl] = { kind = newKind, keys = {} }
@@ -1053,16 +1224,21 @@ local function deserialize(input: string): { [string]: TomlValue }
 				if arrayTableSets[child] then
 					tomlParseError(`cannot extend array-of-tables '${k}' via dotted key`)
 				end
+
 				local m = getMeta(child)
+
 				if m.kind == "array-value" then
 					tomlParseError(`cannot navigate through static array value '${k}'`)
 				end
+
 				if m.kind == "inline" then
 					tomlParseError(`cannot extend inline table via key '${k}'`)
 				end
+
 				if m.kind == "defined" or m.kind == "array-element" then
 					tomlParseError(`cannot extend explicitly-defined table '${k}' via dotted key`)
 				end
+
 				current = child :: { [string]: TomlValue }
 			else
 				tomlParseError(`key '${k}' is not a table`)
@@ -1074,12 +1250,16 @@ local function deserialize(input: string): { [string]: TomlValue }
 	setNestedKey = function(tbl: { [string]: TomlValue }, parts: { string }, value: TomlValue, fromDottedKey: boolean)
 		local newKind = if fromDottedKey then "implicit-dotted" else "implicit-header"
 		local leafTbl, leafKey = navigateDotted(tbl, parts, newKind)
+
 		local m = getMeta(leafTbl)
+
 		if m.keys[leafKey] then
 			tomlParseError(`duplicate key '${leafKey}'`)
 		end
+
 		m.keys[leafKey] = true
 		leafTbl[leafKey] = value
+
 		-- tag any freshly assigned table value
 		if typeof(value) == "table" and not tableMeta[value] then
 			tableMeta[value] = { kind = newKind, keys = {} }
@@ -1090,40 +1270,52 @@ local function deserialize(input: string): { [string]: TomlValue }
 		local result: { [string]: TomlValue } = {}
 		tableMeta[result] = { kind = "inline", keys = {} }
 		skipWhitespaceNewlinesAndComments() -- TOML 1.1: newlines allowed inside inline tables
+
 		if byteAt() == 125 then
 			pos += 1
 			return result
 		end -- empty {}
+
 		while true do
 			skipWhitespaceNewlinesAndComments()
 			if pos > len then
 				tomlParseError("unterminated inline table")
 			end
+
 			if byteAt() == 125 then
 				pos += 1
 				break
 			end -- '}' (trailing comma support)
+
 			local keys = parseKey()
 			skipWhitespace()
+
 			if byteAt() ~= 61 then
 				tomlParseError("expected '=' in inline table")
 			end -- '='
+
 			pos += 1
+
 			local value = parseValue()
 			setNestedKey(result, keys, value, false)
 			skipWhitespaceNewlinesAndComments()
+
 			if pos > len then
 				tomlParseError("unterminated inline table")
 			end
+
 			local c = byteAt()
 			if c == 44 then -- ','
 				pos += 1
-			elseif c == 125 then -- '}'
+				continue
+			end
+
+			if c == 125 then -- '}'
 				pos += 1
 				break
-			else
-				tomlParseError(`expected ',' or '}}' in inline table, got '${string.char(c :: number)}'`)
 			end
+
+			tomlParseError(`expected ',' or '}}' in inline table, got '${string.char(c :: number)}'`)
 		end
 
 		return result
@@ -1139,6 +1331,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 		for i = 1, #parts - 1 do
 			local k = parts[i]
 			local child = current[k]
+
 			if child == nil then
 				local newTbl: { [string]: TomlValue } = {}
 				tableMeta[newTbl] = { kind = "implicit-header", keys = {} }
@@ -1150,12 +1343,15 @@ local function deserialize(input: string): { [string]: TomlValue }
 					current = (child :: { TomlValue })[#(child :: { TomlValue })] :: { [string]: TomlValue }
 				else
 					local m = getMeta(child)
+
 					if m.kind == "array-value" then
 						tomlParseError(`key '${k}' is a static array, cannot navigate through it`)
 					end
+
 					if m.kind == "inline" then
 						tomlParseError("cannot extend inline table")
 					end
+
 					current = child :: { [string]: TomlValue }
 				end
 			else
@@ -1169,55 +1365,74 @@ local function deserialize(input: string): { [string]: TomlValue }
 		if isArrayTable then
 			if existing == nil then
 				local arr: { { [string]: TomlValue } } = {}
+
 				arrayTableSets[arr] = true
 				current[leafKey] = arr :: { TomlValue }
 				getMeta(current).keys[leafKey] = true
+
 				local entry: { [string]: TomlValue } = {}
 				tableMeta[entry] = { kind = "array-element", keys = {} }
 				table.insert(arr, entry)
+
 				return entry
-			elseif typeof(existing) == "table" and arrayTableSets[existing] then
+			end
+
+			if typeof(existing) == "table" and arrayTableSets[existing] then
 				local entry: { [string]: TomlValue } = {}
 				tableMeta[entry] = { kind = "array-element", keys = {} }
 				table.insert(existing :: { { [string]: TomlValue } }, entry)
+
 				return entry
-			else
-				tomlParseError(`cannot define [[${leafKey}]]: key already exists as a different type`)
 			end
-		else
-			if existing == nil then
-				local newTbl: { [string]: TomlValue } = {}
-				tableMeta[newTbl] = { kind = "defined", keys = {} }
-				current[leafKey] = newTbl
-				getMeta(current).keys[leafKey] = true
-				return newTbl
-			elseif typeof(existing) == "table" then
-				-- Check arrayTableSets BEFORE getMeta to avoid creating spurious meta
-				if arrayTableSets[existing] then
-					tomlParseError(`cannot define [${leafKey}]: already an array-of-tables`)
-				end
-				local m = getMeta(existing)
-				if m.kind == "array-value" then
-					tomlParseError(`cannot define [${leafKey}]: key is a static array value`)
-				end
-				if m.kind == "implicit-header" then
-					m.kind = "defined"
-					return existing :: { [string]: TomlValue }
-				elseif m.kind == "defined" then
-					tomlParseError(`duplicate table header [${leafKey}]`)
-				elseif m.kind == "inline" then
-					tomlParseError("cannot extend inline table with a table header")
-				elseif m.kind == "implicit-dotted" then
-					tomlParseError(`table [${leafKey}] was already defined via a dotted key`)
-				elseif m.kind == "array-element" then
-					tomlParseError(`cannot define [${leafKey}]: already an array-of-tables element`)
-				else
-					tomlParseError(`cannot redefine [${leafKey}]`)
-				end
-			else
-				tomlParseError(`key '${leafKey}' is not a table`)
-			end
+
+			tomlParseError(`cannot define [[${leafKey}]]: key already exists as a different type`)
 		end
+
+		if existing == nil then
+			local newTbl: { [string]: TomlValue } = {}
+			tableMeta[newTbl] = { kind = "defined", keys = {} }
+			current[leafKey] = newTbl
+			getMeta(current).keys[leafKey] = true
+			return newTbl
+		end
+
+		if typeof(existing) == "table" then
+			-- Check arrayTableSets BEFORE getMeta to avoid creating spurious meta
+			if arrayTableSets[existing] then
+				tomlParseError(`cannot define [${leafKey}]: already an array-of-tables`)
+			end
+
+			local m = getMeta(existing)
+
+			if m.kind == "array-value" then
+				tomlParseError(`cannot define [${leafKey}]: key is a static array value`)
+			end
+
+			if m.kind == "implicit-header" then
+				m.kind = "defined"
+				return existing :: { [string]: TomlValue }
+			end
+
+			if m.kind == "defined" then
+				tomlParseError(`duplicate table header [${leafKey}]`)
+			end
+
+			if m.kind == "inline" then
+				tomlParseError("cannot extend inline table with a table header")
+			end
+
+			if m.kind == "implicit-dotted" then
+				tomlParseError(`table [${leafKey}] was already defined via a dotted key`)
+			end
+
+			if m.kind == "array-element" then
+				tomlParseError(`cannot define [${leafKey}]: already an array-of-tables element`)
+			end
+
+			tomlParseError(`cannot redefine [${leafKey}]`)
+		end
+
+		tomlParseError(`key '${leafKey}' is not a table`)
 
 		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
 		error("unreachable")

--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -932,7 +932,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 
 		if string.sub(src, pos, pos + 2) == "nan" then
 			pos += 3
-			return 0 / 0
+			return math.nan
 		end
 
 		if not isDigit(c) then
@@ -1065,6 +1065,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 				end
 				return true
 			end
+
 			tomlParseError("invalid value starting with 't'")
 		end
 
@@ -1076,6 +1077,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 				end
 				return false
 			end
+
 			tomlParseError("invalid value starting with 'f'")
 		end
 
@@ -1084,14 +1086,16 @@ local function deserialize(input: string): { [string]: TomlValue }
 				pos += 3
 				return math.huge
 			end
+
 			tomlParseError("invalid value starting with 'i'")
 		end
 
 		if c == 110 then -- n
 			if string.sub(src, pos, pos + 2) == "nan" then
 				pos += 3
-				return 0 / 0
+				return  math.nan
 			end
+
 			tomlParseError("invalid value starting with 'n'")
 		end
 

--- a/batteries/toml.luau
+++ b/batteries/toml.luau
@@ -8,21 +8,28 @@ local function serializeValue(value: string | number): string
 		value = string.gsub(value, "\n", "\\n")
 		value = string.gsub(value, "\t", "\\t")
 		return '"' .. value .. '"'
-	elseif value == math.huge then
-		return "inf"
-	elseif value == -math.huge then
-		return "-inf"
-	elseif value ~= value then
-		return "nan"
-	else
-		return tostring(value)
 	end
+
+	if value == math.huge then
+		return "inf"
+	end
+
+	if value == -math.huge then
+		return "-inf"
+	end
+
+	if value ~= value then
+		return "nan"
+	end
+
+	return tostring(value)
 end
 
 local function quoteKey(key: string): string
 	if not string.match(key, "^[%w_-]+$") then
-		return '"' .. key .. '"'
+		return `"{key}"`
 	end
+
 	return key
 end
 
@@ -32,6 +39,7 @@ local function hasNestedTables(tbl: { [unknown]: unknown }): boolean
 			return true
 		end
 	end
+
 	return false
 end
 
@@ -83,10 +91,12 @@ end
 export type TomlValue = string | number | boolean | { TomlValue } | { [string]: TomlValue }
 
 local function deserialize(input: string): { [string]: TomlValue }
-	-- Reject bare CR (only CRLF → LF is allowed)
+	-- convert CRLF to LF
 	if input:find("\r\n", 1, true) then
 		input = input:gsub("\r\n", "\n")
 	end
+
+	-- Reject bare CR (only CRLF → LF is allowed)
 	if input:find("\r", 1, true) then
 		error("TOML parse error: bare carriage return (\\r) not allowed")
 	end
@@ -362,7 +372,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 				tomlParseError("unescaped control character in basic string")
 			end
 		end
+
 		tomlParseError("unterminated basic string")
+
 		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
 		error("unreachable")
 	end
@@ -370,6 +382,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 	local function parseMultilineBasicString(): string
 		-- trim a single leading newline
 		if byteAt() == 10 then pos += 1 end
+
 		local parts = {}
 		while pos <= len do
 			-- Fast path: scan over plain chars (LF and tab are literal content too)
@@ -426,7 +439,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 				tomlParseError("unescaped control character in multiline basic string")
 			end
 		end
+
 		tomlParseError("unterminated multiline basic string")
+
 		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
 		error("unreachable")
 	end
@@ -447,7 +462,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 				tomlParseError("unescaped control character in literal string")
 			end
 		end
+
 		tomlParseError("unterminated literal string")
+
 		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
 		error("unreachable")
 	end
@@ -488,7 +505,9 @@ local function deserialize(input: string): { [string]: TomlValue }
 				tomlParseError("unescaped control character in multiline literal string")
 			end
 		end
+
 		tomlParseError("unterminated multiline literal string")
+
 		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
 		error("unreachable")
 	end
@@ -736,6 +755,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 				pos += 2
 				return parseMultilineBasicString()
 			end
+
 			return parseBasicString()
 		elseif c == 39 then -- '
 			pos += 1
@@ -743,6 +763,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 				pos += 2
 				return parseMultilineLiteralString()
 			end
+
 			return parseLiteralString()
 		elseif c == 91 then -- [
 			pos += 1
@@ -756,6 +777,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 				if isBareKey(byteAt()) then tomlParseError("invalid value") end
 				return true
 			end
+
 			tomlParseError("invalid value starting with 't'")
 		elseif c == 102 then -- f
 			if string.sub(src, pos, pos + 4) == "false" then
@@ -763,18 +785,21 @@ local function deserialize(input: string): { [string]: TomlValue }
 				if isBareKey(byteAt()) then tomlParseError("invalid value") end
 				return false
 			end
+
 			tomlParseError("invalid value starting with 'f'")
 		elseif c == 105 then -- i
 			if string.sub(src, pos, pos + 2) == "inf" then
 				pos += 3
 				return math.huge
 			end
+
 			tomlParseError("invalid value starting with 'i'")
 		elseif c == 110 then -- n
 			if string.sub(src, pos, pos + 2) == "nan" then
 				pos += 3
 				return 0 / 0
 			end
+
 			tomlParseError("invalid value starting with 'n'")
 		elseif c == 43 then -- +
 			pos += 1
@@ -787,6 +812,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 		else
 			tomlParseError(`unexpected character '${string.char(c)}' in value`)
 		end
+
 		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
 		error("unreachable")
 	end
@@ -796,6 +822,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 		tableMeta[result] = { kind = "array-value", keys = {} } -- mark as static array
 		skipWhitespaceNewlinesAndComments()
 		if byteAt() == 93 then pos += 1; return result end -- empty []
+
 		while true do
 			skipWhitespaceNewlinesAndComments()
 			if pos > len then tomlParseError("unterminated array") end
@@ -813,6 +840,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 				tomlParseError(`expected ',' or ']' in array, got '${string.char(c :: number)}'`)
 			end
 		end
+
 		return result
 	end
 
@@ -852,6 +880,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 				break
 			end
 		end
+
 		return parts
 	end
 
@@ -932,6 +961,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 				tomlParseError(`expected ',' or '}}' in inline table, got '${string.char(c :: number)}'`)
 			end
 		end
+
 		return result
 	end
 
@@ -1020,6 +1050,7 @@ local function deserialize(input: string): { [string]: TomlValue }
 				tomlParseError(`key '${leafKey}' is not a table`)
 			end
 		end
+
 		-- FIXME(Luau): `tomlParseError` paths are not currently treated as not returning
 		error("unreachable")
 	end

--- a/extern/toml-test.tune
+++ b/extern/toml-test.tune
@@ -1,0 +1,5 @@
+[dependency]
+name = "toml-test"
+remote = "https://github.com/toml-lang/toml-test.git"
+branch = "v2.1.0"
+revision = "08ed8697864548b3cdb4b8decbf496bef47e1c82"

--- a/tests/batteries/toml-test.test.luau
+++ b/tests/batteries/toml-test.test.luau
@@ -183,6 +183,7 @@ local function filter(files: { string }): { string }
 	end
 	return out
 end
+
 validFiles = filter(validFiles)
 invalidFiles = filter(invalidFiles)
 

--- a/tests/batteries/toml-test.test.luau
+++ b/tests/batteries/toml-test.test.luau
@@ -31,6 +31,7 @@ end
 
 local function collectTomlFiles(dir: string, results: { string }): ()
 	local entries = fs.listDirectory(dir)
+
 	for _, entry in entries do
 		local fullPath = `{dir}/{entry.name}`
 		if entry.type == "dir" then
@@ -48,12 +49,14 @@ local function isTagged(obj: any): boolean
 	if typeof(obj) ~= "table" then
 		return false
 	end
+
 	local count = 0
 	for k in obj do
 		if typeof(k) ~= "userdata" then
 			count += 1
 		end
 	end
+
 	return count == 2 and typeof(obj.type) == "string" and obj.value ~= nil
 end
 
@@ -65,37 +68,8 @@ local function flattenExpected(value: any): any
 	if typeof(value) ~= "table" then
 		return value
 	end
-	if isTagged(value) then
-		local typ: string = value.type
-		local val: any = value.value
-		if typ == "bool" then
-			return val == "true"
-		elseif typ == "integer" then
-			return tonumber(val)
-		elseif typ == "float" then
-			if val == "inf" or val == "+inf" then
-				return math.huge
-			elseif val == "-inf" then
-				return -math.huge
-			elseif val == "nan" then
-				return 0 / 0
-			else
-				return tonumber(val)
-			end
-		else
-			-- string, datetime, datetime-local, date-local, time-local
-			-- For datetime/time types, normalize trailing zeros in fractional seconds
-			-- so ".600" and ".6" compare equal (toml-test has inconsistent precision).
-			if typ ~= "string" then
-				-- FIXME(Luau): bidirectional typechecking should allow us to avoid this annotation
-				return (val :: string):gsub("%.(%d+)", function(frac: string): string
-					local stripped = frac:gsub("0+$", "")
-					return `.{if stripped ~= "" then stripped else "0"}`
-				end)
-			end
-			return val :: string
-		end
-	else
+
+	if not isTagged(value) then
 		local result: { [any]: any } = {}
 		for k, v in value do
 			if typeof(k) ~= "userdata" then
@@ -104,6 +78,42 @@ local function flattenExpected(value: any): any
 		end
 		return result
 	end
+
+	local typ: string = value.type
+	local val: any = value.value
+
+	if typ == "bool" then
+		return val == "true"
+	end
+
+	if typ == "integer" then
+		return tonumber(val)
+	end
+
+	if typ == "float" then
+		if val == "inf" or val == "+inf" then
+			return math.huge
+		elseif val == "-inf" then
+			return -math.huge
+		elseif val == "nan" then
+			return 0 / 0
+		else
+			return tonumber(val)
+		end
+	end
+
+	-- string, datetime, datetime-local, date-local, time-local
+	-- For datetime/time types, normalize trailing zeros in fractional seconds
+	-- so ".600" and ".6" compare equal (toml-test has inconsistent precision).
+	if typ ~= "string" then
+		-- FIXME(Luau): bidirectional typechecking should allow us to avoid this annotation
+		return (val :: string):gsub("%.(%d+)", function(frac: string): string
+			local stripped = frac:gsub("0+$", "")
+			return `.{if stripped ~= "" then stripped else "0"}`
+		end)
+	end
+
+	return val :: string
 end
 
 -- Deep equality that handles NaN == NaN (which `==` does not).
@@ -112,33 +122,43 @@ local function deepEq(a: any, b: any, path: string): (boolean, string)
 		if a ~= a and b ~= b then
 			return true, "" -- both NaN
 		end
+
 		if a == b then
 			return true, ""
 		end
+
 		return false, `{path}: {a} ~= {b}`
 	end
+
 	if typeof(a) ~= typeof(b) then
 		return false, `{path}: got {typeof(a)} ({tostring(a)}) but expected {typeof(b)} ({tostring(b)})`
 	end
+
 	if typeof(a) ~= "table" then
 		if a == b then
 			return true, ""
 		end
+
 		return false, `{path}: {tostring(a)} ~= {tostring(b)}`
 	end
+
 	for k, v in a :: { [any]: any } do
 		local keyPath = if path == "" then tostring(k) else `{path}.{k}`
+
 		local ok, msg = deepEq(v, (b :: any)[k], keyPath)
 		if not ok then
 			return false, msg
 		end
 	end
+
 	for k in b :: { [any]: any } do
 		if (a :: any)[k] == nil then
 			local keyPath = if path == "" then tostring(k) else `{path}.{k}`
+
 			return false, `{keyPath}: key present in expected but missing in actual`
 		end
 	end
+
 	return true, ""
 end
 

--- a/tests/batteries/toml-test.test.luau
+++ b/tests/batteries/toml-test.test.luau
@@ -5,10 +5,11 @@
 -- counterpart using the toml-test tagged-value format.
 -- Invalid tests: each .toml file must cause toml.deserialize to throw.
 
-local test = require("@std/test")
-local json = require("@std/json")
 local toml = require("@batteries/toml")
+
 local fs = require("@std/fs")
+local json = require("@std/json")
+local test = require("@std/test")
 
 local VALID_DIR = "extern/toml-test/tests/valid"
 local INVALID_DIR = "extern/toml-test/tests/invalid"
@@ -86,7 +87,8 @@ local function flattenExpected(value: any): any
 			-- For datetime/time types, normalize trailing zeros in fractional seconds
 			-- so ".600" and ".6" compare equal (toml-test has inconsistent precision).
 			if typ ~= "string" then
-				return (val :: string):gsub("%.(%d+)", function(frac)
+				-- FIXME(Luau): bidirectional typechecking should allow us to avoid this annotation
+				return (val :: string):gsub("%.(%d+)", function(frac: string): string
 					local stripped = frac:gsub("0+$", "")
 					return `.{if stripped ~= "" then stripped else "0"}`
 				end)
@@ -167,7 +169,7 @@ invalidFiles = filter(invalidFiles)
 table.sort(validFiles)
 table.sort(invalidFiles)
 
-test.suite("toml-test valid", function(suite)
+test.suite("toml-test-valid", function(suite)
 	for _, path in validFiles do
 		local name = testName(path, VALID_DIR)
 		local jsonPath = `{string.sub(path, 1, -6)}.json`
@@ -181,7 +183,7 @@ test.suite("toml-test valid", function(suite)
 	end
 end)
 
-test.suite("toml-test invalid", function(suite)
+test.suite("toml-test-invalid", function(suite)
 	for _, path in invalidFiles do
 		local name = testName(path, INVALID_DIR)
 

--- a/tests/batteries/toml-test.test.luau
+++ b/tests/batteries/toml-test.test.luau
@@ -45,16 +45,16 @@ end
 -- @std/json adds a userdata marker key to every deserialized object, so we
 -- skip userdata keys when counting.
 local function isTagged(obj: any): boolean
-	if type(obj) ~= "table" then
+	if typeof(obj) ~= "table" then
 		return false
 	end
 	local count = 0
 	for k in obj do
-		if type(k) ~= "userdata" then
+		if typeof(k) ~= "userdata" then
 			count += 1
 		end
 	end
-	return count == 2 and type(obj.type) == "string" and obj.value ~= nil
+	return count == 2 and typeof(obj.type) == "string" and obj.value ~= nil
 end
 
 -- Recursively convert a toml-test JSON value tree into plain Lua values.
@@ -62,7 +62,7 @@ end
 -- arrays are recursed into. Userdata marker keys from the JSON deserializer
 -- are skipped.
 local function flattenExpected(value: any): any
-	if type(value) ~= "table" then
+	if typeof(value) ~= "table" then
 		return value
 	end
 	if isTagged(value) then
@@ -98,7 +98,7 @@ local function flattenExpected(value: any): any
 	else
 		local result: { [any]: any } = {}
 		for k, v in value do
-			if type(k) ~= "userdata" then
+			if typeof(k) ~= "userdata" then
 				result[k] = flattenExpected(v)
 			end
 		end
@@ -108,7 +108,7 @@ end
 
 -- Deep equality that handles NaN == NaN (which `==` does not).
 local function deepEq(a: any, b: any, path: string): (boolean, string)
-	if type(a) == "number" and type(b) == "number" then
+	if typeof(a) == "number" and typeof(b) == "number" then
 		if a ~= a and b ~= b then
 			return true, "" -- both NaN
 		end
@@ -117,10 +117,10 @@ local function deepEq(a: any, b: any, path: string): (boolean, string)
 		end
 		return false, `{path}: {a} ~= {b}`
 	end
-	if type(a) ~= type(b) then
-		return false, `{path}: got {type(a)} ({tostring(a)}) but expected {type(b)} ({tostring(b)})`
+	if typeof(a) ~= typeof(b) then
+		return false, `{path}: got {typeof(a)} ({tostring(a)}) but expected {typeof(b)} ({tostring(b)})`
 	end
-	if type(a) ~= "table" then
+	if typeof(a) ~= "table" then
 		if a == b then
 			return true, ""
 		end

--- a/tests/batteries/toml-test.test.luau
+++ b/tests/batteries/toml-test.test.luau
@@ -96,7 +96,7 @@ local function flattenExpected(value: any): any
 		elseif val == "-inf" then
 			return -math.huge
 		elseif val == "nan" then
-			return 0 / 0
+			return math.nan
 		else
 			return tonumber(val)
 		end

--- a/tests/batteries/toml-test.test.luau
+++ b/tests/batteries/toml-test.test.luau
@@ -1,0 +1,194 @@
+-- Tests the toml battery against the official toml-test suite.
+-- Must be run from the repo root (where extern/toml-test/tests/ lives).
+--
+-- Valid tests: each .toml file is parsed and compared against its .json
+-- counterpart using the toml-test tagged-value format.
+-- Invalid tests: each .toml file must cause toml.deserialize to throw.
+
+local test = require("@std/test")
+local json = require("@std/json")
+local toml = require("@batteries/toml")
+local fs = require("@std/fs")
+
+local VALID_DIR = "extern/toml-test/tests/valid"
+local INVALID_DIR = "extern/toml-test/tests/invalid"
+local VERSION_FILE = "extern/toml-test/tests/files-toml-1.1.0"
+
+-- Build a set of paths that are valid for TOML 1.1 (relative to extern/toml-test/tests/)
+local toml11: { [string]: boolean } = {}
+for line in string.gmatch(fs.readFileToString(VERSION_FILE), "[^\n]+") do
+	toml11[line] = true
+end
+
+-- Returns true if the full file path is included in the TOML 1.1 test set.
+local function isToml11(fullPath: string): boolean
+	-- fullPath is e.g. "extern/toml-test/tests/valid/bool/bool.toml"
+	-- version file entries are e.g. "valid/bool/bool.toml"
+	local rel = string.sub(fullPath, #"extern/toml-test/tests/" + 1)
+	return toml11[rel] == true
+end
+
+local function collectTomlFiles(dir: string, results: { string }): ()
+	local entries = fs.listDirectory(dir)
+	for _, entry in entries do
+		local fullPath = `{dir}/{entry.name}`
+		if entry.type == "dir" then
+			collectTomlFiles(fullPath, results)
+		elseif entry.type == "file" and string.match(entry.name, "%.toml$") then
+			table.insert(results, fullPath)
+		end
+	end
+end
+
+-- Detect a toml-test tagged leaf: { type = "<string>", value = <any> }
+-- @std/json adds a userdata marker key to every deserialized object, so we
+-- skip userdata keys when counting.
+local function isTagged(obj: any): boolean
+	if type(obj) ~= "table" then
+		return false
+	end
+	local count = 0
+	for k in obj do
+		if type(k) ~= "userdata" then
+			count += 1
+		end
+	end
+	return count == 2 and type(obj.type) == "string" and obj.value ~= nil
+end
+
+-- Recursively convert a toml-test JSON value tree into plain Lua values.
+-- Tagged leaves are converted to their Lua equivalents; structural tables and
+-- arrays are recursed into. Userdata marker keys from the JSON deserializer
+-- are skipped.
+local function flattenExpected(value: any): any
+	if type(value) ~= "table" then
+		return value
+	end
+	if isTagged(value) then
+		local typ: string = value.type
+		local val: any = value.value
+		if typ == "bool" then
+			return val == "true"
+		elseif typ == "integer" then
+			return tonumber(val)
+		elseif typ == "float" then
+			if val == "inf" or val == "+inf" then
+				return math.huge
+			elseif val == "-inf" then
+				return -math.huge
+			elseif val == "nan" then
+				return 0 / 0
+			else
+				return tonumber(val)
+			end
+		else
+			-- string, datetime, datetime-local, date-local, time-local
+			-- For datetime/time types, normalize trailing zeros in fractional seconds
+			-- so ".600" and ".6" compare equal (toml-test has inconsistent precision).
+			if typ ~= "string" then
+				return (val :: string):gsub("%.(%d+)", function(frac)
+					local stripped = frac:gsub("0+$", "")
+					return `.{if stripped ~= "" then stripped else "0"}`
+				end)
+			end
+			return val :: string
+		end
+	else
+		local result: { [any]: any } = {}
+		for k, v in value do
+			if type(k) ~= "userdata" then
+				result[k] = flattenExpected(v)
+			end
+		end
+		return result
+	end
+end
+
+-- Deep equality that handles NaN == NaN (which `==` does not).
+local function deepEq(a: any, b: any, path: string): (boolean, string)
+	if type(a) == "number" and type(b) == "number" then
+		if a ~= a and b ~= b then
+			return true, "" -- both NaN
+		end
+		if a == b then
+			return true, ""
+		end
+		return false, `{path}: {a} ~= {b}`
+	end
+	if type(a) ~= type(b) then
+		return false, `{path}: got {type(a)} ({tostring(a)}) but expected {type(b)} ({tostring(b)})`
+	end
+	if type(a) ~= "table" then
+		if a == b then
+			return true, ""
+		end
+		return false, `{path}: {tostring(a)} ~= {tostring(b)}`
+	end
+	for k, v in a :: { [any]: any } do
+		local keyPath = if path == "" then tostring(k) else `{path}.{k}`
+		local ok, msg = deepEq(v, (b :: any)[k], keyPath)
+		if not ok then
+			return false, msg
+		end
+	end
+	for k in b :: { [any]: any } do
+		if (a :: any)[k] == nil then
+			local keyPath = if path == "" then tostring(k) else `{path}.{k}`
+			return false, `{keyPath}: key present in expected but missing in actual`
+		end
+	end
+	return true, ""
+end
+
+-- "extern/toml-test/tests/valid/bool/bool.toml" -> "bool/bool"
+local function testName(fullPath: string, baseDir: string): string
+	local rel = string.sub(fullPath, #baseDir + 2)
+	return string.sub(rel, 1, -6)
+end
+
+local validFiles: { string } = {}
+local invalidFiles: { string } = {}
+collectTomlFiles(VALID_DIR, validFiles)
+collectTomlFiles(INVALID_DIR, invalidFiles)
+
+-- Filter to only TOML 1.1 tests
+local function filter(files: { string }): { string }
+	local out: { string } = {}
+	for _, path in files do
+		if isToml11(path) then
+			table.insert(out, path)
+		end
+	end
+	return out
+end
+validFiles = filter(validFiles)
+invalidFiles = filter(invalidFiles)
+
+table.sort(validFiles)
+table.sort(invalidFiles)
+
+test.suite("toml-test valid", function(suite)
+	for _, path in validFiles do
+		local name = testName(path, VALID_DIR)
+		local jsonPath = `{string.sub(path, 1, -6)}.json`
+
+		suite:case(name, function(assert)
+			local actual: any = toml.deserialize(fs.readFileToString(path))
+			local expected = flattenExpected(json.deserialize(fs.readFileToString(jsonPath)))
+			local ok, msg = deepEq(actual, expected, "")
+			assert.that(ok, msg)
+		end)
+	end
+end)
+
+test.suite("toml-test invalid", function(suite)
+	for _, path in invalidFiles do
+		local name = testName(path, INVALID_DIR)
+
+		suite:case(name, function(assert)
+			assert.throws(function()
+				toml.deserialize(fs.readFileToString(path))
+			end)
+		end)
+	end
+end)

--- a/tools/bench-toml.luau
+++ b/tools/bench-toml.luau
@@ -1,0 +1,60 @@
+-- Benchmark the @batteries/toml deserializer against the toml-test corpus.
+-- Run from the repo root:
+--   lute tools/luthier run lute tools/bench-toml.luau
+
+local toml = require("../batteries/toml")
+local fs = require("@std/fs")
+
+local function collectTomlFiles(dir: string, results: { string }): ()
+	local entries = fs.listDirectory(dir)
+	for _, entry in entries do
+		local fullPath = `{dir}/{entry.name}`
+		if entry.type == "dir" then
+			collectTomlFiles(fullPath, results)
+		elseif entry.type == "file" and string.match(entry.name, "%.toml$") then
+			table.insert(results, fullPath)
+		end
+	end
+end
+
+local paths: { string } = {}
+collectTomlFiles("extern/toml-test/tests/valid", paths)
+collectTomlFiles("extern/toml-test/tests/invalid", paths)
+
+-- Pre-read all files so I/O is excluded from timing
+local contents: { string } = {}
+for _, path in paths do
+	local ok, data = pcall(fs.readFileToString, path)
+	if ok then
+		table.insert(contents, data :: string)
+	end
+end
+
+local totalBytes = 0
+for _, src in contents do
+	totalBytes += #src
+end
+
+print(`Corpus: {#contents} files, {totalBytes} bytes total`)
+print()
+
+-- Warm-up pass
+for _, src in contents do
+	pcall(toml.deserialize, src)
+end
+
+local PASSES = 20
+
+local t0 = os.clock()
+for _ = 1, PASSES do
+	for _, src in contents do
+		pcall(toml.deserialize, src)
+	end
+end
+local elapsed = os.clock() - t0
+
+print(`Passes:      {PASSES}`)
+print(`Total time:  {string.format("%.3f", elapsed)} s`)
+print(`Per pass:    {string.format("%.1f", elapsed / PASSES * 1000)} ms`)
+print(`Per file:    {string.format("%.3f", elapsed / PASSES / #contents * 1000)} ms avg`)
+print(`Throughput:  {string.format("%.2f", totalBytes * PASSES / elapsed / 1024 / 1024)} MB/s`)


### PR DESCRIPTION
This PR essentially rewrites the entire implementation of the TOML battery using the specification and test suite defined in [toml-test](https://github.com/toml-lang/toml-test), which we add as an extern dependency for the purpose of pulling in its test suite. The implementation here passes the entire test suite for the TOML 1.1.0 specification, and yields a value of the following Luau type:

```luau
export type TomlValue = string | number | boolean | { TomlValue } | { [string]: TomlValue }
```

It has an associated benchmark script in `tools/` that benchmarks the performance which has the following behavior on my machine (an M4 Max MacBook Pro):

```
Corpus: 745 files, 52713 bytes total

Passes:      20
Total time:  0.455 s
Per pass:    22.8 ms
Per file:    0.031 ms avg
Throughput:  2.21 MB/s
```

I don't know how this compares to other implementations, but 2 MB/s seems like a reasonable throughput for our needs today (which are largely just going to be processing fairly small TOML files used for configuring legacy package managers).
This fixes #1024.