### PR TITLE
loom: implement a shared store for placing package content.

### DIFF
--- a/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
@@ -4,6 +4,7 @@ local lockfile = require("./lockfile")
 local path = require("@std/path")
 local pp = require("@batteries/pp")
 local projectmanifest = require("./projectmanifest")
+local store = require("./store")
 
 local function getManifestPath(directory: string): string
 	return `{directory}/loom.config.luau`
@@ -53,8 +54,14 @@ local function fetchSource(spec: projectmanifest.DependencySpec, rootDirectory: 
 		return sourcePath
 	elseif spec.sourceKind == "github" then
 		assert(spec.rev ~= nil, `Expected rev to be non-nil for GitHub package '{spec.name}'`)
-		local sourcePath = `{rootDirectory}/Packages/{getKey(spec)}`
-		github.installPackage(spec.source, spec.rev, sourcePath)
+		store.ensureStoreDirectory()
+
+		local key = getKey(spec)
+		local sourcePath = store.getPackagePath(key)
+		if not store.hasPackage(key) then
+			github.installPackage(spec.source, spec.rev, sourcePath)
+		end
+
 		return sourcePath
 	else
 		error(`Unsupported source kind: {spec.sourceKind} for package {spec.name}`)
@@ -68,13 +75,6 @@ local function resolve(rootDirectory: string): lockfile.Lockfile
 	end
 
 	local lockfilePath = getLockfilePath(rootDirectory)
-	-- TODO: read lockfile and diff against manifest to determine which packages need to be updated, deleted, etc.
-	-- local lockfile = lockfile.parseFile(lockfilePath)
-	-- for now, just clear the installation directory if it exists
-	local rootInstallPath = `{rootDirectory}/Packages/`
-	if fs.exists(rootInstallPath) then
-		fs.removeDirectory(rootInstallPath, { recursive = true })
-	end
 
 	local queue: { projectmanifest.DependencySpec } = {}
 
@@ -144,7 +144,9 @@ local function resolve(rootDirectory: string): lockfile.Lockfile
 			rev = spec.rev,
 			source = spec.source,
 			sourceKind = spec.sourceKind,
-			installPath = path.format(path.relative(rootDirectory, installPath)),
+			installPath = if spec.sourceKind == "path"
+				then path.format(path.relative(rootDirectory, installPath))
+				else installPath,
 			dependencies = transitiveDependencies,
 		})
 	end

--- a/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/packageresolution.luau
@@ -146,7 +146,7 @@ local function resolve(rootDirectory: string): lockfile.Lockfile
 			sourceKind = spec.sourceKind,
 			installPath = if spec.sourceKind == "path"
 				then path.format(path.relative(rootDirectory, installPath))
-				else installPath,
+				else store.toStorePath(key),
 			dependencies = transitiveDependencies,
 		})
 	end

--- a/lute/cli/commands/pkg/loom-core/src/store.luau
+++ b/lute/cli/commands/pkg/loom-core/src/store.luau
@@ -1,0 +1,30 @@
+local fs = require("@std/fs")
+local path = require("@std/path")
+local process = require("@std/process")
+
+local function getStoreDirectory(): string
+	return path.format(path.join(process.homedir(), ".loom", "store"))
+end
+
+local function getPackagePath(key: string): string
+	return path.format(path.join(getStoreDirectory(), key))
+end
+
+local function hasPackage(key: string): boolean
+	return fs.exists(getPackagePath(key))
+end
+
+local function ensureStoreDirectory(): ()
+	local storeDir = getStoreDirectory()
+
+	if not fs.exists(storeDir) then
+		fs.createDirectory(storeDir, { makeParents = true })
+	end
+end
+
+return {
+	getStoreDirectory = getStoreDirectory,
+	getPackagePath = getPackagePath,
+	hasPackage = hasPackage,
+	ensureStoreDirectory = ensureStoreDirectory,
+}

--- a/lute/cli/commands/pkg/loom-core/src/store.luau
+++ b/lute/cli/commands/pkg/loom-core/src/store.luau
@@ -2,6 +2,8 @@ local fs = require("@std/fs")
 local path = require("@std/path")
 local process = require("@std/process")
 
+local STORE_PATH_PREFIX = "@pkg/"
+
 local function getStoreDirectory(): string
 	return path.format(path.join(process.homedir(), ".loom", "store"))
 end
@@ -22,9 +24,15 @@ local function ensureStoreDirectory(): ()
 	end
 end
 
