### PR TITLE
runtime: fix the external device fallback path for `fs.move`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
           options: ${{ matrix.options }}
           token: ${{ secrets.GITHUB_TOKEN }}
           use-bootstrap: ${{ matrix.use-bootstrap || 'false' }}
+
       - name: Mount cross-device tmpfs for fs.move test
         if: ${{ steps.should_run.outputs.proceed == 'true' && runner.os == 'Linux' }}
         run: |
@@ -72,6 +73,13 @@ jobs:
           sudo mount -t tmpfs tmpfs /mnt/lute-test-tmp
           sudo chmod 777 /mnt/lute-test-tmp
           echo "LUTE_CROSSDEV_TMPDIR=/mnt/lute-test-tmp" >> "$GITHUB_ENV"
+
+      - name: Mount cross-device RAM disk for fs.move test
+        if: ${{ steps.should_run.outputs.proceed == 'true' && runner.os == 'macOS' }}
+        run: |
+          DISK=$(hdiutil attach -nomount ram://131072 | xargs)
+          diskutil erasevolume HFS+ 'LuteTestDisk' "$DISK"
+          echo "LUTE_CROSSDEV_TMPDIR=/Volumes/LuteTestDisk" >> "$GITHUB_ENV"
 
       - name: Run Luau Tests
         if: ${{ steps.should_run.outputs.proceed == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
           options: ${{ matrix.options }}
           token: ${{ secrets.GITHUB_TOKEN }}
           use-bootstrap: ${{ matrix.use-bootstrap || 'false' }}
+      - name: Mount cross-device tmpfs for fs.move test
+        if: ${{ steps.should_run.outputs.proceed == 'true' && runner.os == 'Linux' }}
+        run: |
+          sudo mkdir /mnt/lute-test-tmp
+          sudo mount -t tmpfs tmpfs /mnt/lute-test-tmp
+          sudo chmod 777 /mnt/lute-test-tmp
+          echo "LUTE_CROSSDEV_TMPDIR=/mnt/lute-test-tmp" >> "$GITHUB_ENV"
+
       - name: Run Luau Tests
         if: ${{ steps.should_run.outputs.proceed == 'true' }}
         run: ${{ steps.build_lute.outputs.exe_path }} test --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,13 @@ jobs:
           diskutil erasevolume HFS+ 'LuteTestDisk' "$DISK"
           echo "LUTE_CROSSDEV_TMPDIR=/Volumes/LuteTestDisk" >> "$GITHUB_ENV"
 
+      - name: Set up cross-device directory for fs.move test
+        if: ${{ steps.should_run.outputs.proceed == 'true' && runner.os == 'Windows' }}
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path "D:\lute-test-tmp"
+          echo "LUTE_CROSSDEV_TMPDIR=D:\lute-test-tmp" >> $env:GITHUB_ENV
+
       - name: Run Luau Tests
         if: ${{ steps.should_run.outputs.proceed == 'true' }}
         run: ${{ steps.build_lute.outputs.exe_path }} test --verbose

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -292,7 +292,7 @@ struct FSRename : FSPathPairRequest
     using FSPathPairRequest::FSPathPairRequest;
 
     static void renameCallback(uv_fs_t* req);
-    static void statCallback(uv_fs_t* req);
+    static void crossDeviceFallback(uv_fs_t* req);
 };
 
 // Handles a recursive cross-filesystem directory move as a self-managed async state machine.
@@ -1056,10 +1056,10 @@ void FSRename::renameCallback(uv_fs_t* req)
     // since the fallback copy strategy differs between the two.
     uv_fs_req_cleanup(&r->req);
     uvutils::ScopedUVRequest<FSRename> statReq{std::move(r)};
-    uv_fs_lstat(statReq->getLoop(), &statReq->req, statReq->src.c_str(), FSRename::statCallback);
+    uv_fs_lstat(statReq->getLoop(), &statReq->req, statReq->src.c_str(), FSRename::crossDeviceFallback);
 }
 
-void FSRename::statCallback(uv_fs_t* req)
+void FSRename::crossDeviceFallback(uv_fs_t* req)
 {
     auto r = uvutils::retake<FSRename>(req);
     auto result = req->result;

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -101,7 +101,8 @@ struct FSPathPairRequest : FSRequest
     const std::string dest;
 };
 
-// Heap-managed primitive: creates a symlink at `dest` pointing to `target`.
+// Creates a symlink at `dest` pointing to `target`.
+//
 // On Win32, stats `target` first to determine whether UV_FS_SYMLINK_DIR is needed.
 // Calls onDone(0) on success, onDone(negative_uv_error) on failure. Self-deletes.
 struct FSCreateSymlink
@@ -157,7 +158,8 @@ private:
     }
 };
 
-// Heap-managed primitive: moves a symlink from src to dest.
+// Moves a symlink from src to dest.
+//
 // readlink(src) -> FSCreateSymlink(linkTarget, dest) -> unlink(src).
 // Calls onDone(0) on success, onDone(negative_uv_error) on failure. Self-deletes.
 struct FSMoveSymlink
@@ -230,7 +232,8 @@ private:
     }
 };
 
-// Heap-managed primitive: moves a regular file from src to dest.
+// Moves a regular file from src to dest.
+//
 // copyfile(src, dest) -> unlink(src).
 // Calls onDone(0) on success, onDone(negative_uv_error) on failure. Self-deletes.
 struct FSMoveSingleFile

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -152,9 +152,8 @@ private:
         auto* self = static_cast<FSCreateSymlink*>(req->data);
         int result = req->result;
         uv_fs_req_cleanup(req);
-        auto done = std::move(self->onDone);
+        self->onDone(result);
         delete self;
-        done(result);
     }
 };
 
@@ -295,8 +294,7 @@ struct FSRename : FSPathPairRequest
     static void crossDeviceFallback(uv_fs_t* req);
 };
 
-// Handles a recursive cross-filesystem directory move as a self-managed async state machine.
-// Ownership: heap-allocated; calls `delete this` via succeed() or fail().
+// Handles a recursive move of a direcotry as a sequence of copy-and-delete.
 struct FSCopyDirectory
 {
     FSCopyDirectory(ResumeToken token, uv_loop_t* loop, std::string src, std::string dest)
@@ -311,6 +309,12 @@ struct FSCopyDirectory
     {
         std::string src;
         std::string dest;
+
+        DirPair(std::string src, std::string dest)
+            : src(std::move(src))
+            , dest(std::move(dest))
+        {
+        }
     };
 
     ResumeToken token;
@@ -373,7 +377,7 @@ struct FSCopyDirectory
 
         pendingUnknown.clear();
         unknownIdx = 0;
-        scannedDirs.push_back(pendingDirs.front().src);
+        scannedDirs.emplace_back(pendingDirs.front().src);
         pendingDirs.pop_front();
         start();
     }
@@ -512,15 +516,15 @@ struct FSCopyDirectory
             }
             else if (type == UV_DIRENT_FILE)
             {
-                self->pendingFiles.push_back({childSrc, childDest});
+                self->pendingFiles.emplace_back(childSrc, childDest);
             }
             else if (type == UV_DIRENT_LINK)
             {
-                self->pendingLinks.push_back({childSrc, childDest});
+                self->pendingLinks.emplace_back(childSrc, childDest);
             }
             else if (type == UV_DIRENT_UNKNOWN)
             {
-                self->pendingUnknown.push_back({childSrc, childDest});
+                self->pendingUnknown.emplace_back(childSrc, childDest);
             }
             else
             {
@@ -535,7 +539,7 @@ struct FSCopyDirectory
             return;
         }
 
-        self->scannedDirs.push_back(srcDir);
+        self->scannedDirs.emplace_back(srcDir);
         self->pendingDirs.pop_front();
 
         self->start();
@@ -563,11 +567,11 @@ struct FSCopyDirectory
         }
         else if (S_ISREG(mode))
         {
-            self->pendingFiles.push_back({entry.src, entry.dest});
+            self->pendingFiles.emplace_back(entry.src, entry.dest);
         }
         else if (S_ISLNK(mode))
         {
-            self->pendingLinks.push_back({entry.src, entry.dest});
+            self->pendingLinks.emplace_back(entry.src, entry.dest);
         }
         else
         {

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -160,7 +160,7 @@ private:
 };
 
 // Heap-managed primitive: moves a symlink from src to dest.
-// readlink(src) → FSCreateSymlink(linkTarget, dest) → unlink(src).
+// readlink(src) -> FSCreateSymlink(linkTarget, dest) -> unlink(src).
 // Calls onDone(0) on success, onDone(negative_uv_error) on failure. Self-deletes.
 struct FSMoveSymlink
 {
@@ -234,7 +234,7 @@ private:
 };
 
 // Heap-managed primitive: moves a regular file from src to dest.
-// copyfile(src, dest) → unlink(src).
+// copyfile(src, dest) -> unlink(src).
 // Calls onDone(0) on success, onDone(negative_uv_error) on failure. Self-deletes.
 struct FSMoveSingleFile
 {

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -4,12 +4,12 @@
 #include "lute/userdatas.h"
 #include "lute/uvrequest.h"
 
+#include "Luau/VecDeque.h"
+
 #include "lua.h"
 #include "lualib.h"
 
 #include "uv.h"
-
-#include "Luau/VecDeque.h"
 
 #include <functional>
 
@@ -204,22 +204,21 @@ private:
         uv_fs_req_cleanup(req);
 
         (new FSCreateSymlink(
-            self->loop,
-            self->linkTarget,
-            self->dest,
-            [self](int err)
-            {
-                if (err < 0)
-                {
-                    auto done = std::move(self->onDone);
-                    delete self;
-                    done(err);
-                    return;
-                }
-                uv_fs_unlink(self->loop, &self->req, self->src.c_str(), FSMoveSymlink::unlinkCallback);
-            }
-        ))
-            ->start();
+             self->loop,
+             self->linkTarget,
+             self->dest,
+             [self](int err)
+             {
+                 if (err < 0)
+                 {
+                     auto done = std::move(self->onDone);
+                     delete self;
+                     done(err);
+                     return;
+                 }
+                 uv_fs_unlink(self->loop, &self->req, self->src.c_str(), FSMoveSymlink::unlinkCallback);
+             }
+         ))->start();
     }
 
     static void unlinkCallback(uv_fs_t* req)
@@ -341,7 +340,12 @@ struct FSCopyDirectory
 
     void succeed()
     {
-        token->complete([](lua_State* L) { return 0; });
+        token->complete(
+            [](lua_State* L)
+            {
+                return 0;
+            }
+        );
         delete this;
     }
 
@@ -373,31 +377,30 @@ struct FSCopyDirectory
         start();
     }
 
