### PR TITLE
Update `luau` version from 0.722 -> 0.723

### DIFF
--- a/extern/luau.tune
+++ b/extern/luau.tune
@@ -1,5 +1,5 @@
 [dependency]
 name = "luau"
 remote = "https://github.com/luau-lang/luau.git"
-branch = "0.722"
-revision = "32d52d1b2ceef46fc25d87094a2d7f201c3ea5b8"
+branch = "0.723"
+revision = "e7500c93a7f78803baa4f14118fd95cd3a183cf0"

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -184,7 +184,7 @@ static bool runFile(
 
 static int assertionHandler(const char* expr, const char* file, int line, const char* function)
 {
-    printf("%s(%d): ASSERTION FAILED: %s\n", file, line, expr);
+    fprintf(stderr, "%s(%d): ASSERTION FAILED: %s\n", file, line, expr);
     return 1;
 }
 

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -564,8 +564,8 @@ struct AstSerialize : public Luau::AstVisitor
             serializeToken(item.key->location.begin, std::string(value.data, value.size).data());
             lua_setfield(L, -2, "key");
 
-            LUTE_ASSERT(cstNode->equalsPosition);
-            serializeToken(*cstNode->equalsPosition, "=");
+            LUTE_ASSERT(cstNode->equalsPosition.hasValue());
+            serializeToken(cstNode->equalsPosition, "=");
             lua_setfield(L, -2, "equals");
 
             visit(item.value);
@@ -580,21 +580,21 @@ struct AstSerialize : public Luau::AstVisitor
             lua_pushboolean(L, 1);
             lua_setfield(L, -2, "isTableItem");
 
-            LUTE_ASSERT(cstNode->indexerOpenPosition);
-            withLocation(Luau::Location{*cstNode->indexerOpenPosition, item.value->location.end});
+            LUTE_ASSERT(cstNode->indexerOpenPosition.hasValue());
+            withLocation(Luau::Location{cstNode->indexerOpenPosition, item.value->location.end});
 
-            serializeToken(*cstNode->indexerOpenPosition, "[");
+            serializeToken(cstNode->indexerOpenPosition, "[");
             lua_setfield(L, -2, "indexerOpen");
 
             visit(item.key);
             lua_setfield(L, -2, "key");
 
-            LUTE_ASSERT(cstNode->indexerClosePosition);
-            serializeToken(*cstNode->indexerClosePosition, "]");
+            LUTE_ASSERT(cstNode->indexerClosePosition.hasValue());
+            serializeToken(cstNode->indexerClosePosition, "]");
             lua_setfield(L, -2, "indexerClose");
 
-            LUTE_ASSERT(cstNode->equalsPosition);
-            serializeToken(*cstNode->equalsPosition, "=");
+            LUTE_ASSERT(cstNode->equalsPosition.hasValue());
+            serializeToken(cstNode->equalsPosition, "=");
             lua_setfield(L, -2, "equals");
 
             visit(item.value);
@@ -602,7 +602,7 @@ struct AstSerialize : public Luau::AstVisitor
         }
 
         if (cstNode->separator)
-            serializeToken(*cstNode->separatorPosition, *cstNode->separator == Luau::CstExprTable::Comma ? "," : ";");
+            serializeToken(cstNode->separatorPosition, cstNode->separator == Luau::CstExprTable::Comma ? "," : ";");
         else
             lua_pushnil(L);
         lua_setfield(L, -2, "separator");
@@ -1026,8 +1026,8 @@ struct AstSerialize : public Luau::AstVisitor
         node->func->visit(this);
         lua_setfield(L, -2, "func");
 
-        if (cstNode->openParens)
-            serializeToken(*cstNode->openParens, "(");
+        if (cstNode->openParens.hasValue())
+            serializeToken(cstNode->openParens, "(");
         else
             lua_pushnil(L);
         lua_setfield(L, -2, "openParens");
@@ -1041,8 +1041,8 @@ struct AstSerialize : public Luau::AstVisitor
         serialize(node->argLocation);
         lua_setfield(L, -2, "argLocation");
 
-        if (cstNode->closeParens)
-            serializeToken(*cstNode->closeParens, ")");
+        if (cstNode->closeParens.hasValue())
+            serializeToken(cstNode->closeParens, ")");
         else
             lua_pushnil(L);
         lua_setfield(L, -2, "closeParens");
@@ -1710,9 +1710,9 @@ struct AstSerialize : public Luau::AstVisitor
         node->to->visit(this);
         lua_setfield(L, -2, "to");
 
