### PR TITLE
loom: update the vendored version of luau-unzip and add more tests for `pkg install`

### DIFF
--- a/lute/cli/commands/pkg/loom-core/extern/unzip/crc.luau
+++ b/lute/cli/commands/pkg/loom-core/extern/unzip/crc.luau
@@ -1,4 +1,4 @@
-local CRC32_TABLE = table.create(256) :: { number }
+local CRC32_TABLE = table.create(256)
 
 -- TODO: Maybe compute this AoT as an optimization
 -- Initialize the lookup table and lock it in place
@@ -18,11 +18,38 @@ table.freeze(CRC32_TABLE)
 
 local function crc32(buf: buffer): number
 	local crc = 0xFFFFFFFF
+	local len = buffer.len(buf)
+	local i = 0
 
-	for i = 0, buffer.len(buf) - 1 do
+	-- OPT: Unroll to process 8 bytes at a time for better performance
+	while i + 7 < len do
+		local b0 = buffer.readu8(buf, i)
+		local b1 = buffer.readu8(buf, i + 1)
+		local b2 = buffer.readu8(buf, i + 2)
+		local b3 = buffer.readu8(buf, i + 3)
+		local b4 = buffer.readu8(buf, i + 4)
+		local b5 = buffer.readu8(buf, i + 5)
+		local b6 = buffer.readu8(buf, i + 6)
+		local b7 = buffer.readu8(buf, i + 7)
+
+		crc = bit32.bxor(bit32.rshift(crc, 8), CRC32_TABLE[bit32.band(bit32.bxor(crc, b0), 0xFF)])
+		crc = bit32.bxor(bit32.rshift(crc, 8), CRC32_TABLE[bit32.band(bit32.bxor(crc, b1), 0xFF)])
+		crc = bit32.bxor(bit32.rshift(crc, 8), CRC32_TABLE[bit32.band(bit32.bxor(crc, b2), 0xFF)])
+		crc = bit32.bxor(bit32.rshift(crc, 8), CRC32_TABLE[bit32.band(bit32.bxor(crc, b3), 0xFF)])
+		crc = bit32.bxor(bit32.rshift(crc, 8), CRC32_TABLE[bit32.band(bit32.bxor(crc, b4), 0xFF)])
+		crc = bit32.bxor(bit32.rshift(crc, 8), CRC32_TABLE[bit32.band(bit32.bxor(crc, b5), 0xFF)])
+		crc = bit32.bxor(bit32.rshift(crc, 8), CRC32_TABLE[bit32.band(bit32.bxor(crc, b6), 0xFF)])
+		crc = bit32.bxor(bit32.rshift(crc, 8), CRC32_TABLE[bit32.band(bit32.bxor(crc, b7), 0xFF)])
+
+		i += 8
+	end
+
+	-- Process remaining bytes
+	while i < len do
 		local byte = buffer.readu8(buf, i)
 		local index = bit32.band(bit32.bxor(crc, byte), 0xFF)
 		crc = bit32.bxor(bit32.rshift(crc, 8), CRC32_TABLE[index])
+		i += 1
 	end
 
 	return bit32.bxor(crc, 0xFFFFFFFF)

--- a/lute/cli/commands/pkg/loom-core/extern/unzip/inflate.luau
+++ b/lute/cli/commands/pkg/loom-core/extern/unzip/inflate.luau
@@ -5,6 +5,7 @@ export type Tree = typeof(setmetatable({} :: TreeInner, { __index = Tree }))
 type TreeInner = {
 	table: { number }, -- Length of 16, stores code length counts
 	trans: { number }, -- Length of 288, stores code to symbol translations
+	lookup: { number }?, -- Precomputed Huffman lookup table for fast path
 }
 
 --- Creates a new Tree instance with initialized tables
@@ -13,6 +14,7 @@ function Tree.new(): Tree
 		{
 			table = table.create(16, 0),
 			trans = table.create(288, 0),
+			lookup = nil,
 		} :: TreeInner,
 		{ __index = Tree }
 	)