-    // Phase 2: copy+unlink the next pending regular file, or advance to symlink recreation.
+    // Phase 2: copy and unlink the next pending regular file, or advance to symlink recreation.
     void startFileCopy()
     {
         if (fileIdx < pendingFiles.size())
         {
             (new FSMoveSingleFile(
-                loop,
-                pendingFiles[fileIdx].src,
-                pendingFiles[fileIdx].dest,
-                [this](int err)
-                {
-                    if (err < 0)
-                    {
-                        fail(
-                            "move: Error moving file %s: %s; source and destination may be in an inconsistent state",
-                            pendingFiles[fileIdx].src.c_str(),
-                            uv_strerror(err)
-                        );
-                        return;
-                    }
-                    ++fileIdx;
-                    startFileCopy();
-                }
-            ))
-                ->start();
+                 loop,
+                 pendingFiles[fileIdx].src,
+                 pendingFiles[fileIdx].dest,
+                 [this](int err)
+                 {
+                     if (err < 0)
+                     {
+                         fail(
+                             "move: Error moving file %s: %s; source and destination may be in an inconsistent state",
+                             pendingFiles[fileIdx].src.c_str(),
+                             uv_strerror(err)
+                         );
+                         return;
+                     }
+                     ++fileIdx;
+                     startFileCopy();
+                 }
+             ))->start();
             return;
         }
 
@@ -410,25 +413,24 @@ struct FSCopyDirectory
         if (linkIdx < pendingLinks.size())
         {
             (new FSMoveSymlink(
-                loop,
-                pendingLinks[linkIdx].src,
-                pendingLinks[linkIdx].dest,
-                [this](int err)
-                {
-                    if (err < 0)
-                    {
-                        fail(
-                            "move: Error moving symlink %s: %s; source and destination may be in an inconsistent state",
-                            pendingLinks[linkIdx].src.c_str(),
-                            uv_strerror(err)
-                        );
-                        return;
-                    }
-                    ++linkIdx;
-                    startLinkCopy();
-                }
-            ))
-                ->start();
+                 loop,
+                 pendingLinks[linkIdx].src,
+                 pendingLinks[linkIdx].dest,
+                 [this](int err)
+                 {
+                     if (err < 0)
+                     {
+                         fail(
+                             "move: Error moving symlink %s: %s; source and destination may be in an inconsistent state",
+                             pendingLinks[linkIdx].src.c_str(),
+                             uv_strerror(err)
+                         );
+                         return;
+                     }
+                     ++linkIdx;
+                     startLinkCopy();
+                 }
+             ))->start();
             return;
         }
 
@@ -473,9 +475,7 @@ struct FSCopyDirectory
             std::string srcPath = self->pendingDirs.front().src;
             uv_fs_req_cleanup(req);
             self->fail(
-                "move: Error reading directory %s: %s; some destination subdirectories may have been created",
-                srcPath.c_str(),
-                uv_strerror(result)
+                "move: Error reading directory %s: %s; some destination subdirectories may have been created", srcPath.c_str(), uv_strerror(result)
             );
             return;
         }
@@ -549,11 +549,7 @@ struct FSCopyDirectory
         {
             std::string path = self->pendingUnknown[self->unknownIdx].src;
             uv_fs_req_cleanup(req);
-            self->fail(
-                "move: Error reading %s: %s; some destination subdirectories may have been created",
-                path.c_str(),
-                uv_strerror(result)
-            );
+            self->fail("move: Error reading %s: %s; some destination subdirectories may have been created", path.c_str(), uv_strerror(result));
             return;
         }
 
@@ -576,10 +572,7 @@ struct FSCopyDirectory
         {
             std::string path = entry.src;
             uv_fs_req_cleanup(req);
-            self->fail(
-                "move: Cannot move %s: unsupported file type; some destination subdirectories may have been created",
-                path.c_str()
-            );
+            self->fail("move: Cannot move %s: unsupported file type; some destination subdirectories may have been created", path.c_str());
             return;
         }
 
@@ -995,18 +988,22 @@ int symlink_impl(lua_State* L, const char* path, const char* dest)
     auto* loop = getRuntimeLoop(L);
     std::string src{path}, dst{dest};
     (new FSCreateSymlink(
-        loop,
-        src,
-        dst,
-        [token, src, dst](int err)
-        {
-            if (err < 0)
-                token->fail(uvutils::formatUVError("symlink: Error creating symlink from %s to %s: %s", src.c_str(), dst.c_str(), uv_strerror(err)));
-            else
-                token->complete([](lua_State* L) { return 0; });
-        }
-    ))
-        ->start();
+         loop,
+         src,
+         dst,
+         [token, src, dst](int err)
+         {
+             if (err < 0)
+                 token->fail(uvutils::formatUVError("symlink: Error creating symlink from %s to %s: %s", src.c_str(), dst.c_str(), uv_strerror(err)));
+             else
+                 token->complete(
+                     [](lua_State* L)
+                     {
+                         return 0;
+                     }
+                 );
+         }
+     ))->start();
     return lua_yield(L, 0);
 }
 
@@ -1076,19 +1073,18 @@ void FSRename::statCallback(uv_fs_t* req)
     {
         auto* raw = r.release();
         (new FSMoveSymlink(
-            raw->loop,
-            raw->src,
-            raw->dest,
-            [raw](int err)
-            {
-                std::unique_ptr<FSRename> r(raw);
-                if (err < 0)
-                    r->fail("move: Error moving symlink %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(err));
-                else
-                    r->succeedTrivially();
-            }
-        ))
-            ->start();
+             raw->loop,
+             raw->src,
+             raw->dest,
+             [raw](int err)
+             {
+                 std::unique_ptr<FSRename> r(raw);
+                 if (err < 0)
+                     r->fail("move: Error moving symlink %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(err));
+                 else
+                     r->succeedTrivially();
+             }
+         ))->start();
         return;
     }
 
@@ -1109,19 +1105,18 @@ void FSRename::statCallback(uv_fs_t* req)
 
     auto* raw = r.release();
     (new FSMoveSingleFile(
-        raw->loop,
-        raw->src,
-        raw->dest,
-        [raw](int err)
-        {
-            std::unique_ptr<FSRename> r(raw);
-            if (err < 0)
-                r->fail("move: Error moving file %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(err));
-            else
-                r->succeedTrivially();
-        }
-    ))
-        ->start();
+         raw->loop,
+         raw->src,
+         raw->dest,
+         [raw](int err)
+         {
+             std::unique_ptr<FSRename> r(raw);
+             if (err < 0)
+                 r->fail("move: Error moving file %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(err));
+             else
+                 r->succeedTrivially();
+         }
+     ))->start();
 }
 
 int rename_impl(lua_State* L, const char* path, const char* dest)

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -1092,8 +1092,8 @@ void FSRename::statCallback(uv_fs_t* req)
     {
         // Directory: hand off to FSCopyDirectory. Moving the token transfers coroutine
         // ownership; r is then destroyed cleanly with an empty token.
-        /*auto* copyDir = */new FSCopyDirectory(std::move(r->token), r->loop, r->src, r->dest);
-        //copyDir->start(); FIXME: disabled to confirm that CI breaks if we remove it
+        auto* copyDir = new FSCopyDirectory(std::move(r->token), r->loop, r->src, r->dest);
+        copyDir->start();
         return;
     }
 

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -11,6 +11,8 @@
 
 #include "Luau/VecDeque.h"
 
+#include <functional>
+
 #ifdef _WIN32
 #include <direct.h>
 #else
@@ -101,21 +103,196 @@ struct FSPathPairRequest : FSRequest
     const std::string dest;
 };
 
