### PR TITLE
Upgrade extern dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,9 @@ set(LIBUV_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/libuv/include)
 set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "Do not build examples" FORCE)
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static zlib" FORCE)
 add_subdirectory(extern/zlib)
+if(TARGET zlibstatic AND NOT TARGET ZLIB::ZLIB)
+    add_library(ZLIB::ZLIB ALIAS zlibstatic)
+endif()
 
 set(ZLIB_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/extern/zlib")
 
@@ -118,6 +121,7 @@ else()
 endif()
 set(ZLIB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/zlib;${ZLIB_OUTPUT_DIR})
 set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR} CACHE STRING "" FORCE)
+set(ZLIB_LIBRARIES ZLIB::ZLIB CACHE STRING "" FORCE)
 
 # boringssl setup
 add_subdirectory(extern/boringssl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,10 @@ set(ZLIB_BUILD_STATIC ON CACHE BOOL "Build static zlib" FORCE)
 set(ZLIB_INSTALL OFF CACHE BOOL "Do not install zlib" FORCE)
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static zlib" FORCE)
 add_subdirectory(extern/zlib)
+if(TARGET zlibstatic AND NOT TARGET ZLIB::ZLIB)
+    add_library(ZLIB::ZLIB INTERFACE IMPORTED GLOBAL)
+    target_link_libraries(ZLIB::ZLIB INTERFACE "$<BUILD_INTERFACE:zlibstatic>")
+endif()
 
 set(ZLIB_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/extern/zlib")
 
@@ -120,6 +124,7 @@ else()
 endif()
 set(ZLIB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/zlib;${ZLIB_OUTPUT_DIR} CACHE PATH "" FORCE)
 set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR} CACHE STRING "" FORCE)
+set(ZLIB_LIBRARIES ZLIB::ZLIB CACHE STRING "" FORCE)
 
 # boringssl setup
 add_subdirectory(extern/boringssl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,10 @@ set(LIBUV_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/libuv/include)
 # zlib setup
 #
 set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "Do not build examples" FORCE)
+set(ZLIB_BUILD_TESTING OFF CACHE BOOL "Do not build zlib tests" FORCE)
+set(ZLIB_BUILD_SHARED OFF CACHE BOOL "Do not build shared zlib" FORCE)
+set(ZLIB_BUILD_STATIC ON CACHE BOOL "Build static zlib" FORCE)
+set(ZLIB_INSTALL OFF CACHE BOOL "Do not install zlib" FORCE)
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static zlib" FORCE)
 add_subdirectory(extern/zlib)
 if(TARGET zlibstatic AND NOT TARGET ZLIB::ZLIB)
@@ -109,20 +113,18 @@ endif()
 
 set(ZLIB_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/extern/zlib")
 
-set(ZLIB_FOUND TRUE CACHE BOOL "" FORCE)
-
 if(MSVC)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstaticd.lib")
+        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstaticd.lib" CACHE FILEPATH "" FORCE)
     else()
-        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstatic.lib")
+        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstatic.lib" CACHE FILEPATH "" FORCE)
     endif()
 else()
-    set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/libz.a")
+    set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/libz.a" CACHE FILEPATH "" FORCE)
 endif()
-set(ZLIB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/zlib;${ZLIB_OUTPUT_DIR})
+set(ZLIB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/zlib;${ZLIB_OUTPUT_DIR} CACHE PATH "" FORCE)
 set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR} CACHE STRING "" FORCE)
-set(ZLIB_LIBRARIES ZLIB::ZLIB)
+set(ZLIB_LIBRARIES ZLIB::ZLIB CACHE STRING "" FORCE)
 
 # boringssl setup
 add_subdirectory(extern/boringssl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,28 +100,26 @@ set(LIBUV_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/libuv/include)
 # zlib setup
 #
 set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "Do not build examples" FORCE)
+set(ZLIB_BUILD_TESTING OFF CACHE BOOL "Do not build zlib tests" FORCE)
+set(ZLIB_BUILD_SHARED OFF CACHE BOOL "Do not build shared zlib" FORCE)
+set(ZLIB_BUILD_STATIC ON CACHE BOOL "Build static zlib" FORCE)
+set(ZLIB_INSTALL OFF CACHE BOOL "Do not install zlib" FORCE)
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static zlib" FORCE)
 add_subdirectory(extern/zlib)
