### PR TITLE
loom: unzip into a temporary directory first

### DIFF
--- a/lute/cli/commands/pkg/loom-core/src/github.luau
+++ b/lute/cli/commands/pkg/loom-core/src/github.luau
@@ -3,6 +3,7 @@ local fs = require("@std/fs")
 local net = require("@std/net")
 local path = require("@std/path")
 local process = require("@std/process")
+local system = require("@std/system")
 local unzip = require("../extern/unzip")
 
 local function sanitizePath(path: string): string
@@ -92,7 +93,24 @@ end
 local function installPackage(source: string, rev: string, installPath: string): ()
 	local url = `{source}/archive/{rev}.zip`
 	local zipArchive = downloadFromGitHubArchive(url)
-	installZipArchive(zipArchive, installPath)
+
+	local safeName = rev:gsub("[^%w%-_.]", "-")
+	local tempDir = path.format(path.join(system.tmpdir(), `lute-pkg-install-{safeName}`))
+
+	if fs.exists(tempDir) then
+		fs.removeDirectory(tempDir, { recursive = true })
+	end
+
+	local ok, err = pcall(installZipArchive, zipArchive, tempDir)
+
+	if not ok then
+		if fs.exists(tempDir) then
+			fs.removeDirectory(tempDir, { recursive = true })
+		end
+		error(err, 0)
+	end
+
+	fs.move(tempDir, installPath)
 end
 
 return {


### PR DESCRIPTION
There's a bug possible today with the package manager where you could interrupt the execution during unzipping (or encounter an exception) and we'd leave the packages store in an incorrect state. We can fix this by first unzipping everything into a temporary directory, and then moving that temporary directory into the store after the fact.