+// Heap-managed primitive: creates a symlink at `dest` pointing to `target`.
+// On Win32, stats `target` first to determine whether UV_FS_SYMLINK_DIR is needed.
+// Calls onDone(0) on success, onDone(negative_uv_error) on failure. Self-deletes.
+struct FSMakeSymlink
+{
+    FSMakeSymlink(uv_loop_t* loop, std::string target, std::string dest, std::function<void(int)> onDone)
+        : loop(loop)
+        , target(std::move(target))
+        , dest(std::move(dest))
+        , onDone(std::move(onDone))
+    {
+        req.data = this;
+    }
+
+    void start()
+    {
+#if _WIN32
+        uv_fs_stat(loop, &req, target.c_str(), FSMakeSymlink::statCallback);
+#else
+        doSymlink(this, 0);
+#endif
+    }
+
+    uv_loop_t* loop;
+    uv_fs_t req;
+    std::string target;
+    std::string dest;
+    std::function<void(int)> onDone;
+
+private:
+    static void doSymlink(FSMakeSymlink* self, int flags)
+    {
+        uv_fs_symlink(self->loop, &self->req, self->target.c_str(), self->dest.c_str(), flags, FSMakeSymlink::symlinkCallback);
+    }
+
+#if _WIN32
+    static void statCallback(uv_fs_t* req)
+    {
+        auto* self = static_cast<FSMakeSymlink*>(req->data);
+        int flags = (req->result >= 0 && S_ISDIR(req->statbuf.st_mode)) ? UV_FS_SYMLINK_DIR : 0;
+        uv_fs_req_cleanup(req);
+        doSymlink(self, flags);
+    }
+#endif
+
+    static void symlinkCallback(uv_fs_t* req)
+    {
+        auto* self = static_cast<FSMakeSymlink*>(req->data);
+        int result = req->result;
+        uv_fs_req_cleanup(req);
+        auto done = std::move(self->onDone);
+        delete self;
+        done(result);
+    }
+};
+
+// Heap-managed primitive: moves a symlink from src to dest.
+// readlink(src) → FSMakeSymlink(linkTarget, dest) → unlink(src).
+// Calls onDone(0) on success, onDone(negative_uv_error) on failure. Self-deletes.
+struct FSMoveSymlink
+{
+    FSMoveSymlink(uv_loop_t* loop, std::string src, std::string dest, std::function<void(int)> onDone)
+        : loop(loop)
+        , src(std::move(src))
+        , dest(std::move(dest))
+        , onDone(std::move(onDone))
+    {
+        req.data = this;
+    }
+
+    void start()
+    {
+        uv_fs_readlink(loop, &req, src.c_str(), FSMoveSymlink::readlinkCallback);
+    }
+
+    uv_loop_t* loop;
+    uv_fs_t req;
+    std::string src;
+    std::string dest;
+    std::function<void(int)> onDone;
+    std::string linkTarget;
+
+private:
+    static void readlinkCallback(uv_fs_t* req)
+    {
+        auto* self = static_cast<FSMoveSymlink*>(req->data);
+        int result = req->result;
+
+        if (result < 0)
+        {
+            uv_fs_req_cleanup(req);
+            auto done = std::move(self->onDone);
+            delete self;
+            done(result);
+            return;
+        }
+
+        self->linkTarget = static_cast<const char*>(req->ptr);
+        uv_fs_req_cleanup(req);
+
+        (new FSMakeSymlink(
+            self->loop,
+            self->linkTarget,
+            self->dest,
+            [self](int err)
+            {
+                if (err < 0)
+                {
+                    auto done = std::move(self->onDone);
+                    delete self;
+                    done(err);
+                    return;
+                }
+                uv_fs_unlink(self->loop, &self->req, self->src.c_str(), FSMoveSymlink::unlinkCallback);
+            }
+        ))
+            ->start();
+    }
+
+    static void unlinkCallback(uv_fs_t* req)
+    {
+        auto* self = static_cast<FSMoveSymlink*>(req->data);
+        int result = req->result;
+        uv_fs_req_cleanup(req);
+        auto done = std::move(self->onDone);
+        delete self;
+        done(result);
+    }
+};
+
+// Heap-managed primitive: moves a regular file from src to dest.
+// copyfile(src, dest) → unlink(src).
+// Calls onDone(0) on success, onDone(negative_uv_error) on failure. Self-deletes.
+struct FSMoveSingleFile
+{
+    FSMoveSingleFile(uv_loop_t* loop, std::string src, std::string dest, std::function<void(int)> onDone)
+        : loop(loop)
+        , src(std::move(src))
+        , dest(std::move(dest))
+        , onDone(std::move(onDone))
+    {
+        req.data = this;
+    }
+
+    void start()
+    {
+        uv_fs_copyfile(loop, &req, src.c_str(), dest.c_str(), 0, FSMoveSingleFile::copyCallback);
+    }
+
+    uv_loop_t* loop;
+    uv_fs_t req;
+    std::string src;
+    std::string dest;
+    std::function<void(int)> onDone;
+
+private:
+    static void copyCallback(uv_fs_t* req)
+    {
+        auto* self = static_cast<FSMoveSingleFile*>(req->data);
+        int result = req->result;
+        uv_fs_req_cleanup(req);
+
+        if (result < 0)
+        {
+            auto done = std::move(self->onDone);
+            delete self;
+            done(result);
+            return;
+        }
+
+        uv_fs_unlink(self->loop, &self->req, self->src.c_str(), FSMoveSingleFile::unlinkCallback);
+    }
+
+    static void unlinkCallback(uv_fs_t* req)
+    {
+        auto* self = static_cast<FSMoveSingleFile*>(req->data);
+        int result = req->result;
+        uv_fs_req_cleanup(req);
+        auto done = std::move(self->onDone);
+        delete self;
+        done(result);
+    }
+};
+
 struct FSRename : FSPathPairRequest
 {
     using FSPathPairRequest::FSPathPairRequest;
 
-    std::string linkTarget;
-
     static void renameCallback(uv_fs_t* req);
     static void statCallback(uv_fs_t* req);
-    static void copyCallback(uv_fs_t* req);
-    static void unlinkCallback(uv_fs_t* req);
-    static void readlinkCallback(uv_fs_t* req);
-    static void symlinkCallback(uv_fs_t* req);
-#if _WIN32
-    static void symlinkStatCallback(uv_fs_t* req);
-#endif
 };
 
 // Handles a recursive cross-filesystem directory move as a self-managed async state machine.
@@ -147,7 +324,6 @@ struct FSCopyDirectory
     size_t fileIdx = 0;
     size_t linkIdx = 0;
     size_t removeDirIdx = 0;
-    std::string linkTarget; // readlink result held between readlinkCallback and symlinkCallback
     std::vector<DirPair> pendingUnknown; // dirent-unknown entries awaiting per-entry lstat classification
     size_t unknownIdx = 0;
 
@@ -159,18 +335,7 @@ struct FSCopyDirectory
     template<typename... Args>
     void fail(const char* fmt, Args&&... args)
     {
-        int size = snprintf(nullptr, 0, fmt, std::forward<Args>(args)...);
-        if (size < 0)
-        {
-            token->fail("Format error in fail");
-            delete this;
-            return;
-        }
-
-        std::vector<char> buffer(size + 1);
-        snprintf(buffer.data(), buffer.size(), fmt, std::forward<Args>(args)...);
-        token->fail(std::string(buffer.data()));
-
+        token->fail(uvutils::formatUVError(fmt, std::forward<Args>(args)...));
         delete this;
     }
 
@@ -213,19 +378,57 @@ struct FSCopyDirectory
     {
         if (fileIdx < pendingFiles.size())
         {
-            uv_fs_copyfile(loop, &req, pendingFiles[fileIdx].src.c_str(), pendingFiles[fileIdx].dest.c_str(), 0, FSCopyDirectory::copyFileCallback);
+            (new FSMoveSingleFile(
+                loop,
+                pendingFiles[fileIdx].src,
+                pendingFiles[fileIdx].dest,
+                [this](int err)
+                {
+                    if (err < 0)
+                    {
+                        fail(
+                            "move: Error moving file %s: %s; source and destination may be in an inconsistent state",
+                            pendingFiles[fileIdx].src.c_str(),
+                            uv_strerror(err)
+                        );
+                        return;
+                    }
+                    ++fileIdx;
+                    startFileCopy();
+                }
+            ))
+                ->start();
             return;
         }
 
         startLinkCopy();
     }
 
-    // Phase 4: recreate symlinks at destination via readlink+symlink+unlink.
+    // Phase 4: recreate symlinks at destination via FSMoveSymlink.
     void startLinkCopy()
     {
         if (linkIdx < pendingLinks.size())
         {
-            uv_fs_readlink(loop, &req, pendingLinks[linkIdx].src.c_str(), FSCopyDirectory::readlinkCallback);
+            (new FSMoveSymlink(
+                loop,
+                pendingLinks[linkIdx].src,
+                pendingLinks[linkIdx].dest,
+                [this](int err)
+                {
+                    if (err < 0)
+                    {
+                        fail(
+                            "move: Error moving symlink %s: %s; source and destination may be in an inconsistent state",
+                            pendingLinks[linkIdx].src.c_str(),
+                            uv_strerror(err)
+                        );
+                        return;
+                    }
+                    ++linkIdx;
+                    startLinkCopy();
+                }
+            ))
+                ->start();
             return;
         }
 
@@ -383,122 +586,6 @@ struct FSCopyDirectory
         uv_fs_req_cleanup(req);
         ++self->unknownIdx;
         self->startUnknownClassification();
-    }
-
-    static void copyFileCallback(uv_fs_t* req)
-    {
-        auto* self = fromReq(req);
-        auto result = req->result;
-        uv_fs_req_cleanup(req);
-
-        if (result < 0)
-        {
-            self->fail(
-                "move: Error copying file %s: %s; source and destination may be in an inconsistent state",
-                self->pendingFiles[self->fileIdx].src.c_str(),
-                uv_strerror(result)
-            );
-            return;
-        }
-
-        uv_fs_unlink(self->loop, &self->req, self->pendingFiles[self->fileIdx].src.c_str(), FSCopyDirectory::unlinkFileCallback);
-    }
-
-    static void unlinkFileCallback(uv_fs_t* req)
-    {
-        auto* self = fromReq(req);
-        auto result = req->result;
-        uv_fs_req_cleanup(req);
-
-        if (result < 0)
-        {
-            self->fail(
-                "move: Error removing source file %s: %s; source and destination may be in an inconsistent state",
-                self->pendingFiles[self->fileIdx].src.c_str(),
-                uv_strerror(result)
-            );
-            return;
-        }
-
-        ++self->fileIdx;
-        self->startFileCopy();
-    }
-
-    static void readlinkCallback(uv_fs_t* req)
-    {
-        auto* self = fromReq(req);
-        auto result = req->result;
-
-        if (result < 0)
-        {
-            std::string src = self->pendingLinks[self->linkIdx].src;
-            uv_fs_req_cleanup(req);
-            self->fail(
-                "move: Error reading symlink %s: %s; source and destination may be in an inconsistent state",
-                src.c_str(),
-                uv_strerror(result)
-            );
-            return;
-        }
-
-        // req->ptr holds the link target; copy it before cleanup frees it.
-        self->linkTarget = static_cast<const char*>(req->ptr);
-        uv_fs_req_cleanup(req);
-
-#if _WIN32
-        uv_fs_stat(self->loop, &self->req, self->linkTarget.c_str(), FSCopyDirectory::symlinkStatCallback);
-#else
-        uv_fs_symlink(self->loop, &self->req, self->linkTarget.c_str(), self->pendingLinks[self->linkIdx].dest.c_str(), 0, FSCopyDirectory::symlinkCallback);
-#endif
-    }
-
-#if _WIN32
-    static void symlinkStatCallback(uv_fs_t* req)
-    {
-        auto* self = fromReq(req);
-        int flags = (req->result >= 0 && S_ISDIR(req->statbuf.st_mode)) ? UV_FS_SYMLINK_DIR : 0;
-        uv_fs_req_cleanup(req);
-        uv_fs_symlink(self->loop, &self->req, self->linkTarget.c_str(), self->pendingLinks[self->linkIdx].dest.c_str(), flags, FSCopyDirectory::symlinkCallback);
-    }
-#endif
-
-    static void symlinkCallback(uv_fs_t* req)
-    {
-        auto* self = fromReq(req);
-        auto result = req->result;
-        uv_fs_req_cleanup(req);
-
-        if (result < 0)
-        {
-            self->fail(
-                "move: Error creating symlink %s: %s; source and destination may be in an inconsistent state",
-                self->pendingLinks[self->linkIdx].dest.c_str(),
-                uv_strerror(result)
-            );
-            return;
-        }
-
-        uv_fs_unlink(self->loop, &self->req, self->pendingLinks[self->linkIdx].src.c_str(), FSCopyDirectory::unlinkLinkCallback);
-    }
-
-    static void unlinkLinkCallback(uv_fs_t* req)
-    {
-        auto* self = fromReq(req);
-        auto result = req->result;
-        uv_fs_req_cleanup(req);
-
-        if (result < 0)
-        {
-            self->fail(
-                "move: Error removing source symlink %s: %s; source and destination may be in an inconsistent state",
-                self->pendingLinks[self->linkIdx].src.c_str(),
-                uv_strerror(result)
-            );
-            return;
-        }
-
-        ++self->linkIdx;
-        self->startLinkCopy();
     }
 
     static void rmdirCallback(uv_fs_t* req)
@@ -900,73 +987,24 @@ int link_impl(lua_State* L, const char* path, const char* dest)
     return lua_yield(L, 0);
 }
 
