### PR TITLE
Support bundling alias paths prefixed with "~" 

### DIFF
--- a/lute/require/src/bundlevfs.cpp
+++ b/lute/require/src/bundlevfs.cpp
@@ -81,7 +81,7 @@ static bool isBundleDirectory(const Luau::DenseHashMap<std::string, std::string>
 NavigationStatus BundleVfs::resetToPath(const std::string& path)
 {
     // Handle "@bundle" root
-    if (path == "@bundle")
+    if (path == kBundlePrefix)
     {
         modulePath = ModulePath::create(
             "@bundle",
@@ -99,11 +99,20 @@ NavigationStatus BundleVfs::resetToPath(const std::string& path)
     }
 
     // Handle "@bundle/path/to/file"
-    if (path.rfind(kBundlePrefixPath, 0) != 0)
-        return NavigationStatus::NotFound;
+    std::string filePath;
 
-    // Strip "@bundle/" to get the actual path
-    std::string filePath = path.substr(kBundlePrefixPath.size());
+    if (path.rfind(kBundlePrefixPath, 0) == 0)
+    {
+        filePath = path.substr(kBundlePrefixPath.size());
+    }
+    else if (path.size() > 1 && path[0] == '~' && (path[1] == '/' || path[1] == '\\'))
+    {
+        filePath = path.substr(2);
+    }
+    else
+    {
+        return NavigationStatus::NotFound;
+    }
 
     modulePath = ModulePath::create(
         "@bundle",

--- a/lute/require/src/bundlevfs.cpp
+++ b/lute/require/src/bundlevfs.cpp
@@ -98,13 +98,14 @@ NavigationStatus BundleVfs::resetToPath(const std::string& path)
         return modulePath ? NavigationStatus::Success : NavigationStatus::NotFound;
     }
 
-    // Handle "@bundle/path/to/file"
     std::string filePath;
 
+    // Handle "@bundle/path/to/file"
     if (path.rfind(kBundlePrefixPath, 0) == 0)
     {
         filePath = path.substr(kBundlePrefixPath.size());
     }
+    // Handle "~/path/to/file"
     else if (path.size() > 1 && path[0] == '~' && (path[1] == '/' || path[1] == '\\'))
     {
         filePath = path.substr(2);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(Lute.Test PRIVATE
     src/typeserializefixture.cpp
 
     # Test files
+    src/bundlevfs.test.cpp
     src/compile.test.cpp
     src/runsource.test.cpp
     src/configresolver.test.cpp

--- a/tests/src/bundlevfs.test.cpp
+++ b/tests/src/bundlevfs.test.cpp
@@ -1,0 +1,67 @@
+#include "lute/bundlevfs.h"
+
+#include "lute/modulepath.h"
+
+#include "Luau/DenseHash.h"
+
+#include "doctest.h"
+
+namespace
+{
+
+BundleVfs makeBundle()
+{
+    Luau::DenseHashMap<std::string, std::string> bundleMap{""};
+    bundleMap["modules/main.luau"] = "bytecode-main";
+    bundleMap[".loom/store/package@v0.2.0/modules/init.luau"] = "bytecode-init";
+    bundleMap[".loom/store/package@v0.2.0/modules/locate.luau"] = "bytecode-locate";
+
+    Luau::DenseHashMap<std::string, std::string> configs{""};
+    return BundleVfs{std::move(configs), std::move(bundleMap)};
+}
+
+} // namespace
+
+TEST_CASE("BundleVfs_resets_to_root")
+{
+    BundleVfs vfs = makeBundle();
+    CHECK(vfs.resetToPath("@bundle") == NavigationStatus::Success);
+}
+
+TEST_CASE("BundleVfs_resets_to_existing_bundle_directory")
+{
+    BundleVfs vfs = makeBundle();
+    CHECK(vfs.resetToPath("@bundle/.loom/store/package@v0.2.0/modules") == NavigationStatus::Success);
+}
+
+TEST_CASE("BundleVfs_returns_not_found_for_unknown_bundle_path")
+{
+    BundleVfs vfs = makeBundle();
+    CHECK(vfs.resetToPath("@bundle/missing/path") == NavigationStatus::NotFound);
+}
+
+TEST_CASE("BundleVfs_bridges_tilde_alias_to_bundle_path")
+{
+    // Simulates the loom case: alias value is "~/.loom/store/package@v0.2.0/modules"
+    // and the bundle has the matching directory at LCR-stripped path.
+    BundleVfs vfs = makeBundle();
+    CHECK(vfs.resetToPath("~/.loom/store/package@v0.2.0/modules") == NavigationStatus::Success);
+
+    // Directories with init.luau auto-resolve to the init module — confirms the
+    // bridge points at a real bundled file, not an empty directory.
+    CHECK(vfs.isModulePresent());
+}
+
+TEST_CASE("BundleVfs_user_tilde_path_returns_not_found")
+{
+    // ~user/foo is not supported: BundleVfs has no notion of other users' homes.
+    BundleVfs vfs = makeBundle();
+    CHECK(vfs.resetToPath("~someone/anything") == NavigationStatus::NotFound);
+}
+
+TEST_CASE("BundleVfs_absolute_disk_path_returns_not_found")
+{
+    // Absolute paths without a tilde aren't bridged; they would require knowing the LCR.
+    BundleVfs vfs = makeBundle();
+    CHECK(vfs.resetToPath("/Users/anyone/.loom/store/package@v0.2.0/modules") == NavigationStatus::NotFound);
+}


### PR DESCRIPTION
Resolves https://github.com/luau-lang/lute/issues/1152

Compiling a project whose `.config.luau` defines aliases pointing under `~/` produces a binary that fails to load that alias at runtime, e.g.:
```
error requiring module "@package": could not jump to alias "~/.loom/store/package@v0.2.0/modules"
```

Lute already correctly includes all relevant content in the bundle, but we strip the common path prefix when storing the file path in the bundle, and the alias definition includes an unexpanded `~` which doesn't match to any of the bundled paths. The common prefix path in most cases seems to end up resolving to the home directory, so the simplest fix is to just strip `~` at runtime with the assumption that the common prefix path is the home directory. If this assumption is ever wrong, then the user will simply experience the same error that they currently do.

There are other possible fixes for this that we could implement instead:
1. Re-writing the included alias definitions (basically pre-process bundled `.config.luau` to pre-resolve the `~` prefix)
2. Include the original home directory and computed path prefix in the bundled binary and perform `~` expansion (and prefix stripping) at runtime