### PR TITLE
infra: C ABI for Lute APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,14 @@ if (LUTE_OPTIMIZE_SIZE AND NOT LUTE_ENABLE_SANITIZERS)
     endif()
 endif()
 
+# LUTE_EXTERN_C must be declared before extern/luau is configured so that
+# it can force LUAU_EXTERN_C on — Luau must use longjmp instead of C++
+# exceptions when lute's open functions are exposed with C linkage.
+option(LUTE_EXTERN_C "Use extern C Lute API functions" OFF)
+if(LUTE_EXTERN_C)
+    set(LUAU_EXTERN_C ON)
+endif()
+
 # luau setup
 set(LUAU_BUILD_CLI OFF)
 set(LUAU_BUILD_TESTS OFF)

--- a/lute/common/CMakeLists.txt
+++ b/lute/common/CMakeLists.txt
@@ -12,3 +12,7 @@ target_compile_features(Lute.Common PUBLIC cxx_std_17)
 target_include_directories(Lute.Common PUBLIC include)
 target_link_libraries(Lute.Common PRIVATE Luau.CLI.lib Luau.Common)
 target_compile_options(Lute.Common PRIVATE ${LUTE_OPTIONS})
+
+if(LUTE_EXTERN_C)
+    target_compile_definitions(Lute.Common PUBLIC "LUTE_API=extern \"C\"")
+endif()

--- a/lute/common/include/lute/library.h
+++ b/lute/common/include/lute/library.h
@@ -5,6 +5,10 @@
 
 #include <type_traits>
 
+#ifndef LUTE_API
+#define LUTE_API
+#endif
+
 // A uniform interface for Lute libraries.
 //
 // Each `Derived` Lute library must provide:

--- a/lute/crypto/include/lute/crypto.h
+++ b/lute/crypto/include/lute/crypto.h
@@ -6,9 +6,9 @@
 #include "lualib.h"
 
 // open the library as a standard global luau library
-int luaopen_crypto(lua_State* L);
+LUTE_API int luaopen_crypto(lua_State* L);
 // open the library as a table on top of the stack
-int luteopen_crypto(lua_State* L);
+LUTE_API int luteopen_crypto(lua_State* L);
 
 struct Crypto : LuteLibrary<Crypto>
 {

--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -322,12 +322,12 @@ int Crypto::pushLibrary(lua_State* L)
     return 1;
 }
 
-int luaopen_crypto(lua_State* L)
+LUTE_API int luaopen_crypto(lua_State* L)
 {
     return Crypto::openAsGlobal(L);
 }
 
-int luteopen_crypto(lua_State* L)
+LUTE_API int luteopen_crypto(lua_State* L)
 {
     return Crypto::pushLibrary(L);
 }

--- a/lute/fs/include/lute/fs.h
+++ b/lute/fs/include/lute/fs.h
@@ -6,9 +6,9 @@
 #include "lualib.h"
 
 // open the library as a standard global luau library
-int luaopen_fs(lua_State* L);
+LUTE_API int luaopen_fs(lua_State* L);
 // open the library as a table on top of the stack
-int luteopen_fs(lua_State* L);
+LUTE_API int luteopen_fs(lua_State* L);
 
 struct FS : LuteLibrary<FS>
 {

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -454,12 +454,12 @@ int FS::pushLibrary(lua_State* L)
     return 1;
 }
 
-int luaopen_fs(lua_State* L)
+LUTE_API int luaopen_fs(lua_State* L)
 {
     return FS::openAsGlobal(L);
 }
 
-int luteopen_fs(lua_State* L)
+LUTE_API int luteopen_fs(lua_State* L)
 {
     return FS::pushLibrary(L);
 }

--- a/lute/io/include/lute/io.h
+++ b/lute/io/include/lute/io.h
@@ -6,9 +6,9 @@
 #include "lualib.h"
 
 // open the library as a standard global luau library
-int luaopen_io(lua_State* L);
+LUTE_API int luaopen_io(lua_State* L);
 // open the library as a table on top of the stack
-int luteopen_io(lua_State* L);
+LUTE_API int luteopen_io(lua_State* L);
 
 struct IO : LuteLibrary<IO>
 {

--- a/lute/io/src/io.cpp
+++ b/lute/io/src/io.cpp
@@ -214,12 +214,12 @@ int IO::pushLibrary(lua_State* L)
     return 1;
 }
 