-#if _WIN32
-struct FSSymlink : FSPathPairRequest
-{
-    using FSPathPairRequest::FSPathPairRequest;
-
-    static void statCallback(uv_fs_t* req)
-    {
-        auto r = uvutils::retake<FSSymlink>(req);
-        int flags = (req->result >= 0 && S_ISDIR(req->statbuf.st_mode)) ? UV_FS_SYMLINK_DIR : 0;
-
-        uv_fs_req_cleanup(&r->req);
-        uvutils::ScopedUVRequest<FSSymlink> symlinkReq{std::move(r)};
-        uv_fs_symlink(
-            symlinkReq->getLoop(),
-            &symlinkReq->req,
-            symlinkReq->src.c_str(),
-            symlinkReq->dest.c_str(),
-            flags,
-            FSSymlink::symlinkCallback
-        );
-    }
-
-    static void symlinkCallback(uv_fs_t* req)
-    {
-        auto r = uvutils::retake<FSSymlink>(req);
-        auto result = req->result;
-
-        if (result < 0)
-        {
-            r->fail("symlink: Error creating symlink from %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
-            return;
-        }
-
-        r->succeedTrivially();
-    }
-};
-#endif
-
 int symlink_impl(lua_State* L, const char* path, const char* dest)
 {
-#if _WIN32
-    uvutils::ScopedUVRequest<FSSymlink> req{L, path, dest};
-    uv_fs_stat(req->getLoop(), &req->req, path, FSSymlink::statCallback);
-#else
-    uvutils::ScopedUVRequest<FSPathPairRequest> req{L, path, dest};
-    uv_fs_symlink(
-        req->getLoop(),
-        &req->req,
-        path,
-        dest,
-        0,
-        [](uv_fs_t* req)
+    auto token = getResumeToken(L);
+    auto* loop = getRuntimeLoop(L);
+    std::string src{path}, dst{dest};
+    (new FSMakeSymlink(
+        loop,
+        src,
+        dst,
+        [token, src, dst](int err)
         {
-            auto r = uvutils::retake<FSPathPairRequest>(req);
-            auto result = req->result;
-
-            if (result < 0)
-            {
-                r->fail("symlink: Error creating symlink from %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
-                return;
-            }
-
-            r->succeedTrivially();
+            if (err < 0)
+                token->fail(uvutils::formatUVError("symlink: Error creating symlink from %s to %s: %s", src.c_str(), dst.c_str(), uv_strerror(err)));
+            else
+                token->complete([](lua_State* L) { return 0; });
         }
-    );
-#endif
-
+    ))
+        ->start();
     return lua_yield(L, 0);
 }
 
@@ -1034,10 +1072,21 @@ void FSRename::statCallback(uv_fs_t* req)
 
     if (S_ISLNK(req->statbuf.st_mode))
     {
-        // Top-level source is a symlink: recreate it at the destination.
-        uv_fs_req_cleanup(&r->req);
-        uvutils::ScopedUVRequest<FSRename> readlinkReq{std::move(r)};
-        uv_fs_readlink(readlinkReq->getLoop(), &readlinkReq->req, readlinkReq->src.c_str(), FSRename::readlinkCallback);
+        auto* raw = r.release();
+        (new FSMoveSymlink(
+            raw->loop,
+            raw->src,
+            raw->dest,
+            [raw](int err)
+            {
+                std::unique_ptr<FSRename> r(raw);
+                if (err < 0)
+                    r->fail("move: Error moving symlink %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(err));
+                else
+                    r->succeedTrivially();
+            }
+        ))
+            ->start();
         return;
     }
 
@@ -1056,88 +1105,21 @@ void FSRename::statCallback(uv_fs_t* req)
         return;
     }
 
-    uvutils::ScopedUVRequest<FSRename> copyReq{std::move(r)};
-    uv_fs_copyfile(copyReq->getLoop(), &copyReq->req, copyReq->src.c_str(), copyReq->dest.c_str(), 0, FSRename::copyCallback);
-}
-
-void FSRename::copyCallback(uv_fs_t* req)
-{
-    auto r = uvutils::retake<FSRename>(req);
-    auto result = req->result;
-
-    if (result < 0)
-    {
-        r->fail("move: Error copying %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(result));
-        return;
-    }
-
-    uv_fs_req_cleanup(&r->req);
-    uvutils::ScopedUVRequest<FSRename> unlinkReq{std::move(r)};
-    uv_fs_unlink(unlinkReq->getLoop(), &unlinkReq->req, unlinkReq->src.c_str(), FSRename::unlinkCallback);
-}
-
-void FSRename::unlinkCallback(uv_fs_t* req)
-{
-    auto r = uvutils::retake<FSRename>(req);
-    auto result = req->result;
-
-    if (result < 0)
-    {
-        r->fail("move: Error removing source %s: %s", r->src.c_str(), uv_strerror(result));
-        return;
-    }
-
-    r->succeedTrivially();
-}
-
-void FSRename::readlinkCallback(uv_fs_t* req)
-{
-    auto r = uvutils::retake<FSRename>(req);
-    auto result = req->result;
-
-    if (result < 0)
-    {
-        r->fail("move: Error reading symlink %s: %s", r->src.c_str(), uv_strerror(result));
-        return;
-    }
-
-    r->linkTarget = static_cast<const char*>(req->ptr);
-    uv_fs_req_cleanup(&r->req);
-
-#if _WIN32
-    uvutils::ScopedUVRequest<FSRename> statReq{std::move(r)};
-    uv_fs_stat(statReq->getLoop(), &statReq->req, statReq->linkTarget.c_str(), FSRename::symlinkStatCallback);
-#else
-    uvutils::ScopedUVRequest<FSRename> symlinkReq{std::move(r)};
-    uv_fs_symlink(symlinkReq->getLoop(), &symlinkReq->req, symlinkReq->linkTarget.c_str(), symlinkReq->dest.c_str(), 0, FSRename::symlinkCallback);
-#endif
-}
-
-#if _WIN32
-void FSRename::symlinkStatCallback(uv_fs_t* req)
-{
-    auto r = uvutils::retake<FSRename>(req);
-    int flags = (req->result >= 0 && S_ISDIR(req->statbuf.st_mode)) ? UV_FS_SYMLINK_DIR : 0;
-    uv_fs_req_cleanup(&r->req);
-    uvutils::ScopedUVRequest<FSRename> symlinkReq{std::move(r)};
-    uv_fs_symlink(symlinkReq->getLoop(), &symlinkReq->req, symlinkReq->linkTarget.c_str(), symlinkReq->dest.c_str(), flags, FSRename::symlinkCallback);
-}
-#endif
-
-void FSRename::symlinkCallback(uv_fs_t* req)
-{
-    auto r = uvutils::retake<FSRename>(req);
-    auto result = req->result;
-
-    if (result < 0)
-    {
-        r->fail("move: Error creating symlink %s: %s", r->dest.c_str(), uv_strerror(result));
-        return;
-    }
-
-    uv_fs_req_cleanup(&r->req);
-    uvutils::ScopedUVRequest<FSRename> unlinkReq{std::move(r)};
-    uv_fs_unlink(unlinkReq->getLoop(), &unlinkReq->req, unlinkReq->src.c_str(), FSRename::unlinkCallback);
+    auto* raw = r.release();
+    (new FSMoveSingleFile(
+        raw->loop,
+        raw->src,
+        raw->dest,
+        [raw](int err)
+        {
+            std::unique_ptr<FSRename> r(raw);
+            if (err < 0)
+                r->fail("move: Error moving file %s to %s: %s", r->src.c_str(), r->dest.c_str(), uv_strerror(err));
+            else
+                r->succeedTrivially();
+        }
+    ))
+        ->start();
 }
 
 int rename_impl(lua_State* L, const char* path, const char* dest)

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -11,8 +11,6 @@
 
 #include "uv.h"
 
-#include <functional>
-
 #ifdef _WIN32
 #include <direct.h>
 #else

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -1092,8 +1092,8 @@ void FSRename::statCallback(uv_fs_t* req)
     {
         // Directory: hand off to FSCopyDirectory. Moving the token transfers coroutine
         // ownership; r is then destroyed cleanly with an empty token.
-        auto* copyDir = new FSCopyDirectory(std::move(r->token), r->loop, r->src, r->dest);
-        copyDir->start();
+        /*auto* copyDir = */new FSCopyDirectory(std::move(r->token), r->loop, r->src, r->dest);
+        //copyDir->start(); FIXME: disabled to confirm that CI breaks if we remove it
         return;
     }
 

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -9,6 +9,8 @@
 
 #include "uv.h"
 
+#include "Luau/VecDeque.h"
+
 #ifdef _WIN32
 #include <direct.h>
 #else
@@ -103,9 +105,345 @@ struct FSRename : FSPathPairRequest
 {
     using FSPathPairRequest::FSPathPairRequest;
 
+    std::string linkTarget;
+
     static void renameCallback(uv_fs_t* req);
+    static void statCallback(uv_fs_t* req);
     static void copyCallback(uv_fs_t* req);
     static void unlinkCallback(uv_fs_t* req);
+    static void readlinkCallback(uv_fs_t* req);
+    static void symlinkCallback(uv_fs_t* req);
+#if _WIN32
+    static void symlinkStatCallback(uv_fs_t* req);
+#endif
+};
+
+// Handles a recursive cross-filesystem directory move as a self-managed async state machine.
+// Ownership: heap-allocated; calls `delete this` via succeed() or fail().
+struct FSCopyDirectory
+{
+    FSCopyDirectory(ResumeToken token, uv_loop_t* loop, std::string src, std::string dest)
+        : token(std::move(token))
+        , loop(loop)
+    {
+        req.data = this;
+        pendingDirs.push_back({std::move(src), std::move(dest)});
+    }
+
+    struct DirPair
+    {
+        std::string src;
+        std::string dest;
+    };
+
+    ResumeToken token;
+    uv_loop_t* loop;
+    uv_fs_t req;
+
+    Luau::VecDeque<DirPair> pendingDirs;  // source dirs awaiting mkdir+scandir
+    std::vector<std::string> scannedDirs; // source dirs in breadth-first order; rmdired in reverse
+    std::vector<DirPair> pendingFiles;    // regular files awaiting copyfile+unlink
+    std::vector<DirPair> pendingLinks;    // symlinks awaiting readlink+symlink+unlink
+    size_t fileIdx = 0;
+    size_t linkIdx = 0;
+    size_t removeDirIdx = 0;
+    std::string linkTarget; // readlink result held between readlinkCallback and symlinkCallback
+
+    static FSCopyDirectory* fromReq(uv_fs_t* req)
+    {
+        return static_cast<FSCopyDirectory*>(req->data);
+    }
+
+    template<typename... Args>
+    void fail(const char* fmt, Args&&... args)
+    {
+        int size = snprintf(nullptr, 0, fmt, std::forward<Args>(args)...);
+        if (size < 0)
+        {
+            token->fail("Format error in fail");
+            delete this;
+            return;
+        }
+
+        std::vector<char> buffer(size + 1);
+        snprintf(buffer.data(), buffer.size(), fmt, std::forward<Args>(args)...);
+        token->fail(std::string(buffer.data()));
+
+        delete this;
+    }
+
+    void succeed()
+    {
+        token->complete([](lua_State* L) { return 0; });
+        delete this;
+    }
+
+    // Phase 1: process the next pending source directory, or advance to file copying.
+    void start()
+    {
+        if (!pendingDirs.empty())
+        {
+            uv_fs_mkdir(loop, &req, pendingDirs.front().dest.c_str(), 0777, FSCopyDirectory::mkdirCallback);
+            return;
+        }
+
+        startFileCopy();
+    }
+
+    // Phase 2: copy+unlink the next pending regular file, or advance to symlink recreation.
+    void startFileCopy()
+    {
+        if (fileIdx < pendingFiles.size())
+        {
+            uv_fs_copyfile(loop, &req, pendingFiles[fileIdx].src.c_str(), pendingFiles[fileIdx].dest.c_str(), 0, FSCopyDirectory::copyFileCallback);
+            return;
+        }
+
+        startLinkCopy();
+    }
+
+    // Phase 3: recreate symlinks at destination via readlink+symlink+unlink.
+    void startLinkCopy()
+    {
+        if (linkIdx < pendingLinks.size())
+        {
+            uv_fs_readlink(loop, &req, pendingLinks[linkIdx].src.c_str(), FSCopyDirectory::readlinkCallback);
+            return;
+        }
+
+        startDirRemoval();
+    }
+
+    // Phase 4: rmdir source dirs in reverse breadth-first order (children before parents).
+    void startDirRemoval()
+    {
+        if (removeDirIdx < scannedDirs.size())
+        {
+            const auto& dir = scannedDirs[scannedDirs.size() - 1 - removeDirIdx];
+            uv_fs_rmdir(loop, &req, dir.c_str(), FSCopyDirectory::rmdirCallback);
+            return;
+        }
+
+        succeed();
+    }
+
+    static void mkdirCallback(uv_fs_t* req)
+    {
+        auto* self = fromReq(req);
+        auto result = req->result;
+        uv_fs_req_cleanup(req);
+
+        if (result < 0 && result != UV_EEXIST)
+        {
+            self->fail("move: Error creating directory %s: %s", self->pendingDirs.front().dest.c_str(), uv_strerror(result));
+            return;
+        }
+
+        uv_fs_scandir(self->loop, &self->req, self->pendingDirs.front().src.c_str(), 0, FSCopyDirectory::scandirCallback);
+    }
+
+    static void scandirCallback(uv_fs_t* req)
+    {
+        auto* self = fromReq(req);
+        auto result = req->result;
+
+        if (result < 0)
+        {
+            std::string srcPath = self->pendingDirs.front().src;
+            uv_fs_req_cleanup(req);
+            self->fail(
+                "move: Error reading directory %s: %s; some destination subdirectories may have been created",
+                srcPath.c_str(),
+                uv_strerror(result)
+            );
+            return;
+        }
+
+        // Collect all entries before req_cleanup, which frees the scandir data.
+        std::vector<std::pair<std::string, uv_dirent_type_t>> entries;
+        uv_dirent_t dirent;
+        int err;
+        while ((err = uv_fs_scandir_next(req, &dirent)) >= 0)
+            entries.emplace_back(dirent.name, dirent.type);
+
+        std::string srcDir = self->pendingDirs.front().src;
+        std::string destDir = self->pendingDirs.front().dest;
+        uv_fs_req_cleanup(req);
+
+        if (err != UV_EOF)
+        {
+            self->fail(
+                "move: Error reading directory entry in %s: %s; some destination subdirectories may have been created",
+                srcDir.c_str(),
+                uv_strerror(err)
+            );
+            return;
+        }
+
+        for (auto& [name, type] : entries)
+        {
+            std::string childSrc = srcDir + "/" + name;
+            std::string childDest = destDir + "/" + name;
+            if (type == UV_DIRENT_DIR)
+            {
+                self->pendingDirs.push_back({childSrc, childDest});
+            }
+            else if (type == UV_DIRENT_FILE)
+            {
+                self->pendingFiles.push_back({childSrc, childDest});
+            }
+            else if (type == UV_DIRENT_LINK)
+            {
+                self->pendingLinks.push_back({childSrc, childDest});
+            }
+            else
+            {
+                self->fail("move: Cannot move %s: unsupported file type", childSrc.c_str());
+                return;
+            }
+        }
+
+        self->scannedDirs.push_back(srcDir);
+        self->pendingDirs.pop_front();
+
+        self->start();
+    }
+
+    static void copyFileCallback(uv_fs_t* req)
+    {
+        auto* self = fromReq(req);
+        auto result = req->result;
+        uv_fs_req_cleanup(req);
+
+        if (result < 0)
+        {
+            self->fail(
+                "move: Error copying file %s: %s; source and destination may be in an inconsistent state",
+                self->pendingFiles[self->fileIdx].src.c_str(),
+                uv_strerror(result)
+            );
+            return;
+        }
+
+        uv_fs_unlink(self->loop, &self->req, self->pendingFiles[self->fileIdx].src.c_str(), FSCopyDirectory::unlinkFileCallback);
+    }
+
+    static void unlinkFileCallback(uv_fs_t* req)
+    {
+        auto* self = fromReq(req);
+        auto result = req->result;
+        uv_fs_req_cleanup(req);
+
+        if (result < 0)
+        {
+            self->fail(
+                "move: Error removing source file %s: %s; source and destination may be in an inconsistent state",
+                self->pendingFiles[self->fileIdx].src.c_str(),
+                uv_strerror(result)
+            );
+            return;
+        }
+
+        ++self->fileIdx;
+        self->startFileCopy();
+    }
+
+    static void readlinkCallback(uv_fs_t* req)
+    {
+        auto* self = fromReq(req);
+        auto result = req->result;
+
+        if (result < 0)
+        {
+            std::string src = self->pendingLinks[self->linkIdx].src;
+            uv_fs_req_cleanup(req);
+            self->fail(
+                "move: Error reading symlink %s: %s; source and destination may be in an inconsistent state",
+                src.c_str(),
+                uv_strerror(result)
+            );
+            return;
+        }
+
+        // req->ptr holds the link target; copy it before cleanup frees it.
+        self->linkTarget = static_cast<const char*>(req->ptr);
+        uv_fs_req_cleanup(req);
+
+#if _WIN32
+        uv_fs_stat(self->loop, &self->req, self->linkTarget.c_str(), FSCopyDirectory::symlinkStatCallback);
+#else
+        uv_fs_symlink(self->loop, &self->req, self->linkTarget.c_str(), self->pendingLinks[self->linkIdx].dest.c_str(), 0, FSCopyDirectory::symlinkCallback);
+#endif
+    }
+
+#if _WIN32
+    static void symlinkStatCallback(uv_fs_t* req)
+    {
+        auto* self = fromReq(req);
+        int flags = (req->result >= 0 && S_ISDIR(req->statbuf.st_mode)) ? UV_FS_SYMLINK_DIR : 0;
+        uv_fs_req_cleanup(req);
+        uv_fs_symlink(self->loop, &self->req, self->linkTarget.c_str(), self->pendingLinks[self->linkIdx].dest.c_str(), flags, FSCopyDirectory::symlinkCallback);
+    }
+#endif
+
+    static void symlinkCallback(uv_fs_t* req)
+    {
+        auto* self = fromReq(req);
+        auto result = req->result;
+        uv_fs_req_cleanup(req);
+
+        if (result < 0)
+        {
+            self->fail(
+                "move: Error creating symlink %s: %s; source and destination may be in an inconsistent state",
+                self->pendingLinks[self->linkIdx].dest.c_str(),
+                uv_strerror(result)
+            );
+            return;
+        }
+
+        uv_fs_unlink(self->loop, &self->req, self->pendingLinks[self->linkIdx].src.c_str(), FSCopyDirectory::unlinkLinkCallback);
+    }
+
+    static void unlinkLinkCallback(uv_fs_t* req)
+    {
+        auto* self = fromReq(req);
+        auto result = req->result;
+        uv_fs_req_cleanup(req);
+
+        if (result < 0)
+        {
+            self->fail(
+                "move: Error removing source symlink %s: %s; source and destination may be in an inconsistent state",
+                self->pendingLinks[self->linkIdx].src.c_str(),
+                uv_strerror(result)
+            );
+            return;
+        }
+
+        ++self->linkIdx;
+        self->startLinkCopy();
+    }
+
+    static void rmdirCallback(uv_fs_t* req)
+    {
+        auto* self = fromReq(req);
+        auto result = req->result;
+        uv_fs_req_cleanup(req);
+
+        if (result < 0)
+        {
+            self->fail(
+                "move: Error removing source directory %s: %s; the destination is complete but the source directory tree was not fully removed",
+                self->scannedDirs[self->scannedDirs.size() - 1 - self->removeDirIdx].c_str(),
+                uv_strerror(result)
+            );
+            return;
+        }
+
+        ++self->removeDirIdx;
+        self->startDirRemoval();
+    }
 };
 
 int open_impl(lua_State* L, const char* path, int flags, int mode)
@@ -600,8 +938,42 @@ void FSRename::renameCallback(uv_fs_t* req)
         return;
     }
 
-    // Cross-filesystem: fall back to copy + remove
+    // Cross-filesystem: stat the source first to determine whether it's a file or a directory,
+    // since the fallback copy strategy differs between the two.
     uv_fs_req_cleanup(&r->req);
+    uvutils::ScopedUVRequest<FSRename> statReq{std::move(r)};
+    uv_fs_lstat(statReq->getLoop(), &statReq->req, statReq->src.c_str(), FSRename::statCallback);
+}
+
+void FSRename::statCallback(uv_fs_t* req)
+{
+    auto r = uvutils::retake<FSRename>(req);
+    auto result = req->result;
+
+    if (result < 0)
+    {
+        r->fail("move: Error reading source %s: %s", r->src.c_str(), uv_strerror(result));
+        return;
+    }
+
+    if (S_ISLNK(req->statbuf.st_mode))
+    {
+        // Top-level source is a symlink: recreate it at the destination.
+        uv_fs_req_cleanup(&r->req);
+        uvutils::ScopedUVRequest<FSRename> readlinkReq{std::move(r)};
+        uv_fs_readlink(readlinkReq->getLoop(), &readlinkReq->req, readlinkReq->src.c_str(), FSRename::readlinkCallback);
+        return;
+    }
+
+    if (S_ISDIR(req->statbuf.st_mode))
+    {
+        // Directory: hand off to FSCopyDirectory. Moving the token transfers coroutine
+        // ownership; r is then destroyed cleanly with an empty token.
+        new FSCopyDirectory(std::move(r->token), r->loop, r->src, r->dest);
+        return;
+    }
+
+    // Regular file (or other): use the existing async copyfile → unlink chain.
     uvutils::ScopedUVRequest<FSRename> copyReq{std::move(r)};
     uv_fs_copyfile(copyReq->getLoop(), &copyReq->req, copyReq->src.c_str(), copyReq->dest.c_str(), 0, FSRename::copyCallback);
 }
