### PR TITLE
`@std/fs`: add an `fs.move` operation to move/rename files and directories.

### DIFF
--- a/definitions/fs.luau
+++ b/definitions/fs.luau
@@ -123,9 +123,9 @@ function fs.copy(src: string, dest: string): ()
 	error("not implemented")
 end
 
---- Renames (moves) the file or directory at `src` to `dest`.
+--- Moves the file or directory at `src` to `dest`.
 --- Falls back to a copy-then-remove if `src` and `dest` are on different filesystems.
-function fs.rename(src: string, dest: string): ()
+function fs.move(src: string, dest: string): ()
 	error("not implemented")
 end
 

--- a/definitions/fs.luau
+++ b/definitions/fs.luau
@@ -123,6 +123,12 @@ function fs.copy(src: string, dest: string): ()
 	error("not implemented")
 end
 
+--- Renames (moves) the file or directory at `src` to `dest`.
+--- Falls back to a copy-then-remove if `src` and `dest` are on different filesystems.
+function fs.rename(src: string, dest: string): ()
+	error("not implemented")
+end
+
 --- Returns an array of `DirectoryEntry` values for the immediate children of the directory at `path`.
 function fs.listdir(path: string): { DirectoryEntry }
 	error("not implemented")

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -228,6 +228,20 @@ int symlink(lua_State* L)
     return symlink_impl(L, path, dest);
 }
 
+int rename(lua_State* L)
+{
+    int nArgs = lua_gettop(L);
+    if (nArgs > 2)
+    {
+        luaL_errorL(L, "rename: too many arguments supplied\n");
+    }
+
+    const char* path = luaL_checkstring(L, 1);
+    const char* dest = luaL_checkstring(L, 2);
+
+    return rename_impl(L, path, dest);
+}
+
 struct WatchHandle
 {
     WatchHandle(lua_State* L, int callbackIdx)
@@ -426,6 +440,7 @@ const luaL_Reg FS::lib[] = {
     {"link", fs::link},
     {"symlink", fs::symlink},
     {"copy", fs::copy},
+    {"rename", fs::rename},
 
     {"mkdir", fs::mkdir},
     {"listdir", fs::listdir},

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -233,7 +233,7 @@ int rename(lua_State* L)
     int nArgs = lua_gettop(L);
     if (nArgs > 2)
     {
-        luaL_errorL(L, "rename: too many arguments supplied\n");
+        luaL_errorL(L, "move: too many arguments supplied\n");
     }
 
     const char* path = luaL_checkstring(L, 1);
@@ -440,7 +440,7 @@ const luaL_Reg FS::lib[] = {
     {"link", fs::link},
     {"symlink", fs::symlink},
     {"copy", fs::copy},
-    {"rename", fs::rename},
+    {"move", fs::rename},
 
     {"mkdir", fs::mkdir},
     {"listdir", fs::listdir},

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -110,6 +110,15 @@ struct FSPathPairRequest : FSRequest
     const std::string dest;
 };
 
+struct FSRename : FSPathPairRequest
+{
+    using FSPathPairRequest::FSPathPairRequest;
+
+    static void renameCallback(uv_fs_t* req);
+    static void copyCallback(uv_fs_t* req);
+    static void unlinkCallback(uv_fs_t* req);
+};
+
 int open_impl(lua_State* L, const char* path, int flags, int mode)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);
@@ -548,76 +557,63 @@ int copy_impl(lua_State* L, const char* path, const char* dest)
     return lua_yield(L, 0);
 }
 
