### PR TITLE
Don't include locals in parse results

### DIFF
--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -2890,9 +2890,10 @@ int luau_parse(lua_State* L)
 
     lua_rawcheckstack(L, 6);
 
+    AstSerialize serializer{L, source, result.parseResult.cstNodeMap, result.parseResult.commentLocations};
+
     lua_createtable(L, 0, 4);
 
-    AstSerialize serializer{L, source, result.parseResult.cstNodeMap, result.parseResult.commentLocations};
     serializer.visit(result.parseResult.root);
     lua_setfield(L, -2, "root");
 

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -1958,4 +1958,13 @@ test.suite("AST_nodes_frozen", function(suite)
 			(eof :: any).tag = "modified"
 		end)
 	end)
+
+	suite:case("parseResultOnlyHasFourFields", function(assert)
+		local result = parser.parse("local x = 1")
+		local fieldCount = 0
+		for _k, _v in result :: any do
+			fieldCount = fieldCount + 1
+		end
+		assert.eq(fieldCount, 4)
+	end)
 end)


### PR DESCRIPTION
We were inadvertently including the userdata instances used to point to `AstLocal`s in `ParseResult`. Reordering how we create tables on the stack fixes this issue.