-if(TARGET zlibstatic AND NOT TARGET ZLIB::ZLIB)
-    add_library(ZLIB::ZLIB ALIAS zlibstatic)
-endif()
 
 set(ZLIB_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/extern/zlib")
 
-set(ZLIB_FOUND TRUE CACHE BOOL "" FORCE)
-
 if(MSVC)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstaticd.lib")
+        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstaticd.lib" CACHE FILEPATH "" FORCE)
     else()
-        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstatic.lib")
+        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstatic.lib" CACHE FILEPATH "" FORCE)
     endif()
 else()
-    set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/libz.a")
+    set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/libz.a" CACHE FILEPATH "" FORCE)
 endif()
-set(ZLIB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/zlib;${ZLIB_OUTPUT_DIR})
+set(ZLIB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/zlib;${ZLIB_OUTPUT_DIR} CACHE PATH "" FORCE)
 set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR} CACHE STRING "" FORCE)
-set(ZLIB_LIBRARIES ZLIB::ZLIB CACHE STRING "" FORCE)
 
 # boringssl setup
 add_subdirectory(extern/boringssl)
@@ -161,6 +159,13 @@ set(BUILD_EXAMPLES OFF)
 set(BUILD_CURL_EXE OFF)
 set(BUILD_SHARED_LIBS OFF)
 set(BUILD_STATIC_LIBS ON)
+
+# curl's OpenSSL-family feature probes link against ZLIB::ZLIB when zlib is
+# enabled, but CMake's nested try-compile project cannot see the vendored zlib
+# target. These probes are known-false for our BoringSSL build, so seed them.
+set(HAVE_DES_ECB_ENCRYPT "" CACHE INTERNAL "curl BoringSSL feature probe")
+set(HAVE_SSL_SET0_WBIO "" CACHE INTERNAL "curl BoringSSL feature probe")
+set(HAVE_OPENSSL_SRP "" CACHE INTERNAL "curl BoringSSL feature probe")
 
 # lute/net only speaks HTTP/HTTPS/WebSocket.
 set(CURL_DISABLE_FTP    ON CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,12 @@ set(BUILD_CURL_EXE OFF)
 set(BUILD_SHARED_LIBS OFF)
 set(BUILD_STATIC_LIBS ON)
 
+# curl's OpenSSL-family probes run in nested try-compile projects, where the
+# in-tree ZLIB::ZLIB target is not visible. These are false for BoringSSL.
+set(HAVE_DES_ECB_ENCRYPT "" CACHE INTERNAL "curl BoringSSL feature probe")
+set(HAVE_SSL_SET0_WBIO "" CACHE INTERNAL "curl BoringSSL feature probe")
+set(HAVE_OPENSSL_SRP "" CACHE INTERNAL "curl BoringSSL feature probe")
+
 # lute/net only speaks HTTP/HTTPS/WebSocket.
 set(CURL_DISABLE_FTP    ON CACHE BOOL "" FORCE)
 set(CURL_DISABLE_TFTP   ON CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ set(BUILD_EXAMPLES OFF)
 set(BUILD_CURL_EXE OFF)
 set(BUILD_SHARED_LIBS OFF)
 set(BUILD_STATIC_LIBS ON)
+set(CURL_ENABLE_EXPORT_TARGET OFF)
 
 # curl's OpenSSL-family probes run in nested try-compile projects, where the
 # in-tree ZLIB::ZLIB target is not visible. These are false for BoringSSL.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,10 +100,6 @@ set(LIBUV_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/libuv/include)
 # zlib setup
 #
 set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "Do not build examples" FORCE)
-set(ZLIB_BUILD_TESTING OFF CACHE BOOL "Do not build zlib tests" FORCE)
-set(ZLIB_BUILD_SHARED OFF CACHE BOOL "Do not build shared zlib" FORCE)
-set(ZLIB_BUILD_STATIC ON CACHE BOOL "Build static zlib" FORCE)
-set(ZLIB_INSTALL OFF CACHE BOOL "Do not install zlib" FORCE)
 set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static zlib" FORCE)
 add_subdirectory(extern/zlib)
 if(TARGET zlibstatic AND NOT TARGET ZLIB::ZLIB)
@@ -113,18 +109,20 @@ endif()
 
 set(ZLIB_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/extern/zlib")
 
+set(ZLIB_FOUND TRUE CACHE BOOL "" FORCE)
+
 if(MSVC)
     if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstaticd.lib" CACHE FILEPATH "" FORCE)
+        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstaticd.lib")
     else()
-        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstatic.lib" CACHE FILEPATH "" FORCE)
+        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstatic.lib")
     endif()
 else()
-    set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/libz.a" CACHE FILEPATH "" FORCE)
+    set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/libz.a")
 endif()
-set(ZLIB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/zlib;${ZLIB_OUTPUT_DIR} CACHE PATH "" FORCE)
+set(ZLIB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/zlib;${ZLIB_OUTPUT_DIR})
 set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR} CACHE STRING "" FORCE)
-set(ZLIB_LIBRARIES ZLIB::ZLIB CACHE STRING "" FORCE)
+set(ZLIB_LIBRARIES ZLIB::ZLIB)
 
 # boringssl setup
 add_subdirectory(extern/boringssl)
