### PR TITLE
`@lute/fs`: clean up some smaller problems in the filesystem implementation code

### DIFF
--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -51,7 +51,8 @@ std::optional<int> setFlags(const char* modeStr, int* openFlags)
             modeFlags = 0666;
             break;
         case 'a':
-            *openFlags |= O_WRONLY | O_APPEND;
+            *openFlags |= O_WRONLY | O_APPEND | O_CREAT;
+            modeFlags = 0666;
             break;
         case '+':
             // If we have not set the truncate bit in 'w' mode,

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -97,24 +97,12 @@ int write(lua_State* L)
 
 int open(lua_State* L)
 {
-    int nArgs = lua_gettop(L);
-    if (nArgs < 1)
-    {
-        luaL_errorL(L, "Error: no file supplied\n");
-    }
     const char* path = luaL_checkstring(L, 1);
 
     int openFlags = 0x0000;
     const char* mode = "r";
-    // Default to read mode if no mode is supplied (i.e., mode is nil in Luau)
-    if (nArgs < 2 || lua_isnil(L, 2))
-    {
-        openFlags = O_RDONLY;
-    }
-    else
-    {
+    if (!lua_isnoneornil(L, 2))
         mode = luaL_checkstring(L, 2);
-    }
 
     std::optional<int> modeFlags = setFlags(mode, &openFlags);
     if (!modeFlags)
@@ -127,50 +115,19 @@ int open(lua_State* L)
 
 int remove(lua_State* L)
 {
-    int nArgs = lua_gettop(L);
-    if (nArgs < 1)
-    {
-        luaL_errorL(L, "Error: no file supplied\n");
-    }
-
-    if (nArgs > 1)
-    {
-        luaL_errorL(L, "Error: too many arguments supplied\n");
-    }
     const char* path = luaL_checkstring(L, 1);
-
     return remove_impl(L, path);
 }
 
 int mkdir(lua_State* L)
 {
-    int nArgs = lua_gettop(L);
-    if (nArgs != 1)
-    {
-        luaL_errorL(L, "Error: expected 1 argument\n");
-    }
-
     const char* path = luaL_checkstring(L, 1);
-    int mode = 0777; // default permission for Unix, not used on Windows
-
-    return mkdir_impl(L, path, mode);
+    return mkdir_impl(L, path, 0777);
 }
 
 int rmdir(lua_State* L)
 {
-    int nArgs = lua_gettop(L);
-    if (nArgs < 1)
-    {
-        luaL_errorL(L, "rmdir: no path supplied\n");
-    }
-
-    if (nArgs > 1)
-    {
-        luaL_errorL(L, "rmdir: too many arguments supplied\n");
-    }
-
     const char* path = luaL_checkstring(L, 1);
-
     return rmdir_impl(L, path);
 }
 
@@ -183,57 +140,29 @@ int stat(lua_State* L)
 
 int copy(lua_State* L)
 {
-    int nArgs = lua_gettop(L);
-    if (nArgs > 2)
-    {
-        luaL_errorL(L, "copy: too many arguments supplied\n");
-    }
-
     const char* path = luaL_checkstring(L, 1);
     const char* dest = luaL_checkstring(L, 2);
-
     return copy_impl(L, path, dest);
 }
 
 int link(lua_State* L)
 {
-    int nArgs = lua_gettop(L);
-    if (nArgs > 2)
-    {
-        luaL_errorL(L, "link: too many arguments supplied\n");
-    }
-
     const char* path = luaL_checkstring(L, 1);
     const char* dest = luaL_checkstring(L, 2);
-
     return link_impl(L, path, dest);
 }
 
 int symlink(lua_State* L)
 {
-    int nArgs = lua_gettop(L);
-    if (nArgs > 2)
-    {
-        luaL_errorL(L, "symlink: too many arguments supplied\n");
-    }
-
     const char* path = luaL_checkstring(L, 1);
     const char* dest = luaL_checkstring(L, 2);
-
     return symlink_impl(L, path, dest);
 }
 
 int rename(lua_State* L)
 {
-    int nArgs = lua_gettop(L);
-    if (nArgs > 2)
-    {
-        luaL_errorL(L, "move: too many arguments supplied\n");
-    }
-
     const char* path = luaL_checkstring(L, 1);
     const char* dest = luaL_checkstring(L, 2);
-
     return rename_impl(L, path, dest);
 }
 
@@ -344,14 +273,7 @@ int fs_watch(lua_State* L)
 
 int exists(lua_State* L)
 {
-    int nArgs = lua_gettop(L);
-    if (nArgs > 1)
-    {
-        luaL_errorL(L, "exists: too many arguments supplied\n");
-    }
-
     const char* path = luaL_checkstring(L, 1);
-
     return exists_impl(L, path);
 }
 
@@ -364,14 +286,7 @@ int type(lua_State* L)
 
 int listdir(lua_State* L)
 {
-    int nArgs = lua_gettop(L);
-    if (nArgs > 1)
-    {
-        luaL_errorL(L, "listdir: too many arguments supplied\n");
-    }
-
     const char* path = luaL_checkstring(L, 1);
-
     return listdir_impl(L, path);
 }
 

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -377,7 +377,7 @@ int listdir(lua_State* L)
 
 } // namespace fs
 
