### PR TITLE
cli: fix some typechecker issues that snuck into the CLI commands.

### DIFF
--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -71,20 +71,25 @@ local function runtests(
 		local done = 0
 		for _ = 1, nworkers do
 			task.spawn(function()
-				local current = nil
+				local current: path.Path? = nil
 				xpcall(function()
 					local worker = vm.create("@self/worker")
+
 					while true do
 						current = takenext()
+
 						if not current then
 							break
 						end
+
 						local res = worker.runfile({
-							file = path.format(current),
+							-- FIXME(Luau): we probably should not need the `path.Path` cast here to know `current` is non-nil.
+							file = path.format(current :: path.Path),
 							suite = suiteName,
 							case = caseName,
 							verbose = runOptions.verbose,
 						})
+
 						if res.__tag == "err" then
 							table.insert(workerFailures, res.error)
 						else

--- a/lute/cli/commands/test/reporter.luau
+++ b/lute/cli/commands/test/reporter.luau
@@ -78,7 +78,7 @@ local function workerFailuresReporter(failures: { string })
 	end
 end
 
-local function snapReporter(result: snapty.snapresult)
+local function snapReporter(result: snapty.SnapResult)
 	local total = #result.passed + #result.failed + #result.new
 
 	for _, p in result.passed do
@@ -116,7 +116,7 @@ local function snapReporter(result: snapty.snapresult)
 	end
 
 	print(separator(string.rep("─", 50)))
-	local parts = {}
+	local parts: {string} = {}
 	table.insert(parts, snapsty.pass(`{#result.passed} passed`))
 	if #result.new > 0 then
 		table.insert(parts, snapsty.newstyle(`{#result.new} new`))

--- a/lute/cli/commands/transform/init.luau
+++ b/lute/cli/commands/transform/init.luau
@@ -217,6 +217,10 @@ local function main(...: string)
 	if not migrationPath then
 		print(`Error: No code transformation script specified.\n\n{USAGE}\nUse --help for more information.`)
 		process.exit(1)
+
+		-- FIXME(Luau): the type system doesn't know `process.exit` never returns, and so we need to have an error
+		-- in order to ensure that type refinements still fire as we'd expect to make the type of `migrationPath` non-nil.
+		error("unreachable")
 	end
 
 	local dryRun = args:has("dry-run")


### PR DESCRIPTION
I don't know what went wrong that enabled this to happen (@skberkeley is looking into it), but there's some type errors in a few of the CLI commands. We can fix them pretty easily, they're mostly just refinements not quite working when we'd like them to.