-int luaopen_io(lua_State* L)
+LUTE_API int luaopen_io(lua_State* L)
 {
     return IO::openAsGlobal(L);
 }
 
-int luteopen_io(lua_State* L)
+LUTE_API int luteopen_io(lua_State* L)
 {
     return IO::pushLibrary(L);
 }

--- a/lute/luau/include/lute/luau.h
+++ b/lute/luau/include/lute/luau.h
@@ -7,9 +7,9 @@
 #include "lualib.h"
 
 // open the library as a standard global luau library
-int luaopen_luau(lua_State* L);
+LUTE_API int luaopen_luau(lua_State* L);
 // open the library as a table on top of the stack
-int luteopen_luau(lua_State* L);
+LUTE_API int luteopen_luau(lua_State* L);
 
 struct LuauLib : LuteLibrary<LuauLib>
 {

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -3127,12 +3127,12 @@ int LuauLib::pushLibrary(lua_State* L)
     return luau::initLuauLibrary(L);
 }
 
-int luaopen_luau(lua_State* L)
+LUTE_API int luaopen_luau(lua_State* L)
 {
     return LuauLib::openAsGlobal(L);
 }
 
-int luteopen_luau(lua_State* L)
+LUTE_API int luteopen_luau(lua_State* L)
 {
     return LuauLib::pushLibrary(L);
 }

--- a/lute/net/include/lute/net.h
+++ b/lute/net/include/lute/net.h
@@ -6,12 +6,12 @@
 #include "lualib.h"
 
 // open the library as a standard global luau library
-int luaopen_net(lua_State* L);
+LUTE_API int luaopen_net(lua_State* L);
 // open the library as a table on top of the stack
-int luteopen_net(lua_State* L);
+LUTE_API int luteopen_net(lua_State* L);
 
-int luteopen_net_client(lua_State* L);
-int luteopen_net_server(lua_State* L);
+LUTE_API int luteopen_net_client(lua_State* L);
+LUTE_API int luteopen_net_server(lua_State* L);
 
 struct NetClient : LuteLibrary<NetClient>
 {

--- a/lute/net/src/client.cpp
+++ b/lute/net/src/client.cpp
@@ -326,7 +326,7 @@ int NetClient::pushLibrary(lua_State* L)
     return 1;
 }
 
-int luteopen_net_client(lua_State* L)
+LUTE_API int luteopen_net_client(lua_State* L)
 {
     return NetClient::pushLibrary(L);
 }

--- a/lute/net/src/net.cpp
+++ b/lute/net/src/net.cpp
@@ -27,12 +27,12 @@ int Net::pushLibrary(lua_State* L)
     return 1;
 }
 
-int luaopen_net(lua_State* L)
+LUTE_API int luaopen_net(lua_State* L)
 {
     return Net::openAsGlobal(L);
 }
 
-int luteopen_net(lua_State* L)
+LUTE_API int luteopen_net(lua_State* L)
 {
     return Net::pushLibrary(L);
 }

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -1244,7 +1244,7 @@ int NetServer::pushLibrary(lua_State* L)
     return 1;
 }
 
-int luteopen_net_server(lua_State* L)
+LUTE_API int luteopen_net_server(lua_State* L)
 {
     return NetServer::pushLibrary(L);
 }

--- a/lute/process/include/lute/process.h
+++ b/lute/process/include/lute/process.h
@@ -9,9 +9,9 @@
 #include <string>
 
 // open the library as a standard global luau library
-int luaopen_process(lua_State* L);
+LUTE_API int luaopen_process(lua_State* L);
 // open the library as a table on top of the stack
-int luteopen_process(lua_State* L);
+LUTE_API int luteopen_process(lua_State* L);
 
 struct Process : LuteLibrary<Process>
 {

--- a/lute/process/src/process.cpp
+++ b/lute/process/src/process.cpp
@@ -413,12 +413,12 @@ int Process::pushLibrary(lua_State* L)
     return 1;
 }
 
-int luaopen_process(lua_State* L)
+LUTE_API int luaopen_process(lua_State* L)
 {
     return Process::openAsGlobal(L);
 }
 
-int luteopen_process(lua_State* L)
+LUTE_API int luteopen_process(lua_State* L)
 {
     return Process::pushLibrary(L);
 }

