### PR TITLE
Introduces a tty library in lute

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,6 +247,7 @@ add_subdirectory(lute/process)
 add_subdirectory(lute/system)
 add_subdirectory(lute/time)
 add_subdirectory(lute/io)
+add_subdirectory(lute/tty)
 
 # executables
 add_subdirectory(lute/cli)

--- a/definitions/tty.luau
+++ b/definitions/tty.luau
@@ -1,0 +1,37 @@
+-- lute-lint-global-ignore(unused_variable)
+--- The size of the terminal window.
+export type Winsize = {
+	rows: number,
+	cols: number,
+}
+
+--- Options for `tty.open`.
+--- - `raw`: put the terminal into raw mode (no line buffering, no signal generation).
+export type OpenOptions = {
+	raw: boolean?,
+}
+
+--- A handle to a TTY file descriptor. Created via `tty.open`.
+export type TTY = {
+	--- Reads the next chunk of input from the terminal. Yields until input is
+	--- available. Returns `nil` once the stream reaches EOF or is closed.
+	read: (self: TTY) -> string?,
+	--- Writes `bytes` to the terminal. Buffered: returns immediately without
+	--- yielding for the write to drain.
+	write: (self: TTY, bytes: string) -> (),
+	--- Closes the terminal handle. After `close`, `read` returns `nil` and
+	--- `write` errors.
+	close: (self: TTY) -> (),
+	--- Registers `callback` to be invoked whenever the terminal receives
+	--- a `SIGWINCH`(window changed) event
+	onResize: (self: TTY, callback: (Winsize) -> ()) -> (),
+}
+
+local tty = {}
+
+--- Opens a TTY handle for `fd`. Errors if `fd` is not a TTY.
+function tty.open(fd: number, opts: OpenOptions?): TTY
+	error("not implemented")
+end
+
+return tty

--- a/lute/require/CMakeLists.txt
+++ b/lute/require/CMakeLists.txt
@@ -30,5 +30,5 @@ target_sources(Lute.Require PRIVATE
 
 target_compile_features(Lute.Require PUBLIC cxx_std_17)
 target_include_directories(Lute.Require PUBLIC include)
-target_link_libraries(Lute.Require PUBLIC Luau.Require PRIVATE Luau.CLI.lib Luau.Compiler Luau.CodeGen Lute.Common Lute.Std Lute.CLI.Commands Lute.Batteries Lute.Std Lute.Lute Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Runtime)
+target_link_libraries(Lute.Require PUBLIC Luau.Require PRIVATE Luau.CLI.lib Luau.Compiler Luau.CodeGen Lute.Common Lute.Std Lute.CLI.Commands Lute.Batteries Lute.Std Lute.Lute Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Task Lute.Tty Lute.VM Lute.Process Lute.System Lute.Time Lute.Runtime)
 target_compile_options(Lute.Require PRIVATE ${LUTE_OPTIONS})

--- a/lute/require/src/lutevfs.cpp
+++ b/lute/require/src/lutevfs.cpp
@@ -12,6 +12,7 @@
 #include "lute/system.h"
 #include "lute/task.h"
 #include "lute/time.h"
+#include "lute/tty.h"
 #include "lute/vm.h"
 
 #include "Luau/DenseHash.h"
@@ -33,6 +34,7 @@ const Luau::DenseHashMap<std::string, lua_CFunction> kLuteModules = []()
     map["@lute/system.luau"] = luteopen_system;
     map["@lute/time.luau"] = luteopen_time;
     map["@lute/io.luau"] = luteopen_io;
+    map["@lute/tty.luau"] = luteopen_tty;
     return map;
 }();
 

--- a/lute/runtime/include/lute/userdatas.h
+++ b/lute/runtime/include/lute/userdatas.h
@@ -9,3 +9,4 @@ constexpr int kWebSocketHandleTag = 123;
 constexpr int kServerWebSocketHandleTag = 122;
 constexpr int kUVFileTag = 121;
 constexpr int kSignalHandleTag = 120;
+constexpr int kTtyHandleTag = 119;

--- a/lute/runtime/include/lute/uvstream.h
+++ b/lute/runtime/include/lute/uvstream.h
@@ -143,5 +143,14 @@ struct PipeStream : UVStream<uv_pipe_t>
     }
 };
 
+struct TTYStream : UVStream<uv_tty_t>
+{
+    TTYStream(uv_loop_t* loop, uv_file fd, std::string handleContext)
+        : UVStream<uv_tty_t>(loop, std::move(handleContext))
+    {
+        uv_tty_init(loop, stream.get(), fd, /* readable(unused)*/ -1);
+    }
+};
+
 
 } // namespace uvutils