@@ -634,6 +1006,56 @@ void FSRename::unlinkCallback(uv_fs_t* req)
     }
 
     r->succeedTrivially();
+}
+
+void FSRename::readlinkCallback(uv_fs_t* req)
+{
+    auto r = uvutils::retake<FSRename>(req);
+    auto result = req->result;
+
+    if (result < 0)
+    {
+        r->fail("move: Error reading symlink %s: %s", r->src.c_str(), uv_strerror(result));
+        return;
+    }
+
+    r->linkTarget = static_cast<const char*>(req->ptr);
+    uv_fs_req_cleanup(&r->req);
+
+#if _WIN32
+    uvutils::ScopedUVRequest<FSRename> statReq{std::move(r)};
+    uv_fs_stat(statReq->getLoop(), &statReq->req, statReq->linkTarget.c_str(), FSRename::symlinkStatCallback);
+#else
+    uvutils::ScopedUVRequest<FSRename> symlinkReq{std::move(r)};
+    uv_fs_symlink(symlinkReq->getLoop(), &symlinkReq->req, symlinkReq->linkTarget.c_str(), symlinkReq->dest.c_str(), 0, FSRename::symlinkCallback);
+#endif
+}
+
+#if _WIN32
+void FSRename::symlinkStatCallback(uv_fs_t* req)
+{
+    auto r = uvutils::retake<FSRename>(req);
+    int flags = (req->result >= 0 && S_ISDIR(req->statbuf.st_mode)) ? UV_FS_SYMLINK_DIR : 0;
+    uv_fs_req_cleanup(&r->req);
+    uvutils::ScopedUVRequest<FSRename> symlinkReq{std::move(r)};
+    uv_fs_symlink(symlinkReq->getLoop(), &symlinkReq->req, symlinkReq->linkTarget.c_str(), symlinkReq->dest.c_str(), flags, FSRename::symlinkCallback);
+}
+#endif
+
+void FSRename::symlinkCallback(uv_fs_t* req)
+{
+    auto r = uvutils::retake<FSRename>(req);
+    auto result = req->result;
+
+    if (result < 0)
+    {
+        r->fail("move: Error creating symlink %s: %s", r->dest.c_str(), uv_strerror(result));
+        return;
+    }
+
+    uv_fs_req_cleanup(&r->req);
+    uvutils::ScopedUVRequest<FSRename> unlinkReq{std::move(r)};
+    uv_fs_unlink(unlinkReq->getLoop(), &unlinkReq->req, unlinkReq->src.c_str(), FSRename::unlinkCallback);
 }
 
 int rename_impl(lua_State* L, const char* path, const char* dest)

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -148,6 +148,8 @@ struct FSCopyDirectory
     size_t linkIdx = 0;
     size_t removeDirIdx = 0;
     std::string linkTarget; // readlink result held between readlinkCallback and symlinkCallback
