### PR TITLE
Enables ccache in CI to speed up builds

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -69,12 +69,48 @@ runs:
         path: extern
         key: extern-${{ hashFiles('extern/*.tune') }}
 
+    - name: Install ccache
+      shell: bash
+      run: |
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          sudo apt-get install -y ccache
+        elif [[ "${{ runner.os }}" == "macOS" ]]; then
+          brew install ccache
+        elif [[ "${{ runner.os }}" == "Windows" ]]; then
+          choco install ccache -y
+        fi
+
+    - name: Configure ccache
+      shell: bash
+      run: |
+        echo "CCACHE_DIR=${{ github.workspace }}/.ccache" >> $GITHUB_ENV
+        echo "CCACHE_MAXSIZE=500M" >> $GITHUB_ENV
+        echo "CCACHE_COMPRESS=true" >> $GITHUB_ENV
+        echo "CCACHE_COMPRESSLEVEL=6" >> $GITHUB_ENV
+        # zero statistics
+        ccache -z
+
+    - name: Restore ccache
+      uses: actions/cache/restore@v4
+      id: cache-ccache
+      with:
+        path: .ccache
+        key: ccache-${{ runner.os }}-${{ inputs.options }}-
+        lookup-only: false
+
+
+    - name: ccache stats (pre-build)
+      shell: bash
+      run: |
+        echo "Cache status: ${{ steps.cache-ccache.outputs.cache-hit }}"
+        ccache -sv
+
     - name: Bootstrap Lute (if needed) and set LUTE
       shell: bash
       run: |
         if [[ "${{ inputs.use-bootstrap }}" == "true" ]]; then
           echo "Bootstrapping Lute..."
-          ./tools/bootstrap.sh
+          ./tools/bootstrap.sh --with-ccache --build-debug
           echo "LUTE=./build/lute0" >> $GITHUB_ENV
         else
           echo "LUTE=lute" >> $GITHUB_ENV
@@ -87,11 +123,22 @@ runs:
 
     - name: Configure ${{ inputs.target }}
       shell: bash
-      run: $LUTE ./tools/luthier.luau configure ${{ inputs.target }} --config ${{ inputs.config }} ${{ inputs.options }}
+      run: $LUTE ./tools/luthier.luau configure ${{ inputs.target }} --with-ccache --config ${{ inputs.config }} ${{ inputs.options }}
 
     - name: Build ${{ inputs.target }}
       shell: bash
-      run: $LUTE ./tools/luthier.luau build ${{ inputs.target }} --config ${{ inputs.config }} ${{ inputs.options }}
+      run: $LUTE ./tools/luthier.luau build ${{ inputs.target }} --with-ccache --config ${{ inputs.config }} ${{ inputs.options }}
+
+    - name: ccache stats (post-build)
+      shell: bash
+      run: ccache -sv
+
+    - name: Save ccache
+      if: github.ref_name == 'primary'
+      uses: actions/cache/save@v4
+      with:
+        path: .ccache
+        key: ccache-${{ runner.os }}-${{ inputs.options }}-${{ github.sha }}
 
     - name: Get Artifact Path
       id: artifact_path

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ extern/*/
 generated
 **/generated-types.luau
 WARP.md
+.ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR} CACHE STRING "" FORCE)
 set(ZLIB_LIBRARIES ZLIB::ZLIB CACHE STRING "" FORCE)
 
 # boringssl setup