+-- Returns the portable alias form stored in the lockfile, e.g. "@loom/pkg@rev".
+local function toStorePath(key: string): string
+	return `{STORE_PATH_PREFIX}{key}`
+end
+
 return {
 	getStoreDirectory = getStoreDirectory,
 	getPackagePath = getPackagePath,
 	hasPackage = hasPackage,
 	ensureStoreDirectory = ensureStoreDirectory,
+	toStorePath = toStorePath,
 }

--- a/lute/cli/src/packagerun.cpp
+++ b/lute/cli/src/packagerun.cpp
@@ -2,9 +2,12 @@
 
 #include "lute/common.h"
 #include "lute/userlandvfs.h"
+#include "lute/uvutils.h"
 
 #include "Luau/FileUtils.h"
 #include "Luau/LuauConfig.h"
+
+#include "uv.h"
 
 #include <algorithm>
 #include <cctype>
@@ -12,6 +15,23 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+
+static constexpr std::string_view kStorePathPrefix = "@pkg/";
+
+// Expands "@pkg/<key>" to "<homedir>/.loom/store/<key>".
+// Returns nullopt if the home directory cannot be determined.
+static std::optional<std::string> expandStorePath(std::string_view path)
+{
+    if (path.substr(0, kStorePathPrefix.size()) != kStorePathPrefix)
+        return std::string(path);
+
+    auto result = uvutils::getStringFromUv(uv_os_homedir);
+    std::string* homeDir = result.get_if<std::string>();
+    if (!homeDir)
+        return std::nullopt;
+
+    return *homeDir + "/.loom/store/" + std::string(path.substr(kStorePathPrefix.size()));
+}
 
 std::optional<std::string> getAbsolutePathToNearestLockfile(std::string entryFile)
 {
@@ -135,10 +155,13 @@ std::pair<std::vector<Package::Identifier>, std::vector<std::pair<Package::Ident
             const std::string* installPath = (*entry).find("installPath")->get_if<std::string>();
             if (installPath)
             {
-                if (isAbsolutePath(*installPath))
-                    info.rootDirectory = normalizePath(*installPath);
+                std::optional<std::string> expanded = expandStorePath(*installPath);
+                if (!expanded)
+                    return {};
+                if (isAbsolutePath(*expanded))
+                    info.rootDirectory = normalizePath(*expanded);
                 else
-                    info.rootDirectory = joinPaths(*lockfileParentDir, *installPath);
+                    info.rootDirectory = joinPaths(*lockfileParentDir, *expanded);
             }
             else
                 info.rootDirectory = joinPaths(*lockfileParentDir, "Packages/" + *packageKey);

--- a/lute/cli/src/packagerun.cpp
+++ b/lute/cli/src/packagerun.cpp
@@ -134,7 +134,12 @@ std::pair<std::vector<Package::Identifier>, std::vector<std::pair<Package::Ident
         {
             const std::string* installPath = (*entry).find("installPath")->get_if<std::string>();
             if (installPath)
-                info.rootDirectory = joinPaths(*lockfileParentDir, *installPath);
+            {
+                if (isAbsolutePath(*installPath))
+                    info.rootDirectory = normalizePath(*installPath);
+                else
+                    info.rootDirectory = joinPaths(*lockfileParentDir, *installPath);
+            }
             else
                 info.rootDirectory = joinPaths(*lockfileParentDir, "Packages/" + *packageKey);
         }

--- a/tests/cli/pkg/install.test.luau
+++ b/tests/cli/pkg/install.test.luau
@@ -101,8 +101,6 @@ test.suite("LutePkgInstall", function(suite)
 	end)
 
 	suite:case("installsTransitivePathDependencies", function(assert)
-		-- Use "libs/" not "packages/" — on case-insensitive filesystems the latter
-		-- collides with the Packages/ directory that pkg install clears on startup.
 		local libsDir = path.join(workingDirectory, "libs")
 		fs.createDirectory(libsDir)
 


### PR DESCRIPTION
Currently, `lute pkg install` extracts all GitHub dependencies into a project-local `Packages/` directory and wipes it clean on every run. This means the same package is re-downloaded for every project, and every reinstall re-fetches everything from the network even if nothing changed. This also replicates one of the clunkier things about working with the existing package management tools for Luau, and it was my intention to try to fix that clunkiness.

This PR implements #993, introducing a shared store for dependencies at `~/.loom/store/`. GitHub-source packages are extracted there once, named as `{name}@{rev}`, and reused across all local projects without redownloading them. We recommend only doing this with projects that have enabled immutable releases (which GitHub is pushing for generally), otherwise it may lead to some weird behavior. We also add some functionality to `packagerun` to be aware of a `@pkg` alias that resolves to the store's location so that the lockfiles needn't specify the user's home directory path.