@@ -24,6 +26,7 @@ export type Data = typeof(setmetatable({} :: DataInner, { __index = Data }))
 -- stylua: ignore
 export type DataInner = {
     source: buffer,      -- Input buffer containing compressed data
+    sourceLen: number,   -- Cached length of source buffer
     sourceIndex: number, -- Current position in source buffer
     tag: number,         -- Bit buffer for reading compressed data
     bitcount: number,    -- Number of valid bits in tag
@@ -40,6 +43,7 @@ function Data.new(source: buffer, dest: buffer): Data
 	return setmetatable(
 		{
 			source = source,
+			sourceLen = buffer.len(source),
 			sourceIndex = 0,
 			tag = 0,
 			bitcount = 0,
@@ -73,6 +77,25 @@ local clcIndex = {
 -- Tree used for decoding code lengths in dynamic blocks
 local codeTree = Tree.new()
 local lengths = table.create(288 + 32, 0)
+
+-- Pre-calculate bitmasks for bit extraction, this only runs on the first
+-- require before this module is cached
+local bitMasks = table.create(17, 0)
+for i = 0, 16 do
+	bitMasks[i] = bit32.rshift(0xffff, 16 - i)
+end
+
+-- Maximum bit length for fixed Huffman codes. We selected 9 as a good mean
+-- value instead of 10 or 12 as they seemed to be slightly slower, potentially
+-- due to table memory overhead. In my testing using the `pandoc_soft_links`
+-- file, I found these throughputs:
+--
+-- - 10-bit (1024 entries): 15.0 MB / s
+-- - 12-bit (4096 entries): 11.5 MB / s
+-- - 9-bit  (512 entries):  17.2 MB / s
+
+local LOOKUP_BITS = 9
+local LOOKUP_SIZE = bit32.lshift(1, LOOKUP_BITS) -- OPT: lshift instead of exponentiation
 
 --- Builds the extra bits and base tables for length and distance codes
 local function buildBitsBase(bits: { number }, base: { number }, delta: number, first: number)
@@ -131,6 +154,43 @@ end
 --- Temporary array for building trees
 local offs = table.create(16, 0)
 
+--- Builds a fast lookup table for the first `LOOKUP_BITS` bits of Huffman codes
+local function buildLookupTable(t: Tree)
+	local lookup = table.create(LOOKUP_SIZE, 0)
+
+	for i = 0, LOOKUP_SIZE - 1 do
+		-- Traverse the Huffman tree to find what this bit pattern decodes to
+		local sum, cur, len = 0, 0, 0
+		local bits = i
+
+		repeat
+			cur = 2 * cur + bit32.band(bits, 1)
+			bits = bit32.rshift(bits, 1)
+			len += 1
+
+			-- Huffman codes cannot be longer than 15 bits
+			if len > 15 then
+				break
+			end
+
+			sum += t.table[len]
+			cur -= t.table[len]
+		until cur < 0
+
+		if len <= LOOKUP_BITS then
+			-- Only store in lookup table if it is within the bits range
+			-- High 16 bits = symbol; low 16 bits = length
+			local symbol = t.trans[sum + cur]
+			lookup[i] = bit32.lshift(symbol, 16) + len
+		else
+			-- NOTE: a length of zero signifies no fast path
+			lookup[i] = 0
+		end
+	end
+
+	t.lookup = lookup
+end
+
 --- Builds a Huffman tree from a list of code lengths
 local function buildTree(t: Tree, lengths: { number }, off: number, num: number)
 	-- Initialize the code length count table
@@ -160,6 +220,23 @@ local function buildTree(t: Tree, lengths: { number }, off: number, num: number)
 			offs[len] += 1
 		end
 	end
+
+	-- Build fast lookup table for first LOOKUP_BITS bits
+	buildLookupTable(t)
+end
+
+--- Ensures the bitbuffer has enough bits available
+local function ensureBits(d: Data, minBits: number)
+	if d.bitcount >= minBits then
+		return
+	end
+
+	-- Refill as much as possible at once
+	while d.bitcount < 24 and d.sourceIndex < d.sourceLen do
+		d.tag = bit32.bor(d.tag, bit32.lshift(buffer.readu8(d.source, d.sourceIndex), d.bitcount))
+		d.sourceIndex += 1
+		d.bitcount += 8
+	end
 end
 
 --- Reads a single bit from the input stream
@@ -183,32 +260,42 @@ local function readBits(d: Data, num: number?, base: number): number
 		return base
 	end
 
-	-- Ensure we have enough bits in the buffer
-	while d.bitcount < 24 and d.sourceIndex < buffer.len(d.source) do
-		d.tag = bit32.bor(d.tag, bit32.lshift(buffer.readu8(d.source, d.sourceIndex), d.bitcount))
-		d.sourceIndex += 1
-		d.bitcount += 8
-	end
+	ensureBits(d, num)
 
-	local val = bit32.band(d.tag, bit32.rshift(0xffff, 16 - num))
+	local val = bit32.band(d.tag, bitMasks[num])
 	d.tag = bit32.rshift(d.tag, num)
 	d.bitcount -= num
 
 	return val + base
 end
 
---- Decodes a symbol using a Huffman tree
+--- Decodes a symbol using a Huffman tree with fast lookup table
 local function decodeSymbol(d: Data, t: Tree): number
-	while d.bitcount < 24 and d.sourceIndex < buffer.len(d.source) do
-		d.tag = bit32.bor(d.tag, bit32.lshift(buffer.readu8(d.source, d.sourceIndex), d.bitcount))
-		d.sourceIndex += 1
-		d.bitcount += 8
+	-- Longest possible code in a Huffman table is 15 bits, ensure
+	-- there are enough bits for that
+	ensureBits(d, 15)
+
+	-- Fast path: lookup first `LOOKUP_BITS`
+	local lookup = t.lookup :: { number }
+	local lookupIndex = bit32.band(d.tag, LOOKUP_SIZE - 1)
+	local entry = lookup[lookupIndex]
+	local len = bit32.band(entry, 0xFFFF)
+
+	if len > 0 then
+		-- If the code fits within the `LOOKUP_BITS` size, nothing more
+		-- to be done
+		local symbol = bit32.rshift(entry, 16)
+		d.tag = bit32.rshift(d.tag, len)
+		d.bitcount -= len
+		return symbol
 	end
 
-	local sum, cur, len = 0, 0, 0
+	-- Slow path: code is longer than `LOOKUP_BITS`, we need to traverse
+	-- the full tree on our own
+	local sum, cur = 0, 0
 	local tag = d.tag
+	len = 0
 
-	-- Traverse the Huffman tree to find the symbol
 	repeat
 		cur = 2 * cur + bit32.band(tag, 1)
 		tag = bit32.rshift(tag, 1)
@@ -280,32 +367,188 @@ end
 
 --- Inflates a block of data using Huffman trees
 local function inflateBlockData(d: Data, lengthTree: Tree, distTree: Tree)
-	while true do
-		local sym = decodeSymbol(d, lengthTree)
+	local dest = d.dest
+	local destLen = d.destLen
+	local destSize = buffer.len(dest)
 
-		if sym == 256 then
-			-- End of block
-			return
+	local lastGrowCheck = destLen
+
+	while true do
+		-- OPT: inlined `decodeSymbol` for length tree
+		ensureBits(d, 15)
+		local entry = (lengthTree.lookup :: { number })[bit32.band(d.tag, LOOKUP_SIZE - 1)]
+		local len = bit32.band(entry, 0xFFFF)
+		local sym
+
+		if len > 0 then
+			sym = bit32.rshift(entry, 16)
+			d.tag = bit32.rshift(d.tag, len)
+			d.bitcount -= len
+		else
+			-- Slow path
+			local sum, cur = 0, 0
+			local tag = d.tag
+			len = 0
+
+			repeat
+				cur = 2 * cur + bit32.band(tag, 1)
+				tag = bit32.rshift(tag, 1)
+				len += 1
+				sum += lengthTree.table[len]
+				cur -= lengthTree.table[len]
+			until cur < 0
+
+			d.tag = tag
+			d.bitcount -= len
+			sym = lengthTree.trans[sum + cur]
 		end
 
+		-- OPT: literals are the most common symbols
 		if sym < 256 then
-			-- Literal byte
-			buffer.writeu8(d.dest, d.destLen, sym)
-			d.destLen += 1
+			-- Check growth periodically
+			if destLen - lastGrowCheck >= 64 then
+				if destLen + 64 > destSize then
+					local newSize = destSize * 2
+					local newDest = buffer.create(newSize)
+
+					buffer.copy(newDest, 0, dest, 0, destLen)
+
+					dest = newDest
+					d.dest = newDest
+					destSize = newSize
+				end
+
+				lastGrowCheck = destLen
+			end
+
+			buffer.writeu8(dest, destLen, sym)
+			destLen += 1
+		elseif sym == 256 then
+			-- End of block
+			d.destLen = destLen
+			return
 		else
 			-- Length/distance pair for copying
 			sym -= 257
 
 			local length = readBits(d, lengthBits[sym], lengthBase[sym])
-			local dist = decodeSymbol(d, distTree)
 
-			local offs = d.destLen - readBits(d, distBits[dist], distBase[dist])
+			-- OPT: inlined `decodeSymbol` for distance tree
+			ensureBits(d, 15)
+			entry = (distTree.lookup :: { number })[bit32.band(d.tag, LOOKUP_SIZE - 1)]
+			len = bit32.band(entry, 0xFFFF)
 
-			-- Copy bytes from back reference
-			for i = offs, offs + length - 1 do
-				buffer.writeu8(d.dest, d.destLen, buffer.readu8(d.dest, i))
-				d.destLen += 1
+			local dist
+
+			if len > 0 then
+				dist = bit32.rshift(entry, 16)
+				d.tag = bit32.rshift(d.tag, len)
+				d.bitcount -= len
+			else
+				-- Slow path
+				local sum, cur = 0, 0
+				local tag = d.tag
+				len = 0
+
+				repeat
+					cur = 2 * cur + bit32.band(tag, 1)
+					tag = bit32.rshift(tag, 1)
+					len += 1
+					sum += distTree.table[len]
+					cur -= distTree.table[len]
+				until cur < 0
+
+				d.tag = tag
+				d.bitcount -= len
+				dist = distTree.trans[sum + cur]
 			end
+
+			dist = readBits(d, distBits[dist], distBase[dist])
+			local offs = destLen - dist
+
+			-- Check if we need to grow the buffer
+			if destLen + length > destSize then
+				local newSize = math.max(destSize * 2, destLen + length)
+				local newDest = buffer.create(newSize)
+
+				buffer.copy(newDest, 0, dest, 0, destLen)
+
+				dest = newDest
+				d.dest = newDest
+				destSize = newSize
+			end
+
+			-- Validate offset is within bounds
+			if offs < 0 then
+				error(`Invalid distance: trying to copy from offset {offs} (destLen={destLen}, dist={dist})`)
+			end
+
+			-- OPT: Non-overlapping copies are common
+			if dist >= length then
+				-- We can directly memcpy
+				buffer.copy(dest, destLen, dest, offs, length)
+				destLen += length
+			elseif length <= 8 then
+				-- OPT: small overlapping copies, we can unroll upto 8 bytes manually,
+				-- prepare for extremely ugly code ahead
+				if length <= 4 then
+					buffer.writeu8(dest, destLen, buffer.readu8(dest, offs))
+					buffer.writeu8(dest, destLen + 1, buffer.readu8(dest, offs + 1))
+
+					if length > 2 then
+						buffer.writeu8(dest, destLen + 2, buffer.readu8(dest, offs + 2))
+						if length > 3 then
+							buffer.writeu8(dest, destLen + 3, buffer.readu8(dest, offs + 3))
+						end
+					end
+				else
+					buffer.writeu8(dest, destLen, buffer.readu8(dest, offs))
+					buffer.writeu8(dest, destLen + 1, buffer.readu8(dest, offs + 1))
+					buffer.writeu8(dest, destLen + 2, buffer.readu8(dest, offs + 2))
+					buffer.writeu8(dest, destLen + 3, buffer.readu8(dest, offs + 3))
+
+					if length > 4 then
+						buffer.writeu8(dest, destLen + 4, buffer.readu8(dest, offs + 4))
+						if length > 5 then
+							buffer.writeu8(dest, destLen + 5, buffer.readu8(dest, offs + 5))
+							if length > 6 then
+								buffer.writeu8(dest, destLen + 6, buffer.readu8(dest, offs + 6))
+								if length > 7 then
+									buffer.writeu8(dest, destLen + 7, buffer.readu8(dest, offs + 7))
+								end
+							end
+						end
+					end
+				end
+				destLen += length
+			elseif dist == 1 then
+				-- OPT: single byte repition is common
+				local byte = buffer.readu8(dest, offs)
+				for i = 0, length - 1 do
+					buffer.writeu8(dest, destLen + i, byte)
+				end
+				destLen += length
+			else
+				-- OPT: try chunked overlapping copies
+				local chunkSize = dist
+				local chunks = length // chunkSize
+				local remainder = length % chunkSize
+
+				for _ = 1, chunks do
+					buffer.copy(dest, destLen, dest, offs, chunkSize)
+					destLen += chunkSize
+					offs += chunkSize
+				end
+
+				if remainder > 0 then
+					for i = 0, remainder - 1 do
+						buffer.writeu8(dest, destLen + i, buffer.readu8(dest, offs + i))
+					end
+					destLen += remainder
+				end
+			end
+
+			lastGrowCheck = destLen
 		end
 	end
 end
@@ -332,12 +575,20 @@ local function inflateUncompressedBlock(d: Data)
 
 	d.sourceIndex += 4
 
-	-- Copy uncompressed data to output
-	for _ = 1, length do
-		buffer.writeu8(d.dest, d.destLen, buffer.readu8(d.source, d.sourceIndex))
-		d.destLen += 1
-		d.sourceIndex += 1
+	-- Check if we need to grow the buffer
+	local destSize = buffer.len(d.dest)
+	if d.destLen + length > destSize then
+		local newSize = math.max(destSize * 2, d.destLen + length)
+		local newDest = buffer.create(newSize)
+
+		buffer.copy(newDest, 0, d.dest, 0, d.destLen)
+		d.dest = newDest
 	end
+
+	-- Use bulk copy for uncompressed data
+	buffer.copy(d.dest, d.destLen, d.source, d.sourceIndex, length)
+	d.destLen += length
+	d.sourceIndex += length
 
 	d.bitcount = 0
 end
@@ -348,7 +599,7 @@ local function uncompress(source: buffer, uncompressedSize: number?): buffer
 		-- If the uncompressed size is known, we use that, otherwise we use a default
 		-- size that is a 7 times more than the compressed size; this factor works
 		-- well for most cases other than those with a very high compression ratio
-		uncompressedSize or buffer.len(source) * 7
+		if uncompressedSize and uncompressedSize > 0 then uncompressedSize else buffer.len(source) * 7
 	)
 	local d = Data.new(source, dest)
 
@@ -369,17 +620,19 @@ local function uncompress(source: buffer, uncompressedSize: number?): buffer
 	until bfinal == 1
 
 	-- Trim output buffer to actual size if needed
-	if d.destLen < buffer.len(dest) then
+	if d.destLen < buffer.len(d.dest) then
 		local result = buffer.create(d.destLen)
-		buffer.copy(result, 0, dest, 0, d.destLen)
+		buffer.copy(result, 0, d.dest, 0, d.destLen)
 		return result
 	end
 
-	return dest
+	return d.dest
 end
 
 -- Initialize static trees and lookup tables for DEFLATE format
 buildFixedTrees(staticLengthTree, staticDistTree)
+buildLookupTable(staticLengthTree)
+buildLookupTable(staticDistTree)
 buildBitsBase(lengthBits, lengthBase, 4, 3)
 buildBitsBase(distBits, distBase, 2, 1)
 lengthBits[28] = 0

--- a/lute/cli/commands/pkg/loom-core/extern/unzip/init.luau
+++ b/lute/cli/commands/pkg/loom-core/extern/unzip/init.luau
@@ -1,5 +1,6 @@
 local inflate = require("@self/inflate")
 local validateCrc = require("@self/utils/validate_crc")
+local crc32 = require("@self/crc")
 local path = require("@self/utils/path")
 
 -- The maximum supported PKZIP format specification version that we support
@@ -16,29 +17,6 @@ local SIGNATURES = table.freeze({
 	-- Marks the end of the central directory
 	END_OF_CENTRAL_DIR = 0x06054b50,
 })
-
--- Decompression routines for each supported compression method
-local DECOMPRESSION_ROUTINES: { [number]: { name: CompressionMethod, decompress: (buffer, number, validateCrc.CrcValidationOptions) -> buffer } } =
-	{
-		-- `STORE` decompression method - No compression
-		[0x00] = {
-			name = "STORE" :: CompressionMethod,
-			decompress = function(buf, _, validation): buffer
-				validateCrc(buf, validation)
-				return buf
-			end,
-		},
-
-		-- `DEFLATE` decompression method - Compressed raw deflate chunks
-		[0x08] = {
-			name = "DEFLATE" :: CompressionMethod,
-			decompress = function(buf, uncompressedSize, validation): buffer
-				local decompressed = inflate(buf, uncompressedSize)
-				validateCrc(decompressed, validation)
-				return decompressed
-			end,
-		},
-	}
 
 -- Set of placeholder entry properties for incompatible entries
 local EMPTY_PROPERTIES: ZipEntryProperties = table.freeze({
@@ -76,7 +54,7 @@ local MADE_BY_OS_LOOKUP: { [number]: MadeByOS } = {
 
 --[=[
 	@class ZipEntry
-
+	
 	A single entry (a file or a directory) in a ZIP file, and its properties.
 ]=]
 local ZipEntry = {}
@@ -123,8 +101,8 @@ type ZipEntryInner = {
 
 -- stylua: ignore
 --[=[
-	@within ZipEntry
-	@type MadeByOS "FAT" | "AMIGA" | "VMS" | "UNIX" | "VM/CMS" | "Atari ST" | "OS/2" | "MAC" | "Z-System" | "CP/M" | "NTFS" | "MVS" | "VSE" | "Acorn RISCOS" | "VFAT" | "Alternate MVS" | "BeOS" | "TANDEM" | "OS/400" | "OS/X" | "Unknown"
+	@within ZipEntry	
+	@type MadeByOS "FAT" | "AMIGA" | "VMS" | "UNIX" | "VM/CMS" | "Atari ST" | "OS/2" | "MAC" | "Z-System" | "CP/M" | "NTFS" | "MVS" | "VSE" | "Acorn RISCOS" | "VFAT" | "Alternate MVS" | "BeOS" | "TANDEM" | "OS/400" | "OS/X" | "Unknown"     
 
 	The OS that created the ZIP.
 ]=]
@@ -151,22 +129,74 @@ export type MadeByOS =
 	| "OS/X"          -- 0x13; Darwin
 	| "Unknown"       -- 0x14 - 0xff; Unused
 
+-- stylua: ignore
 --[=[
 	@within ZipEntry
-	@type CompressionMethod "STORE" | "DEFLATE"
+	@type CompressionMethod "STORE" | "SHRUNK" | "REDUCE_F1" | "REDUCE_F2" | "REDUCE_F3" | "REDUCE_F4" | "IMPLODE" | "TOKENIZE" | "DEFLATE" | "DEFLATE64" | "IMPLODE_DCL" | "BZIP2" | "LZMA" | "CMPSC" | "TERSE" | "LZ77" | "ZSTD" | "MP3" | "XZ" | "JPEG" | "WAVPACK" | "PPMD" | "AE_X"
 
-	The method used to compress the file:
-	- `STORE` - No compression
-	- `DEFLATE` - Compressed raw deflate chunks
+	The method used to compress the file. See PKWARE APPNOTE §4.4.5 for details.
+
+	| Method        | Code | Description               |
+	|---------------|------|---------------------------|
+	| `STORE`       |    0 | No compression            |
+	| `SHRUNK`      |    1 | Shrunk                    |
+	| `REDUCE_F1`   |    2 | Reduced factor 1          |
+	| `REDUCE_F2`   |    3 | Reduced factor 2          |
+	| `REDUCE_F3`   |    4 | Reduced factor 3          |
+	| `REDUCE_F4`   |    5 | Reduced factor 4          |
+	| `IMPLODE`     |    6 | Imploded                  |
+	| `TOKENIZE`    |    7 | Reserved for Tokenizing   |
+	| `DEFLATE`     |    8 | Deflated (supported)      |
+	| `DEFLATE64`   |    9 | Enhanced Deflating        |
+	| `IMPLODE_DCL` |   10 | PKWARE DCL Imploding      |
+	| `BZIP2`       |   12 | BZIP2                     |
+	| `LZMA`        |   14 | LZMA                      |
+	| `CMPSC`       |   16 | IBM z/OS CMPSC            |
+	| `TERSE`       |   18 | IBM TERSE (new)           |
+	| `LZ77`        |   19 | IBM LZ77 z Architecture   |
+	| `ZSTD`        |   93 | Zstandard                 |
+	| `MP3`         |   94 | MP3 Compression           |
+	| `XZ`          |   95 | XZ Compression            |
+	| `JPEG`        |   96 | JPEG variant              |
+	| `WAVPACK`     |   97 | WavPack                   |
+	| `PPMD`        |   98 | PPMd version I, Rev 1     |
+	| `AE_X`        |   99 | AE-x encryption marker    |
+
+	Only `STORE` and `DEFLATE` are supported for extraction by this library.
+	Custom decompression routines can be registered via [ZipReader.new] to support
+	additional methods.
 ]=]
-export type CompressionMethod = "STORE" | "DEFLATE"
+export type CompressionMethod = 
+    | "STORE"       -- 0x00: No compression
+    | "SHRUNK"      -- 0x01: Shrunk
+    | "REDUCE_F1"   -- 0x02: Reduced factor 1
+    | "REDUCE_F2"   -- 0x03: Reduced factor 2
+    | "REDUCE_F3"   -- 0x04: Reduced factor 3
+    | "REDUCE_F4"   -- 0x05: Reduced factor 4
+    | "IMPLODE"     -- 0x06: Imploded
+    | "TOKENIZE"    -- 0x07: Reserved for Tokenizing
+    | "DEFLATE"     -- 0x08: Deflated (supported)
+    | "DEFLATE64"   -- 0x09: Enhanced Deflating
+    | "IMPLODE_DCL" -- 0x0A: PKWARE DCL Imploding
+    | "BZIP2"       -- 0x0C: BZIP2
+    | "LZMA"        -- 0x0E: LZMA
+    | "CMPSC"       -- 0x10: IBM z/OS CMPSC
+    | "TERSE"       -- 0x12: IBM TERSE (new)
+    | "LZ77"        -- 0x13: IBM LZ77 z Architecture
+    | "ZSTD"        -- 0x5D: Zstandard
+    | "MP3"         -- 0x5E: MP3 Compression
+    | "XZ"          -- 0x5F: XZ Compression
+    | "JPEG"        -- 0x60: JPEG variant
+    | "WAVPACK"     -- 0x61: WavPack
+    | "PPMD"        -- 0x62: PPMd version I, Rev 1
+    | "AE_X"        -- 0x63: AE-x encryption marker
 
 --[=[
 	@interface ZipEntryProperties
 	@within ZipEntry
 	@private
 
-	A set of properties that describe a ZIP entry. Used internally for construction of
+	A set of properties that describe a ZIP entry. Used internally for construction of 
 	[ZipEntry] objects.
 
 	@field versionMadeBy number -- Version of software and OS that created the ZIP
@@ -178,13 +208,13 @@ export type CompressionMethod = "STORE" | "DEFLATE"
 	@field crc number -- CRC32 checksum of the uncompressed data
 ]=]
 type ZipEntryProperties = {
-	read versionMadeBy: number,
-	read compressedSize: number,
-	read size: number,
-	read attributes: number,
-	read timestamp: number,
-	read method: CompressionMethod?,
-	read crc: number,
+	versionMadeBy: number,
+	compressedSize: number,
+	size: number,
+	attributes: number,
+	timestamp: number,
+	method: CompressionMethod?,
+	crc: number,
 }
 
 --[=[
@@ -239,7 +269,7 @@ end
 	@within ZipEntry
 	@method getPath
 
-	Resolves the path of the entry based on its relationship with other entries. It is recommended to use this
+	Resolves the path of the entry based on its relationship with other entries. It is recommended to use this 
 	method instead of accessing the `name` property directly, although they should be equivalent.
 
 	> [!WARNING]
@@ -301,7 +331,7 @@ end
 
 --[=[
 	@within ZipEntry
-	@method compressionEfficiency
+	@method compressionEfficiency 
 
 	Calculates the compression efficiency of the entry, or `nil` if the entry is a directory.
 
@@ -389,6 +419,73 @@ type ZipReaderInner = {
 	entries: { ZipEntry },
 	directories: { [string]: ZipEntry },
 	root: ZipEntry,
+	decompressionRoutines: DecompressionRoutinesWithDefaults,
+}
+
+--[=[
+	@interface CrcValidationOptions
+	@within ZipReader
+
+	Options passed to a decompression routine regarding CRC checksum
+	validation.
+
+	@field expected number -- The expected hash provided in the ZIP
+	@field skip boolean -- Whether to skip validation altogether 
+]=]
+export type CrcValidationOptions = validateCrc.CrcValidationOptions
+
+--[=[
+	@interface DecompressionRoutine
+	@within ZipReader
+
+	Represents a compression method's decompression implementation. 
+	
+	A default implementation is provided for all of [CompressionMethod]'s 
+	variants but this may be used to override or provide implementations for 
+	unsupported compression methods. 
+
+	Accepted as an argument for [ZipReader.new].
+]=]
+export type DecompressionRoutine = {
+	name: CompressionMethod,
+	decompress: (buffer, number, CrcValidationOptions) -> buffer,
+}
+
+--[=[
+	@interface DecompressionRoutines
+	@within ZipReader
+	@private
+
+	Implementations for decompression methods, keyed by the method's ID. 
+	
+	See [CompressionMethod] to find the ID for a compression method.
+]=]
+type DecompressionRoutines = { [number]: DecompressionRoutine }
+type DecompressionRoutinesWithDefaults = typeof(setmetatable(
+	{} :: DecompressionRoutines,
+	{ __index = {} :: DecompressionRoutines }
+))
+
+-- Default implementations for supported decompression routines
+local DEFAULT_DECOMPRESSION_ROUTINES: DecompressionRoutines = {
+	-- `STORE` decompression method - No compression
+	[0x00] = {
+		name = "STORE",
+		decompress = function(buf, _, validation): buffer
+			validateCrc(buf, validation)
+			return buf
+		end,
+	},
+
+	-- `DEFLATE` decompression method - Compressed raw deflate chunks
+	[0x08] = {
+		name = "DEFLATE",
+		decompress = function(buf, uncompressedSize, validation): buffer
+			local decompressed = inflate(buf, uncompressedSize)
+			validateCrc(decompressed, validation)
+			return decompressed
+		end,
+	},
 }
 
 --[=[
@@ -396,15 +493,20 @@ type ZipReaderInner = {
 	@function new
 
 	Creates a new ZipReader instance from the raw bytes of a ZIP file.
-
+	
 	**Errors if the ZIP file is invalid.**
 
 	@param data buffer -- The buffer containing the raw bytes of the ZIP
+	@param methods DecompressionRoutines? -- Custom implementations for decompression methods
 	@return ZipReader -- The new ZipReader instance
 ]=]
-function ZipReader.new(data): ZipReader
+function ZipReader.new(data: buffer, methods: DecompressionRoutines?): ZipReader
 	local root = ZipEntry.new(0, "/", EMPTY_PROPERTIES)
 	root.isDirectory = true
+
+	local decompressionRoutines = setmetatable((methods or {}) :: DecompressionRoutines, {
+		__index = DEFAULT_DECOMPRESSION_ROUTINES,
+	}) :: DecompressionRoutinesWithDefaults
 
 	local this = setmetatable(
 		{
@@ -412,6 +514,7 @@ function ZipReader.new(data): ZipReader
 			entries = {},
 			directories = {},
 			root = root,
+			decompressionRoutines = decompressionRoutines,
 		} :: ZipReaderInner,
 		{ __index = ZipReader }
 	)
@@ -430,8 +533,8 @@ end
 	implementation is inspired by that of [async_zip], a Rust library for parsing ZIP files
 	asynchronously.
 
-	This method involves buffered reading in reverse and reverse linear searching along those buffers
-	for the EoCD signature. As a result of the buffered approach, we reduce individual reads when compared
+	This method involves buffered reading in reverse and reverse linear searching along those buffers 
+	for the EoCD signature. As a result of the buffered approach, we reduce individual reads when compared 
 	to reading every single byte sequentially, by a factor of the buffer size (4 KB by default). The buffer
 	size of 4 KB was arrived at because it aligns with many systems' page sizes, and also provides a
 	good balance between read efficiency (not too small), memory usage (not too large) and CPU cache
@@ -508,7 +611,7 @@ export type EocdRecord = {
 	using the [ZipReader:findEocdPosition].
 
 	**Errors if the ZIP file is invalid.**
-
+	
 	@error "Invalid Central Directory offset or size"
 
 	@param pos number -- The offset to the End of Central Directory record
@@ -559,11 +662,11 @@ end
 	@method parseCentralDirectory
 	@private
 
-	Parses the central directory of the ZIP file and populates the `entries` and `directories`
+	Parses the central directory of the ZIP file and populates the `entries` and `directories` 
 	fields. Used internally during initialization of the [ZipReader].
 
 	**Errors if the ZIP file is invalid.**
-
+	
 	@error "Invalid Central Directory entry signature"
 	@error "Found different entries than specified in Central Directory"
 ]=]
@@ -626,7 +729,7 @@ function ZipReader.parseCentralDirectory(self: ZipReader): ()
 				compressedSize = compressedSize,
 				size = size,
 				crc = crc,
-				method = DECOMPRESSION_ROUTINES[compressionMethod].name :: CompressionMethod,
+				method = self.decompressionRoutines[compressionMethod].name :: CompressionMethod,
 				timestamp = timestamp,
 				attributes = externalAttrs,
 				isText = bit32.btest(internalAttrs, 0x0001),
@@ -649,7 +752,7 @@ end
 	@method buildDirectoryTree
 	@private
 
-	Builds the directory tree from the entries. Used internally during initialization of the
+	Builds the directory tree from the entries. Used internally during initialization of the 
 	[ZipReader].
 ]=]
 function ZipReader.buildDirectoryTree(self: ZipReader): ()
@@ -657,7 +760,7 @@ function ZipReader.buildDirectoryTree(self: ZipReader): ()
 	-- directories and files in separate passes over the entries, or sort
 	-- the entries so I handled the directories first -- I decided to do
 	-- the latter
-	table.sort<<ZipEntry>>(self.entries, function(a, b)
+	table.sort(self.entries, function(a, b)
 		if a.isDirectory ~= b.isDirectory then
 			return a.isDirectory
 		end
@@ -724,7 +827,7 @@ end
 --[=[
 	@within ZipReader
 	@method findEntry
-
+	
 	Finds a [ZipEntry] by its path in the ZIP archive.
 
 	@param path string -- Path to the entry to find
@@ -780,7 +883,7 @@ type ExtractionOptions = {
 	@within ZipReader
 	@method extract
 
-	Extracts the specified [ZipEntry] from the ZIP archive. See [ZipReader:extractDirectory] for
+	Extracts the specified [ZipEntry] from the ZIP archive. See [ZipReader:extractDirectory] for 
 	extracting directories.
 
 	@error "Cannot extract directory" -- If the entry is a directory, use [ZipReader:extractDirectory] instead
@@ -821,7 +924,13 @@ function ZipReader.extract(self: ZipReader, entry: ZipEntry, options: Extraction
 	}
 
 	-- TODO: Use a `Partial` type function for this in the future!
-	local optionsOrDefault = if options
+	local optionsOrDefault: {
+		followSymlinks: boolean,
+		decompress: boolean,
+		type: "binary" | "text",
+		skipCrcValidation: boolean,
+		skipSizeValidation: boolean,
+	} = if options
 		then setmetatable(options, { __index = defaultOptions }) :: any
 		else defaultOptions
 
@@ -889,7 +998,7 @@ function ZipReader.extract(self: ZipReader, entry: ZipEntry, options: Extraction
 
 	if optionsOrDefault.decompress then
 		local compressionMethod = buffer.readu16(self.data, entry.offset + 8)
-		local algo = DECOMPRESSION_ROUTINES[compressionMethod]
+		local algo = self.decompressionRoutines[compressionMethod]
 		if algo == nil then
 			error(`Unsupported compression, ID: {compressionMethod}`)
 		end
@@ -1017,9 +1126,9 @@ end
 	@interface ZipStatistics
 	@within ZipReader
 
-	@field fileCount number -- The number of files in the ZIP
-	@field dirCount number -- The number of directories in the ZIP
-	@field totalSize number -- The total size of all files in the ZIP
+	@field fileCount number -- The number of files in the ZIP 
+	@field dirCount number -- The number of directories in the ZIP 
+	@field totalSize number -- The total size of all files in the ZIP 
 ]=]
 export type ZipStatistics = { fileCount: number, dirCount: number, totalSize: number }
 
@@ -1053,8 +1162,13 @@ function ZipReader.getStats(self: ZipReader): ZipStatistics
 end
 
 return {
+	ZipReader = ZipReader,
+
 	-- Creates a `ZipReader` from a `buffer` of ZIP data.
 	load = function(data: buffer)
 		return ZipReader.new(data)
 	end,
+
+	-- Optimized Cyclic Redundancy Check (CRC32) computation implementation
+	crc32 = crc32,
 }

--- a/lute/cli/commands/pkg/loom-core/extern/unzip/utils/path.luau
+++ b/lute/cli/commands/pkg/loom-core/extern/unzip/utils/path.luau
@@ -44,7 +44,7 @@ local function replaceBackslashes(input: string, replacement: "/"): string
 		return "\\\\" .. input:sub(3):gsub("\\", replacement)
 	else
 		-- Replace all single backslashes
-		return input:gsub("\\", replacement)
+		return (input:gsub("\\", replacement))
 	end
 end
 

--- a/lute/cli/commands/pkg/loom-core/extern/unzip/utils/path.luau
+++ b/lute/cli/commands/pkg/loom-core/extern/unzip/utils/path.luau
@@ -44,7 +44,7 @@ local function replaceBackslashes(input: string, replacement: "/"): string
 		return "\\\\" .. input:sub(3):gsub("\\", replacement)
 	else
 		-- Replace all single backslashes
-		return (input:gsub("\\", replacement))
+		return input:gsub("\\", replacement)
 	end
 end
 

--- a/lute/cli/commands/pkg/loom-core/extern/unzip/utils/validate_crc.luau
+++ b/lute/cli/commands/pkg/loom-core/extern/unzip/utils/validate_crc.luau
@@ -13,7 +13,7 @@ local function validateCrc(decompressed: buffer, validation: CrcValidationOption
 			validation.expected == computed,
 			`Validation failed; CRC checksum does not match: {string.format("%x", computed)} ~= {string.format(
 				"%x",
-				computed
+				validation.expected
 			)} (expected ~= got)`
 		)
 	end

--- a/tests/cli/pkg/install.test.luau
+++ b/tests/cli/pkg/install.test.luau
@@ -55,12 +55,16 @@ test.suite("LutePkgInstall", function(suite)
 		local libDir = path.join(workingDirectory, "lib")
 		fs.createDirectory(libDir)
 		writeConfig(libDir, "lib", "")
-		writeConfig(workingDirectory, "root", [[
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
 
 			lib = {
 				sourceKind = "path",
 				source = "./lib",
-			},]])
+			},]]
+		)
 
 		local result = run(workingDirectory)
 
@@ -75,7 +79,10 @@ test.suite("LutePkgInstall", function(suite)
 			fs.createDirectory(dir)
 			writeConfig(dir, name, "")
 		end
-		writeConfig(workingDirectory, "root", [[
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
 
 			a = {
 				sourceKind = "path",
@@ -84,7 +91,8 @@ test.suite("LutePkgInstall", function(suite)
 			b = {
 				sourceKind = "path",
 				source = "./b",
-			},]])
+			},]]
+		)
 
 		local result = run(workingDirectory)
 
@@ -104,18 +112,26 @@ test.suite("LutePkgInstall", function(suite)
 		fs.createDirectory(bDir)
 
 		writeConfig(bDir, "b", "")
-		writeConfig(aDir, "a", [[
+		writeConfig(
+			aDir,
+			"a",
+			[[
 
 			b = {
 				sourceKind = "path",
 				source = "../b",
-			},]])
-		writeConfig(workingDirectory, "root", [[
+			},]]
+		)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
 
 			a = {
 				sourceKind = "path",
 				source = "./libs/a",
-			},]])
+			},]]
+		)
 
 		local result = run(workingDirectory)
 
@@ -132,12 +148,16 @@ test.suite("LutePkgInstall", function(suite)
 		local libDir = path.join(workingDirectory, "lib")
 		fs.createDirectory(libDir)
 		writeConfig(libDir, "lib", "")
-		writeConfig(workingDirectory, "root", [[
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
 
 			lib = {
 				sourceKind = "path",
 				source = "./lib",
-			},]])
+			},]]
+		)
 
 		run(workingDirectory)
 
@@ -148,12 +168,16 @@ test.suite("LutePkgInstall", function(suite)
 	end)
 
 	suite:case("failsWhenPathDependencyMissing", function(assert)
-		writeConfig(workingDirectory, "root", [[
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
 
 			missing = {
 				sourceKind = "path",
 				source = "./does-not-exist",
-			},]])
+			},]]
+		)
 
 		local result = run(workingDirectory)
 
