### PR TITLE
Improve JSON correctness for math.huge, nan, and massive serialization parts

### DIFF
--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -196,7 +196,7 @@ serializeAny = function(state: SerializerState, value: Value): ()
 	elseif typeof(value) == "boolean" then
 		writeString(state, if value then "true" else "false")
 	elseif typeof(value) == "number" then
-		if math.isnan(value) or value == math.huge or value == -math.huge then
+		if not math.isfinite(value) then
 			error("Cannot serialize non-finite number", 2)
 		end
 

--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -31,12 +31,17 @@ type SerializerState = {
 
 local function checkState(state: SerializerState, len: number): ()
 	local curLen = buffer.len(state.buf)
+	local requiredLen = state.cursor + len
 
-	if state.cursor + len < curLen then
+	if requiredLen <= curLen then
 		return
 	end
 
-	local newBuffer = buffer.create(curLen * 2)
+	while curLen < requiredLen do
+		curLen *= 2
+	end
+
+	local newBuffer = buffer.create(curLen)
 
 	buffer.copy(newBuffer, 0, state.buf)
 
@@ -191,6 +196,10 @@ serializeAny = function(state: SerializerState, value: Value): ()
 	elseif typeof(value) == "boolean" then
 		writeString(state, if value then "true" else "false")
 	elseif typeof(value) == "number" then
+		if math.isnan(value) or value == math.huge or value == -math.huge then
+			error("Cannot serialize non-finite number", 2)
+		end
+
 		writeString(state, tostring(value))
 	elseif typeof(value) == "string" then
 		serializeString(state, value)

--- a/tests/std/json.test.luau
+++ b/tests/std/json.test.luau
@@ -65,6 +65,20 @@ test.suite("JSONParsingTestSuite", function(suite)
 		assert.eq(out, "[\n    1,\n    2,\n    3\n]")
 	end)
 
+	suite:case("serializeLargeString", function(assert)
+		local value = string.rep("a", 3000)
+		assert.eq(json.serialize(value), `"{value}"`)
+	end)
+
+	suite:case("serializeRejectsNonFiniteNumbers", function(assert)
+		for _, value in { math.nan, math.huge, -math.huge } do
+			local ok = pcall(function()
+				json.serialize(value)
+			end)
+			assert.eq(ok, false)
+		end
+	end)
+
 	suite:case("jsonObjectAndasObject", function(assert)
 		local obj = json.object({
 			name = "Alice",


### PR DESCRIPTION
Improves `@std/json` correctness around two serialization edge cases:

- Rejects non-finite numbers (`math.huge`, `-math.huge`, `math.nan`) instead of emitting invalid JSON tokens
  - We could alternatively emit `null` if we don't want to be as annoying with errors and match what some serializers do, curious if there are any opinions on this
- Grows the serialization buffer until the pending write fits, fixing failures for very large strings or object keys