### PR TITLE
`@lute/fs`: fix a file handle memory leak, double-close race, and exclusive-mode flags

### DIFF
--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -21,15 +21,10 @@ namespace fs
 
 static UVFile* getFileHandle(lua_State* L, int index)
 {
-    if (!lua_islightuserdata(L, index))
-    {
-        luaL_errorL(L, "Error: expected file handle");
-    }
-
-    auto* handle = static_cast<UVFile*>(lua_tolightuserdata(L, index));
+    auto* handle = static_cast<UVFile*>(lua_touserdatatagged(L, index, kUVFileTag));
     if (!handle)
     {
-        luaL_errorL(L, "Error: invalid file handle");
+        luaL_errorL(L, "Error: expected file handle");
     }
 
     return handle;
@@ -385,6 +380,26 @@ int listdir(lua_State* L)
 static void initalizeFS(lua_State* L)
 {
     init_duration_lib(L);
+
+    luaL_newmetatable(L, "FileHandle");
+    lua_pushstring(L, "FileHandle");
+    lua_setfield(L, -2, "__type");
+    lua_setuserdatadtor(
+        L,
+        kUVFileTag,
+        [](lua_State*, void* ud)
+        {
+            auto* file = static_cast<fs::UVFile*>(ud);
+            if (file->fd.has_value())
+            {
+                uv_fs_t req;
+                uv_fs_close(nullptr, &req, *file->fd, nullptr);
+                uv_fs_req_cleanup(&req);
+            }
+            std::destroy_at(file);
+        }
+    );
+    lua_setuserdatametatable(L, kUVFileTag);
 
     luaL_newmetatable(L, "WatchHandle");
 

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -47,8 +47,8 @@ std::optional<int> setFlags(const char* c, int* openFlags)
             modeFlags = 0666;
             break;
         case 'x':
-            *openFlags |= O_CREAT | O_EXCL;
-            modeFlags = 0700;
+            *openFlags |= O_WRONLY | O_CREAT | O_EXCL;
+            modeFlags = 0666;
             break;
         case 'a':
             *openFlags |= O_WRONLY | O_APPEND;

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -84,13 +84,7 @@ struct FSWrite : FSRequest
 
 struct FSClose : FSRequest
 {
-    FSClose(lua_State* L, UVFile* file)
-        : FSRequest(L)
-        , file(file)
-    {
-    }
-
-    UVFile* file = nullptr;
+    using FSRequest::FSRequest;
 };
 
 struct FSPathPairRequest : FSRequest
@@ -250,11 +244,14 @@ int close_impl(lua_State* L, UVFile* handle)
         luaL_errorL(L, "File handle is already closed");
     }
 
-    uvutils::ScopedUVRequest<FSClose> req{L, handle};
+    auto fd = handle->fd.value();
+    handle->fd = std::nullopt;
+
+    uvutils::ScopedUVRequest<FSClose> req{L};
     uv_fs_close(
         req->getLoop(),
         &req->req,
-        handle->fd.value(),
+        fd,
         [](uv_fs_t* req)
         {
             auto r = uvutils::retake<FSClose>(req);
@@ -266,7 +263,6 @@ int close_impl(lua_State* L, UVFile* handle)
                 return;
             }
 
-            r->file->fd = std::nullopt;
             r->succeedTrivially();
         }
     );

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -2,6 +2,7 @@
 
 #include "lute/fileutils.h"
 #include "lute/time.h"
+#include "lute/userdatas.h"
 #include "lute/uvrequest.h"
 
 #include "lua.h"
@@ -89,11 +90,6 @@ struct FSClose : FSRequest
     {
     }
 
-    ~FSClose()
-    {
-        delete file;
-    }
-
     UVFile* file = nullptr;
 };
 
@@ -141,9 +137,9 @@ int open_impl(lua_State* L, const char* path, int flags, int mode)
             r->succeed(
                 [result](lua_State* L)
                 {
-                    auto* file = new UVFile();
+                    void* storage = lua_newuserdatataggedwithmetatable(L, sizeof(UVFile), kUVFileTag);
+                    auto* file = new (storage) UVFile();
                     file->fd = result;
-                    lua_pushlightuserdata(L, file);
                     return 1;
                 }
             );
@@ -270,6 +266,7 @@ int close_impl(lua_State* L, UVFile* handle)
                 return;
             }
 
+            r->file->fd = std::nullopt;
             r->succeedTrivially();
         }
     );

--- a/lute/runtime/include/lute/userdatas.h
+++ b/lute/runtime/include/lute/userdatas.h
@@ -7,3 +7,4 @@ constexpr int kWatchHandleTag = 125;
 constexpr int kHashFunctionTag = 124;
 constexpr int kWebSocketHandleTag = 123;
 constexpr int kServerWebSocketHandleTag = 122;
+constexpr int kUVFileTag = 121;


### PR DESCRIPTION
I found a couple issues with the filesystem implementation while working on #1067.

The biggest is that file handles were previously leaking memory because of how we used them with lightuserdata (and if they didn't leak, we would have had some Luau-land use-after-frees instead). The fix is fairly straightforward, we introduce a full userdata with a registered destructor that allows the garbage collector to clean it up and collect it when it is unused.

This change introduces a reentrancy problem for `FSClose` where it could in principle attempt to double-close the same file descriptor since the handle's file descriptor was being cleared _asynchronously_. It's not clear to me that this issue would ever arise in practice, but we can guard against it pretty readily by taking the file descriptor for ourselves in the close implementation.

Separately, it looks like the exclusive mode (`x`) for opening files is just implemented with the wrong permissions and flags, so I fixed that as well.