-        if (cstNode->stepCommaPosition)
+        if (cstNode->stepCommaPosition.hasValue())
         {
-            serializeToken(*cstNode->stepCommaPosition, ",");
+            serializeToken(cstNode->stepCommaPosition, ",");
             lua_setfield(L, -2, "stepComma");
         }
 
@@ -1979,8 +1979,8 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "prefix");
 
             LUTE_ASSERT(cstNode);
-            LUTE_ASSERT(cstNode->prefixPointPosition);
-            serializeToken(*cstNode->prefixPointPosition, ".");
+            LUTE_ASSERT(cstNode->prefixPointPosition.hasValue());
+            serializeToken(cstNode->prefixPointPosition, ".");
             lua_setfield(L, -2, "prefixPoint");
         }
 
@@ -2082,7 +2082,7 @@ struct AstSerialize : public Luau::AstVisitor
                 lua_setfield(L, -2, "value");
 
                 if (item.separator)
-                    serializeToken(*item.separatorPosition, item.separator == Luau::CstExprTable::Comma ? "," : ";");
+                    serializeToken(item.separatorPosition, item.separator == Luau::CstExprTable::Comma ? "," : ";");
                 else
                     lua_pushnil(L);
                 lua_setfield(L, -2, "separator");
@@ -2173,7 +2173,7 @@ struct AstSerialize : public Luau::AstVisitor
                 lua_setfield(L, -2, "value");
 
                 if (item.separator)
-                    serializeToken(*item.separatorPosition, item.separator == Luau::CstExprTable::Comma ? "," : ";");
+                    serializeToken(item.separatorPosition, item.separator == Luau::CstExprTable::Comma ? "," : ";");
                 else
                     lua_pushnil(L);
                 lua_setfield(L, -2, "separator");
@@ -2242,6 +2242,28 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "type");
 
             lua_rawseti(L, -3, i + 1);
+            lua_rawcheckstack(L, 2);
+            lua_createtable(L, 0, 2);
+
+            {
+                lua_rawcheckstack(L, 2);
+                lua_createtable(L, 0, 3);
+                if (i < node->argNames.size && node->argNames.data[i].has_value())
+                    serializeToken(node->argNames.data[i]->second.begin, node->argNames.data[i]->first.value);
+                else
+                    lua_pushnil(L);
+                lua_setfield(L, -2, "name");
+
+                if (i < cstNode->argumentNameColonPositions.size && cstNode->argumentNameColonPositions.data[i].hasValue())
+                    serializeToken(cstNode->argumentNameColonPositions.data[i], ":");
+                else
+                    lua_pushnil(L);
+                lua_setfield(L, -2, "colon");
+
+                node->argTypes.types.data[i]->visit(this);
+                lua_setfield(L, -2, "type");
+            }
+            lua_setfield(L, -2, "node");
 
             if (i < cstNode->argumentsCommaPositions.size)
                 serializeToken(cstNode->argumentsCommaPositions.data[i], ",");
@@ -2304,8 +2326,8 @@ struct AstSerialize : public Luau::AstVisitor
 
         serializeNodePreamble(node, "union", "type");
 
-        if (cstNode->leadingPosition)
-            serializeToken(*cstNode->leadingPosition, "|");
+        if (cstNode->leadingPosition.hasValue())
+            serializeToken(cstNode->leadingPosition, "|");
         else
             lua_pushnil(L);
         lua_setfield(L, -2, "leading");
@@ -2379,8 +2401,8 @@ struct AstSerialize : public Luau::AstVisitor
 
         serializeNodePreamble(node, "intersection", "type");
 
-        if (cstNode->leadingPosition)
-            serializeToken(*cstNode->leadingPosition, "&");
+        if (cstNode->leadingPosition.hasValue())
+            serializeToken(cstNode->leadingPosition, "&");
         else
             lua_pushnil(L);
         lua_setfield(L, -2, "leading");
@@ -2463,7 +2485,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "name");
 
         if (node->defaultValue)
-            serializeToken(*cstNode->defaultEqualsPosition, "=");
+            serializeToken(cstNode->defaultEqualsPosition, "=");
         else
             lua_pushnil(L);
         lua_setfield(L, -2, "equals");
@@ -2491,7 +2513,7 @@ struct AstSerialize : public Luau::AstVisitor
         lua_setfield(L, -2, "ellipsis");
 
         if (node->defaultValue)