-static void initalizeFS(lua_State* L)
+static void initializeFS(lua_State* L)
 {
     init_duration_lib(L);
 
@@ -479,7 +479,7 @@ int FS::pushLibrary(lua_State* L)
 
     lua_setreadonly(L, -1, 1);
 
-    initalizeFS(L);
+    initializeFS(L);
 
     return 1;
 }

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -30,14 +30,14 @@ static UVFile* getFileHandle(lua_State* L, int index)
     return handle;
 }
 
-std::optional<int> setFlags(const char* c, int* openFlags)
+std::optional<int> setFlags(const char* modeStr, int* openFlags)
 {
     int modeFlags = 0x0000;
 
-    for (const char* it = c; *it != '\0'; it++)
+    for (const char* it = modeStr; *it != '\0'; it++)
     {
-        char c = *it;
-        switch (c)
+        char modeChar = *it;
+        switch (modeChar)
         {
         case 'r':
             *openFlags |= O_RDONLY;

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -335,7 +335,7 @@ static const char* fileModeToType(uint64_t mode)
     }
 }
 
-static int createDurationFromTimespec32(lua_State* L, uv_timespec_t timespec)
+static int createDurationFromTimespec(lua_State* L, uv_timespec_t timespec)
 {
     uv_timespec64_t extended{static_cast<int64_t>(timespec.tv_sec), static_cast<int32_t>(timespec.tv_nsec)};
     return createDurationFromTimespec(L, extended);
@@ -372,13 +372,13 @@ int stat_impl(lua_State* L, const char* path)
                     lua_pushnumber(L, static_cast<double>(stat.st_size));
                     lua_setfield(L, -2, "size");
 
-                    createDurationFromTimespec32(L, stat.st_birthtim);
+                    createDurationFromTimespec(L, stat.st_birthtim);
                     lua_setfield(L, -2, "created");
 
-                    createDurationFromTimespec32(L, stat.st_atim);
+                    createDurationFromTimespec(L, stat.st_atim);
                     lua_setfield(L, -2, "accessed");
 
-                    createDurationFromTimespec32(L, stat.st_mtim);
+                    createDurationFromTimespec(L, stat.st_mtim);
                     lua_setfield(L, -2, "modified");
 
                     // permissions

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -168,10 +168,6 @@ void FSRead::readCallback(uv_fs_t* req)
     // Append the read data to our buffer
     r->buffer.insert(r->buffer.end(), r->chunk.begin(), r->chunk.begin() + bytesRead);
 
-    // It's possible that the next read call will read fewer than chunk.size() bytes
-    // In this case, the chunk buffer might still retain some data from this read. Just to be safe, zero it out
-    std::fill(r->chunk.begin(), r->chunk.end(), 0);
-
     uvutils::ScopedUVRequest<FSRead> scopedReq{std::move(r)};
     uv_fs_read(scopedReq->getLoop(), &scopedReq->req, scopedReq->file->fd.value(), &scopedReq->iov, 1, -1, FSRead::readCallback);
 }


### PR DESCRIPTION
This PR implements a bunch of small fixes/clean up work for various things across the implementation of `@lute/fs`, including:

  - Fixes a typo in the name of `initializeFS` where it was mistakenly `initalizeFS`
  - Rename some of the variables in `setFlags` to have clearer names without shadowing
  - Change `createDurationFromTimespec32` to just be an overload of `createDurationFromTimespec` without suggesting any particular bit sizing
  - Remove the `std::fill` zero-pass over the read chunk buffer in `FSRead::readCallback` since only `bytesRead` bytes are ever appended to the output buffer, meaning nothing ever actually looks at the zeroed bytes.
  - Change the behavior of append (`a`) mode to include `O_CREAT` to make it consistent with general POSIX behavior where append will create non-existent files.
  - Eliminate some duplicated logic for the situation where the mode for files was not present.
  
  The biggest/most disruptive change here is a change to how we validate arguments to functions. Looking at the Luau VM code and the existing built-in libraries for Luau, it's actually _very_ abnormal to do `lua_gettop` and produce errors for argument counts and so forth. The general pattern is that functions will do typechecks for the arguments they're expecting, and silently ignore any additional arguments. I've changed the filesystem library to be consistent with this behavior in this PR, and I'll put up a follow-up PR to make this change across the whole project.