### PR TITLE
Add client tcp stream to `@lute/net`

### DIFF
--- a/definitions/net/client.luau
+++ b/definitions/net/client.luau
@@ -41,4 +41,14 @@ function client.websocket(url: string, options: WebSocketOptions?): WebSocket
 	error("not implemented")
 end
 
+export type TCPStreamHandle = {
+	write: (self: TCPStreamHandle, data: buffer | string) -> (),
+	read: (self: TCPStreamHandle, amount: number?) -> buffer,
+	close: (self: TCPStreamHandle) -> (),
+}
+
+function client.connect(host: string, port: number): TCPStreamHandle
+	error("not implemented")
+end
+
 return client

--- a/definitions/net/client.luau
+++ b/definitions/net/client.luau
@@ -1,4 +1,6 @@
 -- lute-lint-global-ignore(unused_variable)
+local time = require("../time")
+
 local client = {}
 
 --- HTTP request metadata, including optional method, body, and headers.
@@ -43,7 +45,8 @@ end
 
 export type TCPStreamHandle = {
 	write: (self: TCPStreamHandle, data: buffer | string) -> (),
-	read: (self: TCPStreamHandle, amount: number?) -> buffer,
+	read: ((self: TCPStreamHandle, amount: number?, timeout: time.Duration?) -> buffer)
+		& ((self: TCPStreamHandle, timeout: time.Duration) -> buffer),
 	close: (self: TCPStreamHandle) -> (),
 }
 

--- a/definitions/net/client.luau
+++ b/definitions/net/client.luau
@@ -47,11 +47,15 @@ export type TCPStreamHandle = {
 	write: (self: TCPStreamHandle, data: buffer | string) -> (),
 	read: ((self: TCPStreamHandle, amount: number?, timeout: time.Duration?) -> buffer)
 		& ((self: TCPStreamHandle, timeout: time.Duration) -> buffer),
+	handshake: (self: TCPStreamHandle) -> (),
 	close: (self: TCPStreamHandle) -> (),
 }
 
-function client.connect(host: string, port: number): TCPStreamHandle
+client.connect = ((function()
 	error("not implemented")
-end
+end) :: any) :: (
+	((hostname: string, port: number) -> TCPStreamHandle)
+	& (({ hostname: string, port: number, tls: boolean? }) -> TCPStreamHandle)
+)
 
 return client

