### PR TITLE
runtime: change how we handle argument validation to match Luau builtins

### DIFF
--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -58,7 +58,7 @@ int makeHashFunctionMap(lua_State* L)
     return 1;
 }
 
-const env_md_st* getHashFunction(lua_State* L, int idx)
+const env_md_st* checkHashFunction(lua_State* L, int idx)
 {
     if (auto typ = static_cast<const env_md_st*>(lua_tolightuserdatatagged(L, idx, kHashFunctionTag)))
         return typ;
@@ -72,7 +72,7 @@ struct BinaryData
     size_t length;
 };
 
-BinaryData extractData(lua_State* L, int idx)
+BinaryData checkBinaryData(lua_State* L, int idx)
 {
     if (!lua_isstring(L, idx) && !lua_isbuffer(L, idx))
         luaL_typeerrorL(L, idx, "string or buffer");
@@ -100,8 +100,8 @@ BinaryData extractData(lua_State* L, int idx)
 // digest(hash: hash<any>, message: string | buffer): buffer
 int lua_digest(lua_State* L)
 {
-    const env_md_st* hashFunction = getHashFunction(L, 1);
-    BinaryData message = extractData(L, 2);
+    const env_md_st* hashFunction = checkHashFunction(L, 1);
+    BinaryData message = checkBinaryData(L, 2);
 
     uint8_t* buffer = static_cast<uint8_t*>(lua_newbuffer(L, EVP_MD_size(hashFunction)));
     if (EVP_Digest(message.data, message.length, buffer, nullptr, hashFunction, nullptr) == 0)
@@ -123,7 +123,7 @@ int lua_secretbox_keygen(lua_State* L)
 int lua_secretbox_seal(lua_State* L)
 {
     bool hasKey = !lua_isnoneornil(L, 2);
-    BinaryData message = extractData(L, 1);
+    BinaryData message = checkBinaryData(L, 1);
 
     lua_createtable(L, 0, 3);
 

--- a/lute/crypto/src/crypto.cpp
+++ b/lute/crypto/src/crypto.cpp
@@ -100,10 +100,6 @@ BinaryData extractData(lua_State* L, int idx)
 // digest(hash: hash<any>, message: string | buffer): buffer
 int lua_digest(lua_State* L)
 {
-    int argumentCount = lua_gettop(L);
-    if (argumentCount != 2)
-        luaL_error(L, "%s: expected 2 arguments, but got %d", kDigestName, argumentCount);
-
     const env_md_st* hashFunction = getHashFunction(L, 1);
     BinaryData message = extractData(L, 2);
 
@@ -117,10 +113,6 @@ int lua_digest(lua_State* L)
 // keygen(): buffer
 int lua_secretbox_keygen(lua_State* L)
 {
-    int argumentCount = lua_gettop(L);
-    if (argumentCount != 0)
-        luaL_error(L, "%s: expected no arguments, but got %d", kKeygenName, argumentCount);
-
     uint8_t* key = static_cast<uint8_t*>(lua_newbuffer(L, crypto_secretbox_keybytes()));
     crypto_secretbox_keygen(key);
 
@@ -130,10 +122,7 @@ int lua_secretbox_keygen(lua_State* L)
 // seal(message: string | buffer, key: buffer?): { ciphertext: buffer, key: buffer, nonce: buffer }
 int lua_secretbox_seal(lua_State* L)
 {
-    int argumentCount = lua_gettop(L);
-    if (argumentCount != 1 && argumentCount != 2)
-        luaL_error(L, "%s: expected 1 or 2 arguments, but got %d", kSealName, argumentCount);
-
+    bool hasKey = !lua_isnoneornil(L, 2);
     BinaryData message = extractData(L, 1);
 
     lua_createtable(L, 0, 3);
@@ -144,7 +133,7 @@ int lua_secretbox_seal(lua_State* L)
 
     uint8_t* key;
     // user provided a key
-    if (argumentCount == 2)
+    if (hasKey)
     {
         size_t keyLength = 0;
         key = static_cast<uint8_t*>(luaL_checkbuffer(L, 2, &keyLength));
@@ -178,10 +167,6 @@ int lua_secretbox_seal(lua_State* L)
 // open(secretbox: { ciphertext: buffer, key: buffer, nonce: buffer }): buffer
 int lua_secretbox_open(lua_State* L)
 {
-    int argumentCount = lua_gettop(L);
-    if (argumentCount != 1)
-        luaL_error(L, "%s: expected 1 argument, but got %d", kOpenName, argumentCount);
-
     // read all three of the required fields out of the table
     lua_getfield(L, 1, "ciphertext");
     lua_getfield(L, 1, "nonce");
@@ -231,10 +216,6 @@ int makeSecretboxLibrary(lua_State* L)
 // hash(password: string): buffer
 int lua_pwhash(lua_State* L)
 {
-    int argumentCount = lua_gettop(L);
-    if (argumentCount != 1)
-        luaL_error(L, "%s: expected 1 arguments, but got %d", kPasswordHashName, argumentCount);
-
     size_t length = 0;
     const char* password = luaL_checklstring(L, 1, &length);
 
@@ -250,10 +231,6 @@ int lua_pwhash(lua_State* L)
 // verify(hash: buffer, password: string)
 int lua_pwhash_verify(lua_State* L)
 {
-    int argumentCount = lua_gettop(L);
-    if (argumentCount != 2)
-        luaL_error(L, "%s: expected 2 arguments, but got %d", kPasswordHashName, argumentCount);
-
     size_t hashLength = crypto_pwhash_STRBYTES;
     void* hashedPassword = luaL_checkbuffer(L, 1, &hashLength);
 

--- a/lute/fs/src/fs.cpp
+++ b/lute/fs/src/fs.cpp
@@ -19,7 +19,7 @@
 namespace fs
 {
 
-static UVFile* getFileHandle(lua_State* L, int index)
+static UVFile* checkFileHandle(lua_State* L, int index)
 {
     auto* handle = static_cast<UVFile*>(lua_touserdatatagged(L, index, kUVFileTag));
     if (!handle)
@@ -76,19 +76,19 @@ std::optional<int> setFlags(const char* modeStr, int* openFlags)
 
 int close(lua_State* L)
 {
-    auto* handle = getFileHandle(L, 1);
+    auto* handle = checkFileHandle(L, 1);
     return close_impl(L, handle);
 }
 
 int read(lua_State* L)
 {
-    auto* handle = getFileHandle(L, 1);
+    auto* handle = checkFileHandle(L, 1);
     return read_impl(L, handle);
 }
 
 int write(lua_State* L)
 {
-    auto* handle = getFileHandle(L, 1);
+    auto* handle = checkFileHandle(L, 1);
 
     size_t len;
     const char* data = luaL_checklstring(L, 2, &len);

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -31,7 +31,6 @@ namespace luau
 
 static constexpr const char kSpanType[] = "span";
 static constexpr const char kCompileResultType[] = "CompileResult";
-static constexpr const char kSpanCreateName[] = "span.create";
 
 // Recursively freezes the table at the top of the stack and any descendant tables.
 // The table must be at the top of the stack when called.
@@ -191,10 +190,6 @@ static Span checkSpan(lua_State* L, int index)
 
 static int createSpan(lua_State* L)
 {
-    int argumentCount = lua_gettop(L);
-    if (argumentCount != 1)
-        luaL_error(L, "%s: expected 1 argument, but got %d", kSpanCreateName, argumentCount);
-
     lua_checkstack(L, 2);
 
     // check that the argument is compliant with the span interface!

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -387,9 +387,6 @@ static void wsCloseImpl(void* wsPtr, uint16_t code, std::string_view message)
 
 static int server_ws_send(lua_State* L)
 {
-    if (lua_gettop(L) != 2)
-        luaL_errorL(L, "websocket send expects exactly 1 payload argument");
-
     luaL_checktype(L, 1, LUA_TUSERDATA);
     auto* handlePtr = static_cast<std::shared_ptr<ServerWebSocketHandle>*>(lua_touserdatatagged(L, 1, kServerWebSocketHandleTag));
     if (!handlePtr || !(*handlePtr) || (*handlePtr)->closed.load())

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -395,7 +395,7 @@ static int server_ws_send(lua_State* L)
         return 1;
     }
 
-    WebSocketPayload payload = extractWebSocketPayload(L, 2);
+    WebSocketPayload payload = checkWebSocketPayload(L, 2);
 
     int result = 0;
     if (!(*handlePtr)->closed.load() && (*handlePtr)->wsPtr && (*handlePtr)->sendFn)

--- a/lute/net/src/wsclient.cpp
+++ b/lute/net/src/wsclient.cpp
@@ -590,9 +590,6 @@ static std::shared_ptr<WebSocketHandle>* getWebSocketHandle(lua_State* L, int in
 
 int ws_send(lua_State* L)
 {
-    if (lua_gettop(L) != 2)
-        luaL_errorL(L, "websocket send expects exactly 1 payload argument");
-
     luaL_checktype(L, 1, LUA_TUSERDATA);
     auto* handleStorage = getWebSocketHandle(L, 1);
     if (!handleStorage || !(*handleStorage) || (*handleStorage)->closed())

--- a/lute/net/src/wsclient.cpp
+++ b/lute/net/src/wsclient.cpp
@@ -595,7 +595,7 @@ int ws_send(lua_State* L)
     if (!handleStorage || !(*handleStorage) || (*handleStorage)->closed())
         luaL_errorL(L, "Invalid or closed websocket");
 
-    WebSocketPayload payload = extractWebSocketPayload(L, 2);
+    WebSocketPayload payload = checkWebSocketPayload(L, 2);
     (*handleStorage)->send(std::string(payload.data, payload.length), payload.binary);
     return 0;
 }

--- a/lute/net/src/wscommon.cpp
+++ b/lute/net/src/wscommon.cpp
@@ -5,7 +5,7 @@
 namespace net
 {
 
-WebSocketPayload extractWebSocketPayload(lua_State* L, int index)
+WebSocketPayload checkWebSocketPayload(lua_State* L, int index)
 {
     if (lua_isstring(L, index))
     {

--- a/lute/net/src/wscommon.h
+++ b/lute/net/src/wscommon.h
@@ -14,6 +14,6 @@ struct WebSocketPayload
     bool binary = false;
 };
 
-WebSocketPayload extractWebSocketPayload(lua_State* L, int index);
+WebSocketPayload checkWebSocketPayload(lua_State* L, int index);
 
 } // namespace net

--- a/lute/task/src/task.cpp
+++ b/lute/task/src/task.cpp
@@ -190,11 +190,6 @@ int lua_spawn(lua_State* L)
 
 int lua_deferSelf(lua_State* L)
 {
-    if (lua_gettop(L) != 0)
-    {
-        luaL_error(L, "task.deferSelf does not take any arguments");
-        return 0;
-    }
     lua_pushthread(L);
     LuaThread newThread{L, "task.deferSelf"};
     newThread.defer();


### PR DESCRIPTION
In #1073, the biggest change was transforming argument validation to correspond to how Luau builtins generally do things. This PR  applies the same refactoring to the remaining runtime libraries: `@lute/crypto`, `@lute/luau`, `@lute/net`, and `@lute/task`.

The pattern removed is the `lua_gettop` / `nArgs` check that errors on too-few or too-many arguments. Luau's built-in libraries don't do this — they rely on `luaL_check*` to surface missing-argument errors, and silently ignore extra arguments. With this PR, Lute's entire API is now consistent with that convention as well.