+void FSRename::renameCallback(uv_fs_t* req)
+{
+    auto r = uvutils::retake<FSRename>(req);
+    auto result = req->result;
+
+    if (result == 0)
+    {
+        r->succeedTrivially();
+        return;
+    }
+
+    if (result != UV_EXDEV)
+    {
+        r->fail("rename: Error renaming %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
+        return;
+    }
+
+    // Cross-filesystem: fall back to copy + remove
+    uv_fs_req_cleanup(&r->req);
+    uvutils::ScopedUVRequest<FSRename> copyReq{std::move(r)};
+    uv_fs_copyfile(copyReq->getLoop(), &copyReq->req, copyReq->src.c_str(), copyReq->dest.c_str(), 0, FSRename::copyCallback);
+}
+
+void FSRename::copyCallback(uv_fs_t* req)
+{
+    auto r = uvutils::retake<FSRename>(req);
+    auto result = req->result;
+
+    if (result < 0)
+    {
+        r->fail("rename: Error copying %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
+        return;
+    }
+
+    uv_fs_req_cleanup(&r->req);
+    uvutils::ScopedUVRequest<FSRename> unlinkReq{std::move(r)};
+    uv_fs_unlink(unlinkReq->getLoop(), &unlinkReq->req, unlinkReq->src.c_str(), FSRename::unlinkCallback);
+}
+
+void FSRename::unlinkCallback(uv_fs_t* req)
+{
+    auto r = uvutils::retake<FSRename>(req);
+    auto result = req->result;
+
+    if (result < 0)
+    {
+        r->fail("rename: Error removing source %s: %s", r->src.c_str(), uv_strerror(result));
+        return;
+    }
+
+    r->succeedTrivially();
+}
+
 int rename_impl(lua_State* L, const char* path, const char* dest)
 {
-    uvutils::ScopedUVRequest<FSPathPairRequest> req{L, path, dest};
-    uv_fs_rename(
-        req->getLoop(),
-        &req->req,
-        path,
-        dest,
-        [](uv_fs_t* req)
-        {
-            auto r = uvutils::retake<FSPathPairRequest>(req);
-            auto result = req->result;
-
-            if (result == 0)
-            {
-                r->succeedTrivially();
-                return;
-            }
-
-            if (result != UV_EXDEV)
-            {
-                r->fail("rename: Error renaming %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
-                return;
-            }
-
-            // Cross-filesystem: fall back to copy + remove
-            uv_fs_req_cleanup(&r->req);
-            uvutils::ScopedUVRequest<FSPathPairRequest> copyReq{std::move(r)};
-            uv_fs_copyfile(
-                copyReq->getLoop(),
-                &copyReq->req,
-                copyReq->src.c_str(),
-                copyReq->dest.c_str(),
-                0,
-                [](uv_fs_t* req)
-                {
-                    auto r = uvutils::retake<FSPathPairRequest>(req);
-                    auto result = req->result;
-
-                    if (result < 0)
-                    {
-                        r->fail("rename: Error copying %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
-                        return;
-                    }
-
-                    uv_fs_req_cleanup(&r->req);
-                    uvutils::ScopedUVRequest<FSPathPairRequest> unlinkReq{std::move(r)};
-                    uv_fs_unlink(
-                        unlinkReq->getLoop(),
-                        &unlinkReq->req,
-                        unlinkReq->src.c_str(),
-                        [](uv_fs_t* req)
-                        {
-                            auto r = uvutils::retake<FSPathPairRequest>(req);
-                            auto result = req->result;
-
-                            if (result < 0)
-                            {
-                                r->fail("rename: Error removing source %s: %s", r->src.c_str(), uv_strerror(result));
-                                return;
-                            }
-
-                            r->succeedTrivially();
-                        }
-                    );
-                }
-            );
-        }
-    );
-
+    uvutils::ScopedUVRequest<FSRename> req{L, path, dest};
+    uv_fs_rename(req->getLoop(), &req->req, path, dest, FSRename::renameCallback);
     return lua_yield(L, 0);
 }
 

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -191,12 +191,7 @@ void FSWrite::writeCallback(uv_fs_t* req)
     w->offset += bytesWritten;
     if (w->offset == w->toWrite.size())
     {
-        w->succeed(
-            [](lua_State* L)
-            {
-                return 0;
-            }
-        );
+        w->succeedTrivially();
 
         return;
     }
@@ -266,12 +261,7 @@ int close_impl(lua_State* L, UVFile* handle)
                 return;
             }
 
-            r->succeed(
-                [](lua_State* L)
-                {
-                    return 0;
-                }
-            );
+            r->succeedTrivially();
         }
     );
 
@@ -295,12 +285,7 @@ int remove_impl(lua_State* L, const char* path)
                 return;
             }
 
-            r->succeed(
-                [](lua_State* L)
-                {
-                    return 0;
-                }
-            );
+            r->succeedTrivially();
         }
     );
 
@@ -497,12 +482,7 @@ int link_impl(lua_State* L, const char* path, const char* dest)
                 return;
             }
 
-            r->succeed(
-                [](lua_State* L)
-                {
-                    return 0;
-                }
-            );
+            r->succeedTrivially();
         }
     );
 
@@ -534,12 +514,7 @@ int symlink_impl(lua_State* L, const char* path, const char* dest)
                 return;
             }
 