--- a/lute/net/CMakeLists.txt
+++ b/lute/net/CMakeLists.txt
@@ -17,5 +17,5 @@ target_sources(Lute.Net PRIVATE
 
 target_compile_features(Lute.Net PUBLIC cxx_std_17)
 target_include_directories(Lute.Net PUBLIC "include" ${LIBUV_INCLUDE_DIR} ${UWEBSOCKETS_INCLUDE_DIR})
-target_link_libraries(Lute.Net PRIVATE Lute.Common Lute.Runtime Luau.VM Lute.Time uv_a libcurl uWS zlibstatic)
+target_link_libraries(Lute.Net PRIVATE Lute.Common Lute.Runtime Luau.VM Lute.Time uv_a libcurl uWS zlibstatic ssl crypto)
 target_compile_options(Lute.Net PRIVATE ${LUTE_OPTIONS})

--- a/lute/net/CMakeLists.txt
+++ b/lute/net/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(Lute.Net PRIVATE
     src/net.cpp
     src/system_ca.cpp
     src/system_ca.h
+    src/tcpclient.cpp
     src/wsclient.cpp
     src/wscommon.cpp
     src/wscommon.h

--- a/lute/net/CMakeLists.txt
+++ b/lute/net/CMakeLists.txt
@@ -17,5 +17,5 @@ target_sources(Lute.Net PRIVATE
 
 target_compile_features(Lute.Net PUBLIC cxx_std_17)
 target_include_directories(Lute.Net PUBLIC "include" ${LIBUV_INCLUDE_DIR} ${UWEBSOCKETS_INCLUDE_DIR})
-target_link_libraries(Lute.Net PRIVATE Lute.Common Lute.Runtime Luau.VM uv_a libcurl uWS zlibstatic)
+target_link_libraries(Lute.Net PRIVATE Lute.Common Lute.Runtime Luau.VM Lute.Time uv_a libcurl uWS zlibstatic)
 target_compile_options(Lute.Net PRIVATE ${LUTE_OPTIONS})

--- a/lute/net/src/client.cpp
+++ b/lute/net/src/client.cpp
@@ -13,10 +13,15 @@
 namespace net::client
 {
 struct WebSocketHandle;
+struct TCPStreamHandle;
 int request(lua_State* L);
 int websocket(lua_State* L);
+int connect(lua_State* L);
 int ws_send(lua_State* L);
 int ws_close(lua_State* L);
+int tcp_write(lua_State* L);
+int tcp_read(lua_State* L);
+int tcp_close(lua_State* L);
 } // namespace net::client
 
 namespace
@@ -40,8 +45,7 @@ static CurlHolder& globalCurlInit()
     return holder;
 }
 
-static void initializeNetClient(lua_State* L)
-{
+static void initializeWebSocketHandle(lua_State* L) {
     luaL_newmetatable(L, "WebSocketHandle");
 
     lua_pushcfunction(
@@ -82,6 +86,61 @@ static void initializeNetClient(lua_State* L)
 
     lua_setuserdatametatable(L, kWebSocketHandleTag);
 }
+
+static void initializeTCPStreamHandle(lua_State* L) {
+    luaL_newmetatable(L, "TCPStreamHandle");
+
+    lua_pushcfunction(
+        L,
+        [](lua_State* L)
+        {
+            const char* index = luaL_checkstring(L, -1);
+
+            if (strcmp(index, "write") == 0)
+            {
+                lua_pushcfunction(L, net::client::tcp_write, "TCPStreamHandle.write");
+                return 1;
+            }
+
+            if (strcmp(index, "read") == 0)
+            {
+                lua_pushcfunction(L, net::client::tcp_read, "TCPStreamHandle.read");
+                return 1;
+            }
+
+            if (strcmp(index, "close") == 0)
+            {
+                lua_pushcfunction(L, net::client::tcp_close, "TCPStreamHandle.close");
+                return 1;
+            }
+
+            return 0;
+        },
+        "TCPStreamHandle.__index"
+    );
+    lua_setfield(L, -2, "__index");
+
+    lua_pushstring(L, "TCPStreamHandle");
+    lua_setfield(L, -2, "__type");
+
+    lua_setuserdatadtor(
+        L,
+        kTCPStreamHandleTag,
+        [](lua_State*, void* ud)
+        {
+            std::destroy_at(static_cast<std::shared_ptr<net::client::TCPStreamHandle>*>(ud));
+        }
+    );
+
+    lua_setuserdatametatable(L, kTCPStreamHandleTag);
+}
+
+
+static void initializeNetClient(lua_State* L)
+{
+    initializeWebSocketHandle(L);
+    initializeTCPStreamHandle(L);
+}
 } // namespace
 
 const char* const NetClient::properties[] = {nullptr};
@@ -89,6 +148,7 @@ const char* const NetClient::properties[] = {nullptr};
 const luaL_Reg NetClient::lib[] = {
     {"request", net::client::request},
     {"websocket", net::client::websocket},
+    {"connect", net::client::connect},
     {nullptr, nullptr},
 };
 

--- a/lute/net/src/client.cpp
+++ b/lute/net/src/client.cpp
@@ -21,6 +21,7 @@ int ws_send(lua_State* L);
 int ws_close(lua_State* L);
 int tcp_write(lua_State* L);
 int tcp_read(lua_State* L);
+int tcp_handshake(lua_State* L);
 int tcp_close(lua_State* L);
 } // namespace net::client
 
@@ -111,6 +112,12 @@ static void initializeTCPStreamHandle(lua_State* L) {
             if (strcmp(index, "close") == 0)
             {
                 lua_pushcfunction(L, net::client::tcp_close, "TCPStreamHandle.close");
+                return 1;
+            }
+
+            if (strcmp(index, "handshake") == 0)
+            {
+                lua_pushcfunction(L, net::client::tcp_handshake, "TCPStreamHandle.handshake");
                 return 1;
             }
 

--- a/lute/net/src/system_ca.cpp
+++ b/lute/net/src/system_ca.cpp
@@ -1,5 +1,6 @@
 #include "system_ca.h"
 
+#include "openssl/ssl.h"
 #include "curl/curl.h"
 
 #if defined(__linux__)
@@ -58,6 +59,48 @@ void applySystemCA(CURL* curl)
         curl_easy_setopt(curl, CURLOPT_CAINFO, cafile);
     if (capath)
         curl_easy_setopt(curl, CURLOPT_CAPATH, capath);
+#endif
+}
+
+void applySystemCASSL(void* ctx_)
+{
+    auto ctx = static_cast<SSL_CTX*>(ctx_);
+#if defined(_WIN32)
+    // BoringSSL doesn't implement SSL_CTX_load_verify_store, so we'll have to do it manually
+    HCERTSTORE store = CertOpenSystemStoreW(NULL, L"ROOT");
+    if (!store)
+        return;
+
+    X509_STORE* x509Store = SSL_CTX_get_cert_store(ctx);
+    PCCERT_CONTEXT cert = nullptr;
+
+    while ((cert = CertEnumCertificatesInStore(store, cert)) != nullptr)
+    {
+        const uint8_t* ptr =
+            reinterpret_cast<const uint8_t*>(cert->pbCertEncoded);
+
+        X509* x509 = d2i_X509(
+            nullptr,
+            &ptr,
+            cert->cbCertEncoded);
+
+        if (!x509)
+            continue;
+
+        X509_STORE_add_cert(x509Store, x509);
+        X509_free(x509);
+    }
+
+    CertCloseStore(store, 0);
+#elif defined(__APPLE__)
+    SSL_CTX_load_verify_locations(ctx, "/etc/ssl/cert.pem", nullptr);
+#elif defined(__linux__)
+    static const char* cafile = findPath(kCAFiles, sizeof(kCAFiles) / sizeof(kCAFiles[0]), false);
+    static const char* capath = findPath(kCADirs, sizeof(kCADirs) / sizeof(kCADirs[0]), true);
+    if (cafile)
+        SSL_CTX_load_verify_locations(ctx, cafile, nullptr);
+    if (capath)
+        SSL_CTX_load_verify_locations(ctx, nullptr, capath);
 #endif
 }
 

--- a/lute/net/src/system_ca.h
+++ b/lute/net/src/system_ca.h
@@ -7,5 +7,6 @@ namespace net
 
 // Configures `curl` to use the operating system's trusted CA store.
 void applySystemCA(CURL* curl);
+void applySystemCASSL(void* sslContext);
 
 } // namespace net

--- a/lute/net/src/tcpclient.cpp
+++ b/lute/net/src/tcpclient.cpp
@@ -1,0 +1,288 @@
+#include "lute/runtime.h"
+#include "lute/userdatas.h"
+#include "lute/uvstream.h"
+
+#include "Luau/VecDeque.h"
+
+#include "lua.h"
+#include "lualib.h"
+
+#include "curl/curl.h"
+#include "curl/websockets.h"
+
+#include <atomic>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+#include <optional>
+
+#include "system_ca.h"
+#include "wscommon.h"
+
+namespace net::client
+{
+struct TCPStreamHandle;
+
+struct TCPOptions
+{
+    std::string host;
+    int port;
+};
+
+struct ReadWaiter {
+    ResumeToken token;
+    size_t amount;
+};
+
+struct TCPStreamHandle
+{
+    uv_loop_t *loop;
+    ResumeToken token;
+    TCPOptions options;
+    std::unique_ptr<uvutils::TCPStream> stream;
+    std::vector<ReadWaiter> readWaiters;
+    std::vector<char> readBuffer;
+    bool isActive = false;
+    std::optional<std::string> pendingError;
+
+    TCPStreamHandle(lua_State* L, TCPOptions options)
+        : loop(getRuntimeLoop(L)), token(getResumeToken(L)), options(options)
+    {
+        stream = std::make_unique<uvutils::TCPStream>(loop, "TCPStreamHandle");
+    }
+
+    void beginRead() {
+        stream->read(
+            [this](std::string_view data)
+            {
+                readBuffer.insert(readBuffer.end(), data.begin(), data.end());
+                while (!readWaiters.empty() && (readWaiters.front().amount == SIZE_MAX || readWaiters.front().amount <= readBuffer.size()))
+                {
+                    auto& waiter = readWaiters.front();
+                    auto amount = waiter.amount == SIZE_MAX ? readBuffer.size() : waiter.amount;
+                    std::vector<char> buf(readBuffer.begin(), readBuffer.begin() + amount);
+                    readBuffer.erase(readBuffer.begin(), readBuffer.begin() + amount);
+
+                    waiter.token->complete(
+                        [buf = std::move(buf)](lua_State* L)
+                        {
+                            void* luaData = lua_newbuffer(L, buf.size());
+                            std::memcpy(luaData, buf.data(), buf.size());
+                            return 1;
+                        }
+                    );
+
+                    readWaiters.erase(readWaiters.begin());
+                }
+            },
+            [this](std::optional<std::string> error)
+            {
+                if (error) {
+                    pendingError = error;
+                }
+            }
+        );
+    }
+
+    bool connect()
+    {
+        struct sockaddr_in dest;
+        if (uv_ip4_addr(options.host.c_str(), options.port, &dest) != 0)
+        {
+            token->fail("Invalid IP address or port");
+            return false;
+        }
+
+        uv_connect_t* connectReq = new uv_connect_t;
+        connectReq->data = this;
+
+        isActive = true;
+
+        int result = uv_tcp_connect(connectReq, stream->stream.get(), (const struct sockaddr*)&dest,
+            [](uv_connect_t* req, int status)
+            {
+                auto* handle = static_cast<TCPStreamHandle*>(req->data);
+                delete req;
+
+                if (status < 0)
+                {
+                    std::string error = "Connection failed: " + std::string(uv_strerror(status));
+                    handle->token->fail(error);
+                    return;
+                }
+
+                handle->beginRead();
+
+                handle->token->complete(
+                    [handle](lua_State* L)
+                    {
+                        auto* storage = new (static_cast<std::shared_ptr<TCPStreamHandle>*>(
+                            lua_newuserdatataggedwithmetatable(L, sizeof(std::shared_ptr<TCPStreamHandle>), kTCPStreamHandleTag)
+                        )) std::shared_ptr<TCPStreamHandle>(handle);
+                        (void)storage;
+
+                        return 1;
+                    }
+                );
+            }
+        );
+
+        if (result < 0)
+        {
+            std::string error = "Connection initiation failed: " + std::string(uv_strerror(result));
+            token->fail(error);
+            return false;
+        }
+
+        return true;
+    }
+
+    void close(std::function<void()> onClose = [](){})
+    {
+        if (stream && !stream->closed)
+        {
+            stream->close(
+                [this, onClose]()
+                {
+                    if (!pendingError)
+                        pendingError = "Connection closed";
+
+                    for (auto& waiter : readWaiters)
+                    {
+                        waiter.token->fail(*pendingError);
+                    }
+                    readWaiters.clear();
+
+                    onClose();
+                }
+            );
+        }
+    }
+
+    ~TCPStreamHandle()
+    {
+        close();
+    }
+};
+
+std::shared_ptr<TCPStreamHandle>* getTCPStreamHandle(lua_State* L, int index)
+{
+    return static_cast<std::shared_ptr<TCPStreamHandle>*>(lua_touserdatatagged(L, index, kTCPStreamHandleTag));
+}
+
+int tcp_read(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TUSERDATA);
+    auto* handleStorage = getTCPStreamHandle(L, 1);
+    if (!handleStorage || !(*handleStorage) || (*handleStorage)->pendingError)
+    {
+        std::string error = "";
+        if (handleStorage && *handleStorage && (*handleStorage)->pendingError)
+            error += ": " + (*handleStorage)->pendingError.value();
+        luaL_error(L, "Invalid or closed TCP connection: %s", error.c_str());
+        return 0;
+    }
+
+    TCPStreamHandle* handle = (*handleStorage).get();
+
+    int _amount = luaL_optinteger(L, 2, -1);
+    size_t amount = _amount < 0 ? SIZE_MAX : static_cast<size_t>(_amount);
+    
+    if (amount <= handle->readBuffer.size()) {
+        void* data = lua_newbuffer(L, amount);
+        std::memcpy(data, handle->readBuffer.data(), amount);
+        handle->readBuffer.erase(handle->readBuffer.begin(), handle->readBuffer.begin() + amount);
+        return 1;
+    }
+    else {
+        ResumeToken readToken = getResumeToken(L);
+        handle->readWaiters.push_back({readToken, amount});
+        return lua_yield(L, 0);
+    }
+}
+
+int tcp_write(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TUSERDATA);
+    auto* handleStorage = getTCPStreamHandle(L, 1);
+    if (!handleStorage || !(*handleStorage) || (*handleStorage)->pendingError)
+    {
+        std::string error = "";
+        if (handleStorage && *handleStorage && (*handleStorage)->pendingError)
+            error += ": " + (*handleStorage)->pendingError.value();
+        luaL_error(L, "Invalid or closed TCP connection: %s", error.c_str());
+    }
+
+    size_t dataLen;
+    void* data;
+
+    if (lua_isstring(L, 2))
+    {
+        data = (void*)lua_tolstring(L, 2, &dataLen);
+    }
+    else if (lua_isbuffer(L, 2))
+    {
+        data = luaL_checkbuffer(L, 2, &dataLen);
+    } else {
+        luaL_error(L, "Data must be a string or buffer");
+        return 0;
+    }
+
+    TCPStreamHandle* handle = (*handleStorage).get();
+
+    handle->stream->write(data, dataLen,
+        [token = getResumeToken(L)](std::optional<std::string> error)
+        {
+            if (error)
+                token->fail(*error);
+            else
+                token->complete([](lua_State* L) { return 0; });
+        }
+    );
+
+    return lua_yield(L, 0);
+}
+
+int tcp_close(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TUSERDATA);
+    auto* handleStorage = getTCPStreamHandle(L, 1);
+    if (!handleStorage || !(*handleStorage))
+        luaL_error(L, "Invalid TCP connection");
+    if ((*handleStorage)->stream->closed)
+        luaL_error(L, "TCP connection already closed");
+
+    ResumeToken token = getResumeToken(L);
+
+    (*handleStorage)->close(
+        [token = std::move(token)]()
+        {
+            token->complete([](lua_State* L) { return 0; });
+        }
+    );
+
+    return lua_yield(L, 0);
+}
+
+int connect(lua_State* L)
+{
+    std::string host = luaL_checkstring(L, 1);
+    int port = luaL_optinteger(L, 2, -1);
+    if (port < 0 || port > 65535)
+        luaL_error(L, "Invalid port number");
+    
+    TCPOptions options{std::move(host), port};
+    auto* handle = new TCPStreamHandle(L, options);
+    if (!handle->connect())
+    {
+        delete handle;
+        return 0; // token->fail has already been called with the error
+    }
+    
+    return lua_yield(L, 0);
+}
+} // namespace net::client

