### PR TITLE
Enable http/2 on curl / net.request

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,8 +151,33 @@ endif()
 
 # curl setup
 
+# nghttp2 setup
+set(ENABLE_LIB_ONLY ON CACHE BOOL "Only build libnghttp2" FORCE)
+set(ENABLE_APP OFF CACHE BOOL "Do not build nghttp2 applications" FORCE)
+set(ENABLE_HPACK_TOOLS OFF CACHE BOOL "Do not build nghttp2 HPACK tools" FORCE)
+set(ENABLE_EXAMPLES OFF CACHE BOOL "Do not build nghttp2 examples" FORCE)
+set(ENABLE_DOC OFF CACHE BOOL "Do not build nghttp2 documentation" FORCE)
+set(ENABLE_HTTP3 OFF CACHE BOOL "Do not build nghttp2 HTTP/3 tools" FORCE)
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static libraries" FORCE)
+set(BUILD_STATIC_LIBS ON CACHE BOOL "Build static libraries" FORCE)
+add_subdirectory(extern/nghttp2)
+
+set(CURL_USE_PKGCONFIG OFF CACHE BOOL "Do not use pkg-config for curl dependencies" FORCE)
+set(NGHTTP2_FOUND TRUE CACHE BOOL "" FORCE)
+set(NGHTTP2_VERSION "1.69.0" CACHE STRING "" FORCE)
+set(NGHTTP2_INCLUDE_DIRS
+    ${PROJECT_SOURCE_DIR}/extern/nghttp2/lib/includes
+    ${CMAKE_CURRENT_BINARY_DIR}/extern/nghttp2/lib/includes
+    CACHE STRING "" FORCE)
+set(NGHTTP2_LIBRARIES nghttp2_static CACHE STRING "" FORCE)
+set(NGHTTP2_LIBRARY nghttp2_static CACHE STRING "" FORCE)
+set(NGHTTP2_LIBRARY_DIRS "" CACHE STRING "" FORCE)
+set(NGHTTP2_CFLAGS "" CACHE STRING "" FORCE)
+
 set(USE_LIBIDN2 OFF)
-set(USE_NGHTTP2 OFF)
+set(USE_NGHTTP2 ON)
+set(CURL_DISABLE_INSTALL ON CACHE BOOL "Disable curl install targets" FORCE)
+set(CURL_ENABLE_EXPORT_TARGET OFF CACHE BOOL "Disable curl CMake export targets" FORCE)
 set(CURL_USE_LIBPSL OFF)
 set(CURL_USE_LIBSSH2 OFF)
 set(CURL_ZLIB ON)

--- a/extern/nghttp2.tune
+++ b/extern/nghttp2.tune
@@ -1,0 +1,5 @@
+[dependency]
+name = "nghttp2"
+remote = "https://github.com/nghttp2/nghttp2.git"
+branch = "v1.69.0"
+revision = "68cb6900fde14c77f0cd7add0e094a862960eb99"

--- a/lute/net/src/httpclient.cpp
+++ b/lute/net/src/httpclient.cpp
@@ -595,6 +595,7 @@ static std::unique_ptr<HttpRequestState> createRequestState(
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, kDefaultConnectTimeoutMs);
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 20L);
+    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
     applySystemCA(curl);
 
     if (state->method == "HEAD")


### PR DESCRIPTION
Adds ~200kb to the binary size. http/2 has benefits of sharing a connection when multiple requests are made to the same origin. It's a tradeoff worth discussing. This may make a large difference with package management, so maybe we can release this with that.