+set(BUILD_TESTING OFF)
 add_subdirectory(extern/boringssl)
 set(BORINGSSL_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/extern/boringssl")
 set(BORINGSSL_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/boringssl/include)
@@ -189,6 +190,12 @@ set(CURL_DISABLE_GOPHER ON CACHE BOOL "" FORCE)
 set(CURL_DISABLE_RTSP   ON CACHE BOOL "" FORCE)
 set(CURL_DISABLE_MQTT   ON CACHE BOOL "" FORCE)
 set(CURL_DISABLE_IPFS   ON CACHE BOOL "" FORCE)
+
+# One more set of DISABLES. We might need to re-enable these at some point
+# if we need the features they provide
+set(CURL_DISABLE_AWS            ON  CACHE BOOL "" FORCE)
+set(CURL_DISABLE_INSTALL        ON  CACHE BOOL "" FORCE)
+set(ENABLE_UNIX_SOCKETS         OFF CACHE BOOL "" FORCE)
 
 set(HAVE_BORINGSSL ON)
 add_subdirectory(extern/curl)

--- a/README.md
+++ b/README.md
@@ -57,3 +57,14 @@ This will have you performing the steps of the bootstrap script yourself. A manu
 - Configure with `cmake -G=Ninja -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DLUTE_STDLESS=ON` to build a version with no embedded Luau functionality.
 - Build a `lute` executable with `ninja -C build lute/cli/lute` or our test suite with `ninja -C build tests/lute-tests`.
 - Optionally, use this version to run `luthier generate` to generate the embedded Luau source files, then reconfigure without `-DLUTE_STDLESS=ON` and rebuild to get a fully-featured `lute`.
+
+### CCache support
+Lute uses ccache in CI to speed up builds. Both the `bootstrap` and `luthier` build scripts support a `--with-ccache` option, which proxies all compilation through ccache. To benefit from
+caching during local development, download ccache using your systems package manager (apt/brew/choco/etc), and perform a clean configure with `--with-ccache` passed. Subsequent builds
+will then use the cached build artifacts in the .ccache directory.
+Additionally, you'll need to set the following variables:
+```
+CCACHE_DIR=path/to/store/ccachedir
+CCACHE_MAXSIZE=maximum size of the cache
+CCACHE_COMPRESS=true
+```

--- a/tools/bootstrap.sh
+++ b/tools/bootstrap.sh
@@ -2,17 +2,25 @@
 
 set -e
 install_requested=false
+use_ccache=false
+build_config="release"
 
 # simple argument parsing
 for arg in "$@"; do
   if [[ "$arg" == "--install" ]]; then
     install_requested=true
-    break
+  elif [[ "$arg" == "--with-ccache" ]]; then
+    use_ccache=true
+  elif [[ "$arg" == "--build-debug" ]]; then
+    build_config="debug"
   fi
 done
 
 # function to display commands before running them
 exe() { echo ": $@" ; "$@" ; }
+
+stage_start() { STAGE_START=$SECONDS; echo "=== $1 ==="; }
+stage_end() { echo "=== $1 completed in $((SECONDS - STAGE_START))s ==="; echo; }
 
 fetch_dependency() {
   local dep_file="$1"
@@ -24,10 +32,10 @@ fetch_dependency() {
   fi
 
   # extract each field by key
-  name=$(grep '^name' "$file" | sed -E 's/^name *= *"(.*)"/\1/')
-  remote=$(grep '^remote' "$file" | sed -E 's/^remote *= *"(.*)"/\1/')
-  branch=$(grep '^branch' "$file" | sed -E 's/^branch *= *"(.*)"/\1/')
-  revision=$(grep '^revision' "$file" | sed -E 's/^revision *= *"(.*)"/\1/')
+  local name=$(grep '^name' "$dep_file" | sed -E 's/^name *= *"(.*)"/\1/')
+  local remote=$(grep '^remote' "$dep_file" | sed -E 's/^remote *= *"(.*)"/\1/')
+  local branch=$(grep '^branch' "$dep_file" | sed -E 's/^branch *= *"(.*)"/\1/')
+  local revision=$(grep '^revision' "$dep_file" | sed -E 's/^revision *= *"(.*)"/\1/')
 
   # output the parsed variables
   local target_dir="extern/$name"
@@ -52,14 +60,25 @@ fetch_dependency() {
   fi
 }
 
-# download dependencies from the tune files
+stage_start "fetch dependencies"
 find "extern" -mindepth 1 ! -name "*.tune" -prune -exec rm -rf {} +
 for file in extern/*.tune; do
   if [[ -f "$file" ]]; then
     echo "fetching $(basename "$file")"
-    fetch_dependency "extern/$(basename "$file")"
+    fetch_dependency "extern/$(basename "$file")" &
   fi
 done
+wait
+
+# Write the tune file hash so luthier's fetchDependenciesIfNeeded() becomes a no-op.
+# Must match luthier.luau getTuneFilesHash().
+mkdir -p extern/generated
+{ for file in $(ls extern/*.tune | sort); do
+    printf '%s' "$(basename "$file")"
+    cat "$file"
+  done
+} | b2sum -l 256 | cut -d' ' -f1 | tr -d '\n' > extern/generated/hash.txt
+stage_end "fetch dependencies"
 
 ## configure the build system for lute0
 os_type="$(uname)"
@@ -81,18 +100,36 @@ fi
 # directory that luthier will configure afterwards.
 BOOTSTRAP_BUILD_PATH=build/lute0-bootstrap
 rm -rf build && mkdir build
-exe cmake -G=Ninja -B $BOOTSTRAP_BUILD_PATH -DCMAKE_BUILD_TYPE=Debug -DLUTE_STDLESS=ON
+CCACHE_FLAGS=""
+if $use_ccache; then
+  CCACHE_FLAGS="-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache"
+fi
+
+stage_start "configure lute0"
+exe cmake -G=Ninja -B $BOOTSTRAP_BUILD_PATH -DCMAKE_BUILD_TYPE=${build_config} -DLUTE_STDLESS=ON $CCACHE_FLAGS
+stage_end "configure lute0"
 
 # build lute0
+stage_start "build lute0"
 exe ninja -C $BOOTSTRAP_BUILD_PATH $EXE_PATH
-echo ""
+stage_end "build lute0"
 echo "built lute0 at $BOOTSTRAP_BUILD_PATH/$EXE_PATH"
 
 # use lute0 to build lute with the standard library included.
 LUTESTRAP=./$BOOTSTRAP_BUILD_PATH/$EXE_PATH
 mv $LUTESTRAP $OUT_BINARY
-exe $OUT_BINARY tools/luthier.luau configure --config release --clean lute
-exe $OUT_BINARY tools/luthier.luau build --config release --clean lute
+LUTHIER_CCACHE=""
+if $use_ccache; then
+  LUTHIER_CCACHE="--with-ccache"
+fi
+
+stage_start "configure lute"
+exe $OUT_BINARY tools/luthier.luau configure --config $build_config --clean $LUTHIER_CCACHE lute
+stage_end "configure lute"
+
+stage_start "build lute"
+exe $OUT_BINARY tools/luthier.luau build --config $build_config --clean $LUTHIER_CCACHE lute
+stage_end "build lute"
 
 # optionally install the final built lute version
 INSTALL_DIR=$HOME/.lute/bin

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -81,6 +81,7 @@ args:add("which", "flag", { help = "print out the path to the compiled binary an
 args:add("cxx-compiler", "option", { help = "C++ compiler to use" })
 args:add("c-compiler", "option", { help = "C compiler to use" })
 args:add("enable-sanitizers", "flag", { help = "enable sanitizers during configuration" })
+args:add("with-ccache", "flag", { help = "use ccache as the compiler launcher" })
 
 if not isWindows and not isMac and not isLinux then
 	error("Unknown platform " .. os)
@@ -539,6 +540,11 @@ local function getConfigureArguments()
 
 	local configArgs =
 		{ "-G=Ninja", "-B " .. projectPath, "-DCMAKE_BUILD_TYPE=" .. config, "-DCMAKE_EXPORT_COMPILE_COMMANDS=1" }
+
+	if args:has("with-ccache") then
+		table.insert(configArgs, "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache")
+		table.insert(configArgs, "-DCMAKE_C_COMPILER_LAUNCHER=ccache")
+	end
 
 	local cxx_compiler = args:get("cxx-compiler")
 	if cxx_compiler then


### PR DESCRIPTION
This PR attempts to speed up bootstrap builds for lute CI by doing the following:
1. Try to fetch dependencies in extern/ in parallel - there is no reason we need to do these serially.
2. After fetching dependencies, compute the same hash produced by luthier. This avoids us having to refetch those dependencies when building the actual `lute` binary that bootstrap produces.
3. Do a bit less work in cmake for dependencies.

In addition to this, I've also setup ccache for us. We'll use `actions/cache@v4` to cache the .ccache directory. We invalidate and recompute the cache on merges to `primary`, but changes on your branch will just load the cache from primary.

When testing locally, I've brought bootstrap down to about a minute from two minutes.