### PR TITLE
infra: bootstrap into a separate bootstrap directory

### DIFF
--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -76,17 +76,20 @@ else
   BUILD_ROOT=build
 fi
 
-BUILD_PATH=$BUILD_ROOT/debug
+# Use a dedicated directory for the STDLESS bootstrap build so that the
+# cmake cache with LUTE_STDLESS=ON never contaminates the real debug build
+# directory that luthier will configure afterwards.
+BOOTSTRAP_BUILD_PATH=build/lute0-bootstrap
 rm -rf build && mkdir build
-exe cmake -G=Ninja -B $BUILD_PATH -DCMAKE_BUILD_TYPE=Debug -DLUTE_STDLESS=ON
+exe cmake -G=Ninja -B $BOOTSTRAP_BUILD_PATH -DCMAKE_BUILD_TYPE=Debug -DLUTE_STDLESS=ON
 
 # build lute0
-exe ninja -C $BUILD_PATH $EXE_PATH
+exe ninja -C $BOOTSTRAP_BUILD_PATH $EXE_PATH
 echo ""
-echo "built lute0 at $BUILD_PATH/$EXE_PATH"
+echo "built lute0 at $BOOTSTRAP_BUILD_PATH/$EXE_PATH"
 
 # use lute0 to build lute with the standard library included.
-LUTESTRAP=./$BUILD_PATH/$EXE_PATH
+LUTESTRAP=./$BOOTSTRAP_BUILD_PATH/$EXE_PATH
 mv $LUTESTRAP $OUT_BINARY
 exe $OUT_BINARY tools/luthier.luau configure --config release --clean lute
 exe $OUT_BINARY tools/luthier.luau build --config release --clean lute


### PR DESCRIPTION
Our docs builds have been broken, and we discovered #1128 recently, which both share the same underlying cause. The initial debug build of `lute0` during bootstrapping uses the same folder as the "luthier managed" build folders we have. While it does a clean luthier build after, it does so in a release configuration. So, on our CI machines (and in a local setup where you bootstrap and then start developing), you end up in a bad state for your debug builds. The situation would be resolved by doing a clean debug build, but it's easy to forget that, and in the case of our CI environment, we likely don't want to force all of the builds into being clean ones. This PR changes `bootstrap.sh` to bootstrap into a separate folder, so it will never be reused by debug builds, and prevent running into the situation where you incrementally rebuild into a bad state for your `debug` build.

Fixes #1128.