### PR TITLE
cli: `lute run` should be able to list scripts in `.lute`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           allow-external-github-orgs: true
 
       - name: Run StyLua
-        run: stylua --check .
+        run: stylua --check . .lute
 
   build-docs-site:
     runs-on: ubuntu-latest

--- a/.lute/bootstrap.luau
+++ b/.lute/bootstrap.luau
@@ -5,7 +5,7 @@ local process = require("@lute/process")
 -- LUAUFIX: should `...` actually have the type `string...` for command-line environments
 local args: { [number]: string, n: number } = table.pack(...) :: any
 
-local cmd: { string } = { process.execPath(), "tools/luthier.luau", table.unpack(args, 2, args.n) }
+local cmd: { string } = { "tools/bootstrap.sh", table.unpack(args, 2, args.n) }
 
 local result = process.run(cmd, { stdio = "inherit" })
 process.exit(result.exitcode)

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -29,6 +29,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <optional>
+#include <set>
 #include <string>
 #include <utility>
 #include <vector>
@@ -87,6 +88,7 @@ static const char* VERSION_STRING = LUTE_VERSION_FULL;
 static const char* RUN_HELP_STRING = R"(Usage: lute run <script.luau> [args...]
 
 Run Options:
+	--list                  List all available scripts in the nearest .lute folder.
 	--profile               Enable profiling for the script.
 	--profile-output <path> Output file for the profile (default: <datetime>_<filename>.json).
 	--frequency <Hz>        Profiler sampling frequency in Hz (default: 10000).
@@ -96,6 +98,7 @@ Run Options:
 static const char* PKGRUN_HELP_STRING = R"(Usage: lute pkg run <script.luau> [args...]
 
 Run Options:
+	--list        List all available scripts in the nearest .lute folder.
 	-h, --help    Display this usage message.
 )";
 
@@ -255,6 +258,51 @@ static std::pair<bool, std::string> getValidPath(std::string filePath)
     return {false, res};
 }
 
