### PR TITLE
Recommend luau-lsp in Lute workspace

### DIFF
--- a/lute.code-workspace
+++ b/lute.code-workspace
@@ -17,4 +17,7 @@
         "luau-lsp.platform.type": "standard",
         "luau-lsp.fflags.enableByDefault": true,
     },
+    "extensions": {
+        "recommendations": ["johnnymorganz.luau-lsp"]
+    }
 }


### PR DESCRIPTION
We have luau-lsp settings in workplace settings, so we should at least recommend that as an extension. I haven't recommended other extensions since this is more a matter of personal taste and we don't have dependencies on or references to other extensions.