### PR TITLE
Tidies up some code duplication in the websockets library

### DIFF
--- a/lute/net/CMakeLists.txt
+++ b/lute/net/CMakeLists.txt
@@ -9,6 +9,8 @@ target_sources(Lute.Net PRIVATE
     src/server.cpp
     src/system_ca.cpp
     src/system_ca.h
+    src/websocket_common.cpp
+    src/websocket_common.h
 )
 
 target_compile_features(Lute.Net PUBLIC cxx_std_17)

--- a/lute/net/src/client_websocket.cpp
+++ b/lute/net/src/client_websocket.cpp
@@ -2,6 +2,7 @@
 #include "lute/userdatas.h"
 
 #include "system_ca.h"
+#include "websocket_common.h"
 
 #include "Luau/VecDeque.h"
 
@@ -25,13 +26,6 @@ namespace net::client
 struct WebSocketConnection;
 struct WebSocketHandle;
 
-struct WebSocketPayload
-{
-    const char* data = nullptr;
-    size_t length = 0;
-    bool binary = false;
-};
-
 struct PendingSend
 {
     std::string payload;
@@ -44,26 +38,6 @@ struct WebSocketPollState
     uv_poll_t handle{};
     std::shared_ptr<WebSocketConnection> owner;
 };
-
-static WebSocketPayload extractWebSocketPayload(lua_State* L, int index)
-{
-    if (lua_isstring(L, index))
-    {
-        size_t length = 0;
-        const char* data = lua_tolstring(L, index, &length);
-        return {data, length, false};
-    }
-
-    if (lua_isbuffer(L, index))
-    {
-        size_t length = 0;
-        void* data = lua_tobuffer(L, index, &length);
-        return {static_cast<const char*>(data), length, true};
-    }
-
-    luaL_typeerrorL(L, index, "string or buffer");
-    return {};
-}
 
 static void clearWebSocketPollState(WebSocketPollState*& pollState, int& activePollEvents)
 {

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -7,6 +7,8 @@
 #include "Luau/DenseHash.h"
 #include "Luau/Variant.h"
 
+#include "websocket_common.h"
+
 #include "lua.h"
 #include "lualib.h"
 
@@ -30,13 +32,6 @@ namespace net::server
 {
 
 using uWSApp = Luau::Variant<std::unique_ptr<uWS::App>, std::unique_ptr<uWS::SSLApp>>;
-
-struct WebSocketPayload
-{
-    const char* data = nullptr;
-    size_t length = 0;
-    bool binary = false;
-};
 
 static const int kEmptyServerKey = 0;
 static Luau::DenseHashMap<int, uWSApp> serverInstances(kEmptyServerKey);
@@ -74,25 +69,6 @@ struct ServerWebSocketHandle
     int (*sendFn)(void* wsPtr, std::string_view data, bool binary) = nullptr;
     void (*closeFn)(void* wsPtr, uint16_t code, std::string_view message) = nullptr;
 };
-
-static WebSocketPayload extractWebSocketPayload(lua_State* L, int index)
-{
-    if (lua_isstring(L, index))
-    {
-        size_t length = 0;
-        const char* data = lua_tolstring(L, index, &length);
-        return {data, length, false};
-    }
-
-    if (lua_isbuffer(L, index))
-    {
-        size_t length = 0;
-        void* data = lua_tobuffer(L, index, &length);
-        return {static_cast<const char*>(data), length, true};
-    }
-
-    luaL_typeerrorL(L, index, "string or buffer");
-}
 
 template <bool SSL>
 struct PerSocketData

--- a/lute/net/src/websocket_common.cpp
+++ b/lute/net/src/websocket_common.cpp
@@ -1,0 +1,27 @@
+#include "websocket_common.h"
+
+#include "lualib.h"
+
+namespace net
+{
+
+WebSocketPayload extractWebSocketPayload(lua_State* L, int index)
+{
+    if (lua_isstring(L, index))
+    {
+        size_t length = 0;
+        const char* data = lua_tolstring(L, index, &length);
+        return {data, length, false};
+    }
+
+    if (lua_isbuffer(L, index))
+    {
+        size_t length = 0;
+        void* data = lua_tobuffer(L, index, &length);
+        return {static_cast<const char*>(data), length, true};
+    }
+
+    luaL_typeerrorL(L, index, "string or buffer");
+}
+
+} // namespace net

--- a/lute/net/src/websocket_common.h
+++ b/lute/net/src/websocket_common.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "lua.h"
+
+#include <cstddef>
+
+namespace net
+{
+
+struct WebSocketPayload
+{
+    const char* data = nullptr;
+    size_t length = 0;
+    bool binary = false;
+};
+
+WebSocketPayload extractWebSocketPayload(lua_State* L, int index);
+
+} // namespace net


### PR DESCRIPTION
The `extractWebsocketPayload` function and `WebsocketPayload` struct is duplicated between the websocket server and client implementation. I've just pulled them out into a common file.

In a follow up, I'll do some style tidying (these files have to be clang-formatted)