@@ -164,13 +162,6 @@ set(BUILD_EXAMPLES OFF)
 set(BUILD_CURL_EXE OFF)
 set(BUILD_SHARED_LIBS OFF)
 set(BUILD_STATIC_LIBS ON)
-
-# curl's OpenSSL-family feature probes link against ZLIB::ZLIB when zlib is
-# enabled, but CMake's nested try-compile project cannot see the vendored zlib
-# target. These probes are known-false for our BoringSSL build, so seed them.
-set(HAVE_DES_ECB_ENCRYPT "" CACHE INTERNAL "curl BoringSSL feature probe")
-set(HAVE_SSL_SET0_WBIO "" CACHE INTERNAL "curl BoringSSL feature probe")
-set(HAVE_OPENSSL_SRP "" CACHE INTERNAL "curl BoringSSL feature probe")
 
 # lute/net only speaks HTTP/HTTPS/WebSocket.
 set(CURL_DISABLE_FTP    ON CACHE BOOL "" FORCE)

--- a/extern/boringssl.tune
+++ b/extern/boringssl.tune
@@ -1,5 +1,5 @@
 [dependency]
 name = "boringssl"
 remote = "https://github.com/google/boringssl.git"
-branch = "0.20250415.0"
-revision = "2b44a3701a4788e1ef866ddc7f143060a3d196c9"
+branch = "0.20260413.0"
+revision = "78f7fbeec98a2fb15acea6f7a9f1def7f2e6d9a0"

--- a/extern/curl.tune
+++ b/extern/curl.tune
@@ -1,5 +1,5 @@
 [dependency]
 name = "curl"
 remote = "https://github.com/curl/curl.git"
-branch = "curl-8_13_0"
-revision = "1c3149881769e7bd79b072e48374e4c2b3678b2f"
+branch = "curl-8_20_0"
+revision = "a05f34973e6c4bb629d018f7cb51487be1c904d8"

--- a/extern/libuv.tune
+++ b/extern/libuv.tune
@@ -1,5 +1,5 @@
 [dependency]
 name = "libuv"
 remote = "https://github.com/libuv/libuv.git"
-branch = "v1.50.0"
-revision = "8fb9cb919489a48880680a56efecff6a7dfb4504"
+branch = "v1.52.1"
+revision = "1cfa32ff59c076ffb6ed735bbc8c18361558661f"

--- a/extern/libuv.tune
+++ b/extern/libuv.tune
@@ -1,5 +1,5 @@
 [dependency]
 name = "libuv"
 remote = "https://github.com/libuv/libuv.git"
-branch = "v1.52.1"
-revision = "1cfa32ff59c076ffb6ed735bbc8c18361558661f"
+branch = "v1.51.0"
+revision = "5152db2cbfeb5582e9c27c5ea1dba2cd9e10759b"

--- a/extern/uWebSockets.tune
+++ b/extern/uWebSockets.tune
@@ -1,5 +1,5 @@
 [dependency]
 name = "uWebSockets"
 remote = "https://github.com/uNetworking/uWebSockets.git"
-branch = "v20.74.0"
-revision = "c445faa38125bf782eed3fec97f83b4733c7fb91"
+branch = "v20.77.0"
+revision = "6b7f3540cec801a7f1cb01141eae8ab989dd4e70"

--- a/extern/zlib.tune
+++ b/extern/zlib.tune
@@ -1,5 +1,5 @@
 [dependency]
 name = "zlib"
 remote = "https://github.com/madler/zlib.git"
-branch = "v1.3.1"
-revision = "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf"
+branch = "v1.3.2"
+revision = "da607da739fa6047df13e66a2af6b8bec7c2a498"


### PR DESCRIPTION
1. `curl` `8.13.0` -> `8.20.0`
   curl lists `8.13.0` with 23 published security issues, including WebSocket issues relevant to Lute’s curl WebSocket usage.

2. `zlib` `1.3.1` -> `1.3.2`
   `1.3.2` addresses findings from the 7ASecurity audit, including heap overflow, infinite-loop, race/DoS, and leak findings.

3. `BoringSSL` `0.20250415.0` -> latest snapshot, currently `0.20260413.0`
   Generally good to be up to date here for security

4. `uWebSockets` `20.74.0` -> `20.77.0`
   General perf improvements and includes a new way to get data on requests.

5. `libuv` `1.50.0` -> `1.51.0` (`1.52.1` includes a windows bug we hit in ci https://github.com/libuv/libuv/issues/5010)
   Useful crash/leak/build fixes, Windows fd hash memory reduction, and Linux/libuv correctness improvements.