@@ -165,12 +189,16 @@ test.suite("LutePkgInstall", function(suite)
 		local libDir = path.join(workingDirectory, "lib")
 		fs.createDirectory(libDir)
 		writeConfig(libDir, "lib", "")
-		writeConfig(workingDirectory, "root", [[
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
 
 			lib = {
 				sourceKind = "path",
 				source = "./lib",
-			},]])
+			},]]
+		)
 
 		local r1 = run(workingDirectory)
 		local r2 = run(workingDirectory)

--- a/tests/cli/pkg/install.test.luau
+++ b/tests/cli/pkg/install.test.luau
@@ -1,0 +1,182 @@
+local fs = require("@std/fs")
+local path = require("@std/path")
+local process = require("@std/process")
+local system = require("@std/system")
+local test = require("@std/test")
+
+local temporaryDirectory = system.tmpdir()
+local workingDirectory = path.join(temporaryDirectory, "lute-pkg")
+local lutePath = path.format(process.execPath())
+
+local function writeConfig(dir: path.Path, name: string, deps: string)
+	fs.writeStringToFile(
+		path.join(dir, "loom.config.luau"),
+		`return \{\n\tpackage = \{\n\t\tname = "{name}",\n\t\tversion = "0.0.0",\n\t\tdependencies = \{{deps}\n\t\t},\n\t},\n}\n`
+	)
+end
+
+local function run(cwd: path.Path): { exitcode: number, stdout: string, stderr: string }
+	return process.run({ lutePath, "pkg", "install" }, { cwd = path.format(cwd) })
+end
+
+test.suite("LutePkgInstall", function(suite)
+	suite:beforeEach(function()
+		if fs.exists(workingDirectory) then
+			fs.removeDirectory(workingDirectory, { recursive = true })
+		end
+		fs.createDirectory(workingDirectory)
+	end)
+
+	suite:case("failsWithoutManifest", function(assert)
+		local result = run(workingDirectory)
+
+		assert.eq(result.exitcode, 1)
+		assert.strContains(result.stderr, "Manifest file not found")
+	end)
+
+	suite:case("succeedsWithNoDependencies", function(assert)
+		writeConfig(workingDirectory, "root", "")
+
+		local result = run(workingDirectory)
+
+		assert.eq(result.exitcode, 0)
+		assert.strContains(result.stdout, "Resolved 0 package(s).")
+	end)
+
+	suite:case("writesLockfile", function(assert)
+		writeConfig(workingDirectory, "root", "")
+
+		run(workingDirectory)
+
+		assert.that(fs.exists(path.join(workingDirectory, "loom.lock.luau")))
+	end)
+
+	suite:case("installsSinglePathDependency", function(assert)
+		local libDir = path.join(workingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfig(libDir, "lib", "")
+		writeConfig(workingDirectory, "root", [[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]])
+
+		local result = run(workingDirectory)
+
+		assert.eq(result.exitcode, 0)
+		assert.strContains(result.stdout, "Resolved 1 package(s).")
+		assert.strContains(result.stdout, "lib (path, 0 dep(s))")
+	end)
+
+	suite:case("installsMultiplePathDependencies", function(assert)
+		for _, name in { "a", "b" } do
+			local dir = path.join(workingDirectory, name)
+			fs.createDirectory(dir)
+			writeConfig(dir, name, "")
+		end
+		writeConfig(workingDirectory, "root", [[
+
+			a = {
+				sourceKind = "path",
+				source = "./a",
+			},
+			b = {
+				sourceKind = "path",
+				source = "./b",
+			},]])
+
+		local result = run(workingDirectory)
+
+		assert.eq(result.exitcode, 0)
+		assert.strContains(result.stdout, "Resolved 2 package(s).")
+	end)
+
+	suite:case("installsTransitivePathDependencies", function(assert)
+		-- Use "libs/" not "packages/" — on case-insensitive filesystems the latter
+		-- collides with the Packages/ directory that pkg install clears on startup.
+		local libsDir = path.join(workingDirectory, "libs")
+		fs.createDirectory(libsDir)
+
+		local aDir = path.join(libsDir, "a")
+		local bDir = path.join(libsDir, "b")
+		fs.createDirectory(aDir)
+		fs.createDirectory(bDir)
+
+		writeConfig(bDir, "b", "")
+		writeConfig(aDir, "a", [[
+
+			b = {
+				sourceKind = "path",
+				source = "../b",
+			},]])
+		writeConfig(workingDirectory, "root", [[
+
+			a = {
+				sourceKind = "path",
+				source = "./libs/a",
+			},]])
+
+		local result = run(workingDirectory)
+
+		assert.eq(result.exitcode, 0)
+		assert.strContains(result.stdout, "Resolved 1 package(s).")
+		assert.strContains(result.stdout, "a (path, 1 dep(s))")
+
+		local lockfile = fs.readFileToString(path.join(workingDirectory, "loom.lock.luau"))
+		assert.strContains(lockfile, '"a"')
+		assert.strContains(lockfile, '"b"')
+	end)
+
+	suite:case("lockfileRecordsSourceKindAndInstallPath", function(assert)
+		local libDir = path.join(workingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfig(libDir, "lib", "")
+		writeConfig(workingDirectory, "root", [[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]])
+
+		run(workingDirectory)
+
+		local lockfile = fs.readFileToString(path.join(workingDirectory, "loom.lock.luau"))
+		assert.strContains(lockfile, "version = 3")
+		assert.strContains(lockfile, '"path"')
+		assert.strContains(lockfile, "installPath")
+	end)
+
+	suite:case("failsWhenPathDependencyMissing", function(assert)
+		writeConfig(workingDirectory, "root", [[
+
+			missing = {
+				sourceKind = "path",
+				source = "./does-not-exist",
+			},]])
+
+		local result = run(workingDirectory)
+
+		assert.eq(result.exitcode, 1)
+		assert.strContains(result.stderr, "does-not-exist")
+	end)
+
+	suite:case("reinstallIsIdempotent", function(assert)
+		local libDir = path.join(workingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfig(libDir, "lib", "")
+		writeConfig(workingDirectory, "root", [[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]])
+
+		local r1 = run(workingDirectory)
+		local r2 = run(workingDirectory)
+
+		assert.eq(r1.exitcode, 0)
+		assert.eq(r2.exitcode, 0)
+		assert.eq(r1.stdout, r2.stdout)
+	end)
+end)

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -248,10 +248,14 @@ local function writeLines(file, lines: { string })
 	fs.write(file, table.concat(lines, "\n") .. "\n")
 end
 
+local function shouldEmbedFile(relativePath: string): boolean
+	return string.match(relativePath, "%.luau$") ~= nil or string.match(relativePath, "%.luaurc$") ~= nil
+end
+
 local function hashDirectory(path: string): string
 	local toHash = ""
 	traverseFileTree(path, function(filePath, relativePath)
-		if safeFsType(filePath) == "file" then
+		if safeFsType(filePath) == "file" and shouldEmbedFile(relativePath) then
 			toHash ..= "./" .. relativePath
 			toHash ..= readFileToString(filePath)
 		end
@@ -317,6 +321,10 @@ local function generateEmbeddedModulesIfNeeded(config: EmbeddedModuleConfig)
 		local aliasedPath = aliasWithSlash .. relativePath
 
 		if safeFsType(path) == "file" then
+			if not shouldEmbedFile(relativePath) then
+				return
+			end
+
 			local libSrc = readFileToString(path)
 			if #libSrc > 16_000 then
 				-- https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2026


### PR DESCRIPTION
This PR adds some additional tests for `lute pkg` to be able to test `install` more directly, and upgrades the version of `luau-unzip` to v0.2.1 which has some nice performance improvements. We also update `luthier` to ignore a lot of files for the embedding since I noticed e.g. embedding `.DS_Store` on macOS was causing build problems.