### PR TITLE
Renames ParseResult to CstParseResult

### DIFF
--- a/definitions/luau.luau
+++ b/definitions/luau.luau
@@ -817,7 +817,7 @@ export type CstTypePack = CstTypePackExplicit | CstTypePackGeneric | CstTypePack
 export type CstNode = CstExpr | CstStat | CstType | CstTypePack | CstLocal | CstAttribute | CstToken
 
 --- The result of parsing a Luau script, containing the root block, EOF token, and source location info.
-export type ParseResult = {
+export type CstParseResult = {
 	read root: CstStatBlock,
 	read eof: CstEof,
 	read lines: number,
@@ -825,7 +825,7 @@ export type ParseResult = {
 }
 
 --- Parses `source` as a Luau script and returns the resulting CST.
-function luau.parse(source: string): ParseResult
+function luau.parse(source: string): CstParseResult
 	error("not implemented")
 end
 

--- a/lute/cli/commands/transform/types.luau
+++ b/lute/cli/commands/transform/types.luau
@@ -4,7 +4,7 @@ local syntaxTypes = require("@std/syntax/types")
 export type Context<Options = { [any]: any }> = {
 	path: string,
 	source: string,
-	parseresult: syntax.ParseResult,
+	parseresult: syntax.CstParseResult,
 	options: Options,
 }
 

--- a/lute/std/libs/syntax/init.luau
+++ b/lute/std/libs/syntax/init.luau
@@ -181,7 +181,7 @@ export type CstTypePack = types.CstTypePack
 
 export type CstNode = types.CstNode
 
-export type ParseResult = types.ParseResult
+export type CstParseResult = types.CstParseResult
 
 return table.freeze({
 	parseBlock = parser.parseBlock,

--- a/lute/std/libs/syntax/parser.luau
+++ b/lute/std/libs/syntax/parser.luau
@@ -17,8 +17,8 @@ function parser.parseExpr(source: string): types.CstExpr
 	return luau.parseExpr(source)
 end
 
---- Parses `source` as a complete Luau file and returns the full `ParseResult`, including the root block and EOF token.
-function parser.parse(source: string): types.ParseResult
+--- Parses `source` as a complete Luau file and returns the full `CstParseResult`, including the root block and EOF token.
+function parser.parse(source: string): types.CstParseResult
 	return luau.parse(source)
 end
 

--- a/lute/std/libs/syntax/printer.luau
+++ b/lute/std/libs/syntax/printer.luau
@@ -199,7 +199,7 @@ function printerLib.printNode(node: types.CstNode, replacements: types.Replaceme
 end
 
 --- Returns an entire parsed file as source text, including the EOF token, optionally applying `replacements`.
-function printerLib.printFile(result: types.ParseResult, replacements: types.Replacements?): string
+function printerLib.printFile(result: types.CstParseResult, replacements: types.Replacements?): string
 	local printer = printVisitor(replacements)
 	visitor.visitBlock(result.root, printer)
 	visitor.visitToken(result.eof, printer)

--- a/lute/std/libs/syntax/query.luau
+++ b/lute/std/libs/syntax/query.luau
@@ -128,7 +128,7 @@ function queryLib.mapToArray<T, U>(self: Query<T>, fn: (T) -> U?): { U }
 end
 
 --- Creates a new `Query` by visiting every node in `cst` and collecting those for which `fn` returns a non-nil value.
-function queryLib.findAllFromRoot<T>(cst: types.ParseResult | Node, fn: (Node) -> T?): Query<T>
+function queryLib.findAllFromRoot<T>(cst: types.CstParseResult | Node, fn: (Node) -> T?): Query<T>
 	local nodes: { T } = {}
 
 	local selectVisitor = newSelectVisitor(nodes, fn)

--- a/lute/std/libs/syntax/types.luau
+++ b/lute/std/libs/syntax/types.luau
@@ -161,7 +161,7 @@ export type CstTypePack = luau.CstTypePack
 
 export type CstNode = luau.CstNode
 
-export type ParseResult = luau.ParseResult
+export type CstParseResult = luau.CstParseResult
 
 --- The type of a replacement for a CST node.
 --- A replacement can be:

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -1944,8 +1944,8 @@ test.suite("CST_nodes_frozen", function(suite)
 		end
 	end)
 
-	-- ParseResult type
-	suite:case("parseResultFrozen", function(assert)
+	-- CstParseResult type
+	suite:case("cstParseResultFrozen", function(assert)
 		local result = parser.parse("local x = 1")
 		assert.throwsWith(frozenTableMessage, function()
 			(result :: any).root = nil


### PR DESCRIPTION
Part of the refactor of `@std/syntax`, I plan to add `AstParseResult` in a followup