### PR TITLE
lute pkg: refactor `DependencySpec` into a tagged enumeration

### DIFF
--- a/lute/cli/commands/pkg/loom-core/src/authentication.luau
+++ b/lute/cli/commands/pkg/loom-core/src/authentication.luau
@@ -20,7 +20,7 @@ end
 local function loadAuthenticationStore(): AuthenticationStore
 	local authPath = getAuthenticationFilePath()
 	local ok, result = pcall(luau.loadModule, authPath, nil)
-	if not ok or type(result) ~= "table" then
+	if not ok or typeof(result) ~= "table" then
 		return {}
 	end
 	return result

--- a/lute/cli/commands/pkg/loom-core/src/github.luau
+++ b/lute/cli/commands/pkg/loom-core/src/github.luau
@@ -8,7 +8,7 @@ local unzip = require("../extern/unzip")
 
 local function sanitizePath(path: string): string
 	-- Input validation
-	if not path or type(path) ~= "string" then
+	if not path or typeof(path) ~= "string" then
 		error("Path must be a string")
 	end
 

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -1,10 +1,11 @@
 local luau = require("@std/luau")
+local manifest = require("./manifest")
 
 export type LockfileDependency = {
 	read name: string,
 	read rev: string?,
 	read source: string,
-	read sourceKind: string,
+	read sourceKind: manifest.SourceKind,
 	read installPath: string,
 	read dependencies: { [string]: string },
 }
@@ -23,7 +24,10 @@ local function validatePackageEntry(key: string, entry: any)
 		`Expected 'rev' field to be a string or nil for dependency '{key}'`
 	)
 	assert(type(entry.source) == "string", `Expected 'source' field in dependency '{key}'`)
-	assert(type(entry.sourceKind) == "string", `Expected 'sourceKind' field in dependency '{key}'`)
+	assert(
+		manifest.isSourceKind(entry.sourceKind),
+		`Expected 'sourceKind' to be 'path' or 'github' for dependency '{key}', got '{entry.sourceKind}'`
+	)
 	assert(type(entry.installPath) == "string", `Expected 'installPath' field in dependency '{key}'`)
 	assert(type(entry.dependencies) == "table", `Expected 'dependencies' field in dependency '{key}'`)
 	for alias, depKey in entry.dependencies do

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -17,41 +17,41 @@ export type Lockfile = {
 }
 
 local function validatePackageEntry(key: string, entry: any)
-	assert(type(entry) == "table", `Expected table for dependency '{key}'`)
-	assert(type(entry.name) == "string", `Expected 'name' field in dependency '{key}'`)
+	assert(typeof(entry) == "table", `Expected table for dependency '{key}'`)
+	assert(typeof(entry.name) == "string", `Expected 'name' field in dependency '{key}'`)
 	assert(
-		entry.rev == nil or type(entry.rev) == "string",
+		entry.rev == nil or typeof(entry.rev) == "string",
 		`Expected 'rev' field to be a string or nil for dependency '{key}'`
 	)
-	assert(type(entry.source) == "string", `Expected 'source' field in dependency '{key}'`)
+	assert(typeof(entry.source) == "string", `Expected 'source' field in dependency '{key}'`)
 	assert(
 		manifest.isSourceKind(entry.sourceKind),
 		`Expected 'sourceKind' to be 'path' or 'github' for dependency '{key}', got '{entry.sourceKind}'`
 	)
-	assert(type(entry.installPath) == "string", `Expected 'installPath' field in dependency '{key}'`)
-	assert(type(entry.dependencies) == "table", `Expected 'dependencies' field in dependency '{key}'`)
+	assert(typeof(entry.installPath) == "string", `Expected 'installPath' field in dependency '{key}'`)
+	assert(typeof(entry.dependencies) == "table", `Expected 'dependencies' field in dependency '{key}'`)
 	for alias, depKey in entry.dependencies do
-		assert(type(alias) == "string", `Expected alias to be a string for dependency '{key}'`)
-		assert(type(depKey) == "string", `Expected dependency key to be a string for dependency '{key}'`)
+		assert(typeof(alias) == "string", `Expected alias to be a string for dependency '{key}'`)
+		assert(typeof(depKey) == "string", `Expected dependency key to be a string for dependency '{key}'`)
 	end
 	table.freeze(entry.dependencies)
 end
 
 local function parseLockfile(t: any): Lockfile
-	assert(t ~= nil and type(t) == "table", "Expected lockfile to be a table")
+	assert(t ~= nil and typeof(t) == "table", "Expected lockfile to be a table")
 	assert(t.version == 3, `Unsupported lockfile version: {t.version}`)