+    std::vector<DirPair> pendingUnknown; // dirent-unknown entries awaiting per-entry lstat classification
+    size_t unknownIdx = 0;
 
     static FSCopyDirectory* fromReq(uv_fs_t* req)
     {
@@ -190,7 +192,23 @@ struct FSCopyDirectory
         startFileCopy();
     }
 
-    // Phase 2: copy+unlink the next pending regular file, or advance to symlink recreation.
+    // Phase 2: lstat each UV_DIRENT_UNKNOWN entry from the current scandir to classify it.
+    void startUnknownClassification()
+    {
+        if (unknownIdx < pendingUnknown.size())
+        {
+            uv_fs_lstat(loop, &req, pendingUnknown[unknownIdx].src.c_str(), FSCopyDirectory::unknownLstatCallback);
+            return;
+        }
+
+        pendingUnknown.clear();
+        unknownIdx = 0;
+        scannedDirs.push_back(pendingDirs.front().src);
+        pendingDirs.pop_front();
+        start();
+    }
+
+    // Phase 3: copy+unlink the next pending regular file, or advance to symlink recreation.
     void startFileCopy()
     {
         if (fileIdx < pendingFiles.size())
@@ -202,7 +220,7 @@ struct FSCopyDirectory
         startLinkCopy();
     }
 
-    // Phase 3: recreate symlinks at destination via readlink+symlink+unlink.
+    // Phase 4: recreate symlinks at destination via readlink+symlink+unlink.
     void startLinkCopy()
     {
         if (linkIdx < pendingLinks.size())
@@ -214,7 +232,7 @@ struct FSCopyDirectory
         startDirRemoval();
     }
 
-    // Phase 4: rmdir source dirs in reverse breadth-first order (children before parents).
+    // Phase 5: rmdir source dirs in reverse breadth-first order (children before parents).
     void startDirRemoval()
     {
         if (removeDirIdx < scannedDirs.size())
@@ -296,6 +314,10 @@ struct FSCopyDirectory
             {
                 self->pendingLinks.push_back({childSrc, childDest});
             }
+            else if (type == UV_DIRENT_UNKNOWN)
+            {
+                self->pendingUnknown.push_back({childSrc, childDest});
+            }
             else
             {
                 self->fail("move: Cannot move %s: unsupported file type", childSrc.c_str());
@@ -303,10 +325,64 @@ struct FSCopyDirectory
             }
         }
 
+        if (!self->pendingUnknown.empty())
+        {
+            self->startUnknownClassification();
+            return;
+        }
+
         self->scannedDirs.push_back(srcDir);
         self->pendingDirs.pop_front();
 
         self->start();
+    }
+
+    static void unknownLstatCallback(uv_fs_t* req)
+    {
+        auto* self = fromReq(req);
+        auto result = req->result;
+
+        if (result < 0)
+        {
+            std::string path = self->pendingUnknown[self->unknownIdx].src;
+            uv_fs_req_cleanup(req);
+            self->fail(
+                "move: Error reading %s: %s; some destination subdirectories may have been created",
+                path.c_str(),
+                uv_strerror(result)
+            );
+            return;
+        }
+
+        auto mode = req->statbuf.st_mode;
+        const auto& entry = self->pendingUnknown[self->unknownIdx];
+
+        if (S_ISDIR(mode))
+        {
+            self->pendingDirs.push_back({entry.src, entry.dest});
+        }
+        else if (S_ISREG(mode))
+        {
+            self->pendingFiles.push_back({entry.src, entry.dest});
+        }
+        else if (S_ISLNK(mode))
+        {
+            self->pendingLinks.push_back({entry.src, entry.dest});
+        }
+        else
+        {
+            std::string path = entry.src;
+            uv_fs_req_cleanup(req);
+            self->fail(
+                "move: Cannot move %s: unsupported file type; some destination subdirectories may have been created",
+                path.c_str()
+            );
+            return;
+        }
+
+        uv_fs_req_cleanup(req);
+        ++self->unknownIdx;
+        self->startUnknownClassification();
     }
 
     static void copyFileCallback(uv_fs_t* req)

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -1050,7 +1050,12 @@ void FSRename::statCallback(uv_fs_t* req)
         return;
     }
 
-    // Regular file (or other): use the existing async copyfile → unlink chain.
+    if (!S_ISREG(req->statbuf.st_mode))
+    {
+        r->fail("move: Cannot move %s: unsupported file type", r->src.c_str());
+        return;
+    }
+
     uvutils::ScopedUVRequest<FSRename> copyReq{std::move(r)};
     uv_fs_copyfile(copyReq->getLoop(), &copyReq->req, copyReq->src.c_str(), copyReq->dest.c_str(), 0, FSRename::copyCallback);
 }

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -1045,7 +1045,8 @@ void FSRename::statCallback(uv_fs_t* req)
     {
         // Directory: hand off to FSCopyDirectory. Moving the token transfers coroutine
         // ownership; r is then destroyed cleanly with an empty token.
-        new FSCopyDirectory(std::move(r->token), r->loop, r->src, r->dest);
+        auto* copyDir = new FSCopyDirectory(std::move(r->token), r->loop, r->src, r->dest);
+        copyDir->start();
         return;
     }
 

--- a/lute/fs/src/fs_impl.cpp
+++ b/lute/fs/src/fs_impl.cpp
@@ -106,9 +106,9 @@ struct FSPathPairRequest : FSRequest
 // Heap-managed primitive: creates a symlink at `dest` pointing to `target`.
 // On Win32, stats `target` first to determine whether UV_FS_SYMLINK_DIR is needed.
 // Calls onDone(0) on success, onDone(negative_uv_error) on failure. Self-deletes.
