### PR TITLE
Add `find` to `tableext`

### DIFF
--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -31,6 +31,16 @@ function tableext.filter<K, V>(table: { [K]: V }, predicate: (V) -> boolean): { 
 	return new
 end
 
+--- Returns a key-value pair from `table` for which `predicate` returns `true`. key-value pair is not guaranteed.
+function tableext.find<K, V>(table: { [K]: V }, predicate: (V) -> boolean): (V?, K?)
+	for k, v in table do
+		if predicate(v) then
+			return v, k
+		end
+	end
+	return nil, nil
+end
+
 --- Merges all additional tables into `tbl` in order. When the same key appears in multiple tables, the value from the last table containing that key wins. Returns `tbl`.
 function tableext.combine<K, V>(tbl: { [K]: V }, ...: { [K]: V }): { [K]: V }
 	local tables = table.pack(...)

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -31,7 +31,7 @@ function tableext.filter<K, V>(table: { [K]: V }, predicate: (V) -> boolean): { 
 	return new
 end
 
---- Returns a key-value pair from `table` for which `predicate` returns `true`. key-value pair is not guaranteed.
+--- Returns the first key-value pair from `table` for which `predicate` returns `true`. Returns `nil, nil` if the predicate does not hold for any value.
 function tableext.find<K, V>(table: { [K]: V }, predicate: (V) -> boolean): (V?, K?)
 	for k, v in table do
 		if predicate(v) then

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -28,7 +28,7 @@ test.suite("TableExt", function(suite)
 			return v % 2 == 0
 		end)
 		assert.eq(foundA, 2)
-		assert.eq(indexA, "a")
+		assert.eq(indexA, "b")
 		local foundB, indexB = tableext.find(b, function(v: number)
 			return v == 3
 		end)

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -19,6 +19,19 @@ test.suite("TableExt", function(suite)
 		assert.eq(filtered.c, 3)
 	end)
 
+	suite:case("find", function(assert)
+		local a: { [string]: number } = { a = 1, b = 2, c = 3 }
+		local b: { number } = { 1, 2, 3 }
+		local foundA = tableext.find(a, function(v: number)
+			return v % 2 == 0
+		end)
+		assert.eq(foundA, 2)
+		local foundB = tableext.find(b, function(v: number)
+			return v == 3
+		end)
+		assert.eq(foundB, 3)
+	end)
+
 	suite:case("extend", function(assert)
 		local a: { number } = { 1, 2 }
 		local b: { number } = { 3, 4 }

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -22,14 +22,26 @@ test.suite("TableExt", function(suite)
 	suite:case("find", function(assert)
 		local a: { [string]: number } = { a = 1, b = 2, c = 3 }
 		local b: { number } = { 1, 2, 3 }
-		local foundA = tableext.find(a, function(v: number)
+		local c: { number } = { 1, 1, 2 }
+		local d = {}
+		local foundA, indexA = tableext.find(a, function(v: number)
 			return v % 2 == 0
 		end)
 		assert.eq(foundA, 2)
-		local foundB = tableext.find(b, function(v: number)
+		assert.eq(indexA, "a")
+		local foundB, indexB = tableext.find(b, function(v: number)
 			return v == 3
 		end)
 		assert.eq(foundB, 3)
+		assert.eq(indexB, 3)
+		local foundC = tableext.find(c, function(v: number)
+			return v == 1
+		end)
+		assert.eq(foundC, 1)
+		local foundD = tableext.find(d, function()
+			return true
+		end)
+		assert.eq(foundD, nil)
 	end)
 
 	suite:case("extend", function(assert)


### PR DESCRIPTION
Returns the first key-value pair in the table which the predicate returns true. it seems like it would b a useful addition to the std library