-	assert(type(t.packages) == "table", "Expected 'packages' field in lockfile")
-	assert(type(t.dependencies) == "table", "Expected 'dependencies' field in lockfile")
+	assert(typeof(t.packages) == "table", "Expected 'packages' field in lockfile")
+	assert(typeof(t.dependencies) == "table", "Expected 'dependencies' field in lockfile")
 
 	for key, entry in t.packages do
-		assert(type(key) == "string", "Expected package key to be a string")
+		assert(typeof(key) == "string", "Expected package key to be a string")
 		validatePackageEntry(key, entry)
 	end
 	table.freeze(t.packages)
 
 	for alias, key in t.dependencies do
-		assert(type(alias) == "string", "Expected dependency alias to be a string")
-		assert(type(key) == "string", "Expected dependency key to be a string")
+		assert(typeof(alias) == "string", "Expected dependency alias to be a string")
+		assert(typeof(key) == "string", "Expected dependency key to be a string")
 		assert(t.packages[key] ~= nil, `Dependency '{alias}' references package '{key}' which is not in packages`)
 	end
 	table.freeze(t.dependencies)

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -1,10 +1,12 @@
 local luau = require("@std/luau")
 
+export type SourceKind = "path" | "github"
+
 export type DependencySpec = {
 	read name: string,
 	read rev: string?,
 	read source: string,
-	read sourceKind: string,
+	read sourceKind: SourceKind,
 }
 
 export type PackageManifest = {
@@ -16,6 +18,18 @@ export type PackageManifest = {
 export type ProjectManifest = {
 	read package: PackageManifest,
 }
+
+local function isSourceKind(s: unknown): boolean
+	return s == "path" or s == "github"
+end
+
+local function parseSourceKind(s: unknown): SourceKind?
+	if not isSourceKind(s) then
+		return nil
+	end
+
+	return s :: SourceKind
+end
 
 -- FIXME(Luau): running into issues with getting this to type check properly.
 -- We also should also do proper error handling because this is user input.
@@ -40,8 +54,8 @@ local function parseManifest(t: any): ProjectManifest
 				`Expected 'rev' field to be a string or nil in dependency spec for '{name}'`
 			)
 			assert(
-				spec.sourceKind ~= nil and type(spec.sourceKind) == "string",
-				`Expected 'sourceKind' field in dependency spec for '{name}'`
+				isSourceKind(spec.sourceKind),
+				`Expected 'sourceKind' to be 'path' or 'github' in dependency spec for '{name}', got '{spec.sourceKind}'`
 			)
 			assert(
 				spec.source ~= nil and type(spec.source) == "string",
@@ -72,5 +86,7 @@ local function parseFile(manifestPath: string): ProjectManifest
 end
 
 return {
+	isSourceKind = isSourceKind,
+	parseSourceKind = parseSourceKind,
 	parseFile = parseFile,
 }

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -1,6 +1,8 @@
 local luau = require("@std/luau")
 
-export type SourceKind = "path" | "github"
+export type SourceKind =
+	| "path"
+	| "github"
 
 export type DependencySpec = {
 	read name: string,
@@ -31,8 +33,7 @@ local function parseSourceKind(s: unknown): SourceKind?
 	return s :: SourceKind
 end
 
--- FIXME(Luau): running into issues with getting this to type check properly.
--- We also should also do proper error handling because this is user input.
+-- TODO: We should do proper error handling because this is user input.
 local function parseManifest(t: unknown): ProjectManifest
 	assert(t ~= nil and typeof(t) == "table", "Expected a table")
 	assert(t.package ~= nil and typeof(t.package) == "table", "Expected 'package' field in manifest")
@@ -40,10 +41,14 @@ local function parseManifest(t: unknown): ProjectManifest
 	local pkg = t.package
 
 	assert(pkg.name ~= nil and typeof(pkg.name) == "string", "Expected 'name' field in package manifest")
-	assert(pkg.version ~= nil and typeof(pkg.version) == "string", "Expected 'version' field in package manifest")
+	-- FIXME(Luau): Luau currently refines `pkg` to have `version` based on this check, but
+	-- also produces a type error for the access _in_ the condition without the cast here.
+	assert((pkg :: any).version ~= nil and typeof(pkg.version) == "string", "Expected 'version' field in package manifest")
 
 	local dependencies: { [string]: DependencySpec } = {}
-	if pkg.dependencies ~= nil then
+	-- FIXME(Luau): Luau currently refines `pkg` to have `dependencies` based on this check, but
+	-- also produces a type error for the access _in_ the condition without the cast here.
+	if (pkg :: any).dependencies ~= nil then
 		for name, spec in pkg.dependencies do
 			assert(
 				spec.name == nil or typeof(spec.name) == "string",

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -33,24 +33,24 @@ end
 
 -- FIXME(Luau): running into issues with getting this to type check properly.
 -- We also should also do proper error handling because this is user input.
-local function parseManifest(t: any): ProjectManifest
-	assert(t ~= nil and type<<unknown>>(t) == "table", "Expected a table")
-	assert(t.package ~= nil and type(t.package) == "table", "Expected 'package' field in manifest")
+local function parseManifest(t: unknown): ProjectManifest
+	assert(t ~= nil and typeof(t) == "table", "Expected a table")
+	assert(t.package ~= nil and typeof(t.package) == "table", "Expected 'package' field in manifest")
 
 	local pkg = t.package
 
-	assert(pkg.name ~= nil and type(pkg.name) == "string", "Expected 'name' field in package manifest")
-	assert(pkg.version ~= nil and type(pkg.version) == "string", "Expected 'version' field in package manifest")
+	assert(pkg.name ~= nil and typeof(pkg.name) == "string", "Expected 'name' field in package manifest")
+	assert(pkg.version ~= nil and typeof(pkg.version) == "string", "Expected 'version' field in package manifest")
 
 	local dependencies: { [string]: DependencySpec } = {}
 	if pkg.dependencies ~= nil then
 		for name, spec in pkg.dependencies do
 			assert(
-				spec.name == nil or type(spec.name) == "string",
+				spec.name == nil or typeof(spec.name) == "string",
 				`Optional 'name' field in dependency spec for '{name}' expected to be a string`
 			)
 			assert(
-				spec.rev == nil or type(spec.rev) == "string",
+				spec.rev == nil or typeof(spec.rev) == "string",
 				`Expected 'rev' field to be a string or nil in dependency spec for '{name}'`
 			)
 			assert(
@@ -58,7 +58,7 @@ local function parseManifest(t: any): ProjectManifest
 				`Expected 'sourceKind' to be 'path' or 'github' in dependency spec for '{name}', got '{spec.sourceKind}'`
 			)
 			assert(
-				spec.source ~= nil and type(spec.source) == "string",
+				spec.source ~= nil and typeof(spec.source) == "string",
 				`Expected 'source' field in dependency spec for '{name}'`
 			)
 			dependencies[name] = table.freeze({

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -4,12 +4,22 @@ export type SourceKind =
 	| "path"
 	| "github"
 
-export type DependencySpec = {
+export type PathDependencySpec = {
+	read sourceKind: "path",
 	read name: string,
-	read rev: string?,
 	read source: string,
-	read sourceKind: SourceKind,
 }
+
+export type GitHubDependencySpec = {
+	read sourceKind: "github",
+	read name: string,
+	read source: string,
+	read rev: string,
+}
+
+export type DependencySpec =
+  | PathDependencySpec
+  | GitHubDependencySpec
 
 export type PackageManifest = {
 	read name: string,
@@ -55,10 +65,6 @@ local function parseManifest(t: unknown): ProjectManifest
 				`Optional 'name' field in dependency spec for '{name}' expected to be a string`
 			)
 			assert(
-				spec.rev == nil or typeof(spec.rev) == "string",
-				`Expected 'rev' field to be a string or nil in dependency spec for '{name}'`
-			)
-			assert(
 				isSourceKind(spec.sourceKind),
 				`Expected 'sourceKind' to be 'path' or 'github' in dependency spec for '{name}', got '{spec.sourceKind}'`
 			)
@@ -66,12 +72,24 @@ local function parseManifest(t: unknown): ProjectManifest
 				spec.source ~= nil and typeof(spec.source) == "string",
 				`Expected 'source' field in dependency spec for '{name}'`
 			)
-			dependencies[name] = table.freeze({
-				name = spec.name or name, -- use the optional name if provided, otherwise use the alias
-				rev = spec.rev,
-				sourceKind = spec.sourceKind,
-				source = spec.source,
-			})
+
+			if spec.sourceKind == "path" then
+				dependencies[name] = table.freeze({
+					name = spec.name or name,
+					sourceKind = "path",
+					source = spec.source,
+				}) :: PathDependencySpec
+			end
+
+			if spec.sourceKind == "github" then
+				assert(typeof(spec.rev) == "string", `Expected 'rev' field for github dependency '{name}'`)
+				dependencies[name] = table.freeze({
+					name = spec.name or name, -- use the optional name if provided, otherwise use the alias
+					sourceKind = "github",
+					source = spec.source,
+					rev = spec.rev,
+				}) :: GitHubDependencySpec
+			end
 		end
 		table.freeze(dependencies)
 	end

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -1,8 +1,6 @@
 local luau = require("@std/luau")
 
-export type SourceKind =
-	| "path"
-	| "github"
+export type SourceKind = "path" | "github"
 
 export type PathDependencySpec = {
 	read sourceKind: "path",
@@ -17,9 +15,7 @@ export type GitHubDependencySpec = {
 	read rev: string,
 }
 
-export type DependencySpec =
-  | PathDependencySpec
-  | GitHubDependencySpec
+export type DependencySpec = PathDependencySpec | GitHubDependencySpec
 
 export type PackageManifest = {
 	read name: string,
@@ -53,7 +49,10 @@ local function parseManifest(t: unknown): ProjectManifest
 	assert(pkg.name ~= nil and typeof(pkg.name) == "string", "Expected 'name' field in package manifest")
 	-- FIXME(Luau): Luau currently refines `pkg` to have `version` based on this check, but
 	-- also produces a type error for the access _in_ the condition without the cast here.
-	assert((pkg :: any).version ~= nil and typeof(pkg.version) == "string", "Expected 'version' field in package manifest")
+	assert(
+		(pkg :: any).version ~= nil and typeof(pkg.version) == "string",
+		"Expected 'version' field in package manifest"
+	)
 
 	local dependencies: { [string]: DependencySpec } = {}
 	-- FIXME(Luau): Luau currently refines `pkg` to have `dependencies` based on this check, but

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -15,14 +15,27 @@ local function getLockfilePath(directory: string): string
 end
 
 local function getKey(spec: manifest.DependencySpec): string
-	if spec.rev ~= nil then
+	if spec.sourceKind == "github" then
 		return `{spec.name}@{spec.rev}`
 	end
+
 	return spec.name
 end
 
-local function hasConflict(specA: manifest.DependencySpec, specB: manifest.DependencySpec): boolean
-	return specA.rev ~= specB.rev or specA.source ~= specB.source or specA.sourceKind ~= specB.sourceKind
+local function hasConflict(resolved: lockfile.LockfileDependency, incoming: manifest.DependencySpec): boolean
+	if resolved.sourceKind ~= incoming.sourceKind then
+		return true
+	end
+
+	if resolved.source ~= incoming.source then
+		return true
+	end
+
+	if incoming.sourceKind == "github" then
+		return resolved.rev ~= incoming.rev
+	end
+
+	return false
 end
 
 local function normalizePathDependency(
@@ -30,19 +43,21 @@ local function normalizePathDependency(
 	installPath: string,
 	rootDirectory: string
 ): manifest.DependencySpec
-	if spec.sourceKind == "path" then
-		local sourcePath = path.format(path.resolve(installPath, spec.source))
-		if not fs.exists(sourcePath) then
-			error(`Path dependency directory not found: {sourcePath} (for package '{spec.name}')`)
-		end
-		return table.freeze({
-			name = spec.name,
-			rev = spec.rev,
-			source = path.format(path.relative(rootDirectory, sourcePath)),
-			sourceKind = spec.sourceKind,
-		})
+	-- normalization is a no-op if it's not a path dependency
+	if spec.sourceKind ~= "path" then
+		return spec
 	end
-	return spec
+
+	local sourcePath = path.format(path.resolve(installPath, spec.source))
+	if not fs.exists(sourcePath) then
+		error(`Path dependency directory not found: {sourcePath} (for package '{spec.name}')`)
+	end
+
+	return table.freeze({
+		name = spec.name,
+		sourceKind = "path",
+		source = path.format(path.relative(rootDirectory, sourcePath)),
+	}) :: manifest.PathDependencySpec
 end
 
 local function fetchSource(spec: manifest.DependencySpec, rootDirectory: string): string
@@ -53,7 +68,6 @@ local function fetchSource(spec: manifest.DependencySpec, rootDirectory: string)
 		end
 		return sourcePath
 	elseif spec.sourceKind == "github" then
-		assert(spec.rev ~= nil, `Expected rev to be non-nil for GitHub package '{spec.name}'`)
 		store.ensureStoreDirectory()
 
 		local key = getKey(spec)
@@ -141,7 +155,7 @@ local function resolve(rootDirectory: string): lockfile.Lockfile
 
 		packages[key] = table.freeze({
 			name = spec.name,
-			rev = spec.rev,
+			rev = if spec.sourceKind == "github" then spec.rev else nil,
 			source = spec.source,
 			sourceKind = spec.sourceKind,
 			installPath = if spec.sourceKind == "path"


### PR DESCRIPTION
While working on integrating semver, I felt like a lot of the core logic in resolution was being hindered by conflating the different source kinds into one uniform type. It feels like the code will work out nicer for maintainability if we instead had a stronger typed surface for what `DependencySpec` is, and so I've done that here by introducing a `SourceKind` type and changing `DependencySpec` into a union of discrete tagged types for the specific source kind they reflect since the associated fields of that spec vary based on the kind. I've bundled in a few other smaller code cleanup things, like using `typeof` over `type`, and cleaning up a bit of "odd" code, e.g. one of the `type` calls using explicit instantiation for some reason.