### PR TITLE
One missed spot for ccache -sv in build script (at the end of the build)

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -126,7 +126,7 @@ runs:
 
     - name: ccache stats (post-build)
       shell: bash
-      run: ccache -sv
+      run: ccache -s
 
     - name: Save ccache
       if: github.ref_name == 'primary'


### PR DESCRIPTION
We print the result of ccache -s before _and after_ building lute. I missed the ocurrence that takes place after we build.