### PR TITLE
Child runtimes inherit the `RequireCtx` of their parent when spawned

### DIFF
--- a/lute/cli/src/requiresetup.cpp
+++ b/lute/cli/src/requiresetup.cpp
@@ -127,6 +127,8 @@ static void* createBundleRequireContext(
 
 lua_State* setupRunState(Runtime& runtime, std::function<void(lua_State*)> preSandboxInit)
 {
+    runtime.requireContextFactory = createRunRequireContext;
+
     return setupState(
         runtime,
         [preSandboxInit = std::move(preSandboxInit)](lua_State* L)
@@ -143,6 +145,8 @@ lua_State* setupRunState(Runtime& runtime, std::function<void(lua_State*)> preSa
 
 lua_State* setupCliCommandState(Runtime& runtime, std::function<void(lua_State*)> preSandboxInit)
 {
+    runtime.requireContextFactory = createCliCommandRequireContext;
+
     return setupState(
         runtime,
         [preSandboxInit = std::move(preSandboxInit)](lua_State* L)
@@ -157,23 +161,41 @@ lua_State* setupCliCommandState(Runtime& runtime, std::function<void(lua_State*)
     );
 }
 
+struct PkgData
+{
+    std::vector<Package::Identifier> directDependencies;
+    std::vector<std::pair<Package::Identifier, Package::Info>> allDependencies;
+};
+
 lua_State* setupPkgRunState(
     Runtime& runtime,
     std::vector<Package::Identifier> directDependencies,
     std::vector<std::pair<Package::Identifier, Package::Info>> allDependencies
 )
 {
+    std::shared_ptr<PkgData> pkgData = std::make_shared<PkgData>(PkgData{std::move(directDependencies), std::move(allDependencies)});
+    runtime.requireContextFactory = [pkgData = std::move(pkgData)](lua_State* L) -> void*
+    {
+        return createPkgRunRequireContext(L, pkgData->directDependencies, pkgData->allDependencies);
+    };
+
     return setupState(
         runtime,
-        [directDependencies = std::move(directDependencies), allDependencies = std::move(allDependencies)](lua_State* L)
+        [&factory = runtime.requireContextFactory](lua_State* L)
         {
             if (Luau::CodeGen::isSupported())
                 Luau::CodeGen::create(L);
 
-            luaopen_require(L, requireConfigInit, createPkgRunRequireContext(L, std::move(directDependencies), std::move(allDependencies)));
+            luaopen_require(L, requireConfigInit, factory(L));
         }
     );
 }
+
+struct BundleData
+{
+    Luau::DenseHashMap<std::string, std::string> luauConfigFiles;
+    Luau::DenseHashMap<std::string, std::string> bundleMap;
+};
 
 lua_State* setupBundleState(
     Runtime& runtime,
@@ -181,14 +203,20 @@ lua_State* setupBundleState(
     Luau::DenseHashMap<std::string, std::string> bundleMap
 )
 {
+    std::shared_ptr<BundleData> bundleData = std::make_shared<BundleData>(BundleData{std::move(luauConfigFiles), std::move(bundleMap)});
+    runtime.requireContextFactory = [bundleData = std::move(bundleData)](lua_State* L) -> void*
+    {
+        return createBundleRequireContext(L, bundleData->luauConfigFiles, bundleData->bundleMap);
+    };
+
     return setupState(
         runtime,
-        [luauConfigFiles = std::move(luauConfigFiles), bundleMap = std::move(bundleMap)](lua_State* L)
+        [&factory = runtime.requireContextFactory](lua_State* L)
         {
             if (Luau::CodeGen::isSupported())
                 Luau::CodeGen::create(L);
 
-            luaopen_require(L, requireConfigInit, createBundleRequireContext(L, std::move(luauConfigFiles), std::move(bundleMap)));
+            luaopen_require(L, requireConfigInit, factory(L));
         }
     );
 }

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -133,6 +133,10 @@ struct Runtime
     // CLI arguments passed after the script filename
     std::vector<std::string> args;
 
+    // Factory function for creating an identical require context in child
+    // Runtimes. Set during parent Runtime's setup.
+    std::function<void*(lua_State*)> requireContextFactory;
+
 private:
     bool runThreadCompletionHandler(lua_State* L, int status);
     void clearThreadCompletionHandler(lua_State* L);

--- a/lute/vm/src/spawn.cpp
+++ b/lute/vm/src/spawn.cpp
@@ -1,13 +1,12 @@
-#include "lute/vm.h"
-
-#include "lute/clivfs.h"
+#include "lute/common.h"
 #include "lute/ref.h"
 #include "lute/require.h"
 #include "lute/requirevfs.h"
 #include "lute/runtime.h"
+#include "lute/vm.h"
 
-#include "Luau/Require.h"
 #include "Luau/CodeGen.h"
+#include "Luau/Require.h"
 
 #include "lua.h"
 #include "lualib.h"
@@ -176,56 +175,33 @@ static int crossVmMarshallCont(lua_State* L, int status)
     return 0;
 }
 
-static void* createChildVmRequireContext(lua_State* L)
-{
-    void* ctx = lua_newuserdatadtor(
-        L,
-        sizeof(RequireCtx),
-        [](void* ptr)
-        {
-            std::destroy_at(static_cast<RequireCtx*>(ptr));
-        }
-    );
-
-    if (!ctx)
-        luaL_error(L, "unable to allocate RequireCtx");
-
-    // Explicit CliVfs should be removed with https://github.com/luau-lang/lute/issues/1027
-    ctx = new (ctx) RequireCtx{std::make_unique<RequireVfs>(CliVfs{})};
-
-    // Store RequireCtx in the registry to keep it alive for the lifetime of
-    // this lua_State. Memory address is used as a key to avoid collisions.
-    lua_pushlightuserdata(L, ctx);
-    lua_insert(L, -2);
-    lua_settable(L, LUA_REGISTRYINDEX);
-
-    return ctx;
-}
-
 int VM::lua_spawn(lua_State* L)
 {
     const char* file = luaL_checkstring(L, 1);
 
-    auto child = std::make_shared<Runtime>(getRuntime(L)->reporter);
+    Runtime* parent = getRuntime(L);
 
+    auto child = std::make_shared<Runtime>(parent->reporter);
+    child->requireContextFactory = parent->requireContextFactory;
+    LUTE_ASSERT(child->requireContextFactory);
+
+    void* childCtx = nullptr;
     setupState(
         *child,
-        [](lua_State* L)
+        [&factory = child->requireContextFactory, &childCtx](lua_State* childL)
         {
             if (Luau::CodeGen::isSupported())
-                Luau::CodeGen::create(L);
+                Luau::CodeGen::create(childL);
 
-            luaopen_require(L, requireConfigInit, createChildVmRequireContext(L));
+            childCtx = factory(childL);
+            luaopen_require(childL, requireConfigInit, childCtx);
         }
     );
 
     lua_Debug ar;
     lua_getinfo(L, 1, "s", &ar);
 
-    // Require the target module.
-    // Explicit CliVfs should be removed with https://github.com/luau-lang/lute/issues/1027
-    RequireCtx ctx{std::make_unique<RequireVfs>(CliVfs{})};
-    luarequire_pushproxyrequire(child->GL, requireConfigInit, &ctx);
+    luarequire_pushproxyrequire(child->GL, requireConfigInit, childCtx);
     lua_pushstring(child->GL, file);
     lua_pushstring(child->GL, ar.source);
     int status = lua_pcall(child->GL, 2, 1, 0);


### PR DESCRIPTION
Fixes #1027.

To avoid a circular dependency, we don't want `Lute.Runtime` depending on `Lute.Require`. A minimal solution here is to store an opaque callback (`requireContextFactory`) on every Runtime that can be used to construct a new, identical require context. To avoid wasting memory, require contexts that need to store metadata related to packages or bundled libraries store them under a `std::shared_ptr` that all descendants share - this way, we only pay the cost for storing the data once with no copies.

Whenever a child VM is spawned, we use this factory function to construct a new, identical `RequireCtx` so that all require capabilities (e.g. bundle VFS support, CLI support, package awareness) are inherited by the child Runtime. Whenever we create a Runtime - either from the CLI entrypoint or when spawning a new VM - we make sure to set its `requireContextFactory` so that its future descendants can also inherit the same require context.