--- a/lute/tty/CMakeLists.txt
+++ b/lute/tty/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(Lute.Tty STATIC)
+
+target_sources(Lute.Tty PRIVATE
+    include/lute/tty.h
+
+    src/tty.cpp
+)
+
+target_compile_features(Lute.Tty PUBLIC cxx_std_17)
+target_include_directories(Lute.Tty PUBLIC "include" ${LIBUV_INCLUDE_DIR})
+target_link_libraries(Lute.Tty PRIVATE Lute.Common Lute.Process Lute.Runtime Luau.VM uv_a)
+target_compile_options(Lute.Tty PRIVATE ${LUTE_OPTIONS})

--- a/lute/tty/include/lute/tty.h
+++ b/lute/tty/include/lute/tty.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "lute/library.h"
+
+#include "lua.h"
+#include "lualib.h"
+
+LUTE_API int luaopen_tty(lua_State* L);
+LUTE_API int luteopen_tty(lua_State* L);
+
+struct TTY : LuteLibrary<TTY>
+{
+    static constexpr const char kName[] = "tty";
+    static int pushLibrary(lua_State* L);
+    static const luaL_Reg lib[];
+    static const char* const properties[];
+};

--- a/lute/tty/src/tty.cpp
+++ b/lute/tty/src/tty.cpp
@@ -1,0 +1,455 @@
+#include "lute/tty.h"
+
+#include "lute/os_signal.h"
+#include "lute/runtime.h"
+#include "lute/userdatas.h"
+#include "lute/uvstream.h"
+
+#include "Luau/VecDeque.h"
+
+#include "lua.h"
+#include "lualib.h"
+
+#include "uv.h"
+
+#include <cstring>
+#include <memory>
+#include <optional>
+
+namespace
+{
+
+struct OpenOptions
+{
+    bool raw = false;
+};
+
+struct TTYHandle : std::enable_shared_from_this<TTYHandle>
+{
+    static std::shared_ptr<TTYHandle> create(lua_State* L, int fd, const OpenOptions& opts);
+
+    TTYHandle(const TTYHandle&) = delete;
+    TTYHandle& operator=(const TTYHandle&) = delete;
+
+    void close();
+    bool isClosed() const
+    {
+        return closeRequested;
+    }
+
+    std::optional<std::string> popChunk();
+    bool atEof() const
+    {
+        return eof;
+    }
+    bool hasPendingRead() const
+    {
+        return bool(pendingRead);
+    }
+
+    uv_stream_t* writeStream()
+    {
+        return stream->getStream();
+    }
+
+    bool hasResizeListener() const
+    {
+        return listener != nullptr;
+    }
+    void setResizeListener(std::shared_ptr<Ref> cb)
+    {
+        listener = std::move(cb);
+    }
+
+    void beginRead(ResumeToken token);
+    void dispatchResize();
+
+private:
+    TTYHandle(lua_State* L, int fd)
+        : runtime(getRuntime(L))
+        , stream(std::make_unique<uvutils::TTYStream>(runtime->getEventLoop(), fd, "tty"))
+    {
+    }
+
+    void startReading();
+    void installWindowChangeHandler();
+
+    Runtime* runtime;
+    std::unique_ptr<uvutils::TTYStream> stream;
+    std::unique_ptr<process::SignalHandle> windowChangeHandler;
+    std::shared_ptr<Ref> listener;
+
+    Luau::VecDeque<std::string> chunks;
+    ResumeToken pendingRead;
+
+    bool reading = false;
+    bool eof = false;
+    bool closeRequested = false;
+};
+
+void TTYHandle::installWindowChangeHandler()
+{
+    int signum = -1;
+#ifdef SIGWINCH
+    signum = SIGWINCH;
+#endif
+    TTYHandle* raw = this;
+    windowChangeHandler = std::make_unique<process::SignalHandle>(
+        runtime->getEventLoop(),
+        signum,
+        [raw]()
+        {
+            raw->dispatchResize();
+        }
+    );
+}
+
+std::shared_ptr<TTYHandle> TTYHandle::create(lua_State* L, int fd, const OpenOptions& opts)
+{
+    if (uv_guess_handle(fd) != UV_TTY)
+        luaL_errorL(L, "fd %d is not a TTY", fd);
+
+    // Constructor runs uv_tty_init via TTYStream.
+    std::shared_ptr<TTYHandle> handle(new TTYHandle(L, fd));
+
+    if (opts.raw)
+    {
+        int rc = uv_tty_set_mode(handle->stream->stream.get(), UV_TTY_MODE_RAW);
+        if (rc < 0)
+        {
+            handle->close();
+            luaL_errorL(L, "uv_tty_set_mode failed: %s", uv_strerror(rc));
+        }
+    }
+
+    handle->installWindowChangeHandler();
+
+    return handle;
+}
+
+struct WriteRequest
+{
+    uv_write_t req;
+    std::shared_ptr<TTYHandle> handle;
+    std::string data;
+    uv_buf_t buf;
+};
+
+std::optional<std::string> TTYHandle::popChunk()
+{
+    if (chunks.empty())
+        return std::nullopt;
+    std::string chunk = std::move(chunks.front());
+    chunks.pop_front();
+    return chunk;
+}
+
+void TTYHandle::beginRead(ResumeToken token)
+{
+    startReading();
+    pendingRead = std::move(token);
+}
+
+void TTYHandle::close()
+{
+    if (closeRequested)
+        return;
+    closeRequested = true;
+    eof = true;
+
+    if (pendingRead && !pendingRead->completed)
+    {
+        ResumeToken token = std::move(pendingRead);
+        token->complete(
+            [](lua_State* L) -> int
+            {
+                lua_pushnil(L);
+                return 1;
+            }
+        );
+    }
+    pendingRead.reset();
+
+    windowChangeHandler.reset();
+    listener.reset();
+
+    if (stream && !stream->isClosed())
+    {
+        stream->close([keepAlive = shared_from_this()]() {});
+    }
+}
+
+static TTYHandle* checkTTY(lua_State* L, int idx)
+{
+    auto* p = static_cast<std::shared_ptr<TTYHandle>*>(lua_touserdatatagged(L, idx, kTtyHandleTag));
+    if (!p || !*p)
+        luaL_typeerrorL(L, idx, "TTY");
+    return p->get();
+}
+
+void TTYHandle::startReading()
+{
+    if (reading || !stream || stream->isClosed())
+        return;
+
+    reading = true;
+    TTYHandle* h = this;
+    stream->read(
+        [h](std::string_view input)
+        {
+            std::string chunk(input);
+            if (h->pendingRead && !h->pendingRead->completed)
+            {
+                ResumeToken token = std::move(h->pendingRead);
+                token->complete(
+                    [c = std::move(chunk)](lua_State* L) -> int
+                    {
+                        lua_pushlstring(L, c.data(), c.size());
+                        return 1;
+                    }
+                );
+            }
+            else
+            {
+                h->chunks.push_back(std::move(chunk));
+            }
+        },
+        [h](std::optional<std::string> err)
+        {
+            h->eof = true;
+            h->reading = false;
+            if (h->pendingRead && !h->pendingRead->completed)
+            {
+                ResumeToken token = std::move(h->pendingRead);
+                if (err)
+                    token->fail(*err);
+                else
+                    token->complete(
+                        [](lua_State* L) -> int
+                        {
+                            lua_pushnil(L);
+                            return 1;
+                        }
+                    );
+            }
+        }
+    );
+}
+
+static int ttyRead(lua_State* L)
+{
+    TTYHandle* handle = checkTTY(L, 1);
+
+    if (handle->isClosed())
+        luaL_errorL(L, "tty is closed");
+
+    if (auto chunk = handle->popChunk())
+    {
+        lua_pushlstring(L, chunk->data(), chunk->size());
+        return 1;
+    }
+
+    if (handle->atEof())
+    {
+        lua_pushnil(L);
+        return 1;
+    }
+
+    if (handle->hasPendingRead())
+        luaL_errorL(L, "tty:read already pending");
+
+    handle->beginRead(getResumeToken(L));
+    return lua_yield(L, 0);
+}
+
+static int ttyWrite(lua_State* L)
+{
+    TTYHandle* handle = checkTTY(L, 1);
+
+    if (handle->isClosed())
+        luaL_errorL(L, "tty is closed");
+
+    size_t len = 0;
+    const char* data = luaL_checklstring(L, 2, &len);
+
+    if (len == 0)
+        return 0;
+
+    auto* w = new WriteRequest();
+    w->data.assign(data, len);
+    w->buf = uv_buf_init(w->data.data(), unsigned(w->data.size()));
+    w->req.data = w;
+    w->handle = handle->shared_from_this();
+
+    int rc = uv_write(
+        &w->req,
+        handle->writeStream(),
+        &w->buf,
+        1,
+        [](uv_write_t* req, int status)
+        {
+            auto* w = static_cast<WriteRequest*>(req->data);
+            delete w;
+        }
+    );
+    if (rc < 0)
+    {
+        delete w;
+        luaL_errorL(L, "uv_write failed: %s", uv_strerror(rc));
+    }
+    return 0;
+}
+
+static int ttyClose(lua_State* L)
+{
+    TTYHandle* handle = checkTTY(L, 1);
+    handle->close();
+    return 0;
+}
+
+void TTYHandle::dispatchResize()
+{
+    if (!listener || !stream || stream->isClosed())
+        return;
+
+    int width = 0;
+    int height = 0;
+    uv_tty_get_winsize(stream->stream.get(), &width, &height);
+
+    runtime->scheduleLuauCallback(
+        listener,
+        [height, width](lua_State* L) -> int
+        {
+            lua_checkstack(L, 2);
+            lua_createtable(L, 0, 2);
+            lua_pushinteger(L, height);
+            lua_setfield(L, -2, "rows");
+            lua_pushinteger(L, width);
+            lua_setfield(L, -2, "cols");
+            return 1;
+        }
+    );
+}
+
+static int ttyOnResize(lua_State* L)
+{
+    TTYHandle* handle = checkTTY(L, 1);
+    luaL_checktype(L, 2, LUA_TFUNCTION);
+
+    if (handle->isClosed())
+        luaL_errorL(L, "tty is closed");
+
+    if (handle->hasResizeListener())
+        luaL_errorL(L, "tty:onResize listener already registered");
+
+    handle->setResizeListener(std::make_shared<Ref>(L, 2));
+    return 0;
+}
+
+static int ttyOpen(lua_State* L)
+{
+    int fd = int(luaL_checkinteger(L, 1));
+
+    OpenOptions opts;
+    if (lua_istable(L, 2))
+    {
+        lua_getfield(L, 2, "raw");
+        if (!lua_isnil(L, -1))
+            opts.raw = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+    }
+
+    auto handle = TTYHandle::create(L, fd, opts);
+
+    void* storage = lua_newuserdatataggedwithmetatable(L, sizeof(std::shared_ptr<TTYHandle>), kTtyHandleTag);
+    new (storage) std::shared_ptr<TTYHandle>(std::move(handle));
+
+    return 1;
+}
+
+static void registerTTYMetatable(lua_State* L)
+{
+    luaL_newmetatable(L, "TTY");
+
+    lua_pushcfunction(
+        L,
+        [](lua_State* L) -> int
+        {
+            const char* key = luaL_checkstring(L, 2);
+            if (strcmp(key, "read") == 0)
+            {
+                lua_pushcfunction(L, ttyRead, "TTY.read");
+                return 1;
+            }
+            if (strcmp(key, "write") == 0)
+            {
+                lua_pushcfunction(L, ttyWrite, "TTY.write");
+                return 1;
+            }
+            if (strcmp(key, "close") == 0)
+            {
+                lua_pushcfunction(L, ttyClose, "TTY.close");
+                return 1;
+            }
+            if (strcmp(key, "onResize") == 0)
+            {
+                lua_pushcfunction(L, ttyOnResize, "TTY.onResize");
+                return 1;
+            }
+            return 0;
+        },
+        "TTY.__index"
+    );
+    lua_setfield(L, -2, "__index");
+
+    lua_pushstring(L, "TTY");
+    lua_setfield(L, -2, "__type");
+
+    lua_setuserdatadtor(
+        L,
+        kTtyHandleTag,
+        [](lua_State* L, void* ud)
+        {
+            auto* p = static_cast<std::shared_ptr<TTYHandle>*>(ud);
+            if (*p)
+                (*p)->close();
+            std::destroy_at(p);
+        }
+    );
+    lua_setuserdatametatable(L, kTtyHandleTag);
+}
+
+} // namespace
+
+const char* const TTY::properties[] = {nullptr};
+
+const luaL_Reg TTY::lib[] = {
+    {"open", ttyOpen},
+    {nullptr, nullptr},
+};
+
+int TTY::pushLibrary(lua_State* L)
+{
+    registerTTYMetatable(L);
+
+    lua_createtable(L, 0, std::size(TTY::lib));
+    for (auto& [name, func] : TTY::lib)
+    {
+        if (!name || !func)
+            break;
+        lua_pushcfunction(L, func, name);
+        lua_setfield(L, -2, name);
+    }
+    lua_setreadonly(L, -1, 1);
+    return 1;
+}
+
+LUTE_API int luaopen_tty(lua_State* L)
+{
+    return TTY::openAsGlobal(L);
+}
+
+LUTE_API int luteopen_tty(lua_State* L)
+{
+    return TTY::pushLibrary(L);
+}