-struct FSMakeSymlink
+struct FSCreateSymlink
 {
-    FSMakeSymlink(uv_loop_t* loop, std::string target, std::string dest, std::function<void(int)> onDone)
+    FSCreateSymlink(uv_loop_t* loop, std::string target, std::string dest, std::function<void(int)> onDone)
         : loop(loop)
         , target(std::move(target))
         , dest(std::move(dest))
@@ -120,7 +120,7 @@ struct FSMakeSymlink
     void start()
     {
 #if _WIN32
-        uv_fs_stat(loop, &req, target.c_str(), FSMakeSymlink::statCallback);
+        uv_fs_stat(loop, &req, target.c_str(), FSCreateSymlink::statCallback);
 #else
         doSymlink(this, 0);
 #endif
@@ -133,15 +133,15 @@ struct FSMakeSymlink
     std::function<void(int)> onDone;
 
 private:
-    static void doSymlink(FSMakeSymlink* self, int flags)
+    static void doSymlink(FSCreateSymlink* self, int flags)
     {
-        uv_fs_symlink(self->loop, &self->req, self->target.c_str(), self->dest.c_str(), flags, FSMakeSymlink::symlinkCallback);
+        uv_fs_symlink(self->loop, &self->req, self->target.c_str(), self->dest.c_str(), flags, FSCreateSymlink::symlinkCallback);
     }
 
 #if _WIN32
     static void statCallback(uv_fs_t* req)
     {
-        auto* self = static_cast<FSMakeSymlink*>(req->data);
+        auto* self = static_cast<FSCreateSymlink*>(req->data);
         int flags = (req->result >= 0 && S_ISDIR(req->statbuf.st_mode)) ? UV_FS_SYMLINK_DIR : 0;
         uv_fs_req_cleanup(req);
         doSymlink(self, flags);
@@ -150,7 +150,7 @@ private:
 
     static void symlinkCallback(uv_fs_t* req)
     {
-        auto* self = static_cast<FSMakeSymlink*>(req->data);
+        auto* self = static_cast<FSCreateSymlink*>(req->data);
         int result = req->result;
         uv_fs_req_cleanup(req);
         auto done = std::move(self->onDone);
@@ -160,7 +160,7 @@ private:
 };
 
 // Heap-managed primitive: moves a symlink from src to dest.
-// readlink(src) → FSMakeSymlink(linkTarget, dest) → unlink(src).
+// readlink(src) → FSCreateSymlink(linkTarget, dest) → unlink(src).
 // Calls onDone(0) on success, onDone(negative_uv_error) on failure. Self-deletes.
 struct FSMoveSymlink
 {
@@ -203,7 +203,7 @@ private:
         self->linkTarget = static_cast<const char*>(req->ptr);
         uv_fs_req_cleanup(req);
 
-        (new FSMakeSymlink(
+        (new FSCreateSymlink(
             self->loop,
             self->linkTarget,
             self->dest,
@@ -345,7 +345,7 @@ struct FSCopyDirectory
         delete this;
     }
 
-    // Phase 1: process the next pending source directory, or advance to file copying.
+    // Phase 1: mkdir + scandir the next pending source directory, or advance to file copying.
     void start()
     {
         if (!pendingDirs.empty())
@@ -357,7 +357,7 @@ struct FSCopyDirectory
         startFileCopy();
     }
 
-    // Phase 2: lstat each UV_DIRENT_UNKNOWN entry from the current scandir to classify it.
+    // Phase 1a: lstat each UV_DIRENT_UNKNOWN entry from the current scandir to classify it, then loop back to Phase 1.
     void startUnknownClassification()
     {
         if (unknownIdx < pendingUnknown.size())
@@ -373,7 +373,7 @@ struct FSCopyDirectory
         start();
     }
 
-    // Phase 3: copy+unlink the next pending regular file, or advance to symlink recreation.
+    // Phase 2: copy+unlink the next pending regular file, or advance to symlink recreation.
     void startFileCopy()
     {
         if (fileIdx < pendingFiles.size())
@@ -404,7 +404,7 @@ struct FSCopyDirectory
         startLinkCopy();
     }
 
-    // Phase 4: recreate symlinks at destination via FSMoveSymlink.
+    // Phase 3: recreate symlinks at destination via FSMoveSymlink.
     void startLinkCopy()
     {
         if (linkIdx < pendingLinks.size())
@@ -435,7 +435,7 @@ struct FSCopyDirectory
         startDirRemoval();
     }
 
-    // Phase 5: rmdir source dirs in reverse breadth-first order (children before parents).
+    // Phase 4: rmdir source dirs in reverse breadth-first order (children before parents).
     void startDirRemoval()
     {
         if (removeDirIdx < scannedDirs.size())
@@ -670,6 +670,7 @@ void FSRead::readCallback(uv_fs_t* req)
     r->buffer.insert(r->buffer.end(), r->chunk.begin(), r->chunk.begin() + bytesRead);
 
     uvutils::ScopedUVRequest<FSRead> scopedReq{std::move(r)};
+    uv_fs_req_cleanup(&scopedReq->req);
     uv_fs_read(scopedReq->getLoop(), &scopedReq->req, scopedReq->file->fd.value(), &scopedReq->iov, 1, -1, FSRead::readCallback);
 }
 
@@ -698,6 +699,7 @@ void FSWrite::writeCallback(uv_fs_t* req)
     w->iov = uv_buf_init(w->chunk.data(), chunkSize);
 
     uvutils::ScopedUVRequest<FSWrite> scopedReq{std::move(w)};
+    uv_fs_req_cleanup(&scopedReq->req);
     uv_fs_write(scopedReq->getLoop(), &scopedReq->req, scopedReq->file->fd.value(), &scopedReq->iov, 1, -1, FSWrite::writeCallback);
 }
 
@@ -992,7 +994,7 @@ int symlink_impl(lua_State* L, const char* path, const char* dest)
     auto token = getResumeToken(L);
     auto* loop = getRuntimeLoop(L);
     std::string src{path}, dst{dest};
-    (new FSMakeSymlink(
+    (new FSCreateSymlink(
         loop,
         src,
         dst,
@@ -1154,7 +1156,6 @@ int mkdir_impl(lua_State* L, const char* path, int mode)
     return lua_yield(L, 0);
 }
 
-
 int rmdir_impl(lua_State* L, const char* path)
 {
     uvutils::ScopedUVRequest<FSRequest> req(L);
@@ -1178,7 +1179,6 @@ int rmdir_impl(lua_State* L, const char* path)
 
     return lua_yield(L, 0);
 }
-
 
 int listdir_impl(lua_State* L, const char* path)
 {

--- a/lute/runtime/include/lute/uvrequest.h
+++ b/lute/runtime/include/lute/uvrequest.h
@@ -66,7 +66,12 @@ struct UVRequest
 
     void succeedTrivially()
     {
-        succeed([](lua_State* L) { return 0; });
+        succeed(
+            [](lua_State* L)
+            {
+                return 0;
+            }
+        );
     }
 
     ~UVRequest()

--- a/lute/runtime/include/lute/uvrequest.h
+++ b/lute/runtime/include/lute/uvrequest.h
@@ -12,13 +12,13 @@ namespace uvutils
 {
 
 template<typename... Args>
-std::string formatUVError(const char* fmt, Args&&... args)
+std::string formatUVError(const char* fmt, Args... args)
 {
-    int size = snprintf(nullptr, 0, fmt, std::forward<Args>(args)...);
+    int size = snprintf(nullptr, 0, fmt, args...);
     if (size < 0)
         return "Format error";
     std::vector<char> buffer(size + 1);
-    snprintf(buffer.data(), buffer.size(), fmt, std::forward<Args>(args)...);
+    snprintf(buffer.data(), buffer.size(), fmt, args...);
     return std::string(buffer.data());
 }
 

--- a/lute/runtime/include/lute/uvrequest.h
+++ b/lute/runtime/include/lute/uvrequest.h
@@ -103,15 +103,11 @@ struct ScopedUVRequest
 
     ~ScopedUVRequest()
     {
-        // The actual libuv C request struct retains a pointer to the request in the data field.
-        // If we don't call release, this unique_pointer will be freed at the end of the scope that
-        // contains the request, when we actually want this to be freed inside the asynchronously called callback.
-        // The user should then take ownership of the request from the data via `retake` and the destructr
-        // will automatically be invoked after we've scheduled the Luau code to resume
-        if (ptr)
-        {
-            ptr.release();
-        }
+        // The libuv request struct retains a raw pointer to this object via req->data.
+        // Releasing here intentionally leaks so the object stays alive until the callback fires.
+        // The callback must call retake() to reclaim ownership; the destructor then runs after
+        // the Luau coroutine has been scheduled to resume.
+        ptr.release();
     }
 
     // Non-copyable and non-movable to prevent accidental double-release

--- a/lute/runtime/include/lute/uvrequest.h
+++ b/lute/runtime/include/lute/uvrequest.h
@@ -6,9 +6,21 @@
 
 #include <cstddef>
 #include <string>
+#include <vector>
 
 namespace uvutils
 {
+
+template<typename... Args>
+std::string formatUVError(const char* fmt, Args&&... args)
+{
+    int size = snprintf(nullptr, 0, fmt, std::forward<Args>(args)...);
+    if (size < 0)
+        return "Format error";
+    std::vector<char> buffer(size + 1);
+    snprintf(buffer.data(), buffer.size(), fmt, std::forward<Args>(args)...);
+    return std::string(buffer.data());
+}
 
 template<typename ReqT>
 void cleanup_uv_req(ReqT* req)
@@ -40,22 +52,10 @@ struct UVRequest
     UVRequest(UVRequest&&) = delete;
     UVRequest& operator=(UVRequest&&) = delete;
 
-    // Proxy to token->fail with format string support
     template<typename... Args>
     void fail(const char* fmt, Args&&... args)
     {
-        // First, determine the required size
-        int size = snprintf(nullptr, 0, fmt, std::forward<Args>(args)...);
-        if (size < 0)
-        {
-            token->fail("Format error in fail");
-            return;
-        }
-
-        // Allocate buffer with exact size needed (+1 for null terminator)
-        std::vector<char> buffer(size + 1);
-        snprintf(buffer.data(), buffer.size(), fmt, std::forward<Args>(args)...);
-        token->fail(std::string(buffer.data()));
+        token->fail(formatUVError(fmt, std::forward<Args>(args)...));
     }
 
     template<typename F>

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -1,6 +1,7 @@
 local failure = require("@std/test/failure")
 local fs = require("@std/fs")
 local path = require("@std/path")
+local process = require("@std/process")
 local system = require("@std/system")
 local test = require("@std/test")
 local task = require("@lute/task")
@@ -88,6 +89,36 @@ test.suite("FsSuite", function(suite)
 		local subDir = path.join(srcDir, "sub")
 		local destDir = path.join(tmpdir, "move_dest_dir")
 
+		fs.createDirectory(subDir, { makeParents = true })
+		fs.writeStringToFile(path.join(srcDir, "a.txt"), "aaa")
+		fs.writeStringToFile(path.join(subDir, "b.txt"), "bbb")
+
+		fs.move(srcDir, destDir)
+
+		assert.eq(fs.exists(srcDir), false)
+		assert.that(fs.exists(destDir))
+		assert.eq(fs.readFileToString(path.join(destDir, "a.txt")), "aaa")
+		assert.eq(fs.readFileToString(path.join(destDir, "sub", "b.txt")), "bbb")
+
+		fs.removeDirectory(destDir, { recursive = true })
+	end)
+
+	-- Mirrors the `lute pkg install` flow: packages are extracted to system.tmpdir()
+	-- then moved to ~/.loom/store/. In GitHub Actions CI, /tmp and /github/home are
+	-- on different devices, so this exercises the EXDEV cross-device fallback.
+	suite:case("moveDirectoryAcrossDevices", function(assert)
+		local srcDir = path.join(tmpdir, "lute_crossdev_src")
+		local destDir = path.join(process.homedir(), ".lute-test-crossdev")
+
+		if fs.exists(srcDir) then
+			fs.removeDirectory(srcDir, { recursive = true })
+		end
+
+		if fs.exists(destDir) then
+			fs.removeDirectory(destDir, { recursive = true })
+		end
+
+		local subDir = path.join(srcDir, "sub")
 		fs.createDirectory(subDir, { makeParents = true })
 		fs.writeStringToFile(path.join(srcDir, "a.txt"), "aaa")
 		fs.writeStringToFile(path.join(subDir, "b.txt"), "bbb")

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -114,6 +114,19 @@ test.suite("FsSuite", function(suite)
 			return
 		end
 
+		-- Verify the two paths are actually on different devices, so the EXDEV fallback is exercised.
+		local deviceIdFlag = if system.os == "macos" then "-f" else "-c"
+		local crossdevStat = process.run({ "stat", deviceIdFlag, "%d", crossdevTmp })
+		local homeStat = process.run({ "stat", deviceIdFlag, "%d", tostring(process.homedir()) })
+
+		assert.that(crossdevStat.exitcode == 0, `stat failed for LUTE_CROSSDEV_TMPDIR={crossdevTmp}: {crossdevStat.stderr}`)
+		assert.that(homeStat.exitcode == 0, `stat failed for home directory: {homeStat.stderr}`)
+		assert.neq(
+			crossdevStat.stdout:match("%d+"),
+			homeStat.stdout:match("%d+"),
+			`LUTE_CROSSDEV_TMPDIR={crossdevTmp} is on the same device as the home directory; the EXDEV fallback will not be exercised`
+		)
+
 		local srcDir = path.join(crossdevTmp, "lute_crossdev_src")
 		local destDir = path.join(process.homedir(), ".lute-test-crossdev")
 

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -115,20 +115,32 @@ test.suite("FsSuite", function(suite)
 		end
 
 		-- Verify the two paths are actually on different devices, so the EXDEV fallback is exercised.
-		local deviceIdFlag = if system.macos then "-f" else "-c"
-		local crossdevStat = process.run({ "stat", deviceIdFlag, "%d", crossdevTmp })
-		local homeStat = process.run({ "stat", deviceIdFlag, "%d", tostring(process.homedir()) })
+		if system.win32 then
+			-- On Windows, drive letters are the device identity; stat is not reliably available.
+			local crossdevDrive = path.win32.parse(crossdevTmp).drive
+			local homeDrive = path.win32.parse(tostring(process.homedir())).drive
+			assert.neq(
+				crossdevDrive,
+				homeDrive,
+				`LUTE_CROSSDEV_TMPDIR={crossdevTmp} is on the same drive as the home directory; the EXDEV fallback will not be exercised`
+			)
+		else
+			-- On Unix, the device ID from stat can be used to determine if two paths are on the same device.
+			local deviceIdFlag = if system.macos then "-f" else "-c"
+			local crossdevStat = process.run({ "stat", deviceIdFlag, "%d", crossdevTmp })
+			local homeStat = process.run({ "stat", deviceIdFlag, "%d", tostring(process.homedir()) })
 
-		assert.that(
-			crossdevStat.exitcode == 0,
-			`stat failed for LUTE_CROSSDEV_TMPDIR={crossdevTmp}: {crossdevStat.stderr}`
-		)
-		assert.that(homeStat.exitcode == 0, `stat failed for home directory: {homeStat.stderr}`)
-		assert.neq(
-			crossdevStat.stdout:match("%d+"),
-			homeStat.stdout:match("%d+"),
-			`LUTE_CROSSDEV_TMPDIR={crossdevTmp} is on the same device as the home directory; the EXDEV fallback will not be exercised`
-		)
+			assert.that(
+				crossdevStat.exitcode == 0,
+				`stat failed for LUTE_CROSSDEV_TMPDIR={crossdevTmp}: {crossdevStat.stderr}`
+			)
+			assert.that(homeStat.exitcode == 0, `stat failed for home directory: {homeStat.stderr}`)
+			assert.neq(
+				crossdevStat.stdout:match("%d+"),
+				homeStat.stdout:match("%d+"),
+				`LUTE_CROSSDEV_TMPDIR={crossdevTmp} is on the same device as the home directory; the EXDEV fallback will not be exercised`
+			)
+		end
 
 		local srcDir = path.join(crossdevTmp, "lute_crossdev_src")
 		local destDir = path.join(process.homedir(), ".lute-test-crossdev")

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -83,6 +83,25 @@ test.suite("FsSuite", function(suite)
 		fs.remove(dest)
 	end)
 
+	suite:case("moveDirectory", function(assert)
+		local srcDir = path.join(tmpdir, "move_src_dir")
+		local subDir = path.join(srcDir, "sub")
+		local destDir = path.join(tmpdir, "move_dest_dir")
+
+		fs.createDirectory(subDir, { makeParents = true })
+		fs.writeStringToFile(path.join(srcDir, "a.txt"), "aaa")
+		fs.writeStringToFile(path.join(subDir, "b.txt"), "bbb")
+
+		fs.move(srcDir, destDir)
+
+		assert.eq(fs.exists(srcDir), false)
+		assert.that(fs.exists(destDir))
+		assert.eq(fs.readFileToString(path.join(destDir, "a.txt")), "aaa")
+		assert.eq(fs.readFileToString(path.join(destDir, "sub", "b.txt")), "bbb")
+
+		fs.removeDirectory(destDir, { recursive = true })
+	end)
+
 	suite:case("linkAndSymlinkAndCopy", function(assert)
 		local srcfile = "src.txt"
 		local src = path.join(tmpdir, srcfile)

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -103,11 +103,18 @@ test.suite("FsSuite", function(suite)
 		fs.removeDirectory(destDir, { recursive = true })
 	end)
 
-	-- Mirrors the `lute pkg install` flow: packages are extracted to system.tmpdir()
-	-- then moved to ~/.loom/store/. In GitHub Actions CI, /tmp and /github/home are
-	-- on different devices, so this exercises the EXDEV cross-device fallback.
+	-- Exercises the EXDEV cross-device fallback for fs.move.
+	-- Requires a cross-device mount to be set up in order to run.
+	--
+	-- In our CI, this is a tmpfs setup at `LUTE_CROSSDEV_TMPDIR`.
+	-- The test is skipped when `LUTE_CROSSDEV_TMPDIR` is not set.
 	suite:case("moveDirectoryAcrossDevices", function(assert)
-		local srcDir = path.join(tmpdir, "lute_crossdev_src")
+		local crossdevTmp = process.env["LUTE_CROSSDEV_TMPDIR"]
+		if crossdevTmp == nil then
+			return
+		end
+
+		local srcDir = path.join(crossdevTmp, "lute_crossdev_src")
 		local destDir = path.join(process.homedir(), ".lute-test-crossdev")
 
 		if fs.exists(srcDir) then

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -130,14 +130,26 @@ test.suite("FsSuite", function(suite)
 		fs.writeStringToFile(path.join(srcDir, "a.txt"), "aaa")
 		fs.writeStringToFile(path.join(subDir, "b.txt"), "bbb")
 
-		fs.move(srcDir, destDir)
+		local ok, err = pcall(function()
+			fs.move(srcDir, destDir)
 
-		assert.eq(fs.exists(srcDir), false)
-		assert.that(fs.exists(destDir))
-		assert.eq(fs.readFileToString(path.join(destDir, "a.txt")), "aaa")
-		assert.eq(fs.readFileToString(path.join(destDir, "sub", "b.txt")), "bbb")
+			assert.eq(fs.exists(srcDir), false)
+			assert.that(fs.exists(destDir))
+			assert.eq(fs.readFileToString(path.join(destDir, "a.txt")), "aaa")
+			assert.eq(fs.readFileToString(path.join(destDir, "sub", "b.txt")), "bbb")
+		end)
 
-		fs.removeDirectory(destDir, { recursive = true })
+		if fs.exists(srcDir) then
+			fs.removeDirectory(srcDir, { recursive = true })
+		end
+
+		if fs.exists(destDir) then
+			fs.removeDirectory(destDir, { recursive = true })
+		end
+
+		if not ok then
+			error(err)
+		end
 	end)
 
 	suite:case("linkAndSymlinkAndCopy", function(assert)

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -119,7 +119,10 @@ test.suite("FsSuite", function(suite)
 		local crossdevStat = process.run({ "stat", deviceIdFlag, "%d", crossdevTmp })
 		local homeStat = process.run({ "stat", deviceIdFlag, "%d", tostring(process.homedir()) })
 
-		assert.that(crossdevStat.exitcode == 0, `stat failed for LUTE_CROSSDEV_TMPDIR={crossdevTmp}: {crossdevStat.stderr}`)
+		assert.that(
+			crossdevStat.exitcode == 0,
+			`stat failed for LUTE_CROSSDEV_TMPDIR={crossdevTmp}: {crossdevStat.stderr}`
+		)
 		assert.that(homeStat.exitcode == 0, `stat failed for home directory: {homeStat.stderr}`)
 		assert.neq(
 			crossdevStat.stdout:match("%d+"),

--- a/tests/std/fs.test.luau
+++ b/tests/std/fs.test.luau
@@ -115,7 +115,7 @@ test.suite("FsSuite", function(suite)
 		end
 
 		-- Verify the two paths are actually on different devices, so the EXDEV fallback is exercised.
-		local deviceIdFlag = if system.os == "macos" then "-f" else "-c"
+		local deviceIdFlag = if system.macos then "-f" else "-c"
 		local crossdevStat = process.run({ "stat", deviceIdFlag, "%d", crossdevTmp })
 		local homeStat = process.run({ "stat", deviceIdFlag, "%d", tostring(process.homedir()) })
 


### PR DESCRIPTION
We recently got a report of an illegal move operation happening only in CI in #1147 when trying to use `lute pkg install`. I investigated the issue, and the underlying cause here is not that the `move` itself is failing. In GitHub Actions, `/tmp` and `/github/home` are different devices, and the underlying move (it's called "rename" in the syscalls) only works within a device. I had written fall-back code for this case that has us do a copy and then remove, but the fallback code is bugged. It doesn't happen locally since you don't have the same filesystem split, and so you don't hit the fallback. The fix is to make the fallback path deal properly with directories (and symbolic links), which we do here in this PR. We also add an explicit test case that does a move from the temporary directory into the home directory, just like `lute pkg install` does, which _should_ mean that our CI flows for this function now explicitly test the fallback case. It's harder to have a local test available for this since we can't really guarantee the presence or absence of external devices to test with, but you can follow the procedures in the CI script locally to set up such a device locally to test with.