### PR TITLE
Remove crlf to lf on process.run

### DIFF
--- a/lute/cli/commands/test/snap/runner.luau
+++ b/lute/cli/commands/test/snap/runner.luau
@@ -90,8 +90,8 @@ local function posixify(str)
 end
 
 local function normalizeLineEndings(str: string): string
-	local noCrlf, _ = string.gsub(str, "\r\n", "\n")
-	local noCr, _ = string.gsub(noCrlf, "\r", "\n")
+	local noCrlf, _ = string.gsub(str, "\r+\n", "\n")
+	local noCr, _ = string.gsub(noCrlf, "\r+", "\n")
 	return noCr
 end
 

--- a/lute/cli/commands/test/snap/runner.luau
+++ b/lute/cli/commands/test/snap/runner.luau
@@ -89,9 +89,14 @@ local function posixify(str)
 	return posixy
 end
 
+local function normalizeLineEndings(str: string): string
+	local noCrlf, _ = string.gsub(str, "\r\n", "\n")
+	local noCr, _ = string.gsub(noCrlf, "\r", "\n")
+	return noCr
+end
+
 local function normalizeSnapshotOutput(output: string, normalizedCwd: string): string
-	local noCrlf, _ = string.gsub(output, "\r\n", "\n")
-	local nobackslash = posixify(noCrlf)
+	local nobackslash = posixify(normalizeLineEndings(output))
 	local replacedCwd, _ = string.gsub(nobackslash, normalizedCwd, "<ROOT>")
 	return replacedCwd
 end

--- a/lute/process/src/processhandle.cpp
+++ b/lute/process/src/processhandle.cpp
@@ -1,6 +1,5 @@
 #include "lute/processhandle.h"
 
-#include "lute/common.h"
 #include "lute/uvutils.h"
 
 #include "lua.h"
@@ -20,18 +19,6 @@ namespace process
 const std::string kStdioKindDefault = "default";
 const std::string kStdioKindInherit = "inherit";
 const std::string kStdioKindNone = "none";
-
-void convertCRLFtoLF(std::string& str)
-{
-    size_t writePos = 0;
-    for (size_t readPos = 0; readPos < str.size(); ++readPos)
-    {
-        if (str[readPos] == '\r' && readPos + 1 < str.size() && str[readPos + 1] == '\n')
-            continue; // Skip the '\r' in CRLF
-        str[writePos++] = str[readPos];
-    }
-    str.resize(writePos);
-}
 
 ProcessExecutionState::ProcessExecutionState(int maxCompletions)
     : completed(false)
@@ -287,8 +274,6 @@ void ProcessHandle::completeProcessExecution()
         std::string finalStdout = state.stdoutData;
         std::string finalStderr = state.stderrData;
         std::string finalSignalStr = finalTermSignal ? std::to_string(finalTermSignal) : "";
