### PR TITLE
Add overrides to lint config

### DIFF
--- a/docs/cli/lint/index.md
+++ b/docs/cli/lint/index.md
@@ -50,7 +50,7 @@ type Config = {
                     -- Array of globs (.gitignore style) that are EXEMPT from this rule
                     ignores: { string }?,
                     -- Override a rule's default severity
-                    severity: ("warn" | "error" | "info" | "hint")?,
+                    severity: ("warning" | "error" | "info" | "hint")?,
                     -- Pass custom options through to a rule;
                     -- see specific rule's implementation / docs for expected options structure
                     options: { [string]: unknown }?,
@@ -58,9 +58,43 @@ type Config = {
                     off: boolean?,
                 },
             }?,
+            -- Apply lint configuration only to files matching one of the override's paths
+            overrides: {
+                {
+                    -- Array of globs (.gitignore style) that select files for this override
+                    paths: { string },
+                    -- Overrides support the same fields as the top-level lint config
+                    ignores: { string }?,
+                    globals: { [string]: unknown }?,
+                    rulepaths: { [string] }?,
+                    ruleconfigs: {
+                        [RuleName]: {
+                            ignores: { string }?,
+                            severity: ("warning" | "error" | "info" | "hint")?,
+                            options: { [string]: unknown }?,
+                            off: boolean?,
+                        },
+                    }?,
+                },
+            }?,
         }?,
     }?,
 }
+```
+
+#### Config Overrides
+
+Use `overrides` to apply lint configuration to specific paths in a repo. Each override has a required `paths` array containing `.gitignore`-style globs. When a file matches any glob in an override's `paths`, that override is applied for that file.
+
+Overrides are evaluated in order and are cumulative. If multiple overrides match a file, later overrides are merged on top of earlier ones.
+
+Merge behavior:
+
+- `ignores`, rule-specific `ignores`, and `rulepaths` are appended.
+- `globals` are shallow-merged, with later values replacing earlier values for the same key.
+- `ruleconfigs` are merged one level per rule. For example, an override can add `severity = "error"` to a rule while preserving that rule's existing `options`.
+
+ADD EXAMPLE
 ```
 
 ### `-j, --json`

--- a/lute/cli/commands/lib/parseIgnores.luau
+++ b/lute/cli/commands/lib/parseIgnores.luau
@@ -18,7 +18,7 @@ local parseIgnores = {}
 
 --- Converts a glob pattern into a Luau string pattern for efficient matching
 --- The output pattern should be matched against a filepath that is relative to the .gitignore location
-local function parseGlob(glob: string): Glob
+function parseIgnores.parseGlob(glob: string): Glob
 	local onlyMatchDirectories = false
 
 	if glob:sub(-1) == "/" then