--- a/tests/lute/tty.test.luau
+++ b/tests/lute/tty.test.luau
@@ -1,0 +1,122 @@
+local fs = require("@std/fs")
+local pathlib = require("@std/path")
+local process = require("@std/process")
+local system = require("@std/system")
+local test = require("@std/test")
+
+local lutePath = pathlib.format(process.execPath())
+local tmpDir = system.tmpdir()
+
+-- Tests that need a real TTY are run as subprocesses under `script(1)`,
+-- which emulates running a command inside of a terminal. Stdin/out/err get
+-- opened as a pty device, which lets us test this.
+-- Executing these tests like this, as opposed to snapshot testing is much easier
+-- as it avoids multiple levels of process.run indirection
+local function runWithPty(name: string, body: string): process.ProcessResult
+	local file = pathlib.join(tmpDir, `tty_{name}.luau`)
+	fs.writeStringToFile(file, body)
+	local invocation = if system.macos
+		then `script -q /dev/null {lutePath} {pathlib.format(file)}`
+		else `script -q -c "{lutePath} {pathlib.format(file)}" /dev/null`
+	local result = process.run({ "sh", "-c", `exec </dev/null; {invocation}` })
+	fs.remove(file)
+	return result
+end
+
+test.suite("TTYSuite", function(suite)
+	-- Windows doesn't ship a `script(1)` alternative that makes it easy to test
+	if system.win32 then
+		return
+	end
+
+	-- The remaining cases need a real TTY. We only run them on Unix like machines where
+	-- `script(1)` is available to allocate a pty for the child.
+	suite:case("onResizeRejectsSecondListener", function(assert)
+		local r = runWithPty(
+			"second_listener",
+			[[
+				local tty = require("@lute/tty")
+				local handle = tty.open(0)
+				handle:onResize(function() end)
+				local ok, err = pcall(function()
+					handle:onResize(function() end)
+				end)
+				if ok then
+					error("expected second onResize to error")
+				end
+				if not string.find(tostring(err), "listener already registered") then
+					error("unexpected error: " .. tostring(err))
+				end
+				handle:close()
+			]]
+		)
+		assert.eq(r.exitcode, 0)
+	end)
+
+	suite:case("writeReachesTerminal", function(assert)
+		local r = runWithPty(
+			"write_basic",
+			[[
+				local tty = require("@lute/tty")
+				local handle = tty.open(1)
+				handle:write("lute-tty-write-marker")
+				handle:close()
+			]]
+		)
+		assert.eq(r.exitcode, 0)
+		assert.strContains(r.stdout, "lute-tty-write-marker")
+	end)
+
+	suite:case("methodsErrorAfterClose", function(assert)
+		local r = runWithPty(
+			"after_close",
+			[[
+				local tty = require("@lute/tty")
+				local handle = tty.open(1)
+				handle:close()
+
+				local function expectClosed(fn)
+					local ok, err = pcall(fn)
+					if ok then error("expected error") end
+					if not string.find(tostring(err), "tty is closed") then
+						error("unexpected error: " .. tostring(err))
+					end
+				end
+
+				expectClosed(function() handle:write("x") end)
+				expectClosed(function() handle:onResize(function() end) end)
+			]]
+		)
+		assert.eq(r.exitcode, 0)
+	end)
+
+	suite:case("closeIsIdempotent", function(assert)
+		local r = runWithPty(
+			"close_idempotent",
+			[[
+				local tty = require("@lute/tty")
+				local handle = tty.open(0)
+				handle:close()
+				handle:close()
+			]]
+		)
+		assert.eq(r.exitcode, 0)
+	end)
+
+	suite:case("freshHandleAcceptsListener", function(assert)
+		local r = runWithPty(
+			"fresh_listener",
+			[[
+				local tty = require("@lute/tty")
+				local h1 = tty.open(0)
+				h1:onResize(function() end)
+				h1:close()
+
+				local h2 = tty.open(0)
+				h2:onResize(function() end)
+				h2:close()
+			]]
+		)
+		assert.eq(r.exitcode, 0)
+	end)
+end)


### PR DESCRIPTION
Adds support for a basic tty library in lute. I've tried to keep the api surface small, but we will probably need to iterate on this a bit.

Some things to note:
- The tests only run on posix environments. This is because script(1) ships by default on these platforms, which lets us simulate running a subcommand as if it was in the terminal, which makes tty.open(in/out/err) work correctly.
- There isn't an equivalent on windows afaict, and doing so would require writing more platform specific C++ to get pseudoconsoles.