--- a/lute/net/src/tcpclient.cpp
+++ b/lute/net/src/tcpclient.cpp
@@ -1,6 +1,7 @@
 #include "lute/runtime.h"
 #include "lute/userdatas.h"
 #include "lute/uvstream.h"
+#include "lute/time.h"
 
 #include "Luau/VecDeque.h"
 
@@ -34,17 +35,43 @@ struct TCPOptions
 };
 
 struct ReadWaiter {
+    std::shared_ptr<TCPStreamHandle> handle;
     ResumeToken token;
     size_t amount;
+    std::optional<uv_timer_t*> timeout;
+    bool invalid = false;
+
+    void stopTimeout() {
+        if (timeout && *timeout) {
+            auto timer = *timeout;
+            timeout = std::nullopt;
+
+            uv_timer_stop(timer);
+            uv_close((uv_handle_t*)timer, [](uv_handle_t* handle) {
+                auto* timer = reinterpret_cast<uv_timer_t*>(handle);
+                auto* waiter_ptr = static_cast<std::shared_ptr<ReadWaiter>*>(timer->data);
+                if (waiter_ptr) {
+                    auto& waiter = *waiter_ptr;
+                    waiter->timeout = std::nullopt;
+                    delete waiter_ptr;
+                }
+                delete timer;
+            });
+        }
+    }
+
+    ~ReadWaiter() {
+        stopTimeout();
+    }
 };
 