-            serializeToken(*cstNode->defaultEqualsPosition, "=");
+            serializeToken(cstNode->defaultEqualsPosition, "=");
         else
             lua_pushnil(L);
         lua_setfield(L, -2, "equals");
@@ -2517,7 +2539,7 @@ struct AstSerialize : public Luau::AstVisitor
 
         const auto cstNode = lookupCstNode<Luau::CstTypePackExplicit>(node);
 
-        if (cstNode->hasParentheses)
+        if (cstNode->openParenthesesPosition.hasValue() && cstNode->closeParenthesesPosition.hasValue())
             serializeToken(cstNode->openParenthesesPosition, "(");
         else
             lua_pushnil(L);
@@ -2532,7 +2554,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_pushnil(L);
         lua_setfield(L, -2, "tailType");
 
-        if (cstNode->hasParentheses)
+        if (cstNode->openParenthesesPosition.hasValue() && cstNode->closeParenthesesPosition.hasValue())
             serializeToken(cstNode->closeParenthesesPosition, ")");
         else
             lua_pushnil(L);

--- a/lute/luau/src/luau.cpp
+++ b/lute/luau/src/luau.cpp
@@ -601,7 +601,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "value");
         }
 
-        if (cstNode->separator)
+        if (cstNode->separator != Luau::CstExprTable::Missing)
             serializeToken(cstNode->separatorPosition, cstNode->separator == Luau::CstExprTable::Comma ? "," : ";");
         else
             lua_pushnil(L);
@@ -2081,7 +2081,7 @@ struct AstSerialize : public Luau::AstVisitor
                 node->indexer->resultType->visit(this);
                 lua_setfield(L, -2, "value");
 
-                if (item.separator)
+                if (item.separator != Luau::CstExprTable::Missing)
                     serializeToken(item.separatorPosition, item.separator == Luau::CstExprTable::Comma ? "," : ";");
                 else
                     lua_pushnil(L);
@@ -2172,7 +2172,7 @@ struct AstSerialize : public Luau::AstVisitor
                 prop->type->visit(this);
                 lua_setfield(L, -2, "value");
 
-                if (item.separator)
+                if (item.separator != Luau::CstExprTable::Missing)
                     serializeToken(item.separatorPosition, item.separator == Luau::CstExprTable::Comma ? "," : ";");
                 else
                     lua_pushnil(L);
@@ -2232,8 +2232,8 @@ struct AstSerialize : public Luau::AstVisitor
                 lua_pushnil(L);
             lua_setfield(L, -2, "name");
 
-            if (i < cstNode->argumentNameColonPositions.size && cstNode->argumentNameColonPositions.data[i].has_value())
-                serializeToken(*cstNode->argumentNameColonPositions.data[i], ":");
+            if (i < cstNode->argumentNameColonPositions.size && cstNode->argumentNameColonPositions.data[i].hasValue())
+                serializeToken(cstNode->argumentNameColonPositions.data[i], ":");
             else
                 lua_pushnil(L);
             lua_setfield(L, -2, "colon");
@@ -2242,28 +2242,6 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "type");
 
             lua_rawseti(L, -3, i + 1);
-            lua_rawcheckstack(L, 2);
-            lua_createtable(L, 0, 2);
-
-            {
-                lua_rawcheckstack(L, 2);
-                lua_createtable(L, 0, 3);
-                if (i < node->argNames.size && node->argNames.data[i].has_value())
-                    serializeToken(node->argNames.data[i]->second.begin, node->argNames.data[i]->first.value);
-                else
-                    lua_pushnil(L);
-                lua_setfield(L, -2, "name");
-
-                if (i < cstNode->argumentNameColonPositions.size && cstNode->argumentNameColonPositions.data[i].hasValue())
-                    serializeToken(cstNode->argumentNameColonPositions.data[i], ":");
-                else
-                    lua_pushnil(L);
-                lua_setfield(L, -2, "colon");
-
-                node->argTypes.types.data[i]->visit(this);
-                lua_setfield(L, -2, "type");
-            }
-            lua_setfield(L, -2, "node");
 
             if (i < cstNode->argumentsCommaPositions.size)
                 serializeToken(cstNode->argumentsCommaPositions.data[i], ",");

--- a/lute/luau/src/resolvemodule.cpp
+++ b/lute/luau/src/resolvemodule.cpp
@@ -71,7 +71,6 @@ public:
     ConfigStatus getConfigStatus() const override;
 
     ConfigBehavior getConfigBehavior() const override;
