### PR TITLE
Fix unused-var lint bug

### DIFF
--- a/lute/cli/commands/lint/rules/unused_variable.luau
+++ b/lute/cli/commands/lint/rules/unused_variable.luau
@@ -110,14 +110,15 @@ local function unusedLocals(block: syntax.CstStatBlock, writeOnlyAPIs: smallTrie
 			if stat.values[i] then
 				if utils.isRequireCall(stat.values[i]) then
 					visitor.requiredModules[localVar.name.text] = localVar
+					visitorLib.visitExpression(stat.values[i], visitor)
 				else
 					visitor.ignoreReferences[localVar] = true
 					if localVar.annotation then
 						visitorLib.visitType(localVar.annotation, visitor)
 					end
+					visitorLib.visitExpression(stat.values[i], visitor)
 					visitor.ignoreReferences[localVar] = nil
 				end
-				visitorLib.visitExpression(stat.values[i], visitor)
 			end
 		end
 

--- a/lute/cli/commands/lint/rules/unused_variable.luau
+++ b/lute/cli/commands/lint/rules/unused_variable.luau
@@ -115,9 +115,9 @@ local function unusedLocals(block: syntax.CstStatBlock, writeOnlyAPIs: smallTrie
 					if localVar.annotation then
 						visitorLib.visitType(localVar.annotation, visitor)
 					end
-					visitorLib.visitExpression(stat.values[i], visitor)
 					visitor.ignoreReferences[localVar] = nil
 				end
+				visitorLib.visitExpression(stat.values[i], visitor)
 			end
 		end
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -2626,15 +2626,9 @@ return {
 local A = {}
 local _ = require(A.Index)
 ]],
-			expectedExitCode = 1,
+			expectedExitCode = 0,
 			rulePath = defaultRulesPaths.unused_variable,
 			disableDefaultLints = true,
-			outputExpectations = {
-				{
-					expectedOutput = LINT_RULE_MESSAGES.unused_variable,
-					count = 1,
-				},
-			},
 		})
 	end)
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -2624,12 +2624,17 @@ return {
 		lintTestHelper(assert, {
 			content = [[
 local A = {}
-local B = require(A.Index)
+local _ = require(A.Index)
 ]],
-			expectedExitCode = 0,
+			expectedExitCode = 1,
 			rulePath = defaultRulesPaths.unused_variable,
 			disableDefaultLints = true,
-			outputExpectations = {},
+			outputExpectations = {
+				{
+					expectedOutput = LINT_RULE_MESSAGES.unused_variable,
+					count = 1,
+				},
+			},
 		})
 	end)
 

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -2620,6 +2620,19 @@ return {
 		})
 	end)
 
+	suite:case("unusedVariableRegressionTest", function(assert)
+		lintTestHelper(assert, {
+			content = [[
+local A = {}
+local B = require(A.Index)
+]],
+			expectedExitCode = 0,
+			rulePath = defaultRulesPaths.unused_variable,
+			disableDefaultLints = true,
+			outputExpectations = {},
+		})
+	end)
+
 	suite:case("throwsErrorWhenConfigHasInvalidGlobals", function(assert)
 		local err = lintTestHelper(assert, {
 			content = "",


### PR DESCRIPTION
Fixes a bug with required modules being incorrectly detected as unused.

Previously:
```
local Base = ...
local member = require(Base.Member)
```
would yield an unused var error for base

Regression test added