--- a/lute/system/include/lute/system.h
+++ b/lute/system/include/lute/system.h
@@ -6,9 +6,9 @@
 #include "lualib.h"
 
 // open the library as a standard global luau library
-int luaopen_system(lua_State* L);
+LUTE_API int luaopen_system(lua_State* L);
 // open the library as a table on top of the stack
-int luteopen_system(lua_State* L);
+LUTE_API int luteopen_system(lua_State* L);
 
 struct System : LuteLibrary<System>
 {

--- a/lute/system/src/system.cpp
+++ b/lute/system/src/system.cpp
@@ -179,12 +179,12 @@ int System::pushLibrary(lua_State* L)
     return 1;
 }
 
-int luaopen_system(lua_State* L)
+LUTE_API int luaopen_system(lua_State* L)
 {
     return System::openAsGlobal(L);
 }
 
-int luteopen_system(lua_State* L)
+LUTE_API int luteopen_system(lua_State* L)
 {
     return System::pushLibrary(L);
 }

--- a/lute/task/include/lute/task.h
+++ b/lute/task/include/lute/task.h
@@ -6,9 +6,9 @@
 #include "lualib.h"
 
 // open the library as a standard global luau library
-int luaopen_task(lua_State* L);
+LUTE_API int luaopen_task(lua_State* L);
 // open the library as a table on top of the stack
-int luteopen_task(lua_State* L);
+LUTE_API int luteopen_task(lua_State* L);
 
 struct Task : LuteLibrary<Task>
 {

--- a/lute/task/src/task.cpp
+++ b/lute/task/src/task.cpp
@@ -341,12 +341,12 @@ int Task::pushLibrary(lua_State* L)
     return 1;
 }
 
-int luaopen_task(lua_State* L)
+LUTE_API int luaopen_task(lua_State* L)
 {
     return Task::openAsGlobal(L);
 }
 
-int luteopen_task(lua_State* L)
+LUTE_API int luteopen_task(lua_State* L)
 {
     return Task::pushLibrary(L);
 }

--- a/lute/time/include/lute/time.h
+++ b/lute/time/include/lute/time.h
@@ -10,9 +10,9 @@
 #include <string>
 
 // open the library as a standard global luau library
-int luaopen_time(lua_State* L);
+LUTE_API int luaopen_time(lua_State* L);
 // open the library as a table on top of the stack
-int luteopen_time(lua_State* L);
+LUTE_API int luteopen_time(lua_State* L);
 
 static const char kInstantType[] = "instant";
 static const char kDurationType[] = "duration";

--- a/lute/time/src/time.cpp
+++ b/lute/time/src/time.cpp
@@ -638,12 +638,12 @@ int Time::pushLibrary(lua_State* L)
     return 1;
 }
 
-int luaopen_time(lua_State* L)
+LUTE_API int luaopen_time(lua_State* L)
 {
     return Time::openAsGlobal(L);
 }
 
-int luteopen_time(lua_State* L)
+LUTE_API int luteopen_time(lua_State* L)
 {
     return Time::pushLibrary(L);
 }

--- a/lute/vm/include/lute/vm.h
+++ b/lute/vm/include/lute/vm.h
@@ -6,9 +6,9 @@
 #include "lualib.h"
 
 // open the library as a standard global luau library
-int luaopen_vm(lua_State* L);
+LUTE_API int luaopen_vm(lua_State* L);
 // open the library as a table on top of the stack
-int luteopen_vm(lua_State* L);
+LUTE_API int luteopen_vm(lua_State* L);
 
 struct VM : LuteLibrary<VM>
 {

--- a/lute/vm/src/vm.cpp
+++ b/lute/vm/src/vm.cpp
@@ -27,12 +27,12 @@ int VM::pushLibrary(lua_State* L)
     return 1;
 }
 
-int luaopen_vm(lua_State* L)
+LUTE_API int luaopen_vm(lua_State* L)
 {
     return VM::openAsGlobal(L);
 }
 
-int luteopen_vm(lua_State* L)
+LUTE_API int luteopen_vm(lua_State* L)
 {
     return VM::pushLibrary(L);
 }


### PR DESCRIPTION
We've had #121 as a longstanding request, which has a fairly simple path to implementing. We can mimic the same trick Luau itself uses to expose its API in an optionally-extern-C way for Lute. This initial PR determines that the whole exposed surface area is just the `luaopen_` and `luteopen_` functions for the various runtime libraries, but we could consider exposing more in the future as needed.