### PR TITLE
Split tests and snapshots into separate steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,10 @@ jobs:
           use-bootstrap: ${{ matrix.use-bootstrap || 'false' }}
       - name: Run Luau Tests
         if: ${{ steps.should_run.outputs.proceed == 'true' }}
-        run: |
-          ${{ steps.build_lute.outputs.exe_path }} test --verbose
-          ${{ steps.build_lute.outputs.exe_path }} test snapshots
+        run: ${{ steps.build_lute.outputs.exe_path }} test --verbose
+      - name: Run Luau Snapshots
+        if: ${{ steps.should_run.outputs.proceed == 'true' }}
+        run: ${{ steps.build_lute.outputs.exe_path }} test snapshots
 
   run-lute-cxx-unittests:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Since windows uses powershell by default, the `lute test` exit code is ignored and the snapshot one is just used. So if tests fail but snapshots pass, the CI step still passes on windows. By splitting the tests into two separate steps we should fix this. Alternatively we could force the shell to bash, but I think splitting into two steps is fine.

See an example of failing tests but still passing the step: https://github.com/luau-lang/lute/actions/runs/25634139014/job/75242932282?pr=1081