### PR TITLE
Cleanup uWS loop on runtime destruction

### DIFF
--- a/lute/net/src/server.cpp
+++ b/lute/net/src/server.cpp
@@ -36,7 +36,20 @@ static Luau::DenseHashMap<int, uWSApp> serverInstances(kEmptyServerKey);
 static Luau::DenseHashMap<int, std::shared_ptr<struct ServerLoopState>> serverStates(kEmptyServerKey);
 static int nextServerId = 1;
 static int kRequestUpgradeKey = 0;
+static int kRuntimeCleanupKey = 0;
 static constexpr unsigned int kWebSocketMaxPayloadLength = 16 * 1024 * 1024;
+
+static bool hasActiveServer()
+{
+    for (const auto& entry : serverStates)
+    {
+        const auto& state = entry.second;
+        if (state)
+            return true;
+    }
+
+    return false;
+}
 
 struct ServerLoopState
 {
@@ -946,6 +959,24 @@ static bool closeServer(int serverId)
     return true;
 }
 
+static void cleanupRuntimeServers(Runtime* runtime)
+{
+    std::vector<int> serverIds;
+    for (const auto& entry : serverStates)
+    {
+        const int serverId = entry.first;
+        const std::shared_ptr<ServerLoopState>& state = entry.second;
+        if (state && state->runtime == runtime)
+            serverIds.push_back(serverId);
+    }
+
+    for (int serverId : serverIds)
+        closeServer(serverId);
+
+    if (!hasActiveServer())
+        uWS::Loop::get()->free();
+}
+
 int serve(lua_State* L)
 {
     uWS::Loop::get(getRuntimeLoop(L));
@@ -1056,6 +1087,7 @@ int serve(lua_State* L)
     }
 
     Runtime* runtime = getRuntime(L);
+    runtime->addCleanupHook(&kRuntimeCleanupKey, [runtime]() { cleanupRuntimeServers(runtime); });
 
     int serverId = nextServerId++;
 

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -89,6 +89,10 @@ struct Runtime
     // once that thread eventually returns or errors after any number of yields.
     void addThreadCompletionHandler(lua_State* L, ThreadCompletionHandler completion);
 
+    // Register native cleanup to run before the runtime closes its libuv loop.
+    // Reusing the same key replaces the previous cleanup hook.
+    void addCleanupHook(void* key, std::function<void()> cleanup);
+
     // Run 'f' in a libuv work queue
     void runInWorkQueue(std::function<void()> f);
 
@@ -144,6 +148,7 @@ private:
     std::mutex continuationMutex;
     std::vector<std::function<void()>> continuations;
     std::unordered_map<lua_State*, ThreadCompletionHandler> threadCompletionHandlers;
+    std::unordered_map<void*, std::function<void()>> cleanupHooks;
 
     std::atomic<bool> stop;
     std::condition_variable runLoopCv;

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -50,8 +50,18 @@ Runtime::~Runtime()
         uv_thread_join(&runLoopThread);
         runLoopThreadStarted = false;
     }
-    // At this point, Runtime::hasWork will have returned false (i.e uv_loop_alive is false)
-    // This means there are no outstanding handles, or file descriptors or work, to do, and we can exit
+
+    for (auto& entry : cleanupHooks)
+    {
+        if (entry.second)
+            entry.second();
+    }
+    cleanupHooks.clear();
+
+    // Cleanup hooks may call uv_close on handles they own; give libuv one
+    // turn to run those close callbacks before uv_loop_close.
+    uv_run(&eventLoop, UV_RUN_NOWAIT);
+
     uv_loop_close(&eventLoop);
 }
 
@@ -235,6 +245,11 @@ bool Runtime::hasThreads()
 void Runtime::addThreadCompletionHandler(lua_State* L, ThreadCompletionHandler completion)
 {
     threadCompletionHandlers[L] = std::move(completion);
+}
+
+void Runtime::addCleanupHook(void* key, std::function<void()> cleanup)
+{
+    cleanupHooks[key] = std::move(cleanup);
 }
 
 bool Runtime::runThreadCompletionHandler(lua_State* L, int status)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(Lute.Test PRIVATE
     src/lutefs.test.cpp
     src/modulepath.test.cpp
     src/moduleresolver.test.cpp
+    src/netserver.test.cpp
     src/packagerequire.test.cpp
     src/require.test.cpp
     src/runtime.test.cpp

--- a/tests/src/netserver.test.cpp
+++ b/tests/src/netserver.test.cpp
@@ -1,0 +1,18 @@
+#include "cliruntimefixture.h"
+#include "doctest.h"
+
+TEST_CASE_FIXTURE(CliRuntimeFixture, "net_server_runtime_teardown_releases_uws_loop")
+{
+    CHECK(runCode(R"(
+        local server = require("@lute/net/server")
+
+        local instance = server.serve({
+            port = 0,
+            handler = function()
+                return "ok"
+            end,
+        })
+
+        instance.close()
+    )"));
+}


### PR DESCRIPTION
uWS holds onto its loop after creation of a net server. We weren't testing net in c++ tests until #1115 which shows the sanitization failure. This adds a runtime hook on destruction so modules like net server can handle frees related to the runtime. I also tried this on the server close, but a true hook on runtime is probably more correct since net server's loop comes from the runtime.

First commit shows the sanitization failure, second commit fixes it.