### PR TITLE
Add non-yielding server WS handler fast path

### DIFF
--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -67,10 +67,11 @@ struct RequestUpgradeContext
     us_socket_context_t* socketContext = nullptr;
     bool attempted = false;
     bool upgraded = false;
+    bool expired = false;
 
     bool canAttempt() const
     {
-        return !attempted && res && req && socketContext;
+        return !expired && !attempted && res && req && socketContext;
     }
 
     void invalidatePointers()
@@ -78,6 +79,12 @@ struct RequestUpgradeContext
         res = nullptr;
         req = nullptr;
         socketContext = nullptr;
+    }
+
+    void expire()
+    {
+        expired = true;
+        invalidatePointers();
     }
 };
 
@@ -292,13 +299,18 @@ struct HttpYieldContext
 };
 
 template<typename ResT>
-static void finishHttpYield(lua_State* L, int status, const std::shared_ptr<HttpYieldContext<ResT>>& ctx)
+static void finishHttpYield(lua_State* L, int status, const std::shared_ptr<HttpYieldContext<ResT>>& ctx, Runtime* runtime)
 {
     if (!ctx)
     {
+        if (status != LUA_OK && runtime)
+            runtime->reportError(L);
         lua_settop(L, 0);
         return;
     }
+
+    if (status != LUA_OK && runtime)
+        runtime->reportError(L);
 
     ResT* res = ctx->res;
 
@@ -403,6 +415,9 @@ template<bool SSL>
 static int server_upgrade_do(lua_State* L)
 {
     auto* upgradeContext = getRequestUpgradeContext<SSL>(L);
+    if (upgradeContext && upgradeContext->expired)
+        luaL_errorL(L, "request.upgrade cannot be called after handler yields");
+
     if (!upgradeContext || !upgradeContext->canAttempt())
     {
         lua_pushboolean(L, 0);
@@ -755,9 +770,9 @@ static void processRequest(
         );
 
         ThreadCompletionHandler completion;
-        completion.onFinish = [ctx](lua_State* L, int completionStatus)
+        completion.onFinish = [ctx, runtime = state->runtime](lua_State* L, int completionStatus)
         {
-            finishHttpYield<ResT>(L, completionStatus, ctx);
+            finishHttpYield<ResT>(L, completionStatus, ctx, runtime);
         };
 
         state->runtime->addThreadCompletionHandler(L, std::move(completion));
@@ -767,6 +782,7 @@ static void processRequest(
 
     if (status != LUA_OK)
     {
+        state->runtime->reportError(L);
         std::string error = lua_isstring(L, -1) ? lua_tostring(L, -1) : "Server error";
         lua_pop(L, 1);
 
@@ -809,23 +825,45 @@ static void installWebSocketRoutes(AppT* app, const std::shared_ptr<ServerLoopSt
         HandlerThread thread = prepareUpgradeHandlerThread<SSL>(state, headers, route, upgradeContext);
         lua_State* L = thread.L;
         int status = lua_resume(L, nullptr, 2);
-        upgradeContext->invalidatePointers();
         bool upgraded = upgradeContext->upgraded;
+        if (!upgraded)
+            upgradeContext->expire();
 
         if (status == LUA_YIELD)
         {
-            lua_resetthread(L);
-
-            if (!upgraded)
+            if (upgraded)
             {
-                res->writeStatus("500 Internal Server Error");
-                res->end("upgrade handler cannot yield");
+                lua_resetthread(L);
+                state->runtime->reporter.reportError("websocket upgrade handler cannot yield after upgrade");
+                return;
             }
+
+            auto ctx = std::make_shared<HttpYieldContext<uWS::HttpResponse<SSL>>>();
+            ctx->res = res;
+            ctx->threadRef = std::move(thread.threadRef);
+
+            res->onAborted(
+                [ctx]()
+                {
+                    ctx->aborted.store(true);
+                    ctx->res = nullptr;
+                }
+            );
+
+            ThreadCompletionHandler completion;
+            completion.onFinish = [ctx, runtime = state->runtime](lua_State* L, int completionStatus)
+            {
+                finishHttpYield<uWS::HttpResponse<SSL>>(L, completionStatus, ctx, runtime);
+            };
+
+            state->runtime->addThreadCompletionHandler(L, std::move(completion));
+            lua_settop(L, 0);
             return;
         }
 
         if (status != LUA_OK)
         {
+            state->runtime->reportError(L);
             std::string error = lua_isstring(L, -1) ? lua_tostring(L, -1) : "Server error";
             if (!upgraded)
             {

--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -610,6 +610,88 @@ static HandlerThread prepareHttpHandlerThread(
     return thread;
 }
 
+static void pushWebSocketMessage(lua_State* L, std::string_view message, bool binary)
+{
+    if (binary)
+    {
+        void* buf = lua_newbuffer(L, message.size());
+        if (!message.empty())
+            memcpy(buf, message.data(), message.size());
+    }
+    else
+    {
+        lua_pushlstring(L, message.data(), message.size());
+    }
+}
+
+static HandlerThread prepareWebSocketMessageThread(
+    const std::shared_ptr<ServerLoopState>& state,
+    const std::shared_ptr<ServerWebSocketHandle>& handle,
+    std::string_view message,
+    bool binary
+)
+{
+    LUTE_ASSERT(state);
+    LUTE_ASSERT(state->runtime);
+    LUTE_ASSERT(state->wsMessageRef);
+
+    HandlerThread thread = createHandlerThread(state->runtime);
+    lua_State* L = thread.L;
+
+    state->wsMessageRef->push(L);
+    pushServerWebSocket(L, handle);
+    pushWebSocketMessage(L, message, binary);
+    return thread;
+}
+
+struct WebSocketYieldContext
+{
+    std::shared_ptr<Ref> threadRef;
+};
+
+static void finishWebSocketYield(lua_State* L, int status, const std::shared_ptr<WebSocketYieldContext>&, Runtime* runtime)
+{
+    if (status != LUA_OK && runtime)
+        runtime->reportError(L);
+
+    lua_settop(L, 0);
+}
+
+static void processWebSocketMessage(
+    const std::shared_ptr<ServerLoopState>& state,
+    const std::shared_ptr<ServerWebSocketHandle>& handle,
+    std::string_view message,
+    bool binary
+)
+{
+    if (!state->wsMessageRef)
+        return;
+
+    HandlerThread thread = prepareWebSocketMessageThread(state, handle, message, binary);
+    lua_State* L = thread.L;
+    int status = lua_resume(L, nullptr, 2);
+
+    if (status == LUA_YIELD)
+    {
+        auto ctx = std::make_shared<WebSocketYieldContext>();
+        ctx->threadRef = std::move(thread.threadRef);
+
+        ThreadCompletionHandler completion;
+        completion.onFinish = [ctx, runtime = state->runtime](lua_State* L, int completionStatus)
+        {
+            finishWebSocketYield(L, completionStatus, ctx, runtime);
+        };
+
+        state->runtime->addThreadCompletionHandler(L, std::move(completion));
+        return;
+    }
+
+    if (status != LUA_OK)
+        state->runtime->reportError(L);
+
+    lua_settop(L, 0);
+}
+
 template<bool SSL>
 static HandlerThread prepareUpgradeHandlerThread(
     const std::shared_ptr<ServerLoopState>& state,
@@ -780,28 +862,9 @@ static void installWebSocketRoutes(AppT* app, const std::shared_ptr<ServerLoopSt
     behavior.message = [state](auto* ws, std::string_view message, uWS::OpCode opCode)
     {
         auto handle = ws->getUserData()->handle;
-        std::string payload(message.data(), message.size());
         bool binary = (opCode == uWS::OpCode::BINARY);
 
-        resumeWith(
-            state,
-            state->wsMessageRef,
-            [handle, payload = std::move(payload), binary](lua_State* L)
-            {
-                pushServerWebSocket(L, handle);
-                if (binary)
-                {
-                    void* buf = lua_newbuffer(L, payload.size());
-                    if (!payload.empty())
-                        memcpy(buf, payload.data(), payload.size());
-                }
-                else
-                {
-                    lua_pushlstring(L, payload.data(), payload.size());
-                }
-                return 2;
-            }
-        );
+        processWebSocketMessage(state, handle, message, binary);
     };
     behavior.drain = [state](auto* ws)
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(Lute.Test PRIVATE
     src/lutefs.test.cpp
     src/modulepath.test.cpp
     src/moduleresolver.test.cpp
+    src/netserver.test.cpp
     src/packagerequire.test.cpp
     src/require.test.cpp
     src/runtime.test.cpp

--- a/tests/lute/net.test.luau
+++ b/tests/lute/net.test.luau
@@ -5,7 +5,7 @@ local server = require("@lute/net/server")
 local task = require("@lute/task")
 
 test.suite("LuteNetSuite", function(suite)
-	suite:case("serveWebsocketAndConnect", function(assert)
+	suite:case("serveWebsocketSynchronousMessageEchoAndClose", function(assert)
 		local receivedEcho = false
 		local clientClosed = false
 		local clientCloseCode: number? = nil
@@ -168,6 +168,75 @@ test.suite("LuteNetSuite", function(suite)
 			error("binary server send result was not captured")
 		end
 		assert.eq(true, firstServerSendResult > 0)
+
+		instance.close()
+	end)
+
+	suite:case("serveWebsocketYieldedMessageHandler", function(assert)
+		local serverStarted = false
+		local serverResumed = false
+		local sendResult: number? = nil
+		local receivedEcho = false
+		local closed = false
+
+		local instance = server.serve({
+			port = 0,
+			handler = function(req: server.ReceivedRequest, current: server.Server): server.ServerResponse?
+				if current:upgrade(req) then
+					return nil
+				end
+
+				return {
+					status = 200,
+					body = "no upgrade",
+				}
+			end,
+			websocket = {
+				message = function(ws, message)
+					serverStarted = true
+					task.wait()
+					serverResumed = true
+					sendResult = ws:send(`yielded:{message}`)
+				end,
+			},
+		})
+
+		local _ws: client.WebSocket?
+		_ws = client.websocket(`ws://{instance.hostname}:{instance.port}`, {
+			onopen = function()
+				if _ws then
+					_ws:send("hello")
+				end
+			end,
+			onmessage = function(message)
+				if type(message) == "string" and message == "yielded:hello" then
+					receivedEcho = true
+					if _ws then
+						_ws:close()
+					end
+				end
+			end,
+			onclose = function()
+				closed = true
+			end,
+			onerror = function(err: string)
+				error(err)
+			end,
+		})
+
+		local start = os.clock()
+		while (not receivedEcho or not closed or not serverResumed) and os.clock() - start < 5 do
+			task.deferSelf()
+		end
+
+		assert.eq(true, serverStarted)
+		assert.eq(true, serverResumed)
+		assert.eq(true, receivedEcho)
+		assert.eq(true, closed)
+		if sendResult == nil then
+			error("yielded server send result was not captured")
+		end
+		assert.eq(true, sendResult > 0)
 
 		instance.close()
 	end)

--- a/tests/src/netserver.test.cpp
+++ b/tests/src/netserver.test.cpp
@@ -1,0 +1,148 @@
+#include "cliruntimefixture.h"
+#include "doctest.h"
+
+#include <string>
+
+static bool hasReportedErrorContaining(TestReporter& reporter, const std::string& needle)
+{
+    for (const std::string& error : reporter.getErrors())
+    {
+        if (error.find(needle) != std::string::npos)
+            return true;
+    }
+
+    return false;
+}
+
+TEST_CASE_FIXTURE(CliRuntimeFixture, "server_reports_http_and_upgrade_handler_errors")
+{
+    bool ok = runCode(R"(
+        local net = require("@std/net")
+        local server = require("@lute/net/server")
+        local task = require("@lute/task")
+
+        local syncInstance = server.serve({
+            port = 0,
+            handler = function()
+                error("sync-http-boom")
+            end,
+        })
+
+        local syncResponse = net.request(`http://{syncInstance.hostname}:{syncInstance.port}/`)
+        if syncResponse.status ~= 500 then
+            error(`expected 500, got {syncResponse.status}`)
+        end
+        if not string.find(syncResponse.body, "sync-http-boom", 1, true) then
+            error(`missing error body: {syncResponse.body}`)
+        end
+
+        syncInstance.close()
+
+        local yieldedInstance = server.serve({
+            port = 0,
+            handler = function()
+                task.wait()
+                error("yielded-http-boom")
+            end,
+        })
+
+        local yieldedResponse = net.request(`http://{yieldedInstance.hostname}:{yieldedInstance.port}/`)
+        if yieldedResponse.status ~= 500 then
+            error(`expected 500, got {yieldedResponse.status}`)
+        end
+        if not string.find(yieldedResponse.body, "yielded-http-boom", 1, true) then
+            error(`missing error body: {yieldedResponse.body}`)
+        end
+
+        yieldedInstance.close()
+
+        local upgradeErrorInstance = server.serve({
+            port = 0,
+            handler = function()
+                error("upgrade-http-boom")
+            end,
+            websocket = {},
+        })
+
+        local upgradeErrorResponse = net.request(`http://{upgradeErrorInstance.hostname}:{upgradeErrorInstance.port}/`, {
+            headers = {
+                Connection = "Upgrade",
+                Upgrade = "websocket",
+                ["Sec-WebSocket-Key"] = "dGhlIHNhbXBsZSBub25jZQ==",
+                ["Sec-WebSocket-Version"] = "13",
+            },
+        })
+        if upgradeErrorResponse.status ~= 500 then
+            error(`expected 500, got {upgradeErrorResponse.status}`)
+        end
+        if not string.find(upgradeErrorResponse.body, "upgrade-http-boom", 1, true) then
+            error(`missing error body: {upgradeErrorResponse.body}`)
+        end
+
+        upgradeErrorInstance.close()
+
+        local upgradeYieldHttpInstance = server.serve({
+            port = 0,
+            handler = function()
+                task.wait()
+
+                return {
+                    status = 200,
+                    body = "upgrade-yield-ok",
+                }
+            end,
+            websocket = {},
+        })
+
+        local upgradeYieldHttpResponse = net.request(`http://{upgradeYieldHttpInstance.hostname}:{upgradeYieldHttpInstance.port}/`, {
+            headers = {
+                Connection = "Upgrade",
+                Upgrade = "websocket",
+                ["Sec-WebSocket-Key"] = "dGhlIHNhbXBsZSBub25jZQ==",
+                ["Sec-WebSocket-Version"] = "13",
+            },
+        })
+        if upgradeYieldHttpResponse.status ~= 200 then
+            error(`expected 200, got {upgradeYieldHttpResponse.status}`)
+        end
+        if upgradeYieldHttpResponse.body ~= "upgrade-yield-ok" then
+            error(`expected yielded upgrade response, got {upgradeYieldHttpResponse.body}`)
+        end
+
+        upgradeYieldHttpInstance.close()
+
+        local lateUpgradeInstance = server.serve({
+            port = 0,
+            handler = function(req, current)
+                task.wait()
+                current:upgrade(req)
+                return "late upgrade unexpectedly continued"
+            end,
+            websocket = {},
+        })
+
+        local lateUpgradeResponse = net.request(`http://{lateUpgradeInstance.hostname}:{lateUpgradeInstance.port}/`, {
+            headers = {
+                Connection = "Upgrade",
+                Upgrade = "websocket",
+                ["Sec-WebSocket-Key"] = "dGhlIHNhbXBsZSBub25jZQ==",
+                ["Sec-WebSocket-Version"] = "13",
+            },
+        })
+        if lateUpgradeResponse.status ~= 500 then
+            error(`expected 500, got {lateUpgradeResponse.status}`)
+        end
+        if not string.find(lateUpgradeResponse.body, "request.upgrade cannot be called after handler yields", 1, true) then
+            error(`missing late upgrade error body: {lateUpgradeResponse.body}`)
+        end
+
+        lateUpgradeInstance.close()
+    )");
+
+    CHECK(ok);
+    CHECK(hasReportedErrorContaining(getReporter(), "sync-http-boom"));
+    CHECK(hasReportedErrorContaining(getReporter(), "yielded-http-boom"));
+    CHECK(hasReportedErrorContaining(getReporter(), "upgrade-http-boom"));
+    CHECK(hasReportedErrorContaining(getReporter(), "request.upgrade cannot be called after handler yields"));
+    CHECK(!hasReportedErrorContaining(getReporter(), "websocket upgrade handler cannot yield"));
+}


### PR DESCRIPTION
Implements a WebSocket server message fast path similar to HTTP request handling: `websocket.message` now runs its first Luau turn inline from the uWS message callback, so synchronous handlers can call `ws:send(...)` inside uWS’s corked callback window. If the handler yields, the coroutine is retained and completion continues through the existing runtime scheduler flow.

While I was here I also made some small improvements to error handling in the server:
- HTTP handler errors are now reported before being converted into `500` responses.
- WebSocket upgrade handler errors are reported as well.
- Yielding before upgrading now continues as a normal HTTP request, but any later `server:upgrade(req)` attempt errors because the uWS upgrade window has expired.
- Yielding after a successful upgrade remains rejected/reported.

The payload is copied directly into Luau-owned string/buffer storage before the uWS callback returns, avoiding the previous extra C++ payload copy while preserving lifetime correctness for yielded handlers.