### PR TITLE
Updates ccache options to not use -v(verbose)

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -98,7 +98,7 @@ runs:
       shell: bash
       run: |
         echo "Cache status: ${{ steps.cache-ccache.outputs.cache-hit }}"
-        ccache -sv
+        ccache -s
 
     - name: Bootstrap Lute (if needed) and set LUTE
       shell: bash


### PR DESCRIPTION
This is supported on most platforms except one the ccache distributed on one of the linux containers....