### PR TITLE
Convert `Runtime` to shared ownership for cross-VM marshalling

### DIFF
--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -415,7 +415,8 @@ int handleRunCommand(int argc, char** argv, int argOffset, bool packageAwareness
         return 1;
     }
 
-    Runtime runtime{reporter};
+    auto runtimeOwner = Runtime::create(reporter);
+    Runtime& runtime = *runtimeOwner;
 
     if (packageAwareness)
     {
@@ -668,7 +669,8 @@ void setupVersionLibrary(lua_State* L)
 
 int handleCliCommand(CliCommandResult result, int program_argc, char** program_argv, LuteReporter& reporter)
 {
-    Runtime runtime{reporter};
+    auto runtimeOwner = Runtime::create(reporter);
+    Runtime& runtime = *runtimeOwner;
     setupCliCommandState(runtime, setupVersionLibrary);
 
     return runtime.runSource(std::string(result.contents), copts(), "@" + result.path, program_argc, program_argv) ? 0 : 1;
@@ -696,7 +698,8 @@ int cliMain(int argc, char** argv, LuteReporter& reporter)
     LuteExecutable exe{*exePath, reporter};
     if (auto payload = exe.extract())
     {
-        Runtime runtime{reporter};
+        auto runtimeOwner = Runtime::create(reporter);
+        Runtime& runtime = *runtimeOwner;
 
         setupBundleState(runtime, payload->luauConfigFiles, payload->filePathToBytecode);
         std::string entryPoint = payload->entryPointPath;

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -55,9 +55,9 @@ struct StepEmpty
 
 using RuntimeStep = Luau::Variant<StepSuccess, StepErr, StepEmpty>;
 
-struct Runtime
+struct Runtime : std::enable_shared_from_this<Runtime>
 {
-    Runtime(LuteReporter& reporter);
+    static std::shared_ptr<Runtime> create(LuteReporter& reporter);
     ~Runtime();
 
     bool runToCompletion();
@@ -138,6 +138,8 @@ struct Runtime
     std::function<void*(lua_State*)> requireContextFactory;
 
 private:
+    Runtime(LuteReporter& reporter);
+
     bool runThreadCompletionHandler(lua_State* L, int status);
     void clearThreadCompletionHandler(lua_State* L);
 
@@ -155,6 +157,7 @@ private:
 };
 
 Runtime* getRuntime(lua_State* L);
+std::shared_ptr<Runtime> getRuntimeShared(lua_State* L);
 uv_loop_t* getRuntimeLoop(lua_State* L);
 
 struct ResumeTokenData;

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -55,6 +55,11 @@ Runtime::~Runtime()
     uv_loop_close(&eventLoop);
 }
 
+std::shared_ptr<Runtime> Runtime::create(LuteReporter& reporter)
+{
+    return std::shared_ptr<Runtime>(new Runtime(reporter));
+}
+
 bool Runtime::hasWork()
 {
     // TODO: activeTokens and uv_loop_alive have a decent amount of overlap.
@@ -371,6 +376,13 @@ uv_loop_t* Runtime::getEventLoop()
 Runtime* getRuntime(lua_State* L)
 {
     return static_cast<Runtime*>(lua_getthreaddata(lua_mainthread(L)));
+}
+
+std::shared_ptr<Runtime> getRuntimeShared(lua_State* L)
+{
+    if (Runtime* runtime = getRuntime(L))
+        return runtime->shared_from_this();
+    return {};
 }
 
 uv_loop_t* getRuntimeLoop(lua_State* L)

--- a/lute/vm/src/spawn.cpp
+++ b/lute/vm/src/spawn.cpp
@@ -199,7 +199,7 @@ int VM::lua_spawn(lua_State* L)
 
     Runtime* parent = getRuntime(L);
 
-    auto child = std::make_shared<Runtime>(parent->reporter);
+    auto child = Runtime::create(parent->reporter);
     child->requireContextFactory = parent->requireContextFactory;
     LUTE_ASSERT(child->requireContextFactory);
 

--- a/tests/src/cliruntimefixture.cpp
+++ b/tests/src/cliruntimefixture.cpp
@@ -16,7 +16,7 @@ static int report(lua_State* L)
 }
 
 CliRuntimeFixture::CliRuntimeFixture()
-    : runtime(std::make_unique<Runtime>(getReporter()))
+    : runtime(Runtime::create(getReporter()))
 {
     L = setupRunState(
         *runtime,

--- a/tests/src/cliruntimefixture.h
+++ b/tests/src/cliruntimefixture.h
@@ -19,5 +19,5 @@ public:
     lua_State* L;
 
 private:
-    std::unique_ptr<Runtime> runtime;
+    std::shared_ptr<Runtime> runtime;
 };

--- a/tests/src/packagerequire.test.cpp
+++ b/tests/src/packagerequire.test.cpp
@@ -21,7 +21,8 @@
 
 TEST_CASE_FIXTURE(LuteFixture, "package_aware_require")
 {
-    Runtime runtime{getReporter()};
+    auto runtimeOwner = Runtime::create(getReporter());
+    Runtime& runtime = *runtimeOwner;
 
     setupState(
         runtime,


### PR DESCRIPTION
Related to #1080.
All three remaining types (`function` / `thread` / `userdata`) are reference types that can't be cloned across states. 

They're proxied via foreign handles that hold the source value's `Ref` together with a `shared_ptr<Runtime>` to keep the source runtime alive while the handle exists. 

`copyLuauObject` only sees the source state as a `lua_State*`, so it needs a `lua_State* -> shared_ptr<Runtime>` lookup -- which doesn't exist today because `Runtime` is not currently shared-owned. 

This PR adds the lookup via `enable_shared_from_this<Runtime>` plus a `Runtime::create` factory, so any future stack-allocated `Runtime` becomes a compile error rather than a runtime `bad_weak_ptr` deep inside marshalling.