@@ -123,10 +123,10 @@ function parseIgnores.parseIgnoreContents(location: string, contents: string | {
 
 		if stringext.hasPrefix(line, "!") then
 			local globPattern = stringext.removePrefix(line, "!")
-			local glob = parseGlob(globPattern)
+			local glob = parseIgnores.parseGlob(globPattern)
 			table.insert(ignoreData.whitelists, glob)
 		else
-			local glob = parseGlob(line)
+			local glob = parseIgnores.parseGlob(line)
 			table.insert(ignoreData.ignores, glob)
 		end
 	end

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -57,7 +57,7 @@ type Job = {
 local function lintPaths(
 	inputFilePaths: { string },
 	lintRules: { types.LintRule },
-	configData: internalTypes.RuleConfigData,
+	configData: internalTypes.GlobalRuleConfigData,
 	rulesPath: string?,
 	noDefaults: boolean,
 	passedConfigVal: string?,

--- a/lute/cli/commands/lint/internaltypes.luau
+++ b/lute/cli/commands/lint/internaltypes.luau
@@ -10,7 +10,7 @@ export type RuleConfig = {
 	options: types.RuleOptions?,
 }
 
-export type LintConfig = {
+export type LintConfigData = {
 	ignores: { string }?, -- globs/paths to ignore as we walk lintee files
 	globals: types.GlobalsConfig?, -- globals to pass down to all rules via context
 	rulepaths: { path.Pathlike }?, -- paths to local rules to use
@@ -18,6 +18,25 @@ export type LintConfig = {
 		[string]: RuleConfig?,
 	}?,
 }
+
+export type LintConfigOverride = {
+	paths: { string },
+} & LintConfigData
+
+export type LintConfigOverrides = { LintConfigOverride }
+
+export type ResolvedFileConfig = RuleConfigData & {
+	ignoreData: parseIgnores.GitignoreData?,
+	rules: { types.LintRule },
+}
+
+export type ResolvedOverride = RuleConfigData & {
+	ignoreData: parseIgnores.GitignoreData?,
+	paths: { parseIgnores.Glob },
+	rules: { types.LintRule },
+}
+
+export type LintConfig = LintConfigData & { overrides: LintConfigOverrides? }
 
 export type RuleConfigurations = { [string]: RuleConfig }
 
@@ -27,6 +46,10 @@ export type RuleConfigData = {
 	globals: types.GlobalsConfig,
 	ruleConfigs: RuleConfigurations,
 	ruleIgnores: RuleIgnores,
+}
+
+export type GlobalRuleConfigData = RuleConfigData & {
+	overrides: { ResolvedOverride },
 }
 
 export type fix = {

--- a/lute/cli/commands/lint/lint.luau
+++ b/lute/cli/commands/lint/lint.luau
@@ -13,7 +13,7 @@ local lint = {}
 function lint.lintSequential(
 	inputFiles: { pathLib.Path },
 	lintRules: { types.LintRule },
-	configData: internalTypes.RuleConfigData,
+	configData: internalTypes.GlobalRuleConfigData,
 	autofixEnabled: boolean,
 	ignoreData: parseIgnores.GitignoreData,
 	verbose: boolean

--- a/lute/cli/commands/lint/lintCore.luau
+++ b/lute/cli/commands/lint/lintCore.luau
@@ -296,6 +296,24 @@ function lintCore.loadConfig(configPath: pathLib.Pathlike, VERBOSE: boolean): in
 	return lintConfig
 end
 
+local function mergeIgnoreData(
+	base: parseIgnores.GitignoreData?,
+	override: parseIgnores.GitignoreData?
+): parseIgnores.GitignoreData?
+	if override == nil then
+		return base
+	end
+
+	if base == nil then
+		return tableext.deepclone(override)
+	end
+
+	tableext.extend(base.ignores, override.ignores)
+	tableext.extend(base.whitelists, override.whitelists)
+
+	return base
+end
+
 function lintCore.lintString(
 	source: string,
 	lintRules: { types.LintRule },
@@ -358,19 +376,93 @@ function lintCore.lintString(
 	return violations
 end
 
+function lintCore.mergeConfigs(
+	base: internalTypes.ResolvedFileConfig,
+	override: internalTypes.ResolvedOverride
+): internalTypes.ResolvedFileConfig
+	-- deep clone base; merge base with override (we don't want to effect the base table)
+	local clonedBase: internalTypes.ResolvedFileConfig = tableext.deepclone(base :: any)
+
+	tableext.combine<<string, unknown>>(clonedBase.globals, override.globals or {})
+	clonedBase.ignoreData = mergeIgnoreData(clonedBase.ignoreData, override.ignoreData)
+	for rule, overrideRuleIgnores in override.ruleIgnores do
+		clonedBase.ruleIgnores[rule] = mergeIgnoreData(clonedBase.ruleIgnores[rule], overrideRuleIgnores)
+	end
+	for rule, overrideRuleConfig in override.ruleConfigs do
+		local baseRuleConfig = clonedBase.ruleConfigs[rule]
+		if baseRuleConfig == nil then
+			clonedBase.ruleConfigs[rule] = tableext.deepclone(overrideRuleConfig)
+		else
+			-- figure out cast alterntive here
+			tableext.combine(baseRuleConfig :: any, overrideRuleConfig :: any)
+		end
+	end
+	tableext.extend(clonedBase.rules, override.rules)
+
+	return clonedBase
+end
+
+function lintCore.resolveFileConfig(
+	file: pathLib.Pathlike,
+	configData: internalTypes.GlobalRuleConfigData
+): internalTypes.ResolvedFileConfig
+	-- a file paths final rule config is:
+	-- 		if override applies to it (latest override in list of overrides:
+	-- 			merge of global config with override's config (we want to be particular about wht level we merge i.e not a full deep merge, but not a surface level merge either)
+	-- 			i think it should be manual:
+	--				ignores join (maybe, or should we override?)
+	--				globals merge (with identical keys in the override taking precedence)
+	--				ruleconfigs merge (with identical keys in the latter taking precedence)
+	--				joins are joined with global
+
+	local resolvedConfigData: internalTypes.ResolvedFileConfig = {
+		globals = tableext.deepclone(configData.globals),
+		ignoreData = nil,
+		ruleIgnores = tableext.deepclone(configData.ruleIgnores),
+		ruleConfigs = tableext.deepclone(configData.ruleConfigs),
+		rules = {},
+	}
+
+	for _, override in configData.overrides do
+		local matchedOverride = false
+		for _, path in override.paths do
+			if parseIgnores.matchesGlob(path, pathLib.format(file), fs.type(file) == "dir") then
+				matchedOverride = true
+				break
+			end
+		end
+		if matchedOverride then
+			resolvedConfigData = lintCore.mergeConfigs(resolvedConfigData, override)
+		end
+	end
+
+	return resolvedConfigData
+end
+
 function lintCore.lintFile(
 	inputFilePath: pathLib.Path,
 	lintRules: { types.LintRule },
 	autofixEnabled: boolean,
-	configData: internalTypes.RuleConfigData,
+	configData: internalTypes.GlobalRuleConfigData,
 	verbose: boolean
 ): { types.LintViolation }
 	if verbose then
 		print(`Reading input file '{inputFilePath}'`)
 	end
+	local resolvedConfig = lintCore.resolveFileConfig(pathLib.format(inputFilePath), configData)
+	if
+		resolvedConfig.ignoreData ~= nil
+		and parseIgnores.isIgnored(resolvedConfig.ignoreData, pathLib.format(inputFilePath), false)
+	then
+		return {}
+	end
+
+	local resolvedRules = table.clone(lintRules)
+	tableext.extend(resolvedRules, resolvedConfig.rules)
+	resolvedConfig.rules = resolvedRules
 	local fileContent = fs.readFileToString(inputFilePath)
 
-	local violations = lintCore.lintString(fileContent, lintRules, inputFilePath, configData, verbose)
+	local violations = lintCore.lintString(fileContent, resolvedConfig.rules, inputFilePath, resolvedConfig, verbose)
 
 	if not autofixEnabled then
 		return violations
@@ -400,7 +492,7 @@ function lintCore.lintFile(
 
 	fs.writeStringToFile(inputFilePath, newContent)
 
-	return lintCore.lintString(newContent, lintRules, inputFilePath, configData, verbose)
+	return lintCore.lintString(newContent, resolvedConfig.rules, inputFilePath, resolvedConfig, verbose)
 end
 
 function lintCore.initialize(
@@ -408,7 +500,7 @@ function lintCore.initialize(
 	noDefaults: boolean,
 	rulePath: string?,
 	VERBOSE: boolean
-): ({ types.LintRule }, internalTypes.RuleConfigData, parseIgnores.GitignoreData)
+): ({ types.LintRule }, internalTypes.GlobalRuleConfigData, parseIgnores.GitignoreData)
 	if passedConfigVal and fs.type(passedConfigVal) ~= "file" then
 		print(`Error: Configuration path must point to a file, not {fs.type(passedConfigVal)}`)
 		process.exit(1)
@@ -429,6 +521,47 @@ function lintCore.initialize(
 
 	local globalIgnores = if lintConfig.ignores ~= nil then lintConfig.ignores else {}
 	local globalIgnoreData = parseIgnores.parseIgnoreContents(rootLocation, globalIgnores)
+	local overrides: internalTypes.LintConfigOverrides = lintConfig.overrides or {}
+	-- parse overrides into list of: { paths: { Glob } } & LintConfigData
+	-- would like to do this more "type" safely
+	local resolvedOverrides: { internalTypes.ResolvedOverride } = {}
+	for i, override in overrides do
+		local overrideRules, overrideRuleConfigs, overrideRuleIgnores = {}, {}, {}
+		local overrideIgnoreData = if override.ignores ~= nil
+			then parseIgnores.parseIgnoreContents(rootLocation, override.ignores)
+			else nil
+		local globPaths = tableext.map(override.paths, function(path)
+			return parseIgnores.parseGlob(path)
+		end)
+		-- for each override rulepath
+		-- consolidate into single function for reusability; this is repeated elsewhere in file
+		for _, path in override.rulepaths or {} do
+			local resolvedPath = pathLib.resolve(rootLocation, path)
+			local loadedRules, loadedConfigs, loadedIgnoreData =
+				loadLintRules(pathLib.format(resolvedPath), lintConfig, rootLocation, VERBOSE)
+			tableext.extend(overrideRules, loadedRules)
+			tableext.combine(overrideRuleConfigs, loadedConfigs)
+			tableext.combine(overrideRuleIgnores, loadedIgnoreData)
+		end
+		for ruleName, ruleConfig in override.ruleconfigs or {} do
+			overrideRuleConfigs[ruleName] = ruleConfig
+			if ruleConfig.ignores ~= nil then
+				overrideRuleIgnores[ruleName] = mergeIgnoreData(
+					overrideRuleIgnores[ruleName],
+					parseIgnores.parseIgnoreContents(rootLocation, ruleConfig.ignores)
+				)
+			end
+		end
+
+		resolvedOverrides[i] = {
+			paths = globPaths,
+			rules = overrideRules,
+			ignoreData = overrideIgnoreData,
+			globals = if override.globals ~= nil then override.globals else {},
+			ruleConfigs = overrideRuleConfigs,
+			ruleIgnores = overrideRuleIgnores,
+		}
+	end
 
 	if noDefaults then
 		if VERBOSE then
@@ -461,13 +594,14 @@ function lintCore.initialize(
 		tableext.combine(ruleIgnoreData, loadedIgnoreData)
 	end
 
-	local configContextData = {
+	local configContextData: internalTypes.GlobalRuleConfigData = {
 		globals = if lintConfig.globals ~= nil then lintConfig.globals else {},
 		ruleConfigs = ruleConfigurations,
 		ruleIgnores = ruleIgnoreData,
+		overrides = resolvedOverrides,
 	}
 
-	return lintRules, configContextData :: internalTypes.RuleConfigData, globalIgnoreData
+	return lintRules, configContextData, globalIgnoreData
 end
 
 return table.freeze(lintCore)

--- a/lute/cli/commands/lint/worker.luau
+++ b/lute/cli/commands/lint/worker.luau
@@ -5,10 +5,11 @@ local lintCore = require("./lintCore")
 
 -- populate in initialize
 local lintRules: { types.LintRule } = {}
-local configData: internalTypes.RuleConfigData = {
+local configData: internalTypes.GlobalRuleConfigData = {
 	ruleConfigs = {},
 	ruleIgnores = {},
 	globals = {},
+	overrides = {},
 }
 
 local worker = {}

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -107,4 +107,22 @@ function tableext.all<T>(arr: { T }, predicate: (T) -> boolean): boolean
 	return true
 end
 
+-- I want the mehtod to take a generic s.t it returns an identical shape (deepclone(object) -> same object structure)
+-- using K, V generics and { [K]: V } does not yield thise behavior
+-- only using T (afaik)
+-- This is why I must cast on line 119
+function tableext.deepclone<T>(tbl: T): T
+	local clone = {}
+	assert(typeof(tbl) == "table", `{tbl} is not a table`)
+
+	for k, v in tbl :: any do
+		if typeof(v) == "table" then
+			clone[k] = tableext.deepclone(v)
+		else
+			clone[k] = v
+		end
+	end
+	return clone
+end
+
 return table.freeze(tableext)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -3301,6 +3301,470 @@ return {
 		end
 	)
 
+	suite:case("luteLintAppliesCumulativeOverridesByPath", function(assert)
+		local testSubDir = path.join(tmpDir, "module")
+		local sourceDir = path.join(testSubDir, "src")
+		local legacyDir = path.join(sourceDir, "legacy")
+		local unmatchedDir = path.join(sourceDir, "unmatched")
+		fs.createDirectory(testSubDir)
+		fs.createDirectory(sourceDir)
+		fs.createDirectory(legacyDir)
+		fs.createDirectory(unmatchedDir)
+
+		local legacyFile = path.join(legacyDir, "file.luau")
+		local unmatchedFile = path.join(unmatchedDir, "file.luau")
+		fs.writeStringToFile(legacyFile, "print('legacy')")
+		fs.writeStringToFile(unmatchedFile, "print('unmatched')")
+
+		local customRulePath = path.join(testSubDir, "customRule.luau")
+		fs.writeStringToFile(
+			customRulePath,
+			[[
+return {
+	name = "customRule",
+	lint = function(cst, sourcepath, context)
+		return {
+			{
+				lintname = "customRule",
+				severity = "warning",
+				message = `mode={context.globals.mode} flag={context.options.flag}`,
+				location = cst.location,
+				sourcepath = sourcepath,
+			}
+		}
+	end
+}
+]]
+		)
+
+		local configFile = path.join(testSubDir, ".config.luau")
+		fs.writeStringToFile(
+			configFile,
+			[[
+return {
+	lute = {
+		lint = {
+			globals = {
+				mode = "base",
+			},
+			ruleconfigs = {
+				customRule = {
+					options = {
+						flag = "base",
+					},
+				},
+			},
+			overrides = {
+				{
+					paths = { "**/legacy/**" },
+					globals = {
+						mode = "legacy",
+					},
+					ruleconfigs = {
+						customRule = {
+							severity = "error",
+							options = {
+								flag = "legacy",
+							},
+						},
+					},
+				},
+				{
+					paths = { "**/legacy/file.luau" },
+					globals = {
+						mode = "final",
+					},
+					ruleconfigs = {
+						customRule = {
+							options = {
+								flag = "final",
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+}
+]]
+		)
+
+		local result = runProcess({
+			lutePath,
+			"lint",
+			"--no-default-lints",
+			"-r",
+			path.format(customRulePath),
+			"-c",
+			path.format(configFile),
+			path.format(sourceDir),
+		})
+
+		assert.eq(result.exitcode, 1)
+		assert.strContains(result.stdout, "error[customRule]: mode=final flag=final", 1)
+		assert.strContains(result.stdout, "warning[customRule]: mode=base flag=base", 1)
+		assert.strNotContains(result.stdout, "mode=legacy flag=legacy")
+	end)
+
+	suite:case("luteLintMergesOverrideRuleIgnoresWithBaseRuleIgnores", function(assert)
+		local testSubDir = path.join(tmpDir, "module")
+		local sourceDir = path.join(testSubDir, "src")
+		local legacyDir = path.join(sourceDir, "legacy")
+		fs.createDirectory(testSubDir)
+		fs.createDirectory(sourceDir)
+		fs.createDirectory(legacyDir)
+
+		local baseIgnoredFile = path.join(legacyDir, "baseIgnored.luau")
+		local overrideIgnoredFile = path.join(legacyDir, "overrideIgnored.luau")
+		local reportedFile = path.join(legacyDir, "reported.luau")
+		fs.writeStringToFile(baseIgnoredFile, "print('base ignored')")
+		fs.writeStringToFile(overrideIgnoredFile, "print('override ignored')")
+		fs.writeStringToFile(reportedFile, "print('reported')")
+
+		local customRulePath = path.join(testSubDir, "customRule.luau")
+		fs.writeStringToFile(
+			customRulePath,
+			[[
+local path = require("@std/path")
+
+return {
+	name = "customRule",
+	lint = function(cst, sourcepath, context)
+		return {
+			{
+				lintname = "customRule",
+				severity = "warning",
+				message = `custom rule ran on {path.basename(sourcepath)}`,
+				location = cst.location,
+				sourcepath = sourcepath,
+			}
+		}
+	end
+}
+]]
+		)
+
+		local configFile = path.join(testSubDir, ".config.luau")
+		fs.writeStringToFile(
+			configFile,
+			[[
+return {
+	lute = {
+		lint = {
+			ruleconfigs = {
+				customRule = {
+					ignores = { "**/baseIgnored.luau" },
+				},
+			},
+			overrides = {
+				{
+					paths = { "**/legacy/**" },
+					ruleconfigs = {
+						customRule = {
+							ignores = { "**/overrideIgnored.luau" },
+						},
+					},
+				},
+			},
+		}
+	}
+}
+]]
+		)
+
+		local result = runProcess({
+			lutePath,
+			"lint",
+			"--no-default-lints",
+			"-r",
+			path.format(customRulePath),
+			"-c",
+			path.format(configFile),
+			path.format(sourceDir),
+		})
+
+		assert.eq(result.exitcode, 1)
+		assert.strNotContains(result.stdout, "baseIgnored.luau")
+		assert.strNotContains(result.stdout, "overrideIgnored.luau")
+		assert.strContains(result.stdout, "reported.luau")
+		assert.strContains(result.stdout, "custom rule ran", 1)
+	end)
+
+	suite:case("luteLintAppliesOverrideIgnoresOnlyWithinMatchedOverride", function(assert)
+		local testSubDir = path.join(tmpDir, "module")
+		local sourceDir = path.join(testSubDir, "src")
+		local legacyDir = path.join(sourceDir, "legacy")
+		local strictDir = path.join(sourceDir, "strict")
+		fs.createDirectory(testSubDir)
+		fs.createDirectory(sourceDir)
+		fs.createDirectory(legacyDir)
+		fs.createDirectory(strictDir)
+
+		local legacyIgnoredFile = path.join(legacyDir, "legacyIgnored.luau")
+		local legacyReportedFile = path.join(legacyDir, "legacyReported.luau")
+		local strictIgnoredFile = path.join(strictDir, "strictIgnored.luau")
+		fs.writeStringToFile(legacyIgnoredFile, "print('legacy ignored')")
+		fs.writeStringToFile(legacyReportedFile, "print('legacy reported')")
+		fs.writeStringToFile(strictIgnoredFile, "print('strict ignored')")
+
+		local customRulePath = path.join(testSubDir, "customRule.luau")
+		fs.writeStringToFile(
+			customRulePath,
+			[[
+local path = require("@std/path")
+
+return {
+	name = "customRule",
+	lint = function(cst, sourcepath, context)
+		return {
+			{
+				lintname = "customRule",
+				severity = "warning",
+				message = `custom rule ran on {path.basename(sourcepath)}`,
+				location = cst.location,
+				sourcepath = sourcepath,
+			}
+		}
+	end
+}
+]]
+		)
+
+		local configFile = path.join(testSubDir, ".config.luau")
+		fs.writeStringToFile(
+			configFile,
+			[[
+return {
+	lute = {
+		lint = {
+			overrides = {
+				{
+					paths = { "**/legacy/**" },
+					ignores = { "**/legacyIgnored.luau" },
+				},
+			},
+		}
+	}
+}
+]]
+		)
+
+		local result = runProcess({
+			lutePath,
+			"lint",
+			"--no-default-lints",
+			"-r",
+			path.format(customRulePath),
+			"-c",
+			path.format(configFile),
+			path.format(sourceDir),
+		})
+
+		assert.eq(result.exitcode, 1)
+		assert.strNotContains(result.stdout, "custom rule ran on legacyIgnored.luau")
+		assert.strContains(result.stdout, "custom rule ran on legacyReported.luau", 1)
+		assert.strContains(result.stdout, "custom rule ran on strictIgnored.luau", 1)
+	end)
+
+	suite:case("luteLintAppliesOverrideRulePathsOnlyWithinMatchedOverride", function(assert)
+		local testSubDir = path.join(tmpDir, "module")
+		local sourceDir = path.join(testSubDir, "src")
+		local legacyDir = path.join(sourceDir, "legacy")
+		local strictDir = path.join(sourceDir, "strict")
+		fs.createDirectory(testSubDir)
+		fs.createDirectory(sourceDir)
+		fs.createDirectory(legacyDir)
+		fs.createDirectory(strictDir)
+
+		local legacyFile = path.join(legacyDir, "file.luau")
+		local strictFile = path.join(strictDir, "file.luau")
+		fs.writeStringToFile(legacyFile, "print('legacy')")
+		fs.writeStringToFile(strictFile, "print('strict')")
+
+		local baseRulePath = path.join(testSubDir, "baseRule.luau")
+		fs.writeStringToFile(
+			baseRulePath,
+			[[
+return {
+	name = "baseRule",
+	lint = function(cst, sourcepath, context)
+		return {
+			{
+				lintname = "baseRule",
+				severity = "warning",
+				message = "base rule ran",
+				location = cst.location,
+				sourcepath = sourcepath,
+			}
+		}
+	end
+}
+]]
+		)
+
+		local overrideRulePath = path.join(testSubDir, "overrideRule.luau")
+		fs.writeStringToFile(
+			overrideRulePath,
+			[[
+return {
+	name = "overrideRule",
+	lint = function(cst, sourcepath, context)
+		return {
+			{
+				lintname = "overrideRule",
+				severity = "warning",
+				message = "override rule ran",
+				location = cst.location,
+				sourcepath = sourcepath,
+			}
+		}
+	end
+}
+]]
+		)
+
+		local configFile = path.join(testSubDir, ".config.luau")
+		fs.writeStringToFile(
+			configFile,
+			[[
+return {
+	lute = {
+		lint = {
+			overrides = {
+				{
+					paths = { "**/legacy/**" },
+					rulepaths = { "./overrideRule.luau" },
+				},
+			},
+		}
+	}
+}
+]]
+		)
+
+		local result = runProcess({
+			lutePath,
+			"lint",
+			"--no-default-lints",
+			"-r",
+			path.format(baseRulePath),
+			"-c",
+			path.format(configFile),
+			path.format(sourceDir),
+		})
+
+		assert.eq(result.exitcode, 1)
+		assert.strContains(result.stdout, "base rule ran", 2)
+		assert.strContains(result.stdout, "override rule ran", 1)
+	end)
+
+	suite:case("luteLintAppliesOverrideRuleConfigsToOverrideRulePaths", function(assert)
+		local testSubDir = path.join(tmpDir, "module")
+		local sourceDir = path.join(testSubDir, "src")
+		local legacyDir = path.join(sourceDir, "legacy")
+		local strictDir = path.join(sourceDir, "strict")
+		fs.createDirectory(testSubDir)
+		fs.createDirectory(sourceDir)
+		fs.createDirectory(legacyDir)
+		fs.createDirectory(strictDir)
+
+		local legacyFile = path.join(legacyDir, "file.luau")
+		local strictFile = path.join(strictDir, "file.luau")
+		fs.writeStringToFile(legacyFile, "print('legacy')")
+		fs.writeStringToFile(strictFile, "print('strict')")
+
+		local baseRulePath = path.join(testSubDir, "baseRule.luau")
+		fs.writeStringToFile(
+			baseRulePath,
+			[[
+local path = require("@std/path")
+
+return {
+	name = "baseRule",
+	lint = function(cst, sourcepath, context)
+		return {
+			{
+				lintname = "baseRule",
+				severity = "warning",
+				message = `base rule flag={context.options.flag} file={path.basename(sourcepath)}`,
+				location = cst.location,
+				sourcepath = sourcepath,
+			}
+		}
+	end
+}
+]]
+		)
+
+		local overrideRulePath = path.join(testSubDir, "overrideRule.luau")
+		fs.writeStringToFile(
+			overrideRulePath,
+			[[
+return {
+	name = "overrideRule",
+	lint = function(cst, sourcepath, context)
+		return {
+			{
+				lintname = "overrideRule",
+				severity = "warning",
+				message = `override rule flag={context.options.flag}`,
+				location = cst.location,
+				sourcepath = sourcepath,
+			}
+		}
+	end
+}
+]]
+		)
+
+		local configFile = path.join(testSubDir, ".config.luau")
+		fs.writeStringToFile(
+			configFile,
+			[[
+return {
+	lute = {
+		lint = {
+			overrides = {
+				{
+					paths = { "**/legacy/**" },
+					rulepaths = { "./overrideRule.luau" },
+					ruleconfigs = {
+						overrideRule = {
+							options = {
+								flag = "configured",
+							},
+						},
+						baseRule = {
+							options = {
+								flag = "configured",
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+}
+]]
+		)
+
+		local result = runProcess({
+			lutePath,
+			"lint",
+			"--no-default-lints",
+			"-r",
+			path.format(baseRulePath),
+			"-c",
+			path.format(configFile),
+			path.format(sourceDir),
+		})
+
+		assert.eq(result.exitcode, 1)
+		assert.strContains(result.stdout, "override rule flag=configured", 1)
+		assert.strContains(result.stdout, "base rule flag=configured file=file.luau", 1)
+		assert.strContains(result.stdout, "base rule flag=nil file=file.luau", 1)
+	end)
+
 	suite:case("emptyIfBlockBasic", function(assert)
 		lintTestHelper(assert, {
 			content = [[

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -139,4 +139,56 @@ test.suite("TableExt", function(suite)
 		end)
 		assert.that(allInEmpty)
 	end)
+
+	suite:case("deepclone", function(assert)
+		-- Empty table
+		local empty = {}
+		local emptyClone = tableext.deepclone(empty)
+		assert.eq(#emptyClone, 0)
+		assert.that(emptyClone ~= empty)
+
+		-- Flat table: clone has same values
+		local flat = { a = 1, b = 2, c = 3 }
+		local flatClone = tableext.deepclone(flat)
+		assert.eq(flatClone.a, 1)
+		assert.eq(flatClone.b, 2)
+		assert.eq(flatClone.c, 3)
+		assert.that(flatClone ~= flat)
+
+		-- Flat table: mutating clone does not affect original
+		flatClone.a = 99
+		assert.eq(flat.a, 1)
+
+		-- Array-like table
+		local arr = { 10, 20, 30 }
+		local arrClone = tableext.deepclone(arr)
+		assert.eq(arrClone[1], 10)
+		assert.eq(arrClone[2], 20)
+		assert.eq(arrClone[3], 30)
+		assert.that(arrClone ~= arr)
+
+		-- Nested table: clone is deep (independent nested tables)
+		local nested = { x = { y = { z = 42 } } }
+		local nestedClone = tableext.deepclone(nested)
+		assert.eq(nestedClone.x.y.z, 42)
+		assert.that(nestedClone.x ~= nested.x)
+		assert.that(nestedClone.x.y ~= nested.x.y)
+
+		-- Nested table: mutating a nested clone does not affect original
+		nestedClone.x.y.z = 0
+		assert.eq(nested.x.y.z, 42)
+
+		-- Mixed table: nested arrays and dicts
+		local mixed = { nums = { 1, 2, 3 }, meta = { count = 3 } }
+		local mixedClone = tableext.deepclone(mixed)
+		assert.eq(mixedClone.nums[1], 1)
+		assert.eq(mixedClone.meta.count, 3)
+		assert.that(mixedClone.nums ~= mixed.nums)
+		assert.that(mixedClone.meta ~= mixed.meta)
+
+		mixedClone.nums[1] = 99
+		mixedClone.meta.count = 99
+		assert.eq(mixed.nums[1], 1)
+		assert.eq(mixed.meta.count, 3)
+	end)
 end)


### PR DESCRIPTION
Support overrides in lint config, allowing consumers to configure specific behavior for certain files / paths via glob patterns.

Inspired by override mechanisms in [biome](https://biomejs.dev/reference/configuration/#overrides) and [legacy ESLint ](https://archive.eslint.org/docs/7.0.0/user-guide/configuring#configuration-based-on-glob-patterns) configs.

`overrides` is implemented as an additional property on the lint config table, where a user can re-specify the configure structure for certain paths. `overrides` has signature:
```luau
type Overrides = { 
	{
		paths: { string }, -- globs 
	} & LintConfig
}
```


`overrides` behave as follows:
- mantain current config, initially equal to the global config (top level lint config values)
- for every override that the currently linted file matches (in the order they're declared in the config file)
	- merge override's config into current config:
		- current config's `ignores` extended with override's `ignores`
		- current config's `globals` combined with override's `globals` (override takes precedence if conflicting keys)
		- for each rule in current config's `ruleConfigs`, shallow merge with corresponding config in override's `ruleConfigs`
- file is linted with final, merged state of current config

I am open to feedback on the merging behavior and/or override structure, but I think this will be a great feature for adoption and ergonomics in large, messy codebases (particularly where legacy code is prominent) and significantly reduce noise.