-struct TCPStreamHandle
+struct TCPStreamHandle : std::enable_shared_from_this<TCPStreamHandle>
 {
     uv_loop_t *loop;
     ResumeToken token;
     TCPOptions options;
     std::unique_ptr<uvutils::TCPStream> stream;
-    std::vector<ReadWaiter> readWaiters;
+    std::vector<std::shared_ptr<ReadWaiter>> readWaiters;
     std::vector<char> readBuffer;
     bool isActive = false;
     std::optional<std::string> pendingError;
@@ -60,14 +87,26 @@ struct TCPStreamHandle
             [this](std::string_view data)
             {
                 readBuffer.insert(readBuffer.end(), data.begin(), data.end());
-                while (!readWaiters.empty() && (readWaiters.front().amount == SIZE_MAX || readWaiters.front().amount <= readBuffer.size()))
-                {
+                while (!readWaiters.empty()) {
                     auto& waiter = readWaiters.front();
-                    auto amount = waiter.amount == SIZE_MAX ? readBuffer.size() : waiter.amount;
+
+                    if (waiter->invalid) {
+                        // Waiter is invalid, possibly because of timeout handler, just clean up the waiter
+                        readWaiters.erase(readWaiters.begin());
+                        continue;
+                    }
+
+                    if (waiter->amount != SIZE_MAX && waiter->amount > readBuffer.size())
+                        break;
+
+                    waiter->invalid = true;
+                    waiter->stopTimeout();
+
+                    auto amount = waiter->amount == SIZE_MAX ? readBuffer.size() : waiter->amount;
                     std::vector<char> buf(readBuffer.begin(), readBuffer.begin() + amount);
                     readBuffer.erase(readBuffer.begin(), readBuffer.begin() + amount);
 
-                    waiter.token->complete(
+                    waiter->token->complete(
                         [buf = std::move(buf)](lua_State* L)
                         {
                             void* luaData = lua_newbuffer(L, buf.size());
@@ -141,6 +180,27 @@ struct TCPStreamHandle
         return true;
     }
 
+    void startReadTimeout(std::shared_ptr<ReadWaiter> waiter, double timeoutSeconds)
+    {
+        auto timer = new uv_timer_t;
+        waiter->timeout = timer;
+
+        uv_timer_init(loop, timer);
+        timer->data = new (std::shared_ptr<ReadWaiter>)(waiter);
+        uv_timer_start(timer, [](uv_timer_t* handle) {
+            auto* waiter_ptr = static_cast<std::shared_ptr<ReadWaiter>*>(handle->data);
+            auto& waiter = *waiter_ptr;
+            if (waiter->invalid) {
+                waiter->stopTimeout();
+                return;
+            }
+
+            waiter->invalid = true;
+            waiter->token->fail("Read timed out");
+            waiter->stopTimeout();
+        }, static_cast<uint64_t>(timeoutSeconds * 1000), 0);
+    }
+
     void close(std::function<void()> onClose = [](){})
     {
         if (stream && !stream->closed)
@@ -151,15 +211,28 @@ struct TCPStreamHandle
                     if (!pendingError)
                         pendingError = "Connection closed";
 
-                    for (auto& waiter : readWaiters)
-                    {
-                        waiter.token->fail(*pendingError);
+                    for (auto& waiter : readWaiters) {
+                        if (waiter->invalid)
+                            continue;
+                        waiter->token->fail(*pendingError);
                     }
                     readWaiters.clear();
 
                     onClose();
                 }
             );
+        } else {
+            if (!pendingError)
+                pendingError = "Connection closed";
+
+            for (auto& waiter : readWaiters) {
+                if (waiter->invalid)
+                    continue;
+                waiter->token->fail(*pendingError);
+            }
+            readWaiters.clear();
+
+            onClose();
         }
     }
 
@@ -189,7 +262,11 @@ int tcp_read(lua_State* L)
 
     TCPStreamHandle* handle = (*handleStorage).get();
 
-    int _amount = luaL_optinteger(L, 2, -1);
+    // A nil amount means to read everything currently in the buffer
+    int _amount = -1;
+    if (lua_isnumber(L, 2)) {
+        _amount = lua_tointeger(L, 2);
+    }
     size_t amount = _amount < 0 ? SIZE_MAX : static_cast<size_t>(_amount);
     
     if (amount <= handle->readBuffer.size()) {
@@ -199,8 +276,31 @@ int tcp_read(lua_State* L)
         return 1;
     }
     else {
-        ResumeToken readToken = getResumeToken(L);
-        handle->readWaiters.push_back({readToken, amount});
+        // There's not enough data in the buffer, we need to wait for more data to arrive
+        double timeoutSeconds = -1;
+        if (_amount < 0 && lua_isuserdata(L, 2)) {
+            // Didn't read a number at index 2, but there is a userdata, which must be the duration
+            timeoutSeconds = getSecondsFromTimespec(getTimespecFromDuration(L, 2));
+        } else if (lua_isuserdata(L, 3)) {
+            timeoutSeconds = getSecondsFromTimespec(getTimespecFromDuration(L, 3));
+        }
+
+        if (timeoutSeconds == 0) {
+            luaL_error(L, "Read timed out");
+            return 0;
+        }
+
+        std::shared_ptr<ReadWaiter> waiter = std::make_shared<ReadWaiter>();
+        waiter->token = getResumeToken(L);
+        waiter->amount = amount;
+
+        if (timeoutSeconds > 0) {
+            auto duration = getTimespecFromDuration(L, 3);
+            auto seconds = getSecondsFromTimespec(duration);
+            handle->startReadTimeout(waiter, seconds);
+        }
+
+        handle->readWaiters.push_back(waiter);
         return lua_yield(L, 0);
     }
 }

--- a/lute/net/src/tcpclient.cpp
+++ b/lute/net/src/tcpclient.cpp
@@ -1,3 +1,9 @@
+
+#include "system_ca.h"
+#include "openssl/ssl.h"
+#include "openssl/bio.h"
+#include "openssl/err.h"
+
 #include "lute/runtime.h"
 #include "lute/userdatas.h"
 #include "lute/uvstream.h"
@@ -7,9 +13,6 @@
 
 #include "lua.h"
 #include "lualib.h"
-
-#include "curl/curl.h"
-#include "curl/websockets.h"
 
 #include <atomic>
 #include <cstring>
@@ -21,102 +24,188 @@
 #include <vector>
 #include <optional>
 
-#include "system_ca.h"
-#include "wscommon.h"
-
 namespace net::client
 {
 struct TCPStreamHandle;
+
+enum TCPHostnameType
+{
+    TCPHostnameType_IPv4,
+    TCPHostnameType_IPv6,
+    TCPHostnameType_Domain
+};
+
+static TCPHostnameType getHostnameType(const std::string& hostname) {
+    if (hostname.find(':') != std::string::npos)
+        return TCPHostnameType_IPv6;
+
+    if (hostname.find_first_not_of("0123456789.") == std::string::npos)
+        return TCPHostnameType_IPv4;
+
+    return TCPHostnameType_Domain;
+}
 
 struct TCPOptions
 {
     std::string host;
     int port;
+    bool tls = false;
 };
 
-struct ReadWaiter {
+struct TCPWaiter : std::enable_shared_from_this<TCPWaiter> {
     std::shared_ptr<TCPStreamHandle> handle;
     ResumeToken token;
-    size_t amount;
     std::optional<uv_timer_t*> timeout;
     bool invalid = false;
 
-    void stopTimeout() {
-        if (timeout && *timeout) {
-            auto timer = *timeout;
-            timeout = std::nullopt;
+    virtual std::string getTimeoutErrorMessage() const {
+        return "Operation timed out";
+    }
 
-            uv_timer_stop(timer);
-            uv_close((uv_handle_t*)timer, [](uv_handle_t* handle) {
-                auto* timer = reinterpret_cast<uv_timer_t*>(handle);
-                auto* waiter_ptr = static_cast<std::shared_ptr<ReadWaiter>*>(timer->data);
-                if (waiter_ptr) {
-                    auto& waiter = *waiter_ptr;
-                    waiter->timeout = std::nullopt;
-                    delete waiter_ptr;
-                }
-                delete timer;
-            });
+    TCPWaiter(std::shared_ptr<TCPStreamHandle> handle, ResumeToken token, std::optional<uv_timer_t*> timeout = std::nullopt)
+        : handle(std::move(handle)), token(std::move(token)), timeout(timeout)
+    { }
+
+    void addTimeout(double timeoutSeconds);
+    void complete(std::function<int(lua_State*)> cont);
+    void fail(std::string error);
+    void stopTimeout();
+
+    virtual ~TCPWaiter() {
+        stopTimeout();
+    }
+};
+
+struct TCPReadWaiter : TCPWaiter {
+    size_t amount;
+
+    virtual std::string getTimeoutErrorMessage() const override {
+        return "Read timed out";
+    }
+
+    TCPReadWaiter(std::shared_ptr<TCPStreamHandle> handle, ResumeToken token, size_t amount)
+        : TCPWaiter(std::move(handle), std::move(token)), amount(amount)
+    { }
+};
+
+struct TCPConnectWaiter : TCPWaiter {
+    using TCPWaiter::TCPWaiter;
+};
+struct TCPHandshakeWaiter : TCPConnectWaiter {
+    using TCPConnectWaiter::TCPConnectWaiter;
+};
+
+struct TCPCloseWaiter : TCPWaiter {
+    using TCPWaiter::TCPWaiter;
+};
+
+struct TCPStreamSSLContext
+{
+    SSL* ssl = nullptr;
+    BIO* networkIn = nullptr;
+    BIO* networkOut = nullptr;
+    bool handshakeCompleted = false;
+
+    TCPStreamSSLContext(std::string_view host) {
+        SSL_CTX* ctx = getSSLContext();
+        ssl = SSL_new(ctx);
+        if (!ssl) {
+            throw std::runtime_error("Failed to create SSL object");
+        }
+
+        if (!SSL_set_tlsext_host_name(ssl, host.data())) {
+            SSL_free(ssl);
+            throw std::runtime_error("Failed to set TLS host name");
+        }
+
+        if (!SSL_set1_host(ssl, host.data())) {
+            SSL_free(ssl);
+            throw std::runtime_error("Failed to set SNI host name");
+        }
+
+        networkIn = BIO_new(BIO_s_mem());
+        networkOut = BIO_new(BIO_s_mem());
+        if (!networkIn || !networkOut) {
+            if (networkIn) BIO_free(networkIn);
+            if (networkOut) BIO_free(networkOut);
+            SSL_free(ssl);
+            throw std::runtime_error("Failed to create BIO objects");
+        }
+
+        SSL_set_bio(ssl, networkIn, networkOut);
+        SSL_set_connect_state(ssl);
+    }
+
+    ~TCPStreamSSLContext() {
+        if (ssl) {
+            SSL_free(ssl);
         }
     }
 
-    ~ReadWaiter() {
-        stopTimeout();
+private:
+    static SSL_CTX* getSSLContext() {
+        static SSL_CTX* ctx = []() -> SSL_CTX* {
+            SSL_CTX* ctx = SSL_CTX_new(TLS_client_method());
+            if (!ctx) {
+                throw std::runtime_error("Failed to create SSL_CTX");
+            }
+
+            SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+            SSL_CTX_set_read_ahead(ctx, 1);
+
+            applySystemCASSL(ctx);
+
+            // if (!SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION)) {
+            //     SSL_CTX_free(ctx);
+            //     throw std::runtime_error("Failed to set minimum protocol version for SSL_CTX");
+            // }
+            return ctx;
+        }();
+
+        return ctx;
     }
 };
 
 struct TCPStreamHandle : std::enable_shared_from_this<TCPStreamHandle>
 {
     uv_loop_t *loop;
-    ResumeToken token;
     TCPOptions options;
     std::unique_ptr<uvutils::TCPStream> stream;
-    std::vector<std::shared_ptr<ReadWaiter>> readWaiters;
+    std::vector<std::shared_ptr<TCPWaiter>> waiters;
     std::vector<char> readBuffer;
-    bool isActive = false;
+    std::optional<TCPStreamSSLContext> sslContext;
     std::optional<std::string> pendingError;
+    bool isActive = false;
+    std::shared_ptr<TCPStreamHandle> self;
 
-    TCPStreamHandle(lua_State* L, TCPOptions options)
-        : loop(getRuntimeLoop(L)), token(getResumeToken(L)), options(options)
-    {
-        stream = std::make_unique<uvutils::TCPStream>(loop, "TCPStreamHandle");
+    TCPStreamHandle(uv_loop_t *loop, TCPOptions options)
+        : loop(loop), options(options)
+    { }
+
+    void createSSLContext() {
+        if (sslContext)
+            return;
+
+        try {
+            sslContext.emplace(options.host);
+        } catch (const std::exception& ex) {
+            tokenFail(std::string("Failed to create SSL context: ") + ex.what());
+        }
     }
 
     void beginRead() {
         stream->read(
             [this](std::string_view data)
             {
-                readBuffer.insert(readBuffer.end(), data.begin(), data.end());
-                while (!readWaiters.empty()) {
-                    auto& waiter = readWaiters.front();
-
-                    if (waiter->invalid) {
-                        // Waiter is invalid, possibly because of timeout handler, just clean up the waiter
-                        readWaiters.erase(readWaiters.begin());
-                        continue;
-                    }
-
-                    if (waiter->amount != SIZE_MAX && waiter->amount > readBuffer.size())
-                        break;
-
-                    waiter->invalid = true;
-                    waiter->stopTimeout();
-
-                    auto amount = waiter->amount == SIZE_MAX ? readBuffer.size() : waiter->amount;
-                    std::vector<char> buf(readBuffer.begin(), readBuffer.begin() + amount);
-                    readBuffer.erase(readBuffer.begin(), readBuffer.begin() + amount);
-
-                    waiter->token->complete(
-                        [buf = std::move(buf)](lua_State* L)
-                        {
-                            void* luaData = lua_newbuffer(L, buf.size());
-                            std::memcpy(luaData, buf.data(), buf.size());
-                            return 1;
-                        }
-                    );
-
-                    readWaiters.erase(readWaiters.begin());
+                if (sslContext) {
+                    // Write to BIO so that OpenSSL can process the data
+                    BIO_write(sslContext->networkIn, data.data(), static_cast<int>(data.size()));
+                    readFromSSL();
+                } else {
+                    readBuffer.insert(readBuffer.end(), data.begin(), data.end());
                 }
+                
+                handleReadAwaiters();
             },
             [this](std::optional<std::string> error)
             {
@@ -127,120 +216,490 @@ struct TCPStreamHandle : std::enable_shared_from_this<TCPStreamHandle>
         );
     }
 
-    bool connect()
-    {
-        struct sockaddr_in dest;
-        if (uv_ip4_addr(options.host.c_str(), options.port, &dest) != 0)
-        {
-            token->fail("Invalid IP address or port");
-            return false;
+    template<typename T = TCPWaiter>
+    void iterateWaiters(std::function<bool(std::shared_ptr<T>& waiter)> callback) {
+        auto it = waiters.begin();
+        while (!waiters.empty() && it != waiters.end()) {
+            auto& waiter = *it;
+            if (waiter->invalid) {
+                it = waiters.erase(it);
+                continue;
+            }
+
+            auto typedWaiter = std::dynamic_pointer_cast<T>(waiter);
+            if (typedWaiter) {
+                bool result = callback(typedWaiter);
+                if (!result) {
+                    break;
+                }
+                it = waiters.erase(it);
+            } else {
+                ++it;
+            }
         }
 
-        uv_connect_t* connectReq = new uv_connect_t;
-        connectReq->data = this;
+    }
 
-        isActive = true;
+    void handleReadAwaiters() {
+        iterateWaiters<TCPReadWaiter>(
+            [this](std::shared_ptr<TCPReadWaiter>& waiter) {
+                if (waiter->amount != SIZE_MAX && waiter->amount > readBuffer.size())
+                    return false;
+
+                auto amount = waiter->amount == SIZE_MAX ? readBuffer.size() : waiter->amount;
+                std::vector<char> buf(readBuffer.begin(), readBuffer.begin() + amount);
+                readBuffer.erase(readBuffer.begin(), readBuffer.begin() + amount);
+
+                waiter->complete(
+                    [buf = std::move(buf)](lua_State* L)
+                    {
+                        void* luaData = lua_newbuffer(L, buf.size());
+                        std::memcpy(luaData, buf.data(), buf.size());
+                        return 1;
+                    }
+                );
+
+                return true;
+            }
+        );
+    }
+
+    int handleSSLError(const std::string& context, int ret) {
+        if (!sslContext)
+            return -1;
+        
+        int err = SSL_get_error(sslContext->ssl, ret);
+        switch (err) {
+            case SSL_ERROR_NONE:
+            case SSL_ERROR_WANT_READ:
+            case SSL_ERROR_WANT_WRITE:
+                return 1;
+            case SSL_ERROR_ZERO_RETURN:
+                pendingError = "Connection closed by peer";
+                closeTransport();
+                return 0;
+            case SSL_ERROR_SYSCALL:
+                tokenFail(context + ": SSL syscall error: " + std::string(strerror(errno)));
+                closeTransport();
+                return -1;
+            case SSL_ERROR_SSL:
+            {
+                std::string error = context + ": SSL error code - ";
+                char buf[ERR_ERROR_STRING_BUF_LEN];
+                auto sslErr = ERR_get_error();
+                while (sslErr != 0) {
+                    ERR_error_string_n(sslErr, buf, ERR_ERROR_STRING_BUF_LEN);
+                    error += buf;
+                    error += "; ";
+                    sslErr = ERR_get_error();
+                }
+                tokenFail(error);
+                closeTransport();
+                return -1;
+            }
+            default:
+                return -1;
+        }
+    }
+
+    void readFromSSL() {
+        if (!sslContext)
+            return;
+
+        if (!sslContext->handshakeCompleted) {
+            int ret = SSL_do_handshake(sslContext->ssl);
+            flushSSL();
+            if (ret == 1) {
+                sslContext->handshakeCompleted = true;
+                tokenComplete();
+            } else {
+                handleSSLError("Error during SSL handshake", ret);
+                return;
+            }
+        }
+
+        // Read plain text data from SSL and store it in the read buffer
+        char buf[4096];
+        while (true) {
+            int bytesRead = SSL_read(sslContext->ssl, buf, sizeof(buf));
+            flushSSL();
+            if (bytesRead > 0) {
+                readBuffer.insert(readBuffer.end(), buf, buf + bytesRead);
+            } else if (bytesRead == 0) {
+                // Connection was closed cleanly
+                pendingError = "Connection closed by peer";
+                closeTransport();
+                break;
+            } else {
+                handleSSLError("Error reading from SSL", bytesRead);
+                break;
+            }
+        }
+    }
+
+    void flushSSL(uvutils::OnStreamEnd callback = nullptr) {
+        if (!sslContext)
+            return;
+
+        int amount = BIO_pending(sslContext->networkOut);
+        if (amount <= 0) {
+            if (callback)
+                callback(std::nullopt);
+            return;
+        }
+
+        char* data = new char[amount];
+        int bytesRead = BIO_read(sslContext->networkOut, data, amount);
+        if (bytesRead <= 0) {
+            delete[] data;
+            handleSSLError("Error reading from SSL network BIO", bytesRead);
+            callback(pendingError);
+            return;
+        }
+
+        stream->write(data, static_cast<size_t>(bytesRead), [this, data, callback](std::optional<std::string> error) {
+            delete[] data;
+
+            if (error) {
+                pendingError = error;
+                closeTransport();
+            }
+
+            if (callback) {
+                callback(error);
+            }
+        });
+    }
+
+    
+    void tokenFail(std::string error) {
+        iterateWaiters<TCPWaiter>(
+            [&error](std::shared_ptr<TCPWaiter>& waiter) {
+                waiter->fail(error);
+                return true;
+            });
+        pendingError = error;
+    }
+        
+    int createUserData(lua_State* L) {
+        auto* storage = new (static_cast<std::shared_ptr<TCPStreamHandle>*>(
+            lua_newuserdatataggedwithmetatable(L, sizeof(std::shared_ptr<TCPStreamHandle>), kTCPStreamHandleTag)
+        )) std::shared_ptr<TCPStreamHandle>(shared_from_this());
+        (void)storage;
+
+        this->self.reset();
+
+        return 1;
+    }
+
+    void tokenComplete() {
+        iterateWaiters<TCPConnectWaiter>(
+            [this](std::shared_ptr<TCPConnectWaiter>& waiter) {
+                waiter->complete(
+                    [this, waiter = std::shared_ptr<TCPConnectWaiter>(waiter)](lua_State* L) {
+                        // Only create user data for the original connect waiter, not handshake
+                        if (dynamic_cast<TCPHandshakeWaiter*>(waiter.get()) == nullptr) {
+                            return createUserData(L);
+                        }
+                        return 0;
+                    }
+                );
+                return true;
+            }
+        );
+    }
+
+    int connect(lua_State* L)
+    {
+        if (options.tls) {
+            createSSLContext();
+            if (!sslContext) {
+                luaL_error(L, "Failed to create SSL context for TCP connection");
+                return 0;
+            }
+        }
+
+        struct sockaddr dest;
+        switch (getHostnameType(options.host)) {
+            case TCPHostnameType_IPv4:
+                if (uv_ip4_addr(options.host.c_str(), options.port, (sockaddr_in*)&dest) != 0) {
+                    luaL_error(L, "Invalid IPv4 address or port");
+                    return 0;
+                }
+                break;
+            case TCPHostnameType_IPv6:
+            {
+                if (uv_ip6_addr(options.host.c_str(), options.port, (sockaddr_in6*)&dest) != 0) {
+                    luaL_error(L, "Invalid IPv6 address or port");
+                    return 0;
+                }
+                break;
+            }
+            case TCPHostnameType_Domain:
+            {
+                uv_getaddrinfo_t resolver;
+                // No callback is specified because we want it to run synchronously
+                int ret = uv_getaddrinfo(loop, &resolver, nullptr, options.host.c_str(), std::to_string(options.port).c_str(), nullptr);
+                if (ret != 0) {
+                    luaL_error(L, "Failed to resolve hostname: %s", uv_strerror(ret));
+                    return 0;
+                }
+                if (resolver.addrinfo == nullptr) {
+                    luaL_error(L, "Hostname resolution did not return any addresses");
+                    return 0;
+                }
+                std::memcpy(&dest, resolver.addrinfo->ai_addr, resolver.addrinfo->ai_addrlen);
+                uv_freeaddrinfo(resolver.addrinfo);
+                break;
+            }
+        }
+
+        this->self = shared_from_this();
+
+        stream = std::make_unique<uvutils::TCPStream>(loop, "TCPStreamHandle");
+        waiters.emplace_back(std::make_shared<TCPConnectWaiter>(shared_from_this(), getResumeToken(L)));
+
+        uv_connect_t* connectReq = new uv_connect_t;
+        connectReq->data = new (std::shared_ptr<TCPStreamHandle>)(shared_from_this());
 
         int result = uv_tcp_connect(connectReq, stream->stream.get(), (const struct sockaddr*)&dest,
             [](uv_connect_t* req, int status)
             {
-                auto* handle = static_cast<TCPStreamHandle*>(req->data);
+                auto* _handle = static_cast<std::shared_ptr<TCPStreamHandle>*>(req->data);
+                auto handle = *_handle;
+                delete _handle;
                 delete req;
 
                 if (status < 0)
                 {
                     std::string error = "Connection failed: " + std::string(uv_strerror(status));
-                    handle->token->fail(error);
+                    handle->tokenFail(error);
                     return;
                 }
 
+                handle->isActive = true;
                 handle->beginRead();
 
-                handle->token->complete(
-                    [handle](lua_State* L)
-                    {
-                        auto* storage = new (static_cast<std::shared_ptr<TCPStreamHandle>*>(
-                            lua_newuserdatataggedwithmetatable(L, sizeof(std::shared_ptr<TCPStreamHandle>), kTCPStreamHandleTag)
-                        )) std::shared_ptr<TCPStreamHandle>(handle);
-                        (void)storage;
-
-                        return 1;
-                    }
-                );
+                if (handle->options.tls) {
+                    // Wait until the handshake is complete
+                    handle->readFromSSL();
+                } else {
+                    handle->tokenComplete();
+                }
             }
         );
 
-        if (result < 0)
-        {
-            std::string error = "Connection initiation failed: " + std::string(uv_strerror(result));
-            token->fail(error);
-            return false;
+        if (result < 0) {
+            tokenFail("Connection initiation failed: " + std::string(uv_strerror(result)));
         }
 
-        return true;
+        return lua_yield(L, 0);
     }
 
-    void startReadTimeout(std::shared_ptr<ReadWaiter> waiter, double timeoutSeconds)
-    {
-        auto timer = new uv_timer_t;
-        waiter->timeout = timer;
+    int read(lua_State* L, size_t amount, double timeoutSeconds = -1) {
+        // Allow reads to the connection even if the stream is closed, as long as there is enough data in the buffer.
+        if (amount <= readBuffer.size()) {
+            void* data = lua_newbuffer(L, amount);
+            std::memcpy(data, readBuffer.data(), amount);
+            readBuffer.erase(readBuffer.begin(), readBuffer.begin() + amount);
+            return 1;
+        }
+        else {
+            if (pendingError) {
+                luaL_error(L, "TCP connection error: %s", pendingError->c_str());
+                return 0;
+            }
 
-        uv_timer_init(loop, timer);
-        timer->data = new (std::shared_ptr<ReadWaiter>)(waiter);
-        uv_timer_start(timer, [](uv_timer_t* handle) {
-            auto* waiter_ptr = static_cast<std::shared_ptr<ReadWaiter>*>(handle->data);
-            auto& waiter = *waiter_ptr;
-            if (waiter->invalid) {
-                waiter->stopTimeout();
+            if (!stream || stream->isClosed() || !isActive) {
+                luaL_error(L, "TCP connection is closed");
+                return 0;
+            }
+
+            if (timeoutSeconds == 0) {
+                luaL_error(L, "Read timed out");
+                return 0;
+            }
+            auto readWaiter = std::make_shared<TCPReadWaiter>(shared_from_this(), getResumeToken(L), amount);
+            readWaiter->addTimeout(timeoutSeconds);
+            waiters.emplace_back(std::move(readWaiter));
+
+            return lua_yield(L, 0);
+        }
+    }
+
+    int write(lua_State* L, void* data, size_t dataLen) {
+        if (pendingError) {
+            luaL_error(L, "TCP connection error: %s", pendingError->c_str());
+            return 0;
+        }
+
+        if (!stream || stream->isClosed() || !isActive) {
+            luaL_error(L, "TCP connection is closed");
+            return 0;
+        }
+
+        auto token = getResumeToken(L);
+        std::function<void(std::optional<std::string>)> callback = [this, token](std::optional<std::string> error) {
+            if (error) {
+                token->fail("Failed to write to stream: " + *error);
+                closeTransport();
+            }
+            else {
+                token->complete([](lua_State* L) {
+                    return 0;
+                });
+            }
+        };
+
+        if (sslContext) {
+            int bytesWritten = SSL_write(sslContext->ssl, data, static_cast<int>(dataLen));
+            flushSSL();
+            if (bytesWritten <= 0 && handleSSLError("Error writing to SSL", bytesWritten) < 0) {
+                token->fail("Failed to write to SSL stream: " + (pendingError ? *pendingError : "Unknown error"));
+                closeTransport();
+                return lua_yield(L, 0);
+            }
+            flushSSL(callback);
+            return lua_yield(L, 0);
+        } else {
+            stream->write(data, dataLen, callback);
+            return lua_yield(L, 0);
+        }
+    }
+
+    int close(lua_State* L) {
+        if (pendingError) {
+            luaL_error(L, "TCP connection error: %s", pendingError->c_str());
+            return 0;
+        }
+
+        if (!stream || stream->isClosed() || !isActive) {
+            luaL_error(L, "TCP connection is already closed");
+            return 0;
+        }
+
+        if (sslContext) {
+            int ret = SSL_shutdown(sslContext->ssl);
+            if (ret == 0) {
+                if (handleSSLError("Error during SSL shutdown", ret) < 0) {
+                    luaL_error(L, "%s", pendingError->c_str());
+                    return 0;
+                }
+            }
+        }
+
+        waiters.emplace_back(std::make_shared<TCPCloseWaiter>(
+            shared_from_this(),
+            getResumeToken(L)
+        ));
+
+        closeTransport();
+        return lua_yield(L, 0);
+    }
+
+    void closeTransport() {
+        isActive = false;
+        if (stream && !stream->closed) {
+            if (waiters.empty()) {
+                // If we do the other logic in the destructor, we might get a crash, because this is gone by the time stream is closed
+                stream->close([]() {});
+            } else {
+                stream->close([this]() {
+                    iterateWaiters<TCPCloseWaiter>(
+                        [](std::shared_ptr<TCPCloseWaiter>& waiter) {
+                            waiter->complete([](lua_State* L) { return 0; } );
+                            return true;
+                        });
+                    closeTransport();
+                    this->self.reset();
+                });
                 return;
             }
-
-            waiter->invalid = true;
-            waiter->token->fail("Read timed out");
-            waiter->stopTimeout();
-        }, static_cast<uint64_t>(timeoutSeconds * 1000), 0);
-    }
-
-    void close(std::function<void()> onClose = [](){})
-    {
-        if (stream && !stream->closed)
-        {
-            stream->close(
-                [this, onClose]()
-                {
-                    if (!pendingError)
-                        pendingError = "Connection closed";
-
-                    for (auto& waiter : readWaiters) {
-                        if (waiter->invalid)
-                            continue;
-                        waiter->token->fail(*pendingError);
-                    }
-                    readWaiters.clear();
-
-                    onClose();
-                }
-            );
-        } else {
-            if (!pendingError)
-                pendingError = "Connection closed";
-
-            for (auto& waiter : readWaiters) {
-                if (waiter->invalid)
-                    continue;
-                waiter->token->fail(*pendingError);
-            }
-            readWaiters.clear();
-
-            onClose();
         }
+
+        if (!pendingError)
+            pendingError = "Connection closed";
+
+        iterateWaiters<TCPWaiter>(
+            [this](std::shared_ptr<TCPWaiter>& waiter) {
+                waiter->fail(*pendingError);
+                return true;
+            }
+        );
+        waiters.clear();
     }
 
     ~TCPStreamHandle()
     {
-        close();
+        closeTransport();
     }
 };
+
+void TCPWaiter::addTimeout(double timeoutSeconds) {
+    if (timeoutSeconds > 0) {
+        auto timer = new uv_timer_t;
+        timer->data = new (std::shared_ptr<TCPWaiter>)(this->shared_from_this());
+        uv_timer_init(this->handle->loop, timer);
+        uv_timer_start(timer, [](uv_timer_t* timer) {
+            if (timer->data) {
+                auto waiter_ptr = static_cast<std::shared_ptr<TCPWaiter>*>(timer->data);
+                auto& waiter = *waiter_ptr;
+                waiter->timeout = std::nullopt;
+                waiter->fail(waiter->getTimeoutErrorMessage());
+            } else {
+                uv_timer_stop(timer);
+                uv_close((uv_handle_t*)timer, [](uv_handle_t* handle) {
+                    auto* timer = reinterpret_cast<uv_timer_t*>(handle);
+                    delete timer;
+                });
+            }
+        }, static_cast<uint64_t>(timeoutSeconds * 1000), 0);
+        this->timeout = timer;
+    }
+}
+
+void TCPWaiter::complete(std::function<int(lua_State*)> cont) {
+    if (invalid)
+        return;
+
+    auto tokenCopy = token;
+    invalid = true;
+    stopTimeout();
+
+    tokenCopy->complete(std::move(cont));
+}
+
+void TCPWaiter::fail(std::string error) {
+    if (invalid)
+        return;
+
+    auto tokenCopy = token;
+    invalid = true;
+    stopTimeout();
+
+    tokenCopy->fail(std::move(error));
+}
+
+void TCPWaiter::stopTimeout()
+{
+    if (timeout && *timeout) {
+        auto timer = *timeout;
+        timeout = std::nullopt;
+
+        auto waiter_ptr = static_cast<std::shared_ptr<TCPWaiter>*>(timer->data);
+        if (waiter_ptr) {
+            auto& waiter = *waiter_ptr;
+            waiter->timeout = std::nullopt;
+            delete waiter_ptr;
+        }
+
+        uv_timer_stop(timer);
+        uv_close((uv_handle_t*)timer, [](uv_handle_t* handle) {
+            auto* timer = reinterpret_cast<uv_timer_t*>(handle);
+            delete timer;
+        });
+    }
+}
 
 std::shared_ptr<TCPStreamHandle>* getTCPStreamHandle(lua_State* L, int index)
 {
@@ -269,40 +728,15 @@ int tcp_read(lua_State* L)
     }
     size_t amount = _amount < 0 ? SIZE_MAX : static_cast<size_t>(_amount);
     
-    if (amount <= handle->readBuffer.size()) {
-        void* data = lua_newbuffer(L, amount);
-        std::memcpy(data, handle->readBuffer.data(), amount);
-        handle->readBuffer.erase(handle->readBuffer.begin(), handle->readBuffer.begin() + amount);
-        return 1;
+    double timeoutSeconds = -1;
+    if (_amount < 0 && lua_isuserdata(L, 2)) {
+        // Didn't read a number at index 2, but there is a userdata, which must be the duration
+        timeoutSeconds = getSecondsFromTimespec(getTimespecFromDuration(L, 2));
+    } else if (lua_isuserdata(L, 3)) {
+        timeoutSeconds = getSecondsFromTimespec(getTimespecFromDuration(L, 3));
     }
-    else {
-        // There's not enough data in the buffer, we need to wait for more data to arrive
-        double timeoutSeconds = -1;
-        if (_amount < 0 && lua_isuserdata(L, 2)) {
-            // Didn't read a number at index 2, but there is a userdata, which must be the duration
-            timeoutSeconds = getSecondsFromTimespec(getTimespecFromDuration(L, 2));
-        } else if (lua_isuserdata(L, 3)) {
-            timeoutSeconds = getSecondsFromTimespec(getTimespecFromDuration(L, 3));
-        }
 
-        if (timeoutSeconds == 0) {
-            luaL_error(L, "Read timed out");
-            return 0;
-        }
-
-        std::shared_ptr<ReadWaiter> waiter = std::make_shared<ReadWaiter>();
-        waiter->token = getResumeToken(L);
-        waiter->amount = amount;
-
-        if (timeoutSeconds > 0) {
-            auto duration = getTimespecFromDuration(L, 3);
-            auto seconds = getSecondsFromTimespec(duration);
-            handle->startReadTimeout(waiter, seconds);
-        }
-
-        handle->readWaiters.push_back(waiter);
-        return lua_yield(L, 0);
-    }
+    return handle->read(L, amount, timeoutSeconds);
 }
 
 int tcp_write(lua_State* L)
@@ -333,18 +767,7 @@ int tcp_write(lua_State* L)
     }
 
     TCPStreamHandle* handle = (*handleStorage).get();
-
-    handle->stream->write(data, dataLen,
-        [token = getResumeToken(L)](std::optional<std::string> error)
-        {
-            if (error)
-                token->fail(*error);
-            else
-                token->complete([](lua_State* L) { return 0; });
-        }
-    );
-
-    return lua_yield(L, 0);
+    return handle->write(L, data, dataLen);
 }
 
 int tcp_close(lua_State* L)
@@ -356,33 +779,75 @@ int tcp_close(lua_State* L)
     if ((*handleStorage)->stream->closed)
         luaL_error(L, "TCP connection already closed");
 
-    ResumeToken token = getResumeToken(L);
+    return (*handleStorage)->close(L);
+}
 
-    (*handleStorage)->close(
-        [token = std::move(token)]()
-        {
-            token->complete([](lua_State* L) { return 0; });
-        }
-    );
+int tcp_handshake(lua_State* L)
+{
+    luaL_checktype(L, 1, LUA_TUSERDATA);
+    auto* handleStorage = getTCPStreamHandle(L, 1);
+    if (!handleStorage || !(*handleStorage) || (*handleStorage)->pendingError)
+    {
+        std::string error = "";
+        if (handleStorage && *handleStorage && (*handleStorage)->pendingError)
+            error += ": " + (*handleStorage)->pendingError.value();
+        luaL_error(L, "Invalid or closed TCP connection: %s", error.c_str());
+        return 0;
+    }
 
+    TCPStreamHandle* handle = (*handleStorage).get();
+    if (handle->sslContext) {
+        luaL_error(L, "Handshake has already been completed for this connection");
+        return 0;
+    }
+
+    handle->createSSLContext();
+    if (!handle->sslContext) {
+        luaL_error(L, "Failed to create SSL context");
+        return 0;
+    }
+
+    handle->waiters.emplace_back(std::make_shared<TCPHandshakeWaiter>(
+        handle->shared_from_this(),
+        getResumeToken(L),
+        std::nullopt
+    ));
+
+    handle->readFromSSL();
+    
     return lua_yield(L, 0);
 }
 
 int connect(lua_State* L)
 {
-    std::string host = luaL_checkstring(L, 1);
-    int port = luaL_optinteger(L, 2, -1);
-    if (port < 0 || port > 65535)
-        luaL_error(L, "Invalid port number");
-    
-    TCPOptions options{std::move(host), port};
-    auto* handle = new TCPStreamHandle(L, options);
-    if (!handle->connect())
-    {
-        delete handle;
-        return 0; // token->fail has already been called with the error
+    TCPOptions options;
+    if (lua_istable(L, 1)) {
+        lua_getfield(L, 1, "hostname");
+        options.host = luaL_checkstring(L, -1);
+        lua_pop(L, 1);
+        lua_getfield(L, 1, "port");
+        options.port = luaL_optinteger(L, -1, -1);
+        lua_pop(L, 1);
+        
+        lua_getfield(L, 1, "tls");
+        options.tls = lua_toboolean(L, -1);
+        lua_pop(L, 1);
+    } else {
+        options.host = luaL_checkstring(L, 1);
+        options.port = luaL_optinteger(L, 2, -1);
+        options.tls = false;
     }
-    
-    return lua_yield(L, 0);
+
+    if (options.port < 0 || options.port > 65535) {
+        luaL_error(L, "Invalid port number");
+        return 0;
+    }
+
+    auto* loop = getRuntimeLoop(L);
+    auto token = getResumeToken(L);
+
+    auto handle = std::make_shared<TCPStreamHandle>(loop, options);
+    return handle->connect(L);
 }
+
 } // namespace net::client

--- a/lute/runtime/include/lute/userdatas.h
+++ b/lute/runtime/include/lute/userdatas.h
@@ -9,3 +9,4 @@ constexpr int kWebSocketHandleTag = 123;
 constexpr int kServerWebSocketHandleTag = 122;
 constexpr int kUVFileTag = 121;
 constexpr int kSignalHandleTag = 120;
+constexpr int kTCPStreamHandleTag = 119;

--- a/lute/runtime/include/lute/uvstream.h
+++ b/lute/runtime/include/lute/uvstream.h
@@ -143,5 +143,49 @@ struct PipeStream : UVStream<uv_pipe_t>
     }
 };
 
+struct TCPStream : UVStream<uv_tcp_t>
+{
+    TCPStream(uv_loop_t* loop, std::string handleContext)
+        : UVStream<uv_tcp_t>(loop, handleContext)
+    {
+        uv_tcp_init(loop, stream.get());
+    }
+
+    void write(void* data, size_t dataLen, OnStreamEnd callback)
+    {
+        auto req = new uv_write_t;
+        req->data = new OnStreamEnd(std::move(callback));
+
+        uv_buf_t buf;
+        buf.base = static_cast<char*>(data);
+        buf.len = dataLen;
+
+        int result = uv_write(req, getStream(), &buf, 1,
+            [](uv_write_t* req, int status)
+            {
+                auto callbackPtr = static_cast<OnStreamEnd*>(req->data);
+                OnStreamEnd callback = std::move(*callbackPtr);
+                delete callbackPtr;
+                delete req;
+
+                if (status < 0)
+                {
+                    callback(std::make_optional<std::string>(uv_strerror(status)));
+                }
+                else
+                {
+                    callback(std::nullopt);
+                }
+            }
+        );
+
+        if (result < 0)
+        {
+            delete req;
+            callback(std::make_optional<std::string>(uv_strerror(result)));
+        }
+    }
+};
+
 
 } // namespace uvutils

--- a/tests/lute/net.test.luau
+++ b/tests/lute/net.test.luau
@@ -300,4 +300,28 @@ test.suite("LuteNetSuite", function(suite)
 
 		instance.close()
 	end)
+
+	suite:case("tcpConnectAndEcho", function(assert)
+		local payload = "Hello World!"
+
+		local instance = server.serve({
+			port = 0,
+			handler = function(_req: server.ReceivedRequest): server.ServerResponse
+				return {
+					status = 200,
+					body = payload,
+				}
+			end,
+		})
+
+		local connection = client.connect(instance.hostname, instance.port)
+		connection:write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+
+		local buf = connection:read()
+		local data = buffer.readstring(buf, 0, buffer.len(buf))
+		assert.eq(true, data:find(payload) ~= nil, "Expected to find payload in response")
+
+		connection:close()
+		instance.close()
+	end)
 end)

--- a/tests/lute/net.test.luau
+++ b/tests/lute/net.test.luau
@@ -3,6 +3,7 @@ local test = require("@std/test")
 local client = require("@lute/net/client")
 local server = require("@lute/net/server")
 local task = require("@lute/task")
+local time = require("@lute/time")
 
 test.suite("LuteNetSuite", function(suite)
 	suite:case("serveWebsocketAndConnect", function(assert)
@@ -318,6 +319,39 @@ test.suite("LuteNetSuite", function(suite)
 		connection:write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
 
 		local buf = connection:read()
+		local data = buffer.readstring(buf, 0, buffer.len(buf))
+		assert.eq(true, data:find(payload) ~= nil, "Expected to find payload in response")
+
+		connection:close()
+		instance.close()
+	end)
+
+	suite:case("tcpTimeout", function(assert)
+		local payload = "Hello World!"
+
+		local instance = server.serve({
+			port = 0,
+			handler = function(_req: server.ReceivedRequest): server.ServerResponse
+				task.wait(0.3)
+				return {
+					status = 200,
+					body = payload,
+				}
+			end,
+		})
+
+		local connection = client.connect(instance.hostname, instance.port)
+		connection:write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+
+		assert.throws(function()
+			connection:read(time.duration.seconds(0))
+		end)
+
+		assert.throws(function()
+			connection:read(nil, time.duration.milliseconds(100))
+		end)
+
+		local buf = connection:read(nil, time.duration.milliseconds(400))
 		local data = buffer.readstring(buf, 0, buffer.len(buf))
 		assert.eq(true, data:find(payload) ~= nil, "Expected to find payload in response")
 

--- a/tests/lute/net.test.luau
+++ b/tests/lute/net.test.luau
@@ -358,4 +358,33 @@ test.suite("LuteNetSuite", function(suite)
 		connection:close()
 		instance.close()
 	end)
+
+	suite:case("tcpTLS", function(assert)
+		local connection = client.connect({
+			tls = true,
+			hostname = "example.com",
+			port = 443,
+		})
+		connection:write("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
+		local buf = connection:read()
+		local data = buffer.readstring(buf, 0, buffer.len(buf))
+		assert.eq(true, data:find("HTTP/1.1 200 OK") ~= nil, "Expected to find payload in response")
+		pcall(function()
+			-- Might fail because of `Connection: close`
+			connection:close()
+		end)
+	end)
+
+	suite:case("tcpTLSHandshake", function(assert)
+		local connection = client.connect("example.com", 443)
+		connection:handshake()
+		connection:write("GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\n\r\n")
+		local buf = connection:read()
+		local data = buffer.readstring(buf, 0, buffer.len(buf))
+		assert.eq(true, data:find("HTTP/1.1 200 OK") ~= nil, "Expected to find payload in response")
+		pcall(function()
+			-- Might fail because of `Connection: close`
+			connection:close()
+		end)
+	end)
 end)


### PR DESCRIPTION
Implements the basics of a client tcp stream using libuv with the following api:
```luau
export type TCPStreamHandle = {
	write: (self: TCPStreamHandle, data: buffer | string) -> (),
	read: ((self: TCPStreamHandle, amount: number?, timeout: time.Duration?) -> buffer)
		& ((self: TCPStreamHandle, timeout: time.Duration) -> buffer),
	handshake: (self: TCPStreamHandle) -> (),
	close: (self: TCPStreamHandle) -> (),
}

client.connect = ((function()
	error("not implemented")
end) :: any) :: (
	((hostname: string, port: number) -> TCPStreamHandle)
	& (({ hostname: string, port: number, tls: boolean? }) -> TCPStreamHandle)
)
```
A `:read()` with no amount will try to return the entire buffer, or block until something is read.

The API isn't final and will probably be changed as more discussion about buffer vs. string and so on...

I've added a small test in `tests/lute/net.test.luau` that uses the HTTP serve functionality since there isn't any TCP server to test on.

Also, this code is based on wsclient and processhandle because that was my entry into the codebase and what seemed most similar. 