### PR TITLE
Remove unnecessary wrapper on req server param

### DIFF
--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -517,27 +517,17 @@ static void pushRequestTable(
     lua_setmetatable(L, requestIndex);
 }
 
-template<typename PushUpvalues>
-static void pushServerTable(lua_State* L, const std::shared_ptr<Ref>& serverRef, lua_CFunction upgradeFn, int nUpvalues, PushUpvalues pushUpvalues)
+static void pushServerTable(lua_State* L, const std::shared_ptr<Ref>& serverRef)
 {
     if (serverRef)
+    {
         serverRef->push(L);
-    else
-        lua_newtable(L);
+        return;
+    }
 
-    int serverBaseIndex = lua_absindex(L, -1);
-
-    lua_createtable(L, 0, 1);
-    lua_createtable(L, 0, 1);
-    lua_pushvalue(L, serverBaseIndex);
-    lua_setfield(L, -2, "__index");
-    lua_setmetatable(L, -2);
-
-    pushUpvalues(L);
-    lua_pushcclosure(L, upgradeFn, "server.upgrade", nUpvalues);
+    lua_newtable(L);
+    lua_pushcfunction(L, server_upgrade, "server_upgrade");
     lua_setfield(L, -2, "upgrade");
-
-    lua_remove(L, serverBaseIndex);
 }
 
 static HandlerThread prepareHttpHandlerThread(
@@ -557,7 +547,7 @@ static HandlerThread prepareHttpHandlerThread(
     // `lua_resume(L, nullptr, 2)` expects the stack shape `[handler, request, server]`.
     state->handlerRef->push(L);
     pushRequestTable(L, headers, route, body, server_upgrade_noop, 0, [](lua_State*) {});
-    pushServerTable(L, state->serverRef, server_upgrade_noop, 0, [](lua_State*) {});
+    pushServerTable(L, state->serverRef);
     return thread;
 }
 
@@ -590,7 +580,7 @@ static HandlerThread prepareUpgradeHandlerThread(
     // `lua_resume(L, nullptr, 2)` expects the stack shape `[handler, request, server]`.
     state->handlerRef->push(L);
     pushRequestTable(L, headers, route, std::string_view(""), server_upgrade_do<SSL>, 4, pushUpgradeUpvalues);
-    pushServerTable(L, state->serverRef, server_upgrade_do<SSL>, 4, pushUpgradeUpvalues);
+    pushServerTable(L, state->serverRef);
     return thread;
 }
 

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -526,7 +526,7 @@ static void pushServerTable(lua_State* L, const std::shared_ptr<Ref>& serverRef)
     }
 
     lua_newtable(L);
-    lua_pushcfunction(L, server_upgrade, "server_upgrade");
+    lua_pushcfunction(L, server_upgrade, "server.upgrade");
     lua_setfield(L, -2, "upgrade");
 }
 
@@ -1095,7 +1095,7 @@ int serve(lua_State* L)
     lua_settable(L, -3);
 
     lua_pushstring(L, "upgrade");
-    lua_pushcfunction(L, server_upgrade, "server_upgrade");
+    lua_pushcfunction(L, server_upgrade, "server.upgrade");
     lua_settable(L, -3);
 
     state->serverRef = std::make_shared<Ref>(L, -1);

--- a/tests/std/net.test.luau
+++ b/tests/std/net.test.luau
@@ -49,6 +49,26 @@ test.suite("NetTestSuite", function(suite)
 		instance.close()
 	end)
 
+	suite:case("servePassesServerHandleToHandler", function(assert)
+		local instance: server.Server
+		instance = server.serve({
+			port = 0,
+			handler = function(_req: server.ReceivedRequest, current: server.Server): server.ServerResponse
+				return {
+					status = 200,
+					body = tostring(current == instance),
+				}
+			end,
+		})
+
+		local response = net.request(`{instance.hostname}:{instance.port}`, {
+			method = "GET",
+		})
+		assert.eq("true", response.body)
+
+		instance.close()
+	end)
+
 	suite:case("runsMoreThanFourClientRequestsConcurrently", function(assert)
 		local requestCount = 5
 		local responseDelay = 0.2


### PR DESCRIPTION
This wrapper is unnecessary given the type contract we offer and intend to give resulting in unnecessary overhead.