### PR TITLE
Fixes a possible bug in lute compile caused by using argv[0] instead of the process executable path

### DIFF
--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -624,9 +624,15 @@ int cliMain(int argc, char** argv, LuteReporter& reporter)
         setvbuf(stderr, nullptr, _IONBF, 0);
     }
 
-    std::string err = "";
+    std::string err;
+    std::optional<std::string> exePath = Process::getExecPath(&err);
+    if (!exePath)
+    {
+	    reporter.formatError("Unable to find the `lute` executable path: Process::getExecPath failed with error: %s", err.c_str());
+        return 1;
+    }
 
-    LuteExecutable exe{argv[0], reporter};
+    LuteExecutable exe{*exePath, reporter};
     if (auto payload = exe.extract())
     {
         Runtime runtime{reporter};


### PR DESCRIPTION
This PR fixes a bug in `lute compile` that came to me in a dream. When I woke up I realized that argv[0] isn't guaranteed to be the path to the executable being run.
This PR just makes it so that when running a `lute compile`'d executable, we extract the pre-compiled bytecode from the path returned by Process::getExecPath, instead of inspecting `argv[0]` which may or may not be a path.

The `lute compile` command does actually do the right thing.