### PR TITLE
Add cross-VM `buffer` type support

### DIFF
--- a/lute/vm/src/spawn.cpp
+++ b/lute/vm/src/spawn.cpp
@@ -51,6 +51,14 @@ static bool copyLuauObject(lua_State* from, lua_State* to, int fromIdx)
 #endif
     }
     break;
+    case LUA_TBUFFER:
+    {
+        size_t len = 0;
+        void* src = lua_tobuffer(from, fromIdx, &len);
+        void* dst = lua_newbuffer(to, len);
+        memcpy(dst, src, len);
+    }
+    break;
     case LUA_TTABLE:
         lua_createtable(to, 0, 0);
 

--- a/tests/lute/vm.test.luau
+++ b/tests/lute/vm.test.luau
@@ -129,4 +129,103 @@ test.suite("LuteVmSuite", function(suite)
 		fs.remove(child_vm)
 		fs.remove(parent_vm)
 	end)
+
+	suite:case("bufferCrossesVmBoundary", function(assert)
+		local tmpdir = system.tmpdir()
+		local child_vm = path.join(tmpdir, "child_vm_buffer.luau")
+		local parent_vm = path.join(tmpdir, "parent_vm_buffer.luau")
+
+		do
+			local handle = fs.open(child_vm, "w+")
+			assert.that(fs.exists(child_vm))
+			fs.write(
+				handle,
+				[[
+                local exported = {}
+
+                function exported.roundtrip(b)
+                    return b
+                end
+
+                function exported.make()
+                    local b = buffer.create(4)
+                    buffer.writeu8(b, 0, 10)
+                    buffer.writeu8(b, 1, 20)
+                    buffer.writeu8(b, 2, 30)
+                    buffer.writeu8(b, 3, 40)
+                    return b
+                end
+
+                function exported.inTable(t)
+                    return t.b
+                end
+
+                function exported.mutateAndReturn(b)
+                    buffer.writeu8(b, 0, 99)
+                    return b
+                end
+
+                return exported
+            ]]
+			)
+			fs.close(handle)
+		end
+
+		do
+			local handle = fs.open(parent_vm, "w+")
+			assert.that(fs.exists(parent_vm))
+			fs.write(
+				handle,
+				[[
+                local vm = require("@lute/vm")
+                local result = vm.create("./child_vm_buffer")
+
+                local b = buffer.create(3)
+                buffer.writeu8(b, 0, 1)
+                buffer.writeu8(b, 1, 2)
+                buffer.writeu8(b, 2, 3)
+
+                -- roundtrip
+                local r = result.roundtrip(b)
+                assert(typeof(r) == "buffer")
+                assert(buffer.len(r) == 3)
+                assert(buffer.readu8(r, 0) == 1)
+                assert(buffer.readu8(r, 1) == 2)
+                assert(buffer.readu8(r, 2) == 3)
+
+                -- make
+                local m = result.make()
+                assert(typeof(m) == "buffer")
+                assert(buffer.len(m) == 4)
+                assert(buffer.readu8(m, 0) == 10)
+                assert(buffer.readu8(m, 3) == 40)
+
+                -- inTable
+                local src = buffer.create(2)
+                buffer.writeu8(src, 0, 6)
+                buffer.writeu8(src, 1, 7)
+                local nested = result.inTable({ b = src })
+                assert(typeof(nested) == "buffer")
+                assert(buffer.readu8(nested, 0) == 6)
+                assert(buffer.readu8(nested, 1) == 7)
+
+                -- mutateAndReturn: child mutates a copy without affecting the parent
+                local owned = buffer.create(2)
+                buffer.writeu8(owned, 0, 50)
+                buffer.writeu8(owned, 1, 60)
+                local mutated = result.mutateAndReturn(owned)
+                assert(buffer.readu8(owned, 0) == 50)
+                assert(buffer.readu8(mutated, 0) == 99)
+                assert(buffer.readu8(mutated, 1) == 60)
+            ]]
+			)
+			fs.close(handle)
+		end
+
+		local result = process.run({ path.format(process.execPath()), path.format(parent_vm) })
+		assert.eq(result.exitcode, 0)
+
+		fs.remove(child_vm)
+		fs.remove(parent_vm)
+	end)
 end)


### PR DESCRIPTION
Extend cross-VM marshalling with `buffer` type support. 
Related to #1080.