-            r->succeed(
-                [](lua_State* L)
-                {
-                    return 0;
-                }
-            );
+            r->succeedTrivially();
         }
     );
 
@@ -566,12 +541,7 @@ int copy_impl(lua_State* L, const char* path, const char* dest)
                 return;
             }
 
-            r->succeed(
-                [](lua_State* L)
-                {
-                    return 0;
-                }
-            );
+            r->succeedTrivially();
         }
     );
 
@@ -593,7 +563,7 @@ int rename_impl(lua_State* L, const char* path, const char* dest)
 
             if (result == 0)
             {
-                r->succeed([](lua_State* L) { return 0; });
+                r->succeedTrivially();
                 return;
             }
 
@@ -640,7 +610,7 @@ int rename_impl(lua_State* L, const char* path, const char* dest)
                                 return;
                             }
 
-                            r->succeed([](lua_State* L) { return 0; });
+                            r->succeedTrivially();
                         }
                     );
                 }
@@ -669,12 +639,7 @@ int mkdir_impl(lua_State* L, const char* path, int mode)
                 return;
             }
 
-            r->succeed(
-                [](lua_State* L)
-                {
-                    return 0;
-                }
-            );
+            r->succeedTrivially();
         }
     );
 
@@ -699,12 +664,7 @@ int rmdir_impl(lua_State* L, const char* path)
                 return;
             }
 
-            r->succeed(
-                [](lua_State* L)
-                {
-                    return 0;
-                }
-            );
+            r->succeedTrivially();
         }
     );
 

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -578,6 +578,79 @@ int copy_impl(lua_State* L, const char* path, const char* dest)
     return lua_yield(L, 0);
 }
 