+static std::optional<std::string> getNearestLuteFolderPath()
+{
+    for (std::optional<std::string> currentPath = getCurrentWorkingDirectory(); currentPath; currentPath = getParentPath(*currentPath))
+    {
+        std::string lutePath = joinPaths(*currentPath, ".lute");
+        if (isDirectory(lutePath))
+            return lutePath;
+    }
+    return std::nullopt;
+}
+
+static std::vector<std::string> getLuteScripts(const std::string& luteFolderPath)
+{
+    std::set<std::string> names;
+    std::string normalizedPrefix = normalizePath(luteFolderPath);
+    if (!normalizedPrefix.empty() && normalizedPrefix.back() != '/')
+        normalizedPrefix += '/';
+
+    traverseDirectory(luteFolderPath, [&](const std::string& rawFilePath)
+    {
+        std::string filePath = normalizePath(rawFilePath);
+        if (filePath.size() <= normalizedPrefix.size() || filePath.substr(0, normalizedPrefix.size()) != normalizedPrefix)
+            return;
+
+        std::string rel = filePath.substr(normalizedPrefix.size());
+        size_t slashPos = rel.find('/');
+
+        if (slashPos == std::string::npos)
+        {
+            if (rel.size() > 5 && rel.substr(rel.size() - 5) == ".luau")
+                names.insert(rel.substr(0, rel.size() - 5));
+            else if (rel.size() > 4 && rel.substr(rel.size() - 4) == ".lua")
+                names.insert(rel.substr(0, rel.size() - 4));
+        }
+        else
+        {
+            std::string rest = rel.substr(slashPos + 1);
+            if (rest.find('/') == std::string::npos && (rest == "init.lua" || rest == "init.luau"))
+                names.insert(rel.substr(0, slashPos));
+        }
+    });
+
+    return {names.begin(), names.end()};
+}
+
 int handleRunCommand(int argc, char** argv, int argOffset, bool packageAwareness, LuteReporter& reporter)
 {
     std::string command = packageAwareness ? "pkg run" : "run";
@@ -273,6 +321,18 @@ int handleRunCommand(int argc, char** argv, int argOffset, bool packageAwareness
         if (strcmp(currentArg, "-h") == 0 || strcmp(currentArg, "--help") == 0)
         {
             reporter.reportOutput(packageAwareness ? PKGRUN_HELP_STRING : RUN_HELP_STRING);
+            return 0;
+        }
+        else if (strcmp(currentArg, "--list") == 0)
+        {
+            std::optional<std::string> luteFolderPath = getNearestLuteFolderPath();
+            std::string output = "Commands\n";
+            if (luteFolderPath)
+            {
+                for (const std::string& name : getLuteScripts(*luteFolderPath))
+                    output += '\t' + name + '\n';
+            }
+            reporter.reportOutput(output.c_str());
             return 0;
         }
         else if (strcmp(currentArg, "--profile") == 0)

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -69,7 +69,7 @@ Transform Options:
 	lute transform <transformer script> [options...] <files...>
 		Runs the specified code transformation on the provided Luau files.
 			--dry-run               Runs the transformation without actually overwriting or deleting any files.
-			--output <path>         Specifies an output file for a transformed file. Only valid when 
+			--output <path>         Specifies an output file for a transformed file. Only valid when
 			                        transforming a single file. If not specified, files are overwritten in place.
 
 Lint Options:
@@ -263,9 +263,11 @@ static std::optional<std::string> getNearestLuteFolderPath()
     for (std::optional<std::string> currentPath = getCurrentWorkingDirectory(); currentPath; currentPath = getParentPath(*currentPath))
     {
         std::string lutePath = joinPaths(*currentPath, ".lute");
+
         if (isDirectory(lutePath))
             return lutePath;
     }
+
     return std::nullopt;
 }
 
@@ -285,19 +287,21 @@ static std::vector<std::string> getLuteScripts(const std::string& luteFolderPath
         std::string rel = filePath.substr(normalizedPrefix.size());
         size_t slashPos = rel.find('/');
 
-        if (slashPos == std::string::npos)
-        {
-            if (rel.size() > 5 && rel.substr(rel.size() - 5) == ".luau")
-                names.insert(rel.substr(0, rel.size() - 5));
-            else if (rel.size() > 4 && rel.substr(rel.size() - 4) == ".lua")
-                names.insert(rel.substr(0, rel.size() - 4));
-        }
-        else
+        // If there's a slash at the end, we'll check if the rest is init.luau or init.lua, and add it as a command if so.
+        if (slashPos != std::string::npos)
         {
             std::string rest = rel.substr(slashPos + 1);
-            if (rest.find('/') == std::string::npos && (rest == "init.lua" || rest == "init.luau"))
+            if (rest.find('/') == std::string::npos && (rest == "init.luau" || rest == "init.lua"))
                 names.insert(rel.substr(0, slashPos));
+
+            return;
         }
+
+        // Otherwise, we can just look for .luau or .lua files and add them as commands without the extension.
+        if (rel.size() > 5 && rel.substr(rel.size() - 5) == ".luau")
+            names.insert(rel.substr(0, rel.size() - 5));
+        else if (rel.size() > 4 && rel.substr(rel.size() - 4) == ".lua")
+            names.insert(rel.substr(0, rel.size() - 4));
     });
 
     return {names.begin(), names.end()};

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -281,9 +281,6 @@ static std::vector<std::string> getLuteScripts(const std::string& luteFolderPath
     traverseDirectory(luteFolderPath, [&](const std::string& rawFilePath)
     {
         std::string filePath = normalizePath(rawFilePath);
-        if (filePath.size() <= normalizedPrefix.size() || filePath.substr(0, normalizedPrefix.size()) != normalizedPrefix)
-            return;
-
         std::string rel = filePath.substr(normalizedPrefix.size());
         size_t slashPos = rel.find('/');
 


### PR DESCRIPTION
`lute run` supports discovering scripts located in the `.lute` folder of your workspace as an affordance for "extending" the lute executable. For example, scripts like our example `luthier` and `bootstrap` ones let you invoke commands like `lute bootstrap` or `lute luthier`. #1101 raised the issue of discoverability of the scripts in this folder, and proposed a `--list` flag that we could provide to list them out. This PR implements exactly that. The output is fairly straightforward, just an alphabetized list of the commands under a commands header, e.g. for the `lute` repository itself right now:

```
Commands
        bootstrap
        luthier
```

Closes #1101.