### PR TITLE
Refactors syntax.Punctuated

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -56,8 +56,16 @@ export type CstToken<Kind = string> = {
 --- The end-of-file token.
 export type CstEof = CstToken<""> & { read tag: "eof" }
 
-export type Pair<T, Separator> = { read node: T, read separator: CstToken<Separator>? }
-export type Punctuated<T, Separator = ","> = { Pair<T, Separator> }
+type PunctuatedData<T, Separator = ","> = { read [number]: T, read separators: { CstToken<Separator> } }
+
+-- __len not needed because # already returns number of array entries in table
+type PunctuatedMT<T, Separator = ","> = {
+	read __iter: (PunctuatedData<T, Separator>) -> (({ read [number]: T }, number?) -> (number?, T), { T }),
+}
+
+--- A punctuated sequence of items (e.g., function parameters, arguments, type parameters) with separators (e.g., commas).
+--- The `__iter` metamethod modifies generalized iteration so that only nodes are iterated over
+export type Punctuated<T, Separator = ","> = setmetatable<PunctuatedData<T, Separator>, PunctuatedMT<T, Separator>>
 
 --- A local variable binding site in the CST.
 export type CstLocal = {
@@ -742,7 +750,6 @@ export type CstTypeTable = {
 
 --- A parameter in a function type annotation.
 export type CstFunctionTypeParameter = {
-	read location: Span,
 	read name: CstToken?,
 	read colon: CstToken<":">?,
 	read type: CstType,

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -65,7 +65,10 @@ type CstPunctuatedMT<T, Separator = ","> = {
 
 --- A punctuated sequence of items (e.g., function parameters, arguments, type parameters) with separators (e.g., commas).
 --- The `__iter` metamethod modifies generalized iteration so that only nodes are iterated over
-export type CstPunctuated<T, Separator = ","> = setmetatable<CstPunctuatedData<T, Separator>, CstPunctuatedMT<T, Separator>>
+export type CstPunctuated<T, Separator = ","> = setmetatable<
+	CstPunctuatedData<T, Separator>,
+	CstPunctuatedMT<T, Separator>
+>
 
 --- A local variable binding site in the CST.
 export type CstLocal = {

--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -56,16 +56,16 @@ export type CstToken<Kind = string> = {
 --- The end-of-file token.
 export type CstEof = CstToken<""> & { read tag: "eof" }
 
-type PunctuatedData<T, Separator = ","> = { read [number]: T, read separators: { CstToken<Separator> } }
+type CstPunctuatedData<T, Separator = ","> = { read [number]: T, read separators: { CstToken<Separator> } }
 
 -- __len not needed because # already returns number of array entries in table
-type PunctuatedMT<T, Separator = ","> = {
-	read __iter: (PunctuatedData<T, Separator>) -> (({ read [number]: T }, number?) -> (number?, T), { T }),
+type CstPunctuatedMT<T, Separator = ","> = {
+	read __iter: (CstPunctuatedData<T, Separator>) -> (({ read [number]: T }, number?) -> (number?, T), { T }),
 }
 
 --- A punctuated sequence of items (e.g., function parameters, arguments, type parameters) with separators (e.g., commas).
 --- The `__iter` metamethod modifies generalized iteration so that only nodes are iterated over
-export type Punctuated<T, Separator = ","> = setmetatable<PunctuatedData<T, Separator>, PunctuatedMT<T, Separator>>
+export type CstPunctuated<T, Separator = ","> = setmetatable<CstPunctuatedData<T, Separator>, CstPunctuatedMT<T, Separator>>
 
 --- A local variable binding site in the CST.
 export type CstLocal = {
@@ -160,7 +160,7 @@ export type CstExprCall = {
 	read tag: "call",
 	read func: CstExpr,
 	read openParens: CstToken<"(">?,
-	read arguments: Punctuated<CstExpr>,
+	read arguments: CstPunctuated<CstExpr>,
 	read closeParens: CstToken<")">?,
 	read self: boolean,
 	read argLocation: Span,
@@ -174,7 +174,7 @@ export type CstExprInstantiate = {
 	read expr: CstExpr,
 	read leftArrow1: CstToken<"<">,
 	read leftArrow2: CstToken<"<">,
-	read typeArguments: Punctuated<CstType | CstTypePack>,
+	read typeArguments: CstPunctuated<CstType | CstTypePack>,
 	read rightArrow1: CstToken<">">,
 	read rightArrow2: CstToken<">">,
 }
@@ -209,12 +209,12 @@ export type CstExprFunction = {
 	read attributes: { CstAttribute },
 	read functionKeyword: CstToken<"function">,
 	read openGenerics: CstToken<"<">?,
-	read generics: Punctuated<CstGenericType>?,
-	read genericPacks: Punctuated<CstGenericTypePack>?,
+	read generics: CstPunctuated<CstGenericType>?,
+	read genericPacks: CstPunctuated<CstGenericTypePack>?,
 	read closeGenerics: CstToken<">">?,
 	read openParens: CstToken<"(">,
 	read self: CstLocal?,
-	read parameters: Punctuated<CstLocal>,
+	read parameters: CstPunctuated<CstLocal>,
 	read vararg: CstToken<"...">?,
 	read varargColon: CstToken<":">?,
 	read varargAnnotation: CstTypePack?,
@@ -437,7 +437,7 @@ export type CstStatReturn = {
 	read kind: "stat",
 	read tag: "return",
 	read returnKeyword: CstToken<"return">,
-	read expressions: Punctuated<CstExpr>,
+	read expressions: CstPunctuated<CstExpr>,
 }
 
 --- A statement consisting of a bare expression (e.g., a function call used as a statement).
@@ -454,9 +454,9 @@ export type CstStatLocal = {
 	read kind: "stat",
 	read tag: "local",
 	read localKeyword: CstToken<"local">,
-	read variables: Punctuated<CstLocal>,
+	read variables: CstPunctuated<CstLocal>,
 	read equals: CstToken<"=">?,
-	read values: Punctuated<CstExpr>,
+	read values: CstPunctuated<CstExpr>,
 }
 
 --- A `const` variable declaration statement node.
@@ -465,9 +465,9 @@ export type CstStatConst = {
 	read kind: "stat",
 	read tag: "const",
 	read constKeyword: CstToken<"const">,
-	read variables: Punctuated<CstLocal>,
+	read variables: CstPunctuated<CstLocal>,
 	read equals: CstToken<"=">?,
-	read values: Punctuated<CstExpr>,
+	read values: CstPunctuated<CstExpr>,
 }
 
 --- A numeric `for` loop statement node.
@@ -494,9 +494,9 @@ export type CstStatForIn = {
 	read kind: "stat",
 	read tag: "forin",
 	read forKeyword: CstToken<"for">,
-	read variables: Punctuated<CstLocal>,
+	read variables: CstPunctuated<CstLocal>,
 	read inKeyword: CstToken<"in">,
-	read values: Punctuated<CstExpr>,
+	read values: CstPunctuated<CstExpr>,
 	read doKeyword: CstToken<"do">,
 	read body: CstStatBlock,
 	read endKeyword: CstToken<"end">,
@@ -507,9 +507,9 @@ export type CstStatAssign = {
 	read location: Span,
 	read kind: "stat",
 	read tag: "assign",
-	read variables: Punctuated<CstExpr>,
+	read variables: CstPunctuated<CstExpr>,
 	read equals: CstToken<"=">,
-	read values: Punctuated<CstExpr>,
+	read values: CstPunctuated<CstExpr>,
 }
 
 --- A compound assignment statement node (e.g., `x += 1`).
@@ -557,8 +557,8 @@ export type CstStatTypeAlias = {
 	read typeToken: CstToken<"type">,
 	read name: CstToken,
 	read openGenerics: CstToken<"<">?,
-	read generics: Punctuated<CstGenericType>?,
-	read genericPacks: Punctuated<CstGenericTypePack>?,
+	read generics: CstPunctuated<CstGenericType>?,
+	read genericPacks: CstPunctuated<CstGenericTypePack>?,
 	read closeGenerics: CstToken<">">?,
 	read equals: CstToken<"=">,
 	read type: CstType,
@@ -624,7 +624,7 @@ export type CstTypeReference = {
 	read prefixPoint: CstToken<".">?,
 	read name: CstToken<string>,
 	read openParameters: CstToken<"<">?,
-	read parameters: Punctuated<CstType | CstTypePack>?,
+	read parameters: CstPunctuated<CstType | CstTypePack>?,
 	read closeParameters: CstToken<">">?,
 }
 
@@ -678,7 +678,7 @@ export type CstTypeUnion = {
 	read tag: "union",
 	read leading: CstToken<"|">?,
 	-- Separator may be nil for CstTypeOptional
-	read types: Punctuated<CstType, "|">,
+	read types: CstPunctuated<CstType, "|">,
 }
 
 --- An intersection type annotation node (e.g., `A & B`).
@@ -687,7 +687,7 @@ export type CstTypeIntersection = {
 	read kind: "type",
 	read tag: "intersection",
 	read leading: CstToken<"&">?,
-	read types: Punctuated<CstType, "&">,
+	read types: CstPunctuated<CstType, "&">,
 }
 
 --- An array type annotation node (e.g., `{ T }`).
@@ -762,11 +762,11 @@ export type CstTypeFunction = {
 	read kind: "type",
 	read tag: "function",
 	read openGenerics: CstToken<"<">?,
-	read generics: Punctuated<CstGenericType>?,
-	read genericPacks: Punctuated<CstGenericTypePack>?,
+	read generics: CstPunctuated<CstGenericType>?,
+	read genericPacks: CstPunctuated<CstGenericTypePack>?,
 	read closeGenerics: CstToken<">">?,
 	read openParens: CstToken<"(">,
-	read parameters: Punctuated<CstFunctionTypeParameter>,
+	read parameters: CstPunctuated<CstFunctionTypeParameter>,
 	read vararg: CstTypePack?,
 	read closeParens: CstToken<")">,
 	read returnArrow: CstToken<"->">,
@@ -793,7 +793,7 @@ export type CstTypePackExplicit = {
 	read kind: "typepack",
 	read tag: "explicit",
 	read openParens: CstToken<"(">?,
-	read types: Punctuated<CstType>,
+	read types: CstPunctuated<CstType>,
 	read tailType: CstTypePack?,
 	read closeParens: CstToken<")">?,
 }

--- a/examples/lints/almost_swapped.luau
+++ b/examples/lints/almost_swapped.luau
@@ -76,8 +76,8 @@ local function lint(cst: syntax.CstStatBlock, sourcepath: path.Path?): { lintTyp
 				continue
 			end
 
-			local currVar, currVal = currStat.variables[1].node, currStat.values[1].node
-			local nextVar, nextVal = nextStat.variables[1].node, nextStat.values[1].node
+			local currVar, currVal = currStat.variables[1], currStat.values[1]
+			local nextVar, nextVal = nextStat.variables[1], nextStat.values[1]
 
 			if compFuncs.refExprsSame(currVar, nextVal) and compFuncs.refExprsSame(nextVar, currVal) then
 				table.insert(violations, {

--- a/examples/query.luau
+++ b/examples/query.luau
@@ -5,13 +5,12 @@ local utils = require("@std/syntax/utils")
 local cst = syntax.parseExpr("require(OldComponent)")
 
 local p = query.findAllFromRoot(cst, utils.isRequireCall):filter(function(call)
-	local firstArg = call.arguments[1].node
+	local firstArg = call.arguments[1]
 	return firstArg.tag == "indexname" and firstArg.index.text == "OldComponent"
 end)
 
--- Can we improve the type solver here so we don't need to add this annotation?
 local argIndexNames = query.map(p, function(call: syntax.CstExprCall)
-	return call.arguments[1].node :: syntax.CstExprIndexName
+	return call.arguments[1]
 end)
 
 local _replacements = argIndexNames:replace(function(_)

--- a/lute/cli/commands/lint/rules/almost_swapped.luau
+++ b/lute/cli/commands/lint/rules/almost_swapped.luau
@@ -81,8 +81,8 @@ local function lint(
 				continue
 			end
 
-			local currVar, currVal = currStat.variables[1].node, currStat.values[1].node
-			local nextVar, nextVal = nextStat.variables[1].node, nextStat.values[1].node
+			local currVar, currVal = currStat.variables[1], currStat.values[1]
+			local nextVar, nextVal = nextStat.variables[1], nextStat.values[1]
 
 			if compFuncs.refExprsSame(currVar, nextVal) and compFuncs.refExprsSame(nextVar, currVal) then
 				local currVarStr = stringext.trim(printer.printNode(currVar))

--- a/lute/cli/commands/lint/rules/unused_variable.luau
+++ b/lute/cli/commands/lint/rules/unused_variable.luau
@@ -108,22 +108,22 @@ local function unusedLocals(block: syntax.CstStatBlock, writeOnlyAPIs: smallTrie
 		-- For each (var, value) pair, ignore references to the var in the value
 		for i, localVar in stat.variables do
 			if stat.values[i] then
-				if utils.isRequireCall(stat.values[i].node) then
-					visitor.requiredModules[localVar.node.name.text] = localVar.node
+				if utils.isRequireCall(stat.values[i]) then
+					visitor.requiredModules[localVar.name.text] = localVar
 				else
-					visitor.ignoreReferences[localVar.node] = true
-					if localVar.node.annotation then
-						visitorLib.visitType(localVar.node.annotation, visitor)
+					visitor.ignoreReferences[localVar] = true
+					if localVar.annotation then
+						visitorLib.visitType(localVar.annotation, visitor)
 					end
-					visitorLib.visitExpression(stat.values[i].node, visitor)
-					visitor.ignoreReferences[localVar.node] = nil
+					visitorLib.visitExpression(stat.values[i], visitor)
+					visitor.ignoreReferences[localVar] = nil
 				end
 			end
 		end
 
 		-- Mark each var as unused in the current scope
 		for _, localVar in stat.variables do
-			visitor.scopes[#visitor.scopes][localVar.node] = false
+			visitor.scopes[#visitor.scopes][localVar] = false
 		end
 
 		return false
@@ -141,7 +141,7 @@ local function unusedLocals(block: syntax.CstStatBlock, writeOnlyAPIs: smallTrie
 		-- Push a scope for the loop variables
 		local newScope: { [syntax.CstLocal]: boolean } = {}
 		for _, var in stat.variables do
-			newScope[var.node] = false
+			newScope[var] = false
 		end
 		table.insert(visitor.scopes, newScope)
 		return true
@@ -154,8 +154,8 @@ local function unusedLocals(block: syntax.CstStatBlock, writeOnlyAPIs: smallTrie
 		local callFound = false
 		local prevInLValueContext = visitor.inLValueContext
 		while i <= math.min(#stat.variables, #stat.values) do
-			local var = stat.variables[i].node
-			local val = stat.values[i].node
+			local var = stat.variables[i]
+			local val = stat.values[i]
 			-- An unused local doesn't become used just because it's used to assign to itself, eg:
 			-- local x
 			-- x = x + 1
@@ -296,7 +296,7 @@ local function unusedLocals(block: syntax.CstStatBlock, writeOnlyAPIs: smallTrie
 		local newScope: { [syntax.CstLocal]: boolean } = {}
 
 		for _, param in node.parameters do
-			newScope[param.node] = false
+			newScope[param] = false
 		end
 
 		table.insert(visitor.scopes, newScope)
@@ -346,10 +346,10 @@ local function unusedLocals(block: syntax.CstStatBlock, writeOnlyAPIs: smallTrie
 			if writeOnlyIndices[i] then
 				local prevInLValueContext = visitor.inLValueContext
 				visitor.inLValueContext = true
-				visitorLib.visitExpression(arg.node, visitor)
+				visitorLib.visitExpression(arg, visitor)
 				visitor.inLValueContext = prevInLValueContext
 			else
-				visitorLib.visitExpression(arg.node, visitor)
+				visitorLib.visitExpression(arg, visitor)
 			end
 		end
 

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -31,7 +31,7 @@ namespace luau
 
 static constexpr const char kSpanType[] = "span"; // Uncapitalized because the span library lives under `luau.{kSpanType}`
 static constexpr const char kCompileResultType[] = "CompileResult";
-static constexpr const char kPunctuatedType[] = "Punctuated";
+static constexpr const char kCstPunctuatedType[] = "CstPunctuated";
 
 // Recursively freezes the table at the top of the stack and any descendant tables.
 // The table must be at the top of the stack when called.
@@ -777,7 +777,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         lua_setfield(L, -2, "separators");
 
-        luaL_getmetatable(L, kPunctuatedType);
+        luaL_getmetatable(L, kCstPunctuatedType);
         lua_setmetatable(L, -2);
     }
 
@@ -807,7 +807,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         lua_setfield(L, -2, "separators");
 
-        luaL_getmetatable(L, kPunctuatedType);
+        luaL_getmetatable(L, kCstPunctuatedType);
         lua_setmetatable(L, -2);
     }
 
@@ -838,7 +838,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         lua_setfield(L, -2, "separators");
 
-        luaL_getmetatable(L, kPunctuatedType);
+        luaL_getmetatable(L, kCstPunctuatedType);
         lua_setmetatable(L, -2);
     }
 
@@ -2216,7 +2216,7 @@ struct AstSerialize : public Luau::AstVisitor
         serializeToken(cstNode->openArgsPosition, "(");
         lua_setfield(L, -2, "openParens");
 
-        // Punctuated<CstFunctionTypeParameter>
+        // CstPunctuated<CstFunctionTypeParameter>
         lua_createtable(L, node->argTypes.types.size, 1);
 
         lua_createtable(L, cstNode->argumentsCommaPositions.size, 0);
@@ -2253,7 +2253,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         lua_setfield(L, -2, "separators");
 
-        luaL_getmetatable(L, kPunctuatedType);
+        luaL_getmetatable(L, kCstPunctuatedType);
         lua_setmetatable(L, -2);
 
         lua_setfield(L, -2, "parameters");
@@ -2310,7 +2310,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_pushnil(L);
         lua_setfield(L, -2, "leading");
 
-        // types: Punctuated<CstType, "|">
+        // types: CstPunctuated<CstType, "|">
         lua_createtable(L, node->types.size, 1);
 
         // types.separators: { CstToken<"|"> }
@@ -2364,7 +2364,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         lua_setfield(L, -2, "separators");
 
-        luaL_getmetatable(L, kPunctuatedType);
+        luaL_getmetatable(L, kCstPunctuatedType);
         lua_setmetatable(L, -2);
 
         lua_setfield(L, -2, "types");
@@ -3166,7 +3166,7 @@ static int initLuauLibrary(lua_State* L)
 
     lua_pop(L, 1);
 
-    luaL_newmetatable(L, kPunctuatedType);
+    luaL_newmetatable(L, kCstPunctuatedType);
 
     lua_pushcfunction(L, luau::iterPunctuated, "punctuated.__iter");
     lua_setfield(L, -2, "__iter");

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -29,8 +29,9 @@
 namespace luau
 {
 
-static constexpr const char kSpanType[] = "span";
+static constexpr const char kSpanType[] = "span"; // Uncapitalized because the span library lives under `luau.{kSpanType}`
 static constexpr const char kCompileResultType[] = "CompileResult";
+static constexpr const char kPunctuatedType[] = "Punctuated";
 
 // Recursively freezes the table at the top of the stack and any descendant tables.
 // The table must be at the top of the stack when called.
@@ -231,7 +232,6 @@ static int makeSpanLibrary(lua_State* L)
     return 1;
 }
 
-
 static int ltSpan(lua_State* L)
 {
     Span lhs = checkSpan(L, 1);
@@ -253,6 +253,36 @@ static int ltSpan(lua_State* L)
         lua_pushboolean(L, 0);
 
     return 1;
+}
+
+static int iterPunctuatedNext(lua_State* L)
+{
+    // args: PunctuatedData table, node index
+    int i = luaL_checkinteger(L, 2) + 1;
+
+    lua_rawcheckstack(L, 2);
+
+    lua_rawgeti(L, 1, i);
+
+    if (lua_isnil(L, -1))
+        return 1; // return nil to stop iteration
+
+    lua_pushinteger(L, i);
+    lua_insert(L, -2); // stack: ..., i + 1, value
+
+    return 2; // index, value
+}
+
+static int iterPunctuated(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TTABLE);
+
+    lua_rawcheckstack(L, 3);
+
+    lua_pushcfunction(L, iterPunctuatedNext, "iterPunctuatedNext");
+    lua_pushvalue(L, 1);   // state = the punctuated table itself
+    lua_pushinteger(L, 0); // initial index
+    return 3;
 }
 
 struct AstSerialize : public Luau::AstVisitor
@@ -728,49 +758,57 @@ struct AstSerialize : public Luau::AstVisitor
     void serializePunctuated(Luau::AstArray<T> nodes, Luau::AstArray<Luau::Position> separators, const char* separatorText)
     {
         lua_rawcheckstack(L, 3);
-        lua_createtable(L, nodes.size, 0);
+
+        lua_createtable(L, nodes.size, 1);
+
+        lua_createtable(L, separators.size, 0);
 
         for (size_t i = 0; i < nodes.size; i++)
         {
-            lua_createtable(L, 0, 2);
-
             nodes.data[i]->visit(this);
-            lua_setfield(L, -2, "node");
+            lua_rawseti(L, -3, i + 1);
 
             if (i < separators.size)
+            {
                 serializeToken(separators.data[i], separatorText);
-            else
-                lua_pushnil(L);
-            lua_setfield(L, -2, "separator");
-
-            lua_rawseti(L, -2, i + 1);
+                lua_rawseti(L, -2, i + 1);
+            }
         }
+
+        lua_setfield(L, -2, "separators");
+
+        luaL_getmetatable(L, kPunctuatedType);
+        lua_setmetatable(L, -2);
     }
 
     void serializePunctuated(Luau::AstArray<Luau::AstTypeOrPack> nodes, Luau::AstArray<Luau::Position> separators, const char* separatorText)
     {
-        lua_rawcheckstack(L, 2);
-        lua_createtable(L, nodes.size, 0);
+        lua_rawcheckstack(L, 3);
+
+        lua_createtable(L, nodes.size, 1);
+
+        lua_createtable(L, separators.size, 0);
 
         for (size_t i = 0; i < nodes.size; i++)
         {
-            lua_rawcheckstack(L, 2);
-            lua_createtable(L, 0, 2);
-
-            if (nodes.data[i].type)
-                nodes.data[i].type->visit(this);
+            const Luau::AstTypeOrPack& node = nodes.data[i];
+            if (node.type)
+                node.type->visit(this);
             else
-                nodes.data[i].typePack->visit(this);
-            lua_setfield(L, -2, "node");
+                node.typePack->visit(this);
+            lua_rawseti(L, -3, i + 1);
 
             if (i < separators.size)
+            {
                 serializeToken(separators.data[i], separatorText);
-            else
-                lua_pushnil(L);
-            lua_setfield(L, -2, "separator");
-
-            lua_rawseti(L, -2, i + 1);
+                lua_rawseti(L, -2, i + 1);
+            }
         }
+
+        lua_setfield(L, -2, "separators");
+
+        luaL_getmetatable(L, kPunctuatedType);
+        lua_setmetatable(L, -2);
     }
 
     void serializePunctuated(
@@ -781,24 +819,29 @@ struct AstSerialize : public Luau::AstVisitor
     )
     {
         lua_rawcheckstack(L, 3);
-        lua_createtable(L, nodes.size, 0);
+
+        lua_createtable(L, nodes.size, 1);
+
+        lua_createtable(L, separators.size, 0);
 
         for (size_t i = 0; i < nodes.size; i++)
         {
-            lua_createtable(L, 0, 2);
-
-            serialize(nodes.data[i], /* createToken=*/true, colonPositions.size > i ? std::make_optional(colonPositions.data[i]) : std::nullopt);
-            lua_setfield(L, -2, "node");
+            serialize(nodes.data[i], /* createToken */ true, colonPositions.size > i ? std::make_optional(colonPositions.data[i]) : std::nullopt);
+            lua_rawseti(L, -3, i + 1);
 
             if (i < separators.size)
+            {
                 serializeToken(separators.data[i], separatorText);
-            else
-                lua_pushnil(L);
-            lua_setfield(L, -2, "separator");
-
-            lua_rawseti(L, -2, i + 1);
+                lua_rawseti(L, -2, i + 1);
+            }
         }
+
+        lua_setfield(L, -2, "separators");
+
+        luaL_getmetatable(L, kPunctuatedType);
+        lua_setmetatable(L, -2);
     }
+
     void serializeAttribute(Luau::AstAttr* node)
     {
         lua_rawcheckstack(L, 2);
@@ -2147,7 +2190,7 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeType(Luau::AstTypeFunction* node)
     {
-        lua_rawcheckstack(L, 2);
+        lua_rawcheckstack(L, 3);
         lua_createtable(L, 0, preambleSize + 10);
 
         serializeNodePreamble(node, "function", "type");
@@ -2173,40 +2216,46 @@ struct AstSerialize : public Luau::AstVisitor
         serializeToken(cstNode->openArgsPosition, "(");
         lua_setfield(L, -2, "openParens");
 
-        lua_createtable(L, node->argTypes.types.size, 0);
+        // Punctuated<CstFunctionTypeParameter>
+        lua_createtable(L, node->argTypes.types.size, 1);
+
+        lua_createtable(L, cstNode->argumentsCommaPositions.size, 0);
+
         for (size_t i = 0; i < node->argTypes.types.size; i++)
         {
-            lua_rawcheckstack(L, 2);
-            lua_createtable(L, 0, 2);
+            // CstFunctionTypeParameter
+            lua_createtable(L, 0, 3);
 
-            {
-                lua_rawcheckstack(L, 2);
-                lua_createtable(L, 0, 3);
-                if (i < node->argNames.size && node->argNames.data[i].has_value())
-                    serializeToken(node->argNames.data[i]->second.begin, node->argNames.data[i]->first.value);
-                else
-                    lua_pushnil(L);
-                lua_setfield(L, -2, "name");
+            if (i < node->argNames.size && node->argNames.data[i].has_value())
+                serializeToken(node->argNames.data[i]->second.begin, node->argNames.data[i]->first.value);
+            else
+                lua_pushnil(L);
+            lua_setfield(L, -2, "name");
 
-                if (i < cstNode->argumentNameColonPositions.size && cstNode->argumentNameColonPositions.data[i].has_value())
-                    serializeToken(*cstNode->argumentNameColonPositions.data[i], ":");
-                else
-                    lua_pushnil(L);
-                lua_setfield(L, -2, "colon");
+            if (i < cstNode->argumentNameColonPositions.size && cstNode->argumentNameColonPositions.data[i].has_value())
+                serializeToken(*cstNode->argumentNameColonPositions.data[i], ":");
+            else
+                lua_pushnil(L);
+            lua_setfield(L, -2, "colon");
 
-                node->argTypes.types.data[i]->visit(this);
-                lua_setfield(L, -2, "type");
-            }
-            lua_setfield(L, -2, "node");
+            node->argTypes.types.data[i]->visit(this);
+            lua_setfield(L, -2, "type");
+
+            lua_rawseti(L, -3, i + 1);
 
             if (i < cstNode->argumentsCommaPositions.size)
                 serializeToken(cstNode->argumentsCommaPositions.data[i], ",");
             else
                 lua_pushnil(L);
-            lua_setfield(L, -2, "separator");
 
             lua_rawseti(L, -2, i + 1);
         }
+
+        lua_setfield(L, -2, "separators");
+
+        luaL_getmetatable(L, kPunctuatedType);
+        lua_setmetatable(L, -2);
+
         lua_setfield(L, -2, "parameters");
 
         if (node->argTypes.tailType)
@@ -2250,7 +2299,7 @@ struct AstSerialize : public Luau::AstVisitor
     {
         const auto cstNode = lookupCstNode<Luau::CstTypeUnion>(node);
 
-        lua_rawcheckstack(L, 2);
+        lua_rawcheckstack(L, 4);
         lua_createtable(L, 0, preambleSize + 2);
 
         serializeNodePreamble(node, "union", "type");
@@ -2261,13 +2310,15 @@ struct AstSerialize : public Luau::AstVisitor
             lua_pushnil(L);
         lua_setfield(L, -2, "leading");
 
-        lua_createtable(L, node->types.size, 0);
+        // types: Punctuated<CstType, "|">
+        lua_createtable(L, node->types.size, 1);
+
+        // types.separators: { CstToken<"|"> }
+        lua_createtable(L, cstNode->separatorPositions.size, 0);
+
         size_t separatorPositions = 0;
         for (size_t i = 0; i < node->types.size; i++)
         {
-            lua_rawcheckstack(L, 2);
-            lua_createtable(L, 0, 2);
-
             if (node->types.data[i]->is<Luau::AstTypeOptional>())
             {
                 lua_createtable(L, 0, preambleSize + 1);
@@ -2277,7 +2328,8 @@ struct AstSerialize : public Luau::AstVisitor
                 serializeToken(node->types.data[i]->location.begin, "?");
                 lua_setfield(L, -2, "token");
 
-                lua_setfield(L, -2, "node");
+                // types[i + 1] = optionalNode
+                lua_rawseti(L, -3, i + 1);
 
                 // Since this option is an optional type, the separator is always present unless it's the last type
                 if (i < node->types.size - 1 && separatorPositions < cstNode->separatorPositions.size)
@@ -2287,12 +2339,14 @@ struct AstSerialize : public Luau::AstVisitor
                 }
                 else
                     lua_pushnil(L);
-                lua_setfield(L, -2, "separator");
+
+                lua_rawseti(L, -2, i + 1);
             }
             else
             {
                 node->types.data[i]->visit(this);
-                lua_setfield(L, -2, "node");
+
+                lua_rawseti(L, -3, i + 1);
 
                 // If the next type is optional, we don't have a separator token
                 if (i < node->types.size - 1 && !node->types.data[i + 1]->is<Luau::AstTypeOptional>() &&
@@ -2303,11 +2357,16 @@ struct AstSerialize : public Luau::AstVisitor
                 }
                 else
                     lua_pushnil(L);
-                lua_setfield(L, -2, "separator");
-            }
 
-            lua_rawseti(L, -2, i + 1);
+                lua_rawseti(L, -2, i + 1);
+            }
         }
+
+        lua_setfield(L, -2, "separators");
+
+        luaL_getmetatable(L, kPunctuatedType);
+        lua_setmetatable(L, -2);
+
         lua_setfield(L, -2, "types");
     }
 
@@ -3102,6 +3161,15 @@ static int initLuauLibrary(lua_State* L)
 
     lua_pushcfunction(L, luau::ltSpan, "span.__lt");
     lua_setfield(L, -2, "__lt");
+
+    lua_setreadonly(L, -1, 1);
+
+    lua_pop(L, 1);
+
+    luaL_newmetatable(L, kPunctuatedType);
+
+    lua_pushcfunction(L, luau::iterPunctuated, "punctuated.__iter");
+    lua_setfield(L, -2, "__iter");
 
     lua_setreadonly(L, -1, 1);
 

--- a/lute/std/libs/luau.luau
+++ b/lute/std/libs/luau.luau
@@ -79,7 +79,7 @@ function luau.requires(filePath: path.Pathlike): { RequireNode }
 	local requireCalls = query.findAllFromRoot(cst, utils.isRequireCall)
 
 	return requireCalls:mapToArray(function(call: luteLuau.CstExprCall): RequireNode?
-		local argNode = call.arguments[1].node
+		local argNode = call.arguments[1]
 		if argNode == nil then
 			return nil
 		end

--- a/lute/std/libs/syntax/init.luau
+++ b/lute/std/libs/syntax/init.luau
@@ -34,7 +34,7 @@ export type CstToken<Kind = string> = types.CstToken<Kind>
 
 export type CstEof = types.CstEof
 
-export type Punctuated<T, Separator = ","> = types.Punctuated<T, Separator>
+export type CstPunctuated<T, Separator = ","> = types.CstPunctuated<T, Separator>
 
 export type CstLocal = types.CstLocal
 

--- a/lute/std/libs/syntax/init.luau
+++ b/lute/std/libs/syntax/init.luau
@@ -34,7 +34,6 @@ export type CstToken<Kind = string> = types.CstToken<Kind>
 
 export type CstEof = types.CstEof
 
-export type Pair<T, Separator> = types.Pair<T, Separator>
 export type Punctuated<T, Separator = ","> = types.Punctuated<T, Separator>
 
 export type CstLocal = types.CstLocal

--- a/lute/std/libs/syntax/types.luau
+++ b/lute/std/libs/syntax/types.luau
@@ -12,7 +12,7 @@ export type CstToken<Kind = string> = luau.CstToken<Kind>
 
 export type CstEof = luau.CstEof
 
-export type Punctuated<T, Separator = ","> = luau.Punctuated<T, Separator>
+export type CstPunctuated<T, Separator = ","> = luau.CstPunctuated<T, Separator>
 
 export type CstLocal = luau.CstLocal
 

--- a/lute/std/libs/syntax/types.luau
+++ b/lute/std/libs/syntax/types.luau
@@ -12,7 +12,6 @@ export type CstToken<Kind = string> = luau.CstToken<Kind>
 
 export type CstEof = luau.CstEof
 
-export type Pair<T, Separator> = luau.Pair<T, Separator>
 export type Punctuated<T, Separator = ","> = luau.Punctuated<T, Separator>
 
 export type CstLocal = luau.CstLocal

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -170,7 +170,7 @@ local function visitToken<T>(token: types.CstToken<T>, visitor: Visitor)
 	visitor.visitToken(token)
 end
 
-local function visitPunctuated<T, Separator>(list: types.Punctuated<T, Separator>, visitor: Visitor, apply: (T, Visitor) -> ())
+local function visitPunctuated<T, Separator>(list: types.CstPunctuated<T, Separator>, visitor: Visitor, apply: (T, Visitor) -> ())
 	for i, item in list do
 		apply(item, visitor)
 		local sep = list.separators[i]

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -171,10 +171,11 @@ local function visitToken<T>(token: types.CstToken<T>, visitor: Visitor)
 end
 
 local function visitPunctuated<T, Separator>(list: types.Punctuated<T, Separator>, visitor: Visitor, apply: (T, Visitor) -> ())
-	for _, item in list do
-		apply(item.node, visitor)
-		if item.separator then
-			visitToken(item.separator, visitor)
+	for i, item in list do
+		apply(item, visitor)
+		local sep = list.separators[i]
+		if sep then
+			visitToken(sep, visitor)
 		end
 	end
 end

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -389,16 +389,16 @@ test.suite("parseExpr", function(suite)
 		assert.neq(funcExpr.openGenerics, nil)
 		assert.neq(funcExpr.generics, nil)
 
-		assert.eq(#funcExpr.generics :: syntax.Punctuated<syntax.CstGenericType>, 1)
-		local gen = (funcExpr.generics :: syntax.Punctuated<syntax.CstGenericType>)[1]
+		assert.eq(#funcExpr.generics :: syntax.CstPunctuated<syntax.CstGenericType>, 1)
+		local gen = (funcExpr.generics :: syntax.CstPunctuated<syntax.CstGenericType>)[1]
 		assert.eq(gen.name.text, "A")
 		assert.eq(gen.equals, nil)
 		assert.eq(gen.default, nil)
 
 		assert.neq(funcExpr.genericPacks, nil)
-		assert.eq(#funcExpr.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>, 1)
+		assert.eq(#funcExpr.genericPacks :: syntax.CstPunctuated<syntax.CstGenericTypePack>, 1)
 
-		local genPack = (funcExpr.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>)[1]
+		local genPack = (funcExpr.genericPacks :: syntax.CstPunctuated<syntax.CstGenericTypePack>)[1]
 		assert.eq(genPack.name.text, "B")
 		assert.eq(genPack.ellipsis.text, "...")
 		assert.eq(genPack.equals, nil)
@@ -878,9 +878,9 @@ test.suite("parse", function(suite)
 		assert.neq(typeAlias.openGenerics, nil)
 		assert.eq((typeAlias.openGenerics :: syntax.CstToken<"<">).text, "<")
 		assert.neq(typeAlias.generics, nil)
-		assert.eq(#typeAlias.generics :: syntax.Punctuated<syntax.CstGenericType>, 1)
+		assert.eq(#typeAlias.generics :: syntax.CstPunctuated<syntax.CstGenericType>, 1)
 		assert.neq(typeAlias.genericPacks, nil)
-		assert.eq(#typeAlias.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>, 1)
+		assert.eq(#typeAlias.genericPacks :: syntax.CstPunctuated<syntax.CstGenericTypePack>, 1)
 		assert.neq(typeAlias.closeGenerics, nil)
 		assert.eq((typeAlias.closeGenerics :: syntax.CstToken<">">).text, ">")
 	end)
@@ -935,9 +935,9 @@ test.suite("parse types", function(suite)
 		assert.neq(typeRef.openParameters, nil)
 		assert.eq((typeRef.openParameters :: syntax.CstToken<"<">).text, "<")
 		assert.neq(typeRef.parameters, nil)
-		assert.eq(#typeRef.parameters :: syntax.Punctuated<syntax.CstType>, 2)
-		assert.eq((typeRef.parameters :: syntax.Punctuated<syntax.CstType>)[1].tag, "reference")
-		assert.eq((typeRef.parameters :: syntax.Punctuated<syntax.CstType>)[2].tag, "reference")
+		assert.eq(#typeRef.parameters :: syntax.CstPunctuated<syntax.CstType>, 2)
+		assert.eq((typeRef.parameters :: syntax.CstPunctuated<syntax.CstType>)[1].tag, "reference")
+		assert.eq((typeRef.parameters :: syntax.CstPunctuated<syntax.CstType>)[2].tag, "reference")
 		assert.neq(typeRef.closeParameters, nil)
 		assert.eq((typeRef.closeParameters :: syntax.CstToken<">">).text, ">")
 	end)
@@ -1223,12 +1223,12 @@ test.suite("parse types", function(suite)
 		assert.neq(funcType.openGenerics, nil)
 		assert.eq((funcType.openGenerics :: syntax.CstToken<"<">).text, "<")
 		assert.neq(funcType.generics, nil)
-		assert.eq(#funcType.generics :: syntax.Punctuated<syntax.CstGenericType>, 1)
+		assert.eq(#funcType.generics :: syntax.CstPunctuated<syntax.CstGenericType>, 1)
 		assert.neq(funcType.genericPacks, nil)
-		assert.eq(#funcType.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>, 1)
-		assert.eq((funcType.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>)[1].tag, "generic")
+		assert.eq(#funcType.genericPacks :: syntax.CstPunctuated<syntax.CstGenericTypePack>, 1)
+		assert.eq((funcType.genericPacks :: syntax.CstPunctuated<syntax.CstGenericTypePack>)[1].tag, "generic")
 
-		local genericTypePack = (funcType.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>)[1]
+		local genericTypePack = (funcType.genericPacks :: syntax.CstPunctuated<syntax.CstGenericTypePack>)[1]
 		assert.eq(genericTypePack.name.text, "U")
 		assert.eq(genericTypePack.ellipsis.text, "...")
 
@@ -1952,19 +1952,6 @@ test.suite("CST_nodes_frozen", function(suite)
 		end)
 		assert.throwsWith(frozenTableMessage, function()
 			table.insert((result :: any).lineOffsets, nil)
-		end)
-	end)
-
-	-- Pair type (used in Punctuated)
-	suite:case("pairFrozen", function(assert)
-		local block = parser.parseBlock("local x, y = 1, 2")
-		local localStat = block.statements[1] :: syntax.CstStatLocal
-		local pair = localStat.variables[1]
-		assert.throwsWith(frozenTableMessage, function()
-			(pair :: any).node = nil
-		end)
-		assert.throwsWith(frozenTableMessage, function()
-			(pair :: any).separator = nil
 		end)
 	end)
 

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -105,7 +105,7 @@ test.suite("Parser", function(suite)
 		local firstStmt = block.statements[1]
 		assert.eq(firstStmt.tag, "local")
 
-		local trailingToken: syntax.CstExpr = (firstStmt :: syntax.CstStatLocal).values[1].node
+		local trailingToken: syntax.CstExpr = (firstStmt :: syntax.CstStatLocal).values[1]
 		assert.eq(trailingToken.tag, "string")
 		local expr = trailingToken :: syntax.CstExprConstantString
 		assert.eq(#expr.value.trailingTrivia, 3)
@@ -310,8 +310,8 @@ test.suite("parseExpr", function(suite)
 		assert.eq(callWithArgsExpr.tag, "call")
 		assert.eq(callWithArgsExpr.kind, "expr")
 		assert.eq(#(callWithArgsExpr :: syntax.CstExprCall).arguments, 2)
-		assert.eq((callWithArgsExpr :: syntax.CstExprCall).arguments[1].node.tag, "number")
-		assert.eq((callWithArgsExpr :: syntax.CstExprCall).arguments[2].node.tag, "number")
+		assert.eq((callWithArgsExpr :: syntax.CstExprCall).arguments[1].tag, "number")
+		assert.eq((callWithArgsExpr :: syntax.CstExprCall).arguments[2].tag, "number")
 	end)
 
 	suite:case("parseExprInstantiate", function(assert)
@@ -326,10 +326,10 @@ test.suite("parseExpr", function(suite)
 		assert.eq((instExpr :: syntax.CstExprInstantiate).leftArrow1.text, "<")
 		assert.eq((instExpr :: syntax.CstExprInstantiate).leftArrow2.text, "<")
 		assert.eq(#(instExpr :: syntax.CstExprInstantiate).typeArguments, 2)
-		assert.eq(((instExpr :: syntax.CstExprInstantiate).typeArguments[1].node).kind, "type")
-		assert.eq(((instExpr :: syntax.CstExprInstantiate).typeArguments[1].node).tag, "reference")
-		assert.eq(((instExpr :: syntax.CstExprInstantiate).typeArguments[2].node).kind, "typepack")
-		assert.eq(((instExpr :: syntax.CstExprInstantiate).typeArguments[2].node).tag, "variadic")
+		assert.eq(((instExpr :: syntax.CstExprInstantiate).typeArguments[1]).kind, "type")
+		assert.eq(((instExpr :: syntax.CstExprInstantiate).typeArguments[1]).tag, "reference")
+		assert.eq(((instExpr :: syntax.CstExprInstantiate).typeArguments[2]).kind, "typepack")
+		assert.eq(((instExpr :: syntax.CstExprInstantiate).typeArguments[2]).tag, "variadic")
 		assert.eq((instExpr :: syntax.CstExprInstantiate).rightArrow1.text, ">")
 		assert.eq((instExpr :: syntax.CstExprInstantiate).rightArrow2.text, ">")
 	end)
@@ -368,8 +368,8 @@ test.suite("parseExpr", function(suite)
 		assert.eq(funcExpr.self, nil)
 		assert.eq(funcExpr.openParens.text, "(")
 		assert.eq(#funcExpr.parameters, 2)
-		assert.eq(funcExpr.parameters[1].node.name.text, "a")
-		assert.eq(funcExpr.parameters[2].node.name.text, "b")
+		assert.eq(funcExpr.parameters[1].name.text, "a")
+		assert.eq(funcExpr.parameters[2].name.text, "b")
 		assert.eq(funcExpr.vararg, nil)
 		assert.eq(funcExpr.varargColon, nil)
 		assert.eq(funcExpr.varargAnnotation, nil)
@@ -390,7 +390,7 @@ test.suite("parseExpr", function(suite)
 		assert.neq(funcExpr.generics, nil)
 
 		assert.eq(#funcExpr.generics :: syntax.Punctuated<syntax.CstGenericType>, 1)
-		local gen = (funcExpr.generics :: syntax.Punctuated<syntax.CstGenericType>)[1].node
+		local gen = (funcExpr.generics :: syntax.Punctuated<syntax.CstGenericType>)[1]
 		assert.eq(gen.name.text, "A")
 		assert.eq(gen.equals, nil)
 		assert.eq(gen.default, nil)
@@ -398,7 +398,7 @@ test.suite("parseExpr", function(suite)
 		assert.neq(funcExpr.genericPacks, nil)
 		assert.eq(#funcExpr.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>, 1)
 
-		local genPack = (funcExpr.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>)[1].node
+		local genPack = (funcExpr.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>)[1]
 		assert.eq(genPack.name.text, "B")
 		assert.eq(genPack.ellipsis.text, "...")
 		assert.eq(genPack.equals, nil)
@@ -409,7 +409,7 @@ test.suite("parseExpr", function(suite)
 
 		assert.eq(funcExpr.openParens.text, "(")
 		assert.eq(#funcExpr.parameters, 1)
-		local param = funcExpr.parameters[1].node
+		local param = funcExpr.parameters[1]
 		assert.eq(param.name.text, "a")
 		assert.neq(param.colon, nil)
 		assert.eq((param.colon :: syntax.CstToken<":">).text, ":")
@@ -704,19 +704,19 @@ test.suite("parse", function(suite)
 		assert.eq(l.tag, "local")
 		assert.eq(l.localKeyword.text, "local")
 		assert.eq(#l.variables, 2)
-		assert.eq(l.variables[1].node.name.text, "b")
-		assert.neq(l.variables[1].separator, nil)
-		assert.eq((l.variables[1].separator :: syntax.CstToken<",">).text, ",")
-		assert.eq(l.variables[2].node.name.text, "c")
-		assert.eq(l.variables[2].separator, nil)
+		assert.eq(l.variables[1].name.text, "b")
+		assert.neq(l.variables.separators[1], nil)
+		assert.eq((l.variables.separators[1] :: syntax.CstToken<",">).text, ",")
+		assert.eq(l.variables[2].name.text, "c")
+		assert.eq(l.variables.separators[2], nil)
 		assert.neq(l.equals, nil)
 		assert.eq((l.equals :: syntax.CstToken<"=">).text, "=")
 		assert.eq(#l.values, 2)
-		assert.eq(l.values[1].node.tag, "number")
-		assert.neq(l.values[1].separator, nil)
-		assert.eq((l.values[1].separator :: syntax.CstToken<",">).text, ",")
-		assert.eq(l.values[2].node.tag, "number")
-		assert.eq(l.values[2].separator, nil)
+		assert.eq(l.values[1].tag, "number")
+		assert.neq(l.values.separators[1], nil)
+		assert.eq((l.values.separators[1] :: syntax.CstToken<",">).text, ",")
+		assert.eq(l.values[2].tag, "number")
+		assert.eq(l.values.separators[2], nil)
 
 		block = parser.parseBlock("local x")
 		checkIsBlock(block, assert)
@@ -727,8 +727,8 @@ test.suite("parse", function(suite)
 		assert.eq(l.tag, "local")
 		assert.eq(l.localKeyword.text, "local")
 		assert.eq(#l.variables, 1)
-		assert.eq(l.variables[1].node.name.text, "x")
-		assert.eq(l.variables[1].separator, nil)
+		assert.eq(l.variables[1].name.text, "x")
+		assert.eq(l.variables.separators[1], nil)
 		assert.eq(l.equals, nil)
 		assert.eq(#l.values, 0)
 	end)
@@ -784,11 +784,11 @@ test.suite("parse", function(suite)
 		assert.eq(forInStat.tag, "forin")
 		assert.eq(forInStat.forKeyword.text, "for")
 		assert.eq(#forInStat.variables, 2)
-		assert.eq(forInStat.variables[1].node.name.text, "key")
-		assert.eq(forInStat.variables[2].node.name.text, "value")
+		assert.eq(forInStat.variables[1].name.text, "key")
+		assert.eq(forInStat.variables[2].name.text, "value")
 		assert.eq(forInStat.inKeyword.text, "in")
 		assert.eq(#forInStat.values, 1)
-		assert.eq(forInStat.values[1].node.tag, "global")
+		assert.eq(forInStat.values[1].tag, "global")
 		assert.eq(forInStat.doKeyword.text, "do")
 		checkIsBlock(forInStat.body, assert)
 		assert.eq(#forInStat.body.statements, 1)
@@ -803,10 +803,10 @@ test.suite("parse", function(suite)
 		local assign = block.statements[1] :: syntax.CstStatAssign
 		assert.eq(assign.tag, "assign")
 		assert.eq(#assign.variables, 1)
-		assert.eq(assign.variables[1].node.tag, "global")
+		assert.eq(assign.variables[1].tag, "global")
 		assert.eq(assign.equals.text, "=")
 		assert.eq(#assign.values, 1)
-		assert.eq(assign.values[1].node.tag, "number")
+		assert.eq(assign.values[1].tag, "number")
 	end)
 
 	suite:case("parseStatCompoundAssign", function(assert)
@@ -936,8 +936,8 @@ test.suite("parse types", function(suite)
 		assert.eq((typeRef.openParameters :: syntax.CstToken<"<">).text, "<")
 		assert.neq(typeRef.parameters, nil)
 		assert.eq(#typeRef.parameters :: syntax.Punctuated<syntax.CstType>, 2)
-		assert.eq((typeRef.parameters :: syntax.Punctuated<syntax.CstType>)[1].node.tag, "reference")
-		assert.eq((typeRef.parameters :: syntax.Punctuated<syntax.CstType>)[2].node.tag, "reference")
+		assert.eq((typeRef.parameters :: syntax.Punctuated<syntax.CstType>)[1].tag, "reference")
+		assert.eq((typeRef.parameters :: syntax.Punctuated<syntax.CstType>)[2].tag, "reference")
 		assert.neq(typeRef.closeParameters, nil)
 		assert.eq((typeRef.closeParameters :: syntax.CstToken<">">).text, ">")
 	end)
@@ -1009,9 +1009,9 @@ test.suite("parse types", function(suite)
 		local unionType = typeAlias.type :: syntax.CstTypeUnion
 		assert.eq(unionType.leading, nil)
 		assert.eq(#unionType.types, 3)
-		assert.eq(unionType.types[1].node.tag, "reference")
-		assert.eq(unionType.types[2].node.tag, "reference")
-		assert.eq(unionType.types[3].node.tag, "reference")
+		assert.eq(unionType.types[1].tag, "reference")
+		assert.eq(unionType.types[2].tag, "reference")
+		assert.eq(unionType.types[3].tag, "reference")
 
 		block = parser.parseBlock("type T = | number?")
 		typeAlias = block.statements[1] :: syntax.CstStatTypeAlias
@@ -1021,9 +1021,9 @@ test.suite("parse types", function(suite)
 		assert.neq(unionType.leading, nil)
 		assert.eq((unionType.leading :: syntax.CstToken<"|">).text, "|")
 		assert.eq(#unionType.types, 2)
-		assert.eq(unionType.types[1].node.tag, "reference")
-		assert.eq(unionType.types[2].node.tag, "optional")
-		assert.eq((unionType.types[2].node :: syntax.CstTypeOptional).token.text, "?")
+		assert.eq(unionType.types[1].tag, "reference")
+		assert.eq(unionType.types[2].tag, "optional")
+		assert.eq((unionType.types[2] :: syntax.CstTypeOptional).token.text, "?")
 	end)
 
 	suite:case("testTypeUnionWithOptionalPart", function(assert)
@@ -1035,18 +1035,18 @@ test.suite("parse types", function(suite)
 		assert.eq(unionType.leading, nil)
 		assert.eq(#unionType.types, 3)
 
-		local pair1 = unionType.types[1]
-		assert.eq(pair1.node.tag, "reference")
-		assert.eq(pair1.separator, nil)
+		local node = unionType.types[1]
+		assert.eq(node.tag, "reference")
+		assert.eq(unionType.types.separators[1], nil)
 
-		local pair2 = unionType.types[2]
-		assert.eq(pair2.node.tag, "optional")
-		assert.neq(pair2.separator, nil)
-		assert.eq((pair2.separator :: syntax.CstToken<"|">).text, "|")
+		node = unionType.types[2]
+		assert.eq(node.tag, "optional")
+		assert.neq(unionType.types.separators[2], nil)
+		assert.eq((unionType.types.separators[2] :: syntax.CstToken<"|">).text, "|")
 
-		local pair3 = unionType.types[3]
-		assert.eq(pair3.node.tag, "reference")
-		assert.eq(pair3.separator, nil)
+		local node3 = unionType.types[3]
+		assert.eq(node3.tag, "reference")
+		assert.eq(unionType.types.separators[3], nil)
 	end)
 
 	suite:case("testTypeIntersection", function(assert)
@@ -1057,9 +1057,9 @@ test.suite("parse types", function(suite)
 		local intersectionType = typeAlias.type :: syntax.CstTypeIntersection
 		assert.eq(intersectionType.leading, nil)
 		assert.eq(#intersectionType.types, 3)
-		assert.eq(intersectionType.types[1].node.tag, "reference")
-		assert.eq(intersectionType.types[2].node.tag, "reference")
-		assert.eq(intersectionType.types[3].node.tag, "reference")
+		assert.eq(intersectionType.types[1].tag, "reference")
+		assert.eq(intersectionType.types[2].tag, "reference")
+		assert.eq(intersectionType.types[3].tag, "reference")
 
 		block = parser.parseBlock("type T = & B")
 		typeAlias = block.statements[1] :: syntax.CstStatTypeAlias
@@ -1069,7 +1069,7 @@ test.suite("parse types", function(suite)
 		assert.neq(intersectionType.leading, nil)
 		assert.eq((intersectionType.leading :: syntax.CstToken<"&">).text, "&")
 		assert.eq(#intersectionType.types, 1)
-		assert.eq(intersectionType.types[1].node.tag, "reference")
+		assert.eq(intersectionType.types[1].tag, "reference")
 	end)
 
 	suite:case("testTypeArray", function(assert)
@@ -1198,14 +1198,14 @@ test.suite("parse types", function(suite)
 		assert.eq(funcType.openParens.text, "(")
 		assert.eq(#funcType.parameters, 2)
 
-		local param = funcType.parameters[1].node
+		local param = funcType.parameters[1]
 		assert.neq(param.name, nil)
 		assert.eq((param.name :: syntax.CstToken<string>).text, "n")
 		assert.neq(param.colon, nil)
 		assert.eq((param.colon :: syntax.CstToken<":">).text, ":")
 		assert.eq(param.type.tag, "reference")
 
-		param = funcType.parameters[2].node
+		param = funcType.parameters[2]
 		assert.eq(param.name, nil)
 		assert.eq(param.colon, nil)
 		assert.eq(param.type.tag, "reference")
@@ -1226,9 +1226,9 @@ test.suite("parse types", function(suite)
 		assert.eq(#funcType.generics :: syntax.Punctuated<syntax.CstGenericType>, 1)
 		assert.neq(funcType.genericPacks, nil)
 		assert.eq(#funcType.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>, 1)
-		assert.eq((funcType.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>)[1].node.tag, "generic")
+		assert.eq((funcType.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>)[1].tag, "generic")
 
-		local genericTypePack = (funcType.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>)[1].node
+		local genericTypePack = (funcType.genericPacks :: syntax.Punctuated<syntax.CstGenericTypePack>)[1]
 		assert.eq(genericTypePack.name.text, "U")
 		assert.eq(genericTypePack.ellipsis.text, "...")
 
@@ -1327,7 +1327,7 @@ test.suite("CST_nodes_frozen", function(suite)
 	suite:case("cstExprLocalFrozen", function(assert)
 		local block = parser.parseBlock("local x = 1\nreturn x")
 		local returnStat = block.statements[2] :: syntax.CstStatReturn
-		local expr = returnStat.expressions[1].node
+		local expr = returnStat.expressions[1]
 		assert.eq(expr.kind, "expr")
 		assert.eq(expr.tag, "local")
 		assert.throwsWith(frozenTableMessage, function()
@@ -1768,7 +1768,7 @@ test.suite("CST_nodes_frozen", function(suite)
 		local block = parser.parseBlock("type Foo = string?")
 		local typeAlias = block.statements[1] :: syntax.CstStatTypeAlias
 		local unionType = typeAlias.type :: syntax.CstTypeUnion
-		local optionalType = unionType.types[2].node :: syntax.CstTypeOptional
+		local optionalType = unionType.types[2] :: syntax.CstTypeOptional
 		assert.eq(optionalType.kind, "type")
 		assert.eq(optionalType.tag, "optional")
 		assert.throwsWith(frozenTableMessage, function()
@@ -1848,7 +1848,7 @@ test.suite("CST_nodes_frozen", function(suite)
 			(funcType :: any).returnspecifier = nil
 		end)
 		assert.throwsWith(frozenTableMessage, function()
-			(funcType :: any).parameters[1].node.name = nil
+			(funcType :: any).parameters[1].name = nil
 		end)
 	end)
 
@@ -1880,7 +1880,7 @@ test.suite("CST_nodes_frozen", function(suite)
 	suite:case("cstLocalFrozen", function(assert)
 		local block = parser.parseBlock("local x: number = 1")
 		local localStat = block.statements[1] :: syntax.CstStatLocal
-		local local_ = localStat.variables[1].node
+		local local_ = localStat.variables[1]
 		assert.eq(local_.kind, "local")
 		assert.throwsWith(frozenTableMessage, function()
 			(local_ :: any).name = nil
@@ -1890,7 +1890,7 @@ test.suite("CST_nodes_frozen", function(suite)
 	suite:case("cstGenericTypeFrozen", function(assert)
 		local block = parser.parseBlock("type Foo<T = number> = T")
 		local typeAlias = block.statements[1] :: syntax.CstStatTypeAlias
-		local generic = (typeAlias.generics :: any)[1].node
+		local generic = (typeAlias.generics :: any)[1]
 		assert.eq(generic.tag, "generic")
 		assert.throwsWith(frozenTableMessage, function()
 			generic.name = nil
@@ -1900,7 +1900,7 @@ test.suite("CST_nodes_frozen", function(suite)
 	suite:case("cstGenericTypePackFrozen", function(assert)
 		local block = parser.parseBlock("type Foo<T, U...> = (T, U...) -> ()")
 		local typeAlias = block.statements[1] :: syntax.CstStatTypeAlias
-		local genericPack = (typeAlias.genericPacks :: any)[1].node
+		local genericPack = (typeAlias.genericPacks :: any)[1]
 		assert.eq(genericPack.tag, "generic")
 		assert.eq(genericPack.kind, "typepack")
 		assert.throwsWith(frozenTableMessage, function()

--- a/tests/std/syntax/printer.test.luau
+++ b/tests/std/syntax/printer.test.luau
@@ -70,13 +70,13 @@ test.suite("SyntaxPrinter", function(suite)
 		local expected = [[local name: string = "World"]]
 
 		local stat = syntax.parseBlock("local x: string")
-		local ann = (stat.statements[1] :: syntaxTypes.CstStatLocal).variables[1].node.annotation
+		local ann = (stat.statements[1] :: syntaxTypes.CstStatLocal).variables[1].annotation
 
 		checkReplacement(source, expected, function(cst)
 			return query
 				.findAllFromRoot(cst :: any, syntaxUtils.isStatLocal) -- LUAUFIX: Remove any cast once code too complex no longer emitted
 				:map(function(assign)
-					return assign.variables[1].node.annotation
+					return assign.variables[1].annotation
 				end)
 				:replace(function(_)
 					return printer.printNode(ann :: any) -- LUAUFIX: Remove any cast once code too complex no longer emitted

--- a/tests/std/syntax/query.test.luau
+++ b/tests/std/syntax/query.test.luau
@@ -163,7 +163,7 @@ test.suite("CstQuery", function(suite)
 		local locals = query.findAllFromRoot(cst, utils.isStatLocal):flatMap(function(l)
 			local values = {}
 			for _, v in l.values do
-				table.insert(values, v.node)
+				table.insert(values, v)
 			end
 			return values
 		end)
@@ -181,7 +181,7 @@ test.suite("CstQuery", function(suite)
 		local locals = query.findAllFromRoot(cst, utils.isStatLocal):flatMap(function(l)
 			local values = {}
 			for _, v in l.values do
-				table.insert(values, v.node)
+				table.insert(values, v)
 			end
 			return values
 		end)
@@ -198,7 +198,7 @@ test.suite("CstQuery", function(suite)
 		local locals = query.findAllFromRoot(cst, utils.isStatLocal):flatMap(function(l: syntax.CstStatLocal)
 			local vars = {}
 			for _, v in l.variables do
-				table.insert(vars, v.node)
+				table.insert(vars, v)
 			end
 			return vars
 		end)


### PR DESCRIPTION
As part of the planned refactor to add AST parsing to `@std/syntax` (not just CST parsing), I would like CST nodes to subtype covariantly against AST nodes. That is, any program that deals with ASTs should be able to run even if at runtime it receives a CST instead of an AST. In parallel, I would like `Punctuated` to be more ergonomic to program with when dealing with just an AST. In particular, someone programming an the AST version of `Punctuated` will not interact with `separators`, and neither should they have to index into `nodes` every time they see `Punctuated`. This PR makes these changes to the current version of the `Punctuated`, in advance of adding an AST-specific version.

Specifically, it moves `Punctuated`'s subnodes from an array stored in the `nodes` field to the array entries in `Punctuated` itself, and adds an `__iter` override to support iterating over those nodes. Finally, we also rename `Punctuated` to `CstPunctuated`.