### PR TITLE
Add cross-VM `vector` type support

### DIFF
--- a/lute/vm/src/spawn.cpp
+++ b/lute/vm/src/spawn.cpp
@@ -41,6 +41,16 @@ static bool copyLuauObject(lua_State* from, lua_State* to, int fromIdx)
         lua_pushlstring(to, str, len);
     }
     break;
+    case LUA_TVECTOR:
+    {
+        const float* v = lua_tovector(from, fromIdx);
+#if LUA_VECTOR_SIZE == 4
+        lua_pushvector(to, v[0], v[1], v[2], v[3]);
+#else
+        lua_pushvector(to, v[0], v[1], v[2]);
+#endif
+    }
+    break;
     case LUA_TTABLE:
         lua_createtable(to, 0, 0);
 

--- a/tests/lute/vm.test.luau
+++ b/tests/lute/vm.test.luau
@@ -65,4 +65,68 @@ test.suite("LuteVmSuite", function(suite)
 		fs.remove(child_vm)
 		fs.remove(parent_vm)
 	end)
+
+	suite:case("vectorCrossesVmBoundary", function(assert)
+		local tmpdir = system.tmpdir()
+		local child_vm = path.join(tmpdir, "child_vm_vector.luau")
+		local parent_vm = path.join(tmpdir, "parent_vm_vector.luau")
+
+		do
+			local handle = fs.open(child_vm, "w+")
+			assert.that(fs.exists(child_vm))
+			fs.write(
+				handle,
+				[[
+                local exported = {}
+
+                function exported.roundtrip(v)
+                    return v
+                end
+
+                function exported.make(x, y, z)
+                    return vector.create(x, y, z)
+                end
+
+                function exported.inTable(t)
+                    return t.v
+                end
+
+                return exported
+            ]]
+			)
+			fs.close(handle)
+		end
+
+		do
+			local handle = fs.open(parent_vm, "w+")
+			assert.that(fs.exists(parent_vm))
+			fs.write(
+				handle,
+				[[
+                local vm = require("@lute/vm")
+                local result = vm.create("./child_vm_vector")
+
+                local v = vector.create(1.5, -2.25, 3.5)
+                local r = result.roundtrip(v)
+                assert(typeof(r) == "vector")
+                assert(r.x == 1.5 and r.y == -2.25 and r.z == 3.5)
+
+                local m = result.make(4, 5, 6)
+                assert(typeof(m) == "vector")
+                assert(m.x == 4 and m.y == 5 and m.z == 6)
+
+                local nested = result.inTable({ v = vector.create(7, 8, 9) })
+                assert(typeof(nested) == "vector")
+                assert(nested.x == 7 and nested.y == 8 and nested.z == 9)
+            ]]
+			)
+			fs.close(handle)
+		end
+
+		local result = process.run({ path.format(process.execPath()), path.format(parent_vm) })
+		assert.eq(result.exitcode, 0)
+
+		fs.remove(child_vm)
+		fs.remove(parent_vm)
+	end)
 end)


### PR DESCRIPTION
Extend cross-VM marshalling with `vector` type support. 
Related to #1080.