-    std::optional<std::string> getAlias(const std::string& alias) const override;
     std::optional<std::string> getConfig() const override;
 
     FileVfs vfs;
@@ -111,11 +110,6 @@ NC::ConfigStatus FileVfsContext::getConfigStatus() const
 NC::ConfigBehavior FileVfsContext::getConfigBehavior() const
 {
     return NC::ConfigBehavior::GetConfig;
-}
-
-std::optional<std::string> FileVfsContext::getAlias(const std::string& alias) const
-{
-    return std::nullopt;
 }
 
 std::optional<std::string> FileVfsContext::getConfig() const
@@ -301,11 +295,6 @@ public:
     ConfigBehavior getConfigBehavior() const override
     {
         return NC::ConfigBehavior::GetConfig;
-    }
-
-    std::optional<std::string> getAlias(const std::string& alias) const override
-    {
-        return std::nullopt;
     }
 
     std::optional<std::string> getConfig() const override

--- a/lute/require/include/lute/modulepath.h
+++ b/lute/require/include/lute/modulepath.h
@@ -110,26 +110,6 @@ public:
         return convert(current.toChild(component));
     }
 
-    ConfigStatus getConfigStatus() const override
-    {
-        return ConfigStatus::Absent;
-    }
-
-    ConfigBehavior getConfigBehavior() const override
-    {
-        return ConfigBehavior::GetConfig;
-    }
-
-    std::optional<std::string> getAlias(const std::string& alias) const override
-    {
-        return std::nullopt;
-    }
-
-    std::optional<std::string> getConfig() const override
-    {
-        return std::nullopt;
-    }
-
 private:
     ModulePath current;
     ModulePath start;

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -479,14 +479,14 @@ test.suite("parseExpr", function(suite)
 		local commaSep = parser.parseExpr("{1, 2}") :: syntax.CstExprTable
 		assert.eq(#commaSep.entries, 2)
 		assert.neq(commaSep.entries[1].separator, nil)
-		assert.eq((commaSep.entries[1].separator :: any).text, ",")
+		assert.eq((commaSep.entries[1].separator :: syntax.CstToken<",">).text, ",")
 		assert.eq(commaSep.entries[2].separator, nil)
 
 		-- Semicolon separator must be preserved
 		local semiSep = parser.parseExpr("{1; 2}") :: syntax.CstExprTable
 		assert.eq(#semiSep.entries, 2)
 		assert.neq(semiSep.entries[1].separator, nil)
-		assert.eq((semiSep.entries[1].separator :: any).text, ";")
+		assert.eq((semiSep.entries[1].separator :: syntax.CstToken<";">).text, ";")
 		assert.eq(semiSep.entries[2].separator, nil)
 	end)
 

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -469,6 +469,27 @@ test.suite("parseExpr", function(suite)
 		assert.eq(entry3.separator, nil)
 	end)
 
+	suite:case("parseExprTableSeparators", function(assert)
+		-- Single item, no trailing separator: must not crash
+		local singleItem = parser.parseExpr("{a = 1}") :: syntax.CstExprTable
+		assert.eq(#singleItem.entries, 1)
+		assert.eq(singleItem.entries[1].separator, nil)
+
+		-- Comma separator must be preserved (Comma must not be treated as falsy)
+		local commaSep = parser.parseExpr("{1, 2}") :: syntax.CstExprTable
+		assert.eq(#commaSep.entries, 2)
+		assert.neq(commaSep.entries[1].separator, nil)
+		assert.eq((commaSep.entries[1].separator :: any).text, ",")
+		assert.eq(commaSep.entries[2].separator, nil)
+
+		-- Semicolon separator must be preserved
+		local semiSep = parser.parseExpr("{1; 2}") :: syntax.CstExprTable
+		assert.eq(#semiSep.entries, 2)
+		assert.neq(semiSep.entries[1].separator, nil)
+		assert.eq((semiSep.entries[1].separator :: any).text, ";")
+		assert.eq(semiSep.entries[2].separator, nil)
+	end)
+
 	suite:case("parseExprUnary", function(assert)
 		local notExpr = parser.parseExpr("not x")
 		assert.eq(notExpr.tag, "unary")


### PR DESCRIPTION
Bump luau version from 0.722 to 0.723. This PR also adds a regression test to highlight a failure in serializing CstExprTables that was uncovered in the bump + fixes this issue.
I've also tweaked our assert handler to print to stderr, which (might?) reduce incidences of weird crashes without assertions being printed in CI.