-        convertCRLFtoLF(finalStdout);
-        convertCRLFtoLF(finalStderr);
         resumeToken->complete(
             [=](lua_State* L)
             {

--- a/tests/cli/compile.test.luau
+++ b/tests/cli/compile.test.luau
@@ -3,6 +3,7 @@ local process = require("@std/process")
 local path = require("@std/path")
 local system = require("@std/system")
 local test = require("@std/test")
+local testutil = require("../testutil")
 
 local COMPILER_CONTENTS = [[
 local luau = require("@lute/luau")
@@ -23,12 +24,6 @@ local COMPILEE_CONTENTS = [[return "Hello world"]]
 local lutePath = process.execPath()
 local tmpDir = system.tmpdir()
 
-local function normalizeLineEndings(contents: string): string
-	local normalized = contents:gsub("\r\n", "\n")
-	local lfOnly = normalized:gsub("\r", "\n")
-	return lfOnly
-end
-
 test.suite("LuteCliCompile", function(suite)
 	suite:case("runCompile", function(check)
 		-- Setup
@@ -46,7 +41,7 @@ test.suite("LuteCliCompile", function(suite)
 		local result = process.run({ path.format(lutePath), path.format(compilerPath), path.format(compileePath) })
 		-- Compilation should work with no memory leaks
 		check.eq(result.stderr, "")
-		check.eq(normalizeLineEndings(result.stdout), "SUCCESS\n")
+		check.eq(testutil.normalizeLineEndings(result.stdout), "SUCCESS\n")
 		check.eq(result.exitcode, 0)
 
 		-- -- Cleanup

--- a/tests/cli/compile.test.luau
+++ b/tests/cli/compile.test.luau
@@ -23,6 +23,12 @@ local COMPILEE_CONTENTS = [[return "Hello world"]]
 local lutePath = process.execPath()
 local tmpDir = system.tmpdir()
 
+local function normalizeLineEndings(contents: string): string
+	local normalized = contents:gsub("\r\n", "\n")
+	local lfOnly = normalized:gsub("\r", "\n")
+	return lfOnly
+end
+
 test.suite("LuteCliCompile", function(suite)
 	suite:case("runCompile", function(check)
 		-- Setup
@@ -40,7 +46,7 @@ test.suite("LuteCliCompile", function(suite)
 		local result = process.run({ path.format(lutePath), path.format(compilerPath), path.format(compileePath) })
 		-- Compilation should work with no memory leaks
 		check.eq(result.stderr, "")
-		check.eq(result.stdout, "SUCCESS\n")
+		check.eq(normalizeLineEndings(result.stdout), "SUCCESS\n")
 		check.eq(result.exitcode, 0)
 
 		-- -- Cleanup

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -5,6 +5,7 @@ local system = require("@std/system")
 local tableext = require("@std/tableext")
 local test = require("@std/test")
 local testTypes = require("@std/test/types")
+local testutil = require("../testutil")
 
 local lutePath = path.format(process.execPath())
 local tmpDir = system.tmpdir()
@@ -36,16 +37,10 @@ local LINT_RULE_MESSAGES = {
 
 local USAGE = "Usage: lute lint [OPTIONS] [...PATHS]"
 
-local function normalizeLineEndings(contents: string): string
-	local normalized = contents:gsub("\r\n", "\n")
-	local lfOnly = normalized:gsub("\r", "\n")
-	return lfOnly
-end
-
 local function runProcess(args: { string }, options: process.ProcessRunOptions?): process.ProcessResult
 	local result = process.run(args, options)
-	result.stdout = normalizeLineEndings(result.stdout)
-	result.stderr = normalizeLineEndings(result.stderr)
+	result.stdout = testutil.normalizeLineEndings(result.stdout)
+	result.stderr = testutil.normalizeLineEndings(result.stderr)
 	return result
 end
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -36,6 +36,19 @@ local LINT_RULE_MESSAGES = {
 
 local USAGE = "Usage: lute lint [OPTIONS] [...PATHS]"
 
+local function normalizeLineEndings(contents: string): string
+	local normalized = contents:gsub("\r\n", "\n")
+	local lfOnly = normalized:gsub("\r", "\n")
+	return lfOnly
+end
+
+local function runProcess(args: { string }, options: process.ProcessRunOptions?): process.ProcessResult
+	local result = process.run(args, options)
+	result.stdout = normalizeLineEndings(result.stdout)
+	result.stderr = normalizeLineEndings(result.stderr)
+	return result
+end
+
 type lintTestParams = {
 	content: string,
 	expectedExitCode: number,
@@ -93,7 +106,7 @@ local function lintTestHelper(assert: testTypes.Asserts, params: lintTestParams)
 
 	table.insert(lintArgs, violatorPath)
 
-	local result = process.run(lintArgs, params.processOptions)
+	local result = runProcess(lintArgs, params.processOptions)
 
 	-- Check
 	assert.eq(result.exitcode, params.expectedExitCode)
@@ -130,17 +143,17 @@ test.suite("lute lint", function(suite)
 	end)
 
 	suite:case("luteLintHelpMessage", function(assert)
-		local result = process.run({ lutePath, "lint", "-h" })
+		local result = runProcess({ lutePath, "lint", "-h" })
 
 		assert.eq(result.exitcode, 0)
 		assert.strContains(result.stdout, USAGE)
 
-		result = process.run({ lutePath, "lint", "--h" })
+		result = runProcess({ lutePath, "lint", "--h" })
 
 		assert.eq(result.exitcode, 0)
 		assert.strContains(result.stdout, USAGE)
 
-		result = process.run({ lutePath, "lint", "--help" })
+		result = runProcess({ lutePath, "lint", "--help" })
 
 		assert.eq(result.exitcode, 0)
 		assert.strContains(result.stdout, USAGE)
@@ -471,7 +484,7 @@ y = x
 
 		-- Do
 		-- Run the transformer on the transformee
-		local result = process.run({ lutePath, "lint", "-v", violatorPath1, path.format(modulePath) })
+		local result = runProcess({ lutePath, "lint", "-v", violatorPath1, path.format(modulePath) })
 
 		-- Check
 		assert.eq(result.exitcode, 1)
@@ -542,7 +555,7 @@ b = a
 
 		-- Do
 		-- Run the transformer on the transformee
-		local result = process.run({ lutePath, "lint", lintee, violatorPath })
+		local result = runProcess({ lutePath, "lint", lintee, violatorPath })
 
 		-- Check
 		assert.eq(result.exitcode, 1)
@@ -986,7 +999,7 @@ local y = 10 / 0
 
 		-- Do
 		-- Run the transformer on the transformee
-		local result = process.run({ lutePath, "lint", path.format(modulePath) })
+		local result = runProcess({ lutePath, "lint", path.format(modulePath) })
 
 		-- Check
 		assert.eq(result.exitcode, 1)
@@ -1089,7 +1102,7 @@ b = a
 
 		-- Do
 		-- Run the linter on string input
-		local result = process.run({ lutePath, "lint", "-s", inputString })
+		local result = runProcess({ lutePath, "lint", "-s", inputString })
 
 		-- Check
 		assert.eq(result.exitcode, 1)
@@ -1111,7 +1124,7 @@ b = a
 
 		-- Do
 		-- Run the linter on string input with verbose flag
-		local result = process.run({ lutePath, "lint", "-v", "-s", inputString })
+		local result = runProcess({ lutePath, "lint", "-v", "-s", inputString })
 
 		-- Check
 		assert.eq(result.exitcode, 1)
@@ -1128,7 +1141,7 @@ b = a
 
 		-- Do
 		-- Run the linter on string input
-		local result = process.run({ lutePath, "lint", "-v", "-s", inputString })
+		local result = runProcess({ lutePath, "lint", "-v", "-s", inputString })
 
 		-- Check
 		assert.eq(result.exitcode, 0)
@@ -1140,7 +1153,7 @@ b = a
 
 		-- Do
 		-- Run the linter on string input with json flag
-		local result = process.run({ lutePath, "lint", "-j", "-s", inputString })
+		local result = runProcess({ lutePath, "lint", "-j", "-s", inputString })
 
 		-- Check
 		assert.eq(result.exitcode, 0)
@@ -1483,7 +1496,7 @@ local e = next(t) ~= nil
 
 		-- Do
 		-- Run the linter on string input with json flag
-		local result = process.run({ lutePath, "lint", "-j", "-s", inputString })
+		local result = runProcess({ lutePath, "lint", "-j", "-s", inputString })
 
 		-- Check
 		assert.eq(result.exitcode, 0)
@@ -2690,7 +2703,7 @@ return {
 		]]
 		fs.writeStringToFile(configFile, configContents)
 
-		local result = process.run({ lutePath, "lint", "-c", path.format(configFile), path.format(testSubDir) })
+		local result = runProcess({ lutePath, "lint", "-c", path.format(configFile), path.format(testSubDir) })
 		assert.eq(result.exitcode, 1) -- errors but ONLY from valid.luau
 		assert.strNotContains(result.stdout, "ignored.luau")
 		assert.strContains(result.stdout, "valid.luau")
@@ -2721,7 +2734,7 @@ return {
 		]]
 		fs.writeStringToFile(configFile, configContents)
 
-		local result = process.run({ lutePath, "lint", path.format(testSubDir) }, {
+		local result = runProcess({ lutePath, "lint", path.format(testSubDir) }, {
 			cwd = path.format(testSubDir),
 		})
 		assert.eq(result.exitcode, 0) -- no errors
@@ -2759,7 +2772,7 @@ return {
 		]]
 		fs.writeStringToFile(configFile, configContents)
 
-		local result = process.run({ lutePath, "lint", "-c", path.format(configFile), path.format(testSubDir) })
+		local result = runProcess({ lutePath, "lint", "-c", path.format(configFile), path.format(testSubDir) })
 		assert.eq(result.exitcode, 0) -- no errors bc we ignore BOTH files in the dir
 		assert.strNotContains(result.stdout, "almost_swapped")
 		assert.strNotContains(result.stdout, "divide_by_zero")
@@ -2798,7 +2811,7 @@ return {
 		]]
 		fs.writeStringToFile(configFile, configContents)
 
-		local result = process.run({ lutePath, "lint", "-c", path.format(configFile), path.format(testSubDir) })
+		local result = runProcess({ lutePath, "lint", "-c", path.format(configFile), path.format(testSubDir) })
 		assert.eq(result.exitcode, 1) -- errors but ONLY from notIgnored.luau
 
 		-- Should NOT contain violations from the ignored directory
@@ -2838,7 +2851,7 @@ return {
 		fs.writeStringToFile(configFile, configContents)
 
 		-- Pass config as a relative path, setting cwd to ensure relative config path is correct
-		local result = process.run({ lutePath, "lint", "-c", ".config.luau", "." }, {
+		local result = runProcess({ lutePath, "lint", "-c", ".config.luau", "." }, {
 			cwd = path.format(testSubDir),
 		})
 		assert.eq(result.exitcode, 1) -- errors but ONLY from valid.luau
@@ -2873,7 +2886,7 @@ return {
 		fs.writeStringToFile(configFile, configContents)
 
 		-- Pass config as an absolute path, with cwd set to a different directory (homedir)
-		local result = process.run({ lutePath, "lint", "-c", path.format(configFile), path.format(testSubDir) })
+		local result = runProcess({ lutePath, "lint", "-c", path.format(configFile), path.format(testSubDir) })
 		assert.eq(result.exitcode, 1) -- errors but ONLY from valid.luau
 		assert.strNotContains(result.stdout, "ignored.luau")
 		assert.strContains(result.stdout, "valid.luau")
@@ -2958,7 +2971,7 @@ return {
 		fs.writeStringToFile(configFile, configContents)
 
 		-- assert that violations are present without config
-		local result = process.run({ lutePath, "lint", path.format(violatorFile) }, {
+		local result = runProcess({ lutePath, "lint", path.format(violatorFile) }, {
 			cwd = path.format(process.homedir()),
 		})
 		assert.eq(result.exitcode, 1) -- should be violations
@@ -2967,7 +2980,7 @@ return {
 		assert.strContains(result.stdout, "[almost_swapped]")
 
 		-- with config, there should be violations but NOT for divide_by_zero
-		result = process.run({ lutePath, "lint", "-c", path.format(configFile), path.format(violatorFile) }, {
+		result = runProcess({ lutePath, "lint", "-c", path.format(configFile), path.format(violatorFile) }, {
 			cwd = path.format(process.homedir()),
 		})
 		assert.eq(result.exitcode, 1)
@@ -3010,7 +3023,7 @@ return {
 ]]
 		fs.writeStringToFile(configFile, configContents)
 
-		local result = process.run({ lutePath, "lint", "-c", path.format(configFile), path.format(testSubDir) })
+		local result = runProcess({ lutePath, "lint", "-c", path.format(configFile), path.format(testSubDir) })
 		assert.eq(result.exitcode, 1)
 
 		-- Both files should still report almost_swapped (the non-ignored rule)
@@ -3259,7 +3272,7 @@ return {
 			fs.writeStringToFile(ignoredFile, violatingContents)
 			fs.writeStringToFile(notIgnoredFile, violatingContents)
 
-			local result = process.run({
+			local result = runProcess({
 				lutePath,
 				"lint",
 				"-c",
@@ -3565,7 +3578,7 @@ end
 		local violatorPath = path.format(path.join(testSubDir, "violator.luau"))
 		fs.writeStringToFile(violatorPath, "local x = 1 / 0")
 
-		local result = process.run({ lutePath, "lint" }, {
+		local result = runProcess({ lutePath, "lint" }, {
 			cwd = path.format(testSubDir),
 		})
 
@@ -3580,7 +3593,7 @@ end
 		local violatorPath = path.format(path.join(testSubDir, "violator.lua"))
 		fs.writeStringToFile(violatorPath, "local x = 1 / 0")
 
-		local result = process.run({ lutePath, "lint" }, {
+		local result = runProcess({ lutePath, "lint" }, {
 			cwd = path.format(testSubDir),
 		})
 
@@ -3597,7 +3610,7 @@ end
 		local violatorPath = path.format(path.join(nestedDir, "violator.luau"))
 		fs.writeStringToFile(violatorPath, "local x = 1 / 0")
 
-		local result = process.run({ lutePath, "lint" }, {
+		local result = runProcess({ lutePath, "lint" }, {
 			cwd = path.format(testSubDir),
 		})
 
@@ -3609,7 +3622,7 @@ end
 		local testSubDir = path.join(tmpDir, "module")
 		fs.createDirectory(testSubDir)
 
-		local result = process.run({ lutePath, "lint" }, {
+		local result = runProcess({ lutePath, "lint" }, {
 			cwd = path.format(testSubDir),
 		})
 

--- a/tests/cli/loadmodule.test.luau
+++ b/tests/cli/loadmodule.test.luau
@@ -3,6 +3,7 @@ local process = require("@std/process")
 local path = require("@std/path")
 local system = require("@std/system")
 local test = require("@std/test")
+local testutil = require("../testutil")
 
 local REQUIRER_CONTENTS = [[
 local args = { ... }
@@ -20,12 +21,6 @@ local lutePath = process.execPath()
 local tmpDirStr = system.tmpdir()
 local testDir = path.join(tmpDirStr, "lute_require_test")
 local testDirStr = path.format(testDir)
-
-local function normalizeLineEndings(contents: string): string
-	local normalized = contents:gsub("\r\n", "\n")
-	local lfOnly = normalized:gsub("\r", "\n")
-	return lfOnly
-end
 
 test.suite("LuteCliRun", function(suite)
 	suite:beforeAll(function()
@@ -49,7 +44,7 @@ test.suite("LuteCliRun", function(suite)
 
 		local result = process.run({ tostring(lutePath), requirerPath, requireePath })
 		check.eq(result.exitcode, 0)
-		check.eq(normalizeLineEndings(result.stdout), "Success\n")
+		check.eq(testutil.normalizeLineEndings(result.stdout), "Success\n")
 
 		-- Cleanup
 		fs.remove(requirerPath)

--- a/tests/cli/loadmodule.test.luau
+++ b/tests/cli/loadmodule.test.luau
@@ -21,6 +21,12 @@ local tmpDirStr = system.tmpdir()
 local testDir = path.join(tmpDirStr, "lute_require_test")
 local testDirStr = path.format(testDir)
 
+local function normalizeLineEndings(contents: string): string
+	local normalized = contents:gsub("\r\n", "\n")
+	local lfOnly = normalized:gsub("\r", "\n")
+	return lfOnly
+end
+
 test.suite("LuteCliRun", function(suite)
 	suite:beforeAll(function()
 		if not fs.exists(testDirStr) then
@@ -43,7 +49,7 @@ test.suite("LuteCliRun", function(suite)
 
 		local result = process.run({ tostring(lutePath), requirerPath, requireePath })
 		check.eq(result.exitcode, 0)
-		check.eq(result.stdout, "Success\n")
+		check.eq(normalizeLineEndings(result.stdout), "Success\n")
 
 		-- Cleanup
 		fs.remove(requirerPath)
@@ -52,7 +58,7 @@ test.suite("LuteCliRun", function(suite)
 
 	suite:afterAll(function()
 		if fs.exists(testDirStr) then
-			fs.removeDirectory(testDirStr)
+			fs.removeDirectory(testDirStr, { recursive = true })
 		end
 	end)
 end)

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -4,6 +4,12 @@ local test = require("@std/test")
 
 local lutePath = path.format(process.execPath())
 
+local function normalizeLineEndings(contents: string): string
+	local normalized = contents:gsub("\r\n", "\n")
+	local lfOnly = normalized:gsub("\r", "\n")
+	return lfOnly
+end
+
 local expected = [[Anonymous:
 	passing
 ExampleSuite:
@@ -37,7 +43,7 @@ test.suite("LuteTestCommand", function(suite)
 
 		-- Check that it discovers test files (.test.luau and .spec.luau)
 		assert.eq(result.exitcode, 0)
-		assert.eq(expected, result.stdout)
+		assert.eq(expected, normalizeLineEndings(result.stdout))
 	end)
 
 	suite:case("filterBySuiteName", function(assert)

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -1,14 +1,9 @@
 local path = require("@std/path")
 local process = require("@std/process")
 local test = require("@std/test")
+local testutil = require("../testutil")
 
 local lutePath = path.format(process.execPath())
-
-local function normalizeLineEndings(contents: string): string
-	local normalized = contents:gsub("\r\n", "\n")
-	local lfOnly = normalized:gsub("\r", "\n")
-	return lfOnly
-end
 
 local expected = [[Anonymous:
 	passing
@@ -43,7 +38,7 @@ test.suite("LuteTestCommand", function(suite)
 
 		-- Check that it discovers test files (.test.luau and .spec.luau)
 		assert.eq(result.exitcode, 0)
-		assert.eq(expected, normalizeLineEndings(result.stdout))
+		assert.eq(expected, testutil.normalizeLineEndings(result.stdout))
 	end)
 
 	suite:case("filterBySuiteName", function(assert)

--- a/tests/cli/transform.test.luau
+++ b/tests/cli/transform.test.luau
@@ -3,6 +3,7 @@ local path = require("@std/path")
 local process = require("@std/process")
 local system = require("@std/system")
 local test = require("@std/test")
+local testutil = require("../testutil")
 
 local TRANSFORMEE_CONTENT = [[
 local x = math.sqrt(-1)
@@ -15,12 +16,6 @@ local transformeePath = path.format(path.join(tmpDir, "transformee.luau"))
 local outputPath = path.format(path.join(tmpDir, "transformee_output.luau"))
 
 local USAGE = "Usage: lute transform [options] <migration-path> [files...] [-- [--option value...]]"
-
-local function normalizeLineEndings(contents: string): string
-	local normalized = contents:gsub("\r\n", "\n")
-	local lfOnly = normalized:gsub("\r", "\n")
-	return lfOnly
-end
 
 test.suite("LuteTransform", function(suite)
 	suite:beforeEach(function()
@@ -60,7 +55,7 @@ test.suite("LuteTransform", function(suite)
 
 		assert.eq(result.exitcode, 1)
 		assert.strContains(
-			normalizeLineEndings(result.stdout),
+			testutil.normalizeLineEndings(result.stdout),
 			`Error: No code transformation script specified.\n\n{USAGE}\nUse --help for more information.`
 		)
 	end)

--- a/tests/cli/transform.test.luau
+++ b/tests/cli/transform.test.luau
@@ -16,6 +16,12 @@ local outputPath = path.format(path.join(tmpDir, "transformee_output.luau"))
 
 local USAGE = "Usage: lute transform [options] <migration-path> [files...] [-- [--option value...]]"
 
+local function normalizeLineEndings(contents: string): string
+	local normalized = contents:gsub("\r\n", "\n")
+	local lfOnly = normalized:gsub("\r", "\n")
+	return lfOnly
+end
+
 test.suite("LuteTransform", function(suite)
 	suite:beforeEach(function()
 		-- Create a transformee file
@@ -54,7 +60,7 @@ test.suite("LuteTransform", function(suite)
 
 		assert.eq(result.exitcode, 1)
 		assert.strContains(
-			result.stdout,
+			normalizeLineEndings(result.stdout),
 			`Error: No code transformation script specified.\n\n{USAGE}\nUse --help for more information.`
 		)
 	end)

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -3,13 +3,8 @@ local pathlib = require("@std/path")
 local process = require("@std/process")
 local system = require("@std/system")
 local test = require("@std/test")
+local testutil = require("../testutil")
 local windowsPath = require("@std/path/win32")
-
-local function normalizeLineEndings(contents: string): string
-	local normalized = contents:gsub("\r\n", "\n")
-	local lfOnly = normalized:gsub("\r", "\n")
-	return lfOnly
-end
 
 test.suite("ProcessSuite", function(suite)
 	suite:case("processArgsIsTable", function(assert)
@@ -52,7 +47,7 @@ test.suite("ProcessSuite", function(suite)
 
 	suite:case("runEchoArrayViaSystem", function(assert)
 		local r = process.system("echo hello-from-lute")
-		assert.eq(normalizeLineEndings(r.stdout), "hello-from-lute\n")
+		assert.eq(testutil.normalizeLineEndings(r.stdout), "hello-from-lute\n")
 	end)
 
 	suite:case("runSystemAndCwd", function(check)
@@ -86,7 +81,7 @@ test.suite("ProcessSuite", function(suite)
 
 		-- LUAUFIX: we shouldn't need to upcast the result of `process.system` to `{ [any]: any }`
 		local r2 = process.system("echo hello!") :: { [any]: any }
-		r2.stdout = normalizeLineEndings(r2.stdout)
+		r2.stdout = testutil.normalizeLineEndings(r2.stdout)
 		check.eq(r2, {
 			exitcode = 0,
 			stdout = "hello!\n",

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -5,6 +5,12 @@ local system = require("@std/system")
 local test = require("@std/test")
 local windowsPath = require("@std/path/win32")
 
+local function normalizeLineEndings(contents: string): string
+	local normalized = contents:gsub("\r\n", "\n")
+	local lfOnly = normalized:gsub("\r", "\n")
+	return lfOnly
+end
+
 test.suite("ProcessSuite", function(suite)
 	suite:case("processArgsIsTable", function(assert)
 		assert.eq(type(process.args), "table")
@@ -46,7 +52,7 @@ test.suite("ProcessSuite", function(suite)
 
 	suite:case("runEchoArrayViaSystem", function(assert)
 		local r = process.system("echo hello-from-lute")
-		assert.eq(r.stdout, "hello-from-lute\n")
+		assert.eq(normalizeLineEndings(r.stdout), "hello-from-lute\n")
 	end)
 
 	suite:case("runSystemAndCwd", function(check)
@@ -80,6 +86,7 @@ test.suite("ProcessSuite", function(suite)
 
 		-- LUAUFIX: we shouldn't need to upcast the result of `process.system` to `{ [any]: any }`
 		local r2 = process.system("echo hello!") :: { [any]: any }
+		r2.stdout = normalizeLineEndings(r2.stdout)
 		check.eq(r2, {
 			exitcode = 0,
 			stdout = "hello!\n",

--- a/tests/std/process.test.luau
+++ b/tests/std/process.test.luau
@@ -26,6 +26,24 @@ test.suite("ProcessSuite", function(suite)
 		assert.eq(r.stdout, "hello-from-lute\n")
 	end)
 
+	suite:case("runPreservesCapturedOutputBytes", function(assert)
+		local lutePath = pathlib.format(process.execPath())
+		local scriptPath = pathlib.join(system.tmpdir(), "process_binary_stdout.luau")
+
+		fs.writeStringToFile(
+			pathlib.format(scriptPath),
+			[[
+			local io = require("@lute/io")
+			io.write("A\r\nB")
+		]]
+		)
+
+		local r = process.run({ lutePath, pathlib.format(scriptPath) })
+		fs.remove(scriptPath)
+
+		assert.eq(r.stdout, "A\r\nB")
+	end)
+
 	suite:case("runEchoArrayViaSystem", function(assert)
 		local r = process.system("echo hello-from-lute")
 		assert.eq(r.stdout, "hello-from-lute\n")

--- a/tests/testutil.luau
+++ b/tests/testutil.luau
@@ -1,0 +1,9 @@
+local testutil = {}
+
+function testutil.normalizeLineEndings(contents: string): string
+	local noCrlf, _ = contents:gsub("\r+\n", "\n")
+	local noCr, _ = noCrlf:gsub("\r+", "\n")
+	return noCr
+end
+
+return table.freeze(testutil)


### PR DESCRIPTION
See #1090, fixes bug with binary data corrupting.