+int rename_impl(lua_State* L, const char* path, const char* dest)
+{
+    uvutils::ScopedUVRequest<FSPathPairRequest> req{L, path, dest};
+    uv_fs_rename(
+        req->getLoop(),
+        &req->req,
+        path,
+        dest,
+        [](uv_fs_t* req)
+        {
+            auto r = uvutils::retake<FSPathPairRequest>(req);
+            auto result = req->result;
+
+            if (result == 0)
+            {
+                r->succeed([](lua_State* L) { return 0; });
+                return;
+            }
+
+            if (result != UV_EXDEV)
+            {
+                r->fail("rename: Error renaming %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
+                return;
+            }
+
+            // Cross-filesystem: fall back to copy + remove
+            uv_fs_req_cleanup(&r->req);
+            uvutils::ScopedUVRequest<FSPathPairRequest> copyReq{std::move(r)};
+            uv_fs_copyfile(
+                copyReq->getLoop(),
+                &copyReq->req,
+                copyReq->src.c_str(),
+                copyReq->dest.c_str(),
+                0,
+                [](uv_fs_t* req)
+                {
+                    auto r = uvutils::retake<FSPathPairRequest>(req);
+                    auto result = req->result;
+
+                    if (result < 0)
+                    {
+                        r->fail("rename: Error copying %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
+                        return;
+                    }
+
+                    uv_fs_req_cleanup(&r->req);
+                    uvutils::ScopedUVRequest<FSPathPairRequest> unlinkReq{std::move(r)};
+                    uv_fs_unlink(
+                        unlinkReq->getLoop(),
+                        &unlinkReq->req,
+                        unlinkReq->src.c_str(),
+                        [](uv_fs_t* req)
+                        {
+                            auto r = uvutils::retake<FSPathPairRequest>(req);
+                            auto result = req->result;
+
+                            if (result < 0)
+                            {
+                                r->fail("rename: Error removing source %s: %s", r->src.c_str(), uv_strerror(result));
+                                return;
+                            }
+
+                            r->succeed([](lua_State* L) { return 0; });
+                        }
+                    );
+                }
+            );
+        }
+    );
+
+    return lua_yield(L, 0);
+}
+
 int mkdir_impl(lua_State* L, const char* path, int mode)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -570,7 +570,7 @@ void FSRename::renameCallback(uv_fs_t* req)
 
     if (result != UV_EXDEV)
     {
-        r->fail("rename: Error renaming %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
+        r->fail("move: Error moving %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
         return;
     }
 
@@ -587,7 +587,7 @@ void FSRename::copyCallback(uv_fs_t* req)
 
     if (result < 0)
     {
-        r->fail("rename: Error copying %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
+        r->fail("move: Error copying %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
         return;
     }
 
@@ -603,7 +603,7 @@ void FSRename::unlinkCallback(uv_fs_t* req)
 
     if (result < 0)
     {
-        r->fail("rename: Error removing source %s: %s", r->src.c_str(), uv_strerror(result));
+        r->fail("move: Error removing source %s: %s", r->src.c_str(), uv_strerror(result));
         return;
     }
 

--- a/lute/fs/src/fs_impl.h
+++ b/lute/fs/src/fs_impl.h
@@ -48,6 +48,8 @@ int link_impl(lua_State* L, const char* path, const char* dest);
 int symlink_impl(lua_State* L, const char* path, const char* dest);
 int copy_impl(lua_State* L, const char* path, const char* dest);
 
+int rename_impl(lua_State* L, const char* path, const char* dest);
+
 int mkdir_impl(lua_State* L, const char* path, int mode);
 int rmdir_impl(lua_State* L, const char* path);
 int listdir_impl(lua_State* L, const char* path);

--- a/lute/runtime/include/lute/uvrequest.h
+++ b/lute/runtime/include/lute/uvrequest.h
@@ -64,6 +64,11 @@ struct UVRequest
         token->complete(std::forward<F>(cont));
     }
 
+    void succeedTrivially()
+    {
+        succeed([](lua_State* L) { return 0; });
+    }
+
     ~UVRequest()
     {
         cleanup_uv_req(&req);

--- a/lute/std/libs/fs.luau
+++ b/lute/std/libs/fs.luau
@@ -154,6 +154,12 @@ function fslib.copy(src: Pathlike, dest: Pathlike): ()
 	return fs.copy(pathlib.format(src), pathlib.format(dest))
 end
 
+--- Renames (moves) the file or directory at `src` to `dest`.
+--- Falls back to a copy-then-remove if `src` and `dest` are on different filesystems.
+function fslib.rename(src: Pathlike, dest: Pathlike): ()
+	return fs.rename(pathlib.format(src), pathlib.format(dest))
+end
+
 --- Returns an array of `DirectoryEntry` values for the immediate children of the directory at `path`.
 function fslib.listDirectory(path: Pathlike): { DirectoryEntry }
 	return fs.listdir(pathlib.format(path))

--- a/lute/std/libs/fs.luau
+++ b/lute/std/libs/fs.luau
@@ -154,10 +154,10 @@ function fslib.copy(src: Pathlike, dest: Pathlike): ()
 	return fs.copy(pathlib.format(src), pathlib.format(dest))
 end
 
---- Renames (moves) the file or directory at `src` to `dest`.
+--- Moves the file or directory at `src` to `dest`.
 --- Falls back to a copy-then-remove if `src` and `dest` are on different filesystems.
-function fslib.rename(src: Pathlike, dest: Pathlike): ()
-	return fs.rename(pathlib.format(src), pathlib.format(dest))
+function fslib.move(src: Pathlike, dest: Pathlike): ()
+	return fs.move(pathlib.format(src), pathlib.format(dest))
 end
 
 --- Returns an array of `DirectoryEntry` values for the immediate children of the directory at `path`.

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -74,7 +74,7 @@ test.suite("FsSuite", function(suite)
 
 		fs.writeStringToFile(src, "renamed content")
 
-		fs.rename(src, dest)
+		fs.move(src, dest)
 
 		assert.eq(fs.exists(src), false)
 		assert.that(fs.exists(dest))

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -68,6 +68,21 @@ test.suite("FsSuite", function(suite)
 		fs.removeDirectory(dir)
 	end)
 
+	suite:case("renameFile", function(assert)
+		local src = path.join(tmpdir, "rename_src.txt")
+		local dest = path.join(tmpdir, "rename_dest.txt")
+
+		fs.writeStringToFile(src, "renamed content")
+
+		fs.rename(src, dest)
+
+		assert.eq(fs.exists(src), false)
+		assert.that(fs.exists(dest))
+		assert.eq(fs.readFileToString(dest), "renamed content")
+
+		fs.remove(dest)
+	end)
+
 	suite:case("linkAndSymlinkAndCopy", function(assert)
 		local srcfile = "src.txt"
 		local src = path.join(tmpdir, srcfile)


### PR DESCRIPTION
I was surprised to see that we hadn't actually authored a move operation of any sort for the filesystem library, but this is obviously useful. This PR implements it analogously to the other filesystem operations, using libuv for the underlying core implementation. When the rename fails due to being to an external device, our rename operation automatically falls back to a copy followed by an unlink.