### PR TITLE
lute pkg: update version constraint solving to add backtracking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 
 # Package management
 /lute/cli/commands/pkg/ @luau-lang/lute-pkg-maintainers
+/tests/cli/pkg/ @luau-lang/lute-pkg-maintainers

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -195,12 +195,19 @@ local function resolve(rootDirectory: string, universe: semver.Universe?): lockf
 
 		local resolution = semver.solve(universe, registryRequirements)
 
-		for name, pkgVersion in resolution do
+		-- Build a lookup from package name to resolved version(s) for slot-keyed results.
+		local versionsByPackageName = {}
+		for _, pkgVersion in resolution do
+			versionsByPackageName[pkgVersion.name] = pkgVersion
+		end
+
+		for _, pkgVersion in resolution do
+			local name = pkgVersion.name
 			local key = `{name}@{pkgVersion.versionString}`
 
 			local transitiveDependencies: { [string]: string } = {}
 			for alias, dependency in pkgVersion.dependencies do
-				local resolvedVersion = resolution[dependency.name]
+				local resolvedVersion = versionsByPackageName[dependency.name]
 				assert(resolvedVersion ~= nil, `Solver produced an incomplete resolution: missing '{dependency.name}'`)
 
 				transitiveDependencies[alias] = `{dependency.name}@{resolvedVersion.versionString}`
@@ -220,7 +227,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?): lockf
 		for pkgKey, unresolvedAliases in unresolvedRegistryDependencies do
 			local packageDependencies = openDependencies[pkgKey]
 			for dependencyAlias, registryName in unresolvedAliases do
-				local pkgVersion = resolution[registryName]
+				local pkgVersion = versionsByPackageName[registryName]
 				assert(pkgVersion ~= nil, `Solver did not resolve transitive registry dependency '{registryName}'`)
 				packageDependencies[dependencyAlias] = `{registryName}@{pkgVersion.versionString}`
 			end
@@ -229,7 +236,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?): lockf
 		-- Write root-level registry dependency aliases now that versions are resolved.
 		for _, alias in rootRegistryAliases do
 			local req = registryRequirements[alias]
-			local pkgVersion = resolution[req.name]
+			local pkgVersion = versionsByPackageName[req.name]
 			assert(pkgVersion ~= nil, `Solver did not resolve root dependency '{req.name}'`)
 			dependencies[alias] = `{req.name}@{pkgVersion.versionString}`
 		end

--- a/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
+++ b/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
@@ -57,7 +57,7 @@ local function slotFromConstraint(name: string, constraint: parser.Constraint): 
 		end
 	end
 
-	-- split nil checks for better type inference.
+	-- FIXME(Luau): we had to split nil checks for better type inference, refinements _should_ still work if it was one check
 	if lower == nil then
 		return nil
 	end

--- a/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
+++ b/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
@@ -191,48 +191,6 @@ local function propagateDeps(
 	return out
 end
 
-local function checkAcyclic(selected: Resolution, universe: Universe)
-	local path: { string } = {}
-	local onPath: { [string]: number } = {}
-	local done: { [string]: boolean } = {}
-
-	local function visit(slotKey: string)
-		if done[slotKey] then
-			return
-		end
-		if onPath[slotKey] then
-			local cycleStart = onPath[slotKey]
-			local cycle: { string } = {}
-			for i = cycleStart, #path do
-				table.insert(cycle, path[i])
-			end
-			table.insert(cycle, slotKey)
-			error(`circular dependency: {table.concat(cycle, " -> ")}`)
-		end
-
-		table.insert(path, slotKey)
-		onPath[slotKey] = #path
-
-		local pkg = selected[slotKey]
-		if pkg then
-			for _, dep in pkg.dependencies do
-				local depSlot = resolveSlotKey(dep.name, dep.constraint, universe)
-				if selected[depSlot] then
-					visit(depSlot)
-				end
-			end
-		end
-
-		onPath[slotKey] = nil
-		table.remove(path)
-		done[slotKey] = true
-	end
-
-	for slotKey in selected do
-		visit(slotKey)
-	end
-end
-
 type DecisionFrame = {
 	read slotKey: string,
 	read candidates: { PackageVersion },
@@ -265,7 +223,6 @@ local function solve(universe: Universe, roots: { [string]: Requirement }): Reso
 		local slotKey = pickPending(constraints, selected, universe)
 
 		if slotKey == nil then
-			checkAcyclic(selected, universe)
 			return table.freeze(selected)
 		end
 

--- a/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
+++ b/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
@@ -27,7 +27,6 @@ export type Resolution = { [string]: PackageVersion }
 -- Constraints accumulated during the search, keyed by slot.
 type ConstraintSet = { [string]: { [string]: Requirement } }
 
-
 local function computeSlot(name: string, version: parser.Version): string
 	if version.major > 0 then
 		return `{name}@{version.major}`
@@ -119,7 +118,7 @@ local function constraintsFor(set: ConstraintSet, slotKey: string): { Requiremen
 end
 
 -- Pick the slot with the fewest satisfying candidates (MRV heuristic).
--- Tie-break alphabetically for determinism. 
+-- Tie-break alphabetically for determinism.
 -- Returns nil when all constrained slots are already selected.
 local function pickPending(set: ConstraintSet, selected: Resolution, universe: Universe): string?
 	local best: string? = nil
@@ -150,7 +149,7 @@ local function pickPending(set: ConstraintSet, selected: Resolution, universe: U
 		if count == 0 then
 			return slotKey
 		end
-		
+
 		-- fewest candiates with alphabetical tie-breaker
 		if best == nil or count < bestCount or (count == bestCount and slotKey < best) then
 			best = slotKey
@@ -162,7 +161,7 @@ local function pickPending(set: ConstraintSet, selected: Resolution, universe: U
 end
 
 -- Merge `deps` into the constraint set under sourceKey.
--- TODO check the constraints against already-selected versions (forward checking). 
+-- TODO check the constraints against already-selected versions (forward checking).
 local function propagateDeps(
 	set: ConstraintSet,
 	sourceKey: string,
@@ -317,10 +316,8 @@ local function solve(universe: Universe, roots: { [string]: Requirement }): Reso
 					local sourceKey = `{candidate.name}@{candidate.versionString}`
 					local nextSelected = table.clone(frame.prevSelected)
 					nextSelected[frame.slotKey] = candidate
-					local nextConstraints = propagateDeps(
-						frame.prevConstraints, sourceKey,
-						candidate.dependencies, universe
-					)
+					local nextConstraints =
+						propagateDeps(frame.prevConstraints, sourceKey, candidate.dependencies, universe)
 
 					frame.candidateIdx = idx
 					constraints = nextConstraints

--- a/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
+++ b/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
@@ -1,7 +1,6 @@
 --!strict
 
 local tableext = require("@std/tableext")
-local deque = require("@batteries/collections/deque")
 
 local parser = require("./parser")
 
@@ -21,224 +20,329 @@ export type Requirement = {
 -- All known versions per package name, sorted newest-first.
 export type Universe = { [string]: { PackageVersion } }
 
--- One selected PackageVersion per package name.
+-- One selected PackageVersion per compatibility slot.
+-- Slot keys: "name@major" (major>0), "name@0.minor" (0.Y), "name@0.0.patch" (0.0.Z)
 export type Resolution = { [string]: PackageVersion }
 
--- Find the highest-precedence version in `versions` satisfying all requirements.
--- `versions` must already be sorted newest-first.
-local function findBest(versions: { PackageVersion }?, requirements: { Requirement }): PackageVersion?
-	if versions == nil then
+-- Constraints accumulated during the search, keyed by slot.
+type ConstraintSet = { [string]: { [string]: Requirement } }
+
+
+local function computeSlot(name: string, version: parser.Version): string
+	if version.major > 0 then
+		return `{name}@{version.major}`
+	elseif version.minor > 0 then
+		return `{name}@0.{version.minor}`
+	else
+		return `{name}@0.0.{version.patch}`
+	end
+end
+
+local function slotFromConstraint(name: string, constraint: parser.Constraint): string?
+	if #constraint == 0 then
 		return nil
 	end
 
-	for _, pv in versions do
-		if tableext.all(requirements, function(req)
-			return parser.satisfies(pv.version, req.constraint)
-		end) then
-			return pv
+	if #constraint == 1 and constraint[1].op == "=" then
+		return computeSlot(name, constraint[1].version)
+	end
+
+	local lower: parser.Version? = nil
+	local upper: parser.Version? = nil
+	for _, comp in constraint do
+		if (comp.op == ">=" or comp.op == ">") and lower == nil then
+			lower = comp.version
+		elseif comp.op == "<" and upper == nil then
+			upper = comp.version
 		end
 	end
+
+	-- split nil checks for better type inference.
+	if lower == nil then
+		return nil
+	end
+	if upper == nil then
+		return nil
+	end
+
+	if lower.major > 0 and upper.major <= lower.major + 1 then
+		return `{name}@{lower.major}`
+	elseif lower.major == 0 and lower.minor > 0 and upper.major == 0 and upper.minor <= lower.minor + 1 then
+		return `{name}@0.{lower.minor}`
+	elseif lower.major == 0 and lower.minor == 0 and upper.major == 0 and upper.minor == 0 then
+		return `{name}@0.0.{lower.patch}`
+	end
+
 	return nil
 end
 
-local function formatConflict(name: string, requirements: { Requirement }): string
-	local lines: { string } = { `version conflict for '{name}': no available version satisfies:` }
-
-	for _, req in requirements do
-		local source = req.requiredBy or "root"
-		table.insert(lines, `  {parser.formatConstraint(req.constraint)}  (required by {source})`)
-	end
-
-	return table.concat(lines, "\n")
+local function nameFromSlot(slotKey: string): string
+	local name = slotKey:match("^(.+)@")
+	return name or slotKey
 end
 
-local function solve(universe: Universe, roots: { [string]: Requirement }): Resolution
-	-- constraintsBySource[targetPkg][sourceKey] = Requirement.
-	-- Keyed by source lets us retract constraints when a selection changes.
-	-- Source keys: "root:<alias>" for root requirements, "<pkg>@<version>" for transitive deps.
-	local constraintsBySource: { [string]: { [string]: Requirement } } = {}
-
-	local selected: Resolution = {}
-
-	-- Set-based FIFO queue: each package name appears at most once at a time.
-	local queue = deque.new<<string>>()
-	local inQueue: { [string]: boolean } = {}
-
-	local function enqueue(name: string)
-		if inQueue[name] then
-			return
-		end
-
-		inQueue[name] = true
-		queue:pushback(name)
+local function resolveSlotKey(name: string, constraint: parser.Constraint, universe: Universe): string
+	local slot = slotFromConstraint(name, constraint)
+	if slot then
+		return slot
 	end
 
-	local function dequeue(): string
-		local name = queue:popfront()
-		inQueue[name] = nil
-		return name
-	end
-
-	local function addConstraint(targetName: string, sourceKey: string, req: Requirement)
-		constraintsBySource[targetName] = constraintsBySource[targetName] or {}
-		constraintsBySource[targetName][sourceKey] = req
-		enqueue(targetName)
-	end
-
-	local function removeConstraintsFrom(sourceKey: string, deps: { [string]: Requirement })
-		for alias, dep in deps do
-			local targets = constraintsBySource[dep.name]
-			local key = `{sourceKey}:{alias}`
-
-			if not targets or targets[key] == nil then
-				continue
+	local candidates = universe[name]
+	if candidates then
+		for _, c in candidates do
+			if parser.satisfies(c.version, constraint) then
+				return computeSlot(name, c.version)
 			end
-
-			targets[key] = nil
-			enqueue(dep.name)
 		end
 	end
 
-	local function getConstraintList(name: string): { Requirement }
-		local list: { Requirement } = {}
+	return `{name}@0`
+end
 
-		for _, req in constraintsBySource[name] or {} do
-			table.insert(list, req)
-		end
-
-		return list
+local function formatConflict(name: string, requirements: { Requirement }): string
+	local body: { string } = {}
+	for _, req in requirements do
+		local source = req.requiredBy or "root"
+		table.insert(body, `  {parser.formatConstraint(req.constraint)}  (required by {source})`)
 	end
+	table.sort(body)
 
-	-- Process root requirements in sorted alias order for deterministic resolution.
-	local rootAliases: { string } = {}
+	return `version conflict for '{name}': no available version satisfies:\n` .. table.concat(body, "\n")
+end
 
-	for alias, _ in roots do
-		table.insert(rootAliases, alias)
+local function constraintsFor(set: ConstraintSet, slotKey: string): { Requirement }
+	local list: { Requirement } = {}
+	for _, req in set[slotKey] or {} do
+		table.insert(list, req)
 	end
+	return list
+end
 
-	table.sort(rootAliases)
+-- Pick the slot with the fewest satisfying candidates (MRV heuristic).
+-- Tie-break alphabetically for determinism. 
+-- Returns nil when all constrained slots are already selected.
+local function pickPending(set: ConstraintSet, selected: Resolution, universe: Universe): string?
+	local best: string? = nil
+	local bestCount: number = math.huge
 
-	for _, alias in rootAliases do
-		local req = roots[alias]
-		addConstraint(
-			req.name,
-			`root:{alias}`,
-			table.freeze({
-				name = req.name,
-				constraint = req.constraint,
-				requiredBy = req.requiredBy,
-			})
-		)
-	end
-
-	-- Tracks which versions have ever been selected per package.
-	-- Re-selecting a version that was already unselected signals a circular dependency.
-	local everSelected: { [string]: { [string]: boolean } } = {}
-
-	while #queue > 0 do
-		local name = dequeue()
-
-		local constraints = getConstraintList(name)
-
-		if #constraints == 0 then
-			-- All constraints retracted: deselect and propagate retraction to dependents.
-			local old = selected[name]
-			if old then
-				selected[name] = nil
-				removeConstraintsFrom(`{old.name}@{old.versionString}`, old.dependencies)
-			end
+	for slotKey in set do
+		if selected[slotKey] ~= nil then
 			continue
 		end
+
+		local name = nameFromSlot(slotKey)
+		local candidates = universe[name]
+		if candidates == nil then
+			return slotKey
+		end
+
+		local reqs = constraintsFor(set, slotKey)
+		local count = 0
+		for _, candidate in candidates do
+			local satisfiesAll = tableext.all(reqs, function(req)
+				return parser.satisfies(candidate.version, req.constraint)
+			end)
+			if satisfiesAll then
+				count += 1
+			end
+		end
+
+		if count == 0 then
+			return slotKey
+		end
+		
+		-- fewest candiates with alphabetical tie-breaker
+		if best == nil or count < bestCount or (count == bestCount and slotKey < best) then
+			best = slotKey
+			bestCount = count
+		end
+	end
+
+	return best
+end
+
+-- Merge `deps` into the constraint set under sourceKey.
+-- TODO check the constraints against already-selected versions (forward checking). 
+local function propagateDeps(
+	set: ConstraintSet,
+	sourceKey: string,
+	deps: { [string]: Requirement },
+	universe: Universe
+): ConstraintSet
+	local out: ConstraintSet = table.clone(set)
+
+	for alias, dep in deps do
+		local slotKey = resolveSlotKey(dep.name, dep.constraint, universe)
+
+		local existing = out[slotKey]
+		local merged: { [string]: Requirement } = if existing then table.clone(existing) else {}
+		merged[`{sourceKey}:{alias}`] = table.freeze({
+			name = dep.name,
+			constraint = dep.constraint,
+			requiredBy = sourceKey,
+		})
+		out[slotKey] = merged
+	end
+
+	return out
+end
+
+local function checkAcyclic(selected: Resolution, universe: Universe)
+	local path: { string } = {}
+	local onPath: { [string]: number } = {}
+	local done: { [string]: boolean } = {}
+
+	local function visit(slotKey: string)
+		if done[slotKey] then
+			return
+		end
+		if onPath[slotKey] then
+			local cycleStart = onPath[slotKey]
+			local cycle: { string } = {}
+			for i = cycleStart, #path do
+				table.insert(cycle, path[i])
+			end
+			table.insert(cycle, slotKey)
+			error(`circular dependency: {table.concat(cycle, " -> ")}`)
+		end
+
+		table.insert(path, slotKey)
+		onPath[slotKey] = #path
+
+		local pkg = selected[slotKey]
+		if pkg then
+			for _, dep in pkg.dependencies do
+				local depSlot = resolveSlotKey(dep.name, dep.constraint, universe)
+				if selected[depSlot] then
+					visit(depSlot)
+				end
+			end
+		end
+
+		onPath[slotKey] = nil
+		table.remove(path)
+		done[slotKey] = true
+	end
+
+	for slotKey in selected do
+		visit(slotKey)
+	end
+end
+
+type DecisionFrame = {
+	read slotKey: string,
+	read candidates: { PackageVersion },
+	candidateIdx: number,
+	read prevConstraints: ConstraintSet,
+	read prevSelected: Resolution,
+}
+
+local function solve(universe: Universe, roots: { [string]: Requirement }): Resolution
+	-- Seed the constraint set from root requirements, keyed by slot.
+	local initial: ConstraintSet = {}
+	for alias, req in roots do
+		local slotKey = resolveSlotKey(req.name, req.constraint, universe)
+		initial[slotKey] = initial[slotKey] or {}
+		initial[slotKey][`root:{alias}`] = table.freeze({
+			name = req.name,
+			constraint = req.constraint,
+			requiredBy = req.requiredBy,
+		})
+	end
+
+	local stuck: { name: string, requirements: { Requirement }, depth: number }? = nil
+
+	local stack: { DecisionFrame } = {}
+	local constraints = initial
+	local selected: Resolution = {}
+
+	while true do
+		local slotKey = pickPending(constraints, selected, universe)
+
+		if slotKey == nil then
+			checkAcyclic(selected, universe)
+			return table.freeze(selected)
+		end
+
+		local name = nameFromSlot(slotKey)
 
 		if universe[name] == nil then
 			error(`unknown package '{name}': not found in universe`)
 		end
 
-		local best = findBest(universe[name], constraints)
+		local reqs = constraintsFor(constraints, slotKey)
 
-		if best == nil then
-			-- A pending item may retract a constraint once evaluated, making this
-			-- conflict spurious. Defer until the queue is settled.
-			if #queue > 0 then
-				enqueue(name)
-				continue
+		-- Filter candidates to those satisfying all current constraints.
+		local candidates: { PackageVersion } = {}
+		for _, candidate in universe[name] do
+			local satisfiesAll = tableext.all(reqs, function(r)
+				return parser.satisfies(candidate.version, r.constraint)
+			end)
+			if satisfiesAll then
+				table.insert(candidates, candidate)
+			end
+		end
+
+		-- Advance with the first candidate (universe is sorted newest-first).
+		if #candidates > 0 then
+			local candidate = candidates[1]
+			local sourceKey = `{candidate.name}@{candidate.versionString}`
+			local nextSelected = table.clone(selected)
+			nextSelected[slotKey] = candidate
+			local nextConstraints = propagateDeps(constraints, sourceKey, candidate.dependencies, universe)
+
+			table.insert(stack, {
+				slotKey = slotKey,
+				candidates = candidates,
+				candidateIdx = 1,
+				prevConstraints = constraints,
+				prevSelected = selected,
+			})
+			constraints = nextConstraints
+			selected = nextSelected
+		else
+			local depth = #stack
+			if stuck == nil or depth < stuck.depth then
+				stuck = { name = name, requirements = reqs, depth = depth }
 			end
 
-			error(formatConflict(name, constraints))
-		end
+			-- Backtrack: try next candidates at earlier decision levels.
+			local backtracked = false
+			while #stack > 0 do
+				local frame = stack[#stack]
 
-		-- Two PackageVersion objects with equal versions (differing only in build metadata)
-		-- are treated as the same selection.
-		local alreadySelected = selected[name] ~= nil and parser.compare(selected[name].version, best.version) == 0
-		if alreadySelected then
-			continue
-		end
+				if frame.candidateIdx < #frame.candidates then
+					local idx = frame.candidateIdx + 1
+					local candidate = frame.candidates[idx]
+					local sourceKey = `{candidate.name}@{candidate.versionString}`
+					local nextSelected = table.clone(frame.prevSelected)
+					nextSelected[frame.slotKey] = candidate
+					local nextConstraints = propagateDeps(
+						frame.prevConstraints, sourceKey,
+						candidate.dependencies, universe
+					)
 
-		-- Re-selecting a previously unselected version means circular dependency.
-		if not everSelected[name] then
-			everSelected[name] = {}
-		end
-
-		if everSelected[name][best.versionString] then
-			error(`circular dependency detected for package '{name}'`)
-		end
-		everSelected[name][best.versionString] = true
-
-		local old = selected[name]
-		selected[name] = best
-
-		-- Retract constraints contributed by the old selection.
-		if old then
-			removeConstraintsFrom(`{old.name}@{old.versionString}`, old.dependencies)
-		end
-
-		-- Publish constraints from the new selection.
-		local newKey = `{best.name}@{best.versionString}`
-		for alias, dep in best.dependencies do
-			addConstraint(
-				dep.name,
-				`{newKey}:{alias}`,
-				table.freeze({
-					name = dep.name,
-					constraint = dep.constraint,
-					requiredBy = newKey,
-				})
-			)
-		end
-	end
-
-	local visiting: { [string]: boolean } = {}
-	local done: { [string]: boolean } = {}
-
-	local function checkCycles(name: string)
-		if done[name] then
-			return
-		end
-
-		if visiting[name] then
-			error(`circular dependency detected for package '{name}'`)
-		end
-
-		visiting[name] = true
-
-		local pkg = selected[name]
-		if pkg then
-			for _, dep in pkg.dependencies do
-				if selected[dep.name] then
-					checkCycles(dep.name)
+					frame.candidateIdx = idx
+					constraints = nextConstraints
+					selected = nextSelected
+					backtracked = true
+					if stuck and stuck.depth > #stack then
+						stuck = nil
+					end
+					break
 				end
+
+				table.remove(stack)
+			end
+
+			if not backtracked then
+				if stuck then
+					error(formatConflict(stuck.name, stuck.requirements))
+				end
+				error("dependency resolution failed")
 			end
 		end
-
-		visiting[name] = false
-		done[name] = true
 	end
-
-	for name in selected do
-		checkCycles(name)
-	end
-
-	return table.freeze(selected)
 end
 
 return {

--- a/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
+++ b/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
@@ -103,7 +103,11 @@ local function formatConflict(name: string, requirements: { Requirement }): stri
 	local body: { string } = {}
 	for _, req in requirements do
 		local source = req.requiredBy or "root"
-		table.insert(body, `  {parser.formatConstraint(req.constraint)}  (required by {source})`)
+		if req.aliasedAs then
+			table.insert(body, `  {parser.formatConstraint(req.constraint)}  (required by {source} as {req.aliasedAs})`)
+		else
+			table.insert(body, `  {parser.formatConstraint(req.constraint)}  (required by {source})`)
+		end
 	end
 	table.sort(body)
 
@@ -247,6 +251,7 @@ local function solve(universe: Universe, roots: { [string]: Requirement }): Reso
 			name = req.name,
 			constraint = req.constraint,
 			requiredBy = req.requiredBy,
+			aliasedAs = req.aliasedAs,
 		})
 	end
 

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -347,20 +347,20 @@ test.suite("RegistryResolution", function(suite)
 				sourceKind = "registry",
 				name = "citrus",
 				source = "citrus",
-				version = "^1.0.0",
+				version = "^1.5.0",
 			},
 			lime = {
 				sourceKind = "registry",
 				name = "citrus",
 				source = "citrus",
-				version = "^2.0.0",
+				version = "<1.3.0",
 			},]]
 		)
 
 		local universe: solver.Universe = {
 			citrus = {
-				namedVersion("citrus", "1.0.0"),
-				namedVersion("citrus", "2.0.0"),
+				namedVersion("citrus", "1.5.0"),
+				namedVersion("citrus", "1.2.0"),
 			},
 		}
 

--- a/tests/cli/pkg/semver/solver.test.luau
+++ b/tests/cli/pkg/semver/solver.test.luau
@@ -243,7 +243,7 @@ test.suite("solver.solve", function(suite)
 		assert.eq(resolution["shared@2"].versionString, "2.0.0")
 	end)
 
-	suite:case("circularDependencyErrors", function(assert)
+	suite:case("circularDependencyResolves", function(assert)
 		local universe: solver.Universe = {
 			a = {
 				namedVersion("a", "1.0.0", { b = req("b", "^1.0.0") }),
@@ -253,11 +253,11 @@ test.suite("solver.solve", function(suite)
 			},
 		}
 
-		assert.throwsWith("circular dependency: a@1 -> b@1 -> a@1", function()
-			solver.solve(universe, {
-				a = req("a", "^1.0.0"),
-			})
-		end)
+		local resolution = solver.solve(universe, {
+			a = req("a", "^1.0.0"),
+		})
+		assert.eq(resolution["a@1"].versionString, "1.0.0")
+		assert.eq(resolution["b@1"].versionString, "1.0.0")
 	end)
 
 	suite:case("backtracksWithinSameSlot", function(assert)
@@ -591,7 +591,7 @@ test.suite("solver.solve", function(suite)
 		assert.eq(resolution["Z@2"], nil)
 	end)
 
-	suite:case("indirectCircularDependencyShowsFullCycle", function(assert)
+	suite:case("indirectCircularDependencyResolves", function(assert)
 		local universe: solver.Universe = {
 			a = {
 				namedVersion("a", "1.0.0", { b = req("b", "^1.0.0") }),
@@ -603,11 +603,12 @@ test.suite("solver.solve", function(suite)
 				namedVersion("c", "1.0.0", { a = req("a", "^1.0.0") }),
 			},
 		}
-		assert.throwsWith("circular dependency: a@1 -> b@1 -> c@1 -> a@1", function()
-			solver.solve(universe, {
-				a = req("a", "^1.0.0"),
-			})
-		end)
+		local resolution = solver.solve(universe, {
+			a = req("a", "^1.0.0"),
+		})
+		assert.eq(resolution["a@1"].versionString, "1.0.0")
+		assert.eq(resolution["b@1"].versionString, "1.0.0")
+		assert.eq(resolution["c@1"].versionString, "1.0.0")
 	end)
 
 	suite:case("multiMajorBacktracking", function(assert)

--- a/tests/cli/pkg/semver/solver.test.luau
+++ b/tests/cli/pkg/semver/solver.test.luau
@@ -32,8 +32,8 @@ test.suite("solver.solve", function(suite)
 			lemon = req("lemon", "^1.0.0"),
 		})
 
-		assert.neq(resolution.lemon, nil)
-		assert.eq(resolution.lemon.versionString, "1.0.0")
+		assert.neq(resolution["lemon@1"], nil)
+		assert.eq(resolution["lemon@1"].versionString, "1.0.0")
 	end)
 
 	suite:case("picksHighestSatisfying", function(assert)
@@ -50,7 +50,7 @@ test.suite("solver.solve", function(suite)
 			lemon = req("lemon", "^1.0.0"),
 		})
 
-		assert.eq(resolution.lemon.versionString, "1.3.0")
+		assert.eq(resolution["lemon@1"].versionString, "1.3.0")
 	end)
 
 	suite:case("multiplePackagesNoConflict", function(assert)
@@ -64,15 +64,11 @@ test.suite("solver.solve", function(suite)
 			lime = req("lime", ">=0.5.0"),
 		})
 
-		assert.eq(resolution.lemon.versionString, "1.3.0")
-		assert.eq(resolution.lime.versionString, "0.5.1")
+		assert.eq(resolution["lemon@1"].versionString, "1.3.0")
+		assert.eq(resolution["lime@0.5"].versionString, "0.5.1")
 	end)
 
 	suite:case("diamondDependency", function(assert)
-		-- app -> lemon ^1.0.0, lime ^0.5.0
-		-- lemon 1.3.0 -> citrus ^1.0.0
-		-- lime 0.5.1  -> citrus ^1.2.0
-		-- should resolve citrus to 1.2.x-compatible version (e.g. 1.5.0)
 		local universe: solver.Universe = {
 			lemon = {
 				namedVersion("lemon", "1.3.0", { citrus = req("citrus", "^1.0.0") }),
@@ -93,18 +89,13 @@ test.suite("solver.solve", function(suite)
 			lime = req("lime", "^0.5.0"),
 		})
 
-		assert.neq(resolution.citrus, nil)
-		-- Must satisfy both ^1.0.0 and ^1.2.0
-		assert.that(parser.satisfies(resolution.citrus.version, parser.parseConstraint("^1.0.0")))
-		assert.that(parser.satisfies(resolution.citrus.version, parser.parseConstraint("^1.2.0")))
-		assert.eq(resolution.citrus.versionString, "1.5.0")
+		assert.neq(resolution["citrus@1"], nil)
+		assert.that(parser.satisfies(resolution["citrus@1"].version, parser.parseConstraint("^1.0.0")))
+		assert.that(parser.satisfies(resolution["citrus@1"].version, parser.parseConstraint("^1.2.0")))
+		assert.eq(resolution["citrus@1"].versionString, "1.5.0")
 	end)
 
 	suite:case("constraintUpgrade", function(assert)
-		-- A requires ^1.0.0, B requires ^1.5.0
-		-- Initial pick for A would be 1.3.0, but B pushes it to 1.5.0 which also satisfies A
-		-- a 1.0.0 needs shared ^1.0.0, b 1.0.0 needs shared ^1.5.0
-		-- We need to process both and end up at shared 1.5.0
 		local universeWithDeps: solver.Universe = {
 			a = {
 				namedVersion("a", "1.0.0", { shared = req("shared", "^1.0.0") }),
@@ -122,11 +113,10 @@ test.suite("solver.solve", function(suite)
 			a = req("a", "^1.0.0"),
 			b = req("b", "^1.0.0"),
 		})
-		assert.eq(resolution.shared.versionString, "1.5.0")
+		assert.eq(resolution["shared@1"].versionString, "1.5.0")
 	end)
 
 	suite:case("transitiveDepResolved", function(assert)
-		-- app -> parent -> child
 		local universe: solver.Universe = {
 			parent = {
 				namedVersion("parent", "1.0.0", { child = req("child", "^2.0.0") }),
@@ -139,24 +129,43 @@ test.suite("solver.solve", function(suite)
 		local resolution = solver.solve(universe, {
 			parent = req("parent", "^1.0.0"),
 		})
-		assert.neq(resolution.child, nil)
-		assert.eq(resolution.child.versionString, "2.1.0")
+		assert.neq(resolution["child@2"], nil)
+		assert.eq(resolution["child@2"].versionString, "2.1.0")
 	end)
 
-	suite:case("trueConflictErrors", function(assert)
-		-- ^1.0.0 AND ^2.0.0 can never both be satisfied
+	suite:case("sameSlotConflictErrors", function(assert)
+		-- ^1.5.0 and <1.3.0 are in the same slot but incompatible
 		local universe: solver.Universe = {
 			conflict = {
-				namedVersion("conflict", "2.0.0"),
-				namedVersion("conflict", "1.0.0"),
+				namedVersion("conflict", "1.5.0"),
+				namedVersion("conflict", "1.2.0"),
 			},
 		}
-		assert.throwsWith("  >=2.0.0 <3.0.0  (required by root)", function()
+		local ok, err = pcall(function()
 			solver.solve(universe, {
-				v1 = req("conflict", "^1.0.0"),
-				v2 = req("conflict", "^2.0.0"),
+				v1 = req("conflict", "^1.5.0"),
+				v2 = req("conflict", ">=1.0.0 <1.3.0"),
 			})
 		end)
+		assert.eq(ok, false)
+		local errStr = tostring(err)
+		assert.strContains(errStr, "version conflict for 'conflict'")
+	end)
+
+	suite:case("multiMajorCoexistence", function(assert)
+		-- ^1.0.0 and ^2.0.0 go into different slots and both resolve
+		local universe: solver.Universe = {
+			shared = {
+				namedVersion("shared", "2.0.0"),
+				namedVersion("shared", "1.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			v1 = req("shared", "^1.0.0"),
+			v2 = req("shared", "^2.0.0"),
+		})
+		assert.eq(resolution["shared@1"].versionString, "1.0.0")
+		assert.eq(resolution["shared@2"].versionString, "2.0.0")
 	end)
 
 	suite:case("unknownPackageErrors", function(assert)
@@ -174,26 +183,21 @@ test.suite("solver.solve", function(suite)
 				namedVersion("pkg", "1.0.0"),
 			},
 		}
-		-- ^1.0.0 and ^2.0.0 conflict; error should mention both.
-		-- ^X.0.0 expands to ">=X.0.0 <X+1.0.0" so we match those substrings.
-		local ok = xpcall(function()
+		-- ^1.5.0 and <1.1.0 in the same slot; error should mention both.
+		local ok, err = pcall(function()
 			solver.solve(universe, {
-				a = req("pkg", "^1.0.0", "root"),
-				b = req("pkg", "^2.0.0", "root"),
+				a = req("pkg", "^1.5.0", "root"),
+				b = req("pkg", ">=1.0.0 <1.1.0", "root"),
 			})
-
-			assert.that(false, "Expected solver to error due to conflict, but it succeeded")
-		end, function(err)
-			local errStr = tostring(err)
-			assert.strContains(errStr, ">=1.0.0")
-			assert.strContains(errStr, ">=2.0.0")
 		end)
 
 		assert.eq(ok, false)
+		local errStr = tostring(err)
+		assert.strContains(errStr, ">=1.5.0")
+		assert.strContains(errStr, "<1.1.0")
 	end)
 
 	suite:case("deduplicatesSameRequirement", function(assert)
-		-- Two roots ask for the same package with compatible constraints; should not duplicate
 		local universe: solver.Universe = {
 			shared = {
 				namedVersion("shared", "1.2.0"),
@@ -206,17 +210,19 @@ test.suite("solver.solve", function(suite)
 			b = req("shared", ">=1.1.0"),
 		})
 
-		-- Only one entry for "shared"
+		-- Only one slot entry for shared@1
 		local count = 0
 		for _ in resolution do
 			count += 1
 		end
 
 		assert.eq(count, 1)
-		assert.eq(resolution.shared.versionString, "1.2.0")
+		assert.eq(resolution["shared@1"].versionString, "1.2.0")
 	end)
 
-	suite:case("keepsMultipleConstraintsFromSameVersion", function(assert)
+	suite:case("multiMajorFromTransitiveDeps", function(assert)
+		-- parent has deps on both shared ^1.0.0 and shared ^2.0.0
+		-- Under multi-major, both slots are resolved
 		local universe: solver.Universe = {
 			parent = {
 				namedVersion("parent", "1.0.0", {
@@ -230,11 +236,11 @@ test.suite("solver.solve", function(suite)
 			},
 		}
 
-		assert.throwsWith("  >=1.0.0 <2.0.0  (required by parent@1.0.0)", function()
-			solver.solve(universe, {
-				parent = req("parent", "^1.0.0"),
-			})
-		end)
+		local resolution = solver.solve(universe, {
+			parent = req("parent", "^1.0.0"),
+		})
+		assert.eq(resolution["shared@1"].versionString, "1.0.0")
+		assert.eq(resolution["shared@2"].versionString, "2.0.0")
 	end)
 
 	suite:case("circularDependencyErrors", function(assert)
@@ -247,85 +253,44 @@ test.suite("solver.solve", function(suite)
 			},
 		}
 
-		assert.throwsWith("circular dependency detected for package 'a'", function()
+		assert.throwsWith("circular dependency: a@1 -> b@1 -> a@1", function()
 			solver.solve(universe, {
 				a = req("a", "^1.0.0"),
 			})
 		end)
 	end)
 
-	suite:case("constraintRetraction", function(assert)
-		-- Exercises the retraction code path:
-		-- root requires pkga >=1.0.0 (allows 2.x) and pkgb ^1.0.0.
-		-- pkga 2.0.0 requires pkgc <2.0.0 — solver picks this first (newest).
-		-- pkgb 1.0.0 requires pkgc ^3.0.0 (>=3.0.0 <4.0.0).
-		-- pkgc now has <2.0.0 AND >=3.0.0 — unsatisfiable.
-		-- pkgb also requires pkga <2.0.0, forcing pkga to downgrade to 1.0.0.
-		-- pkga 1.0.0's old constraint (<2.0.0 on pkgc) is retracted; new constraint is <4.0.0.
-		-- pkgc now only has >=3.0.0 <4.0.0, resolving to 3.0.0.
-		local universe: solver.Universe = {
-			pkga = {
-				namedVersion("pkga", "2.0.0", { pkgc = req("pkgc", "<2.0.0") }),
-				namedVersion("pkga", "1.0.0", { pkgc = req("pkgc", "<4.0.0") }),
-			},
-			pkgb = {
-				namedVersion("pkgb", "1.0.0", {
-					pkgc = req("pkgc", "^3.0.0"),
-					pkga = req("pkga", "<2.0.0"),
-				}),
-			},
-			pkgc = {
-				namedVersion("pkgc", "3.0.0"),
-				namedVersion("pkgc", "1.5.0"),
-			},
-		}
-
-		local resolution = solver.solve(universe, {
-			pkga = req("pkga", ">=1.0.0"),
-			pkgb = req("pkgb", "^1.0.0"),
-		})
-
-		-- pkga must have downgraded to 1.0.0 so its old pkgc <2.0.0 constraint is retracted
-		assert.eq(resolution.pkga.versionString, "1.0.0")
-		assert.eq(resolution.pkgb.versionString, "1.0.0")
-		assert.eq(resolution.pkgc.versionString, "3.0.0")
-	end)
-
-	suite:case("greedyFailure_siblingsWithIncompatibleLatest", function(assert)
-		-- Limitation: the greedy solver picks the highest satisfying version for each
-		-- package without lookahead. It chooses A@1.1.0 (needs shared ^2.0.0) and
-		-- B@1.1.0 (needs shared ^1.0.0), then fails on the shared conflict — even though
-		-- downgrading A to 1.0.0 (shared ^1.0.0) would yield a valid solution.
-		-- FIXME(awe): A better algorithm would backtrack to A and retry with 1.0.0.
+	suite:case("backtracksWithinSameSlot", function(assert)
+		-- A@1.1.0 and B@1.0.0 both need shared in slot @1, but:
+		-- A@1.1.0 needs shared ^1.5.0, B needs shared ^1.0.0 <1.3.0
+		-- These conflict within the same slot. Solver must backtrack A to 1.0.0
+		-- (which needs shared ^1.0.0) so shared@1 can satisfy both at 1.2.0.
 		local universe: solver.Universe = {
 			A = {
-				namedVersion("A", "1.1.0", { shared = req("shared", "^2.0.0") }),
+				namedVersion("A", "1.1.0", { shared = req("shared", "^1.5.0") }),
 				namedVersion("A", "1.0.0", { shared = req("shared", "^1.0.0") }),
 			},
 			B = {
-				namedVersion("B", "1.1.0", { shared = req("shared", "^1.0.0") }),
-				namedVersion("B", "1.0.0", { shared = req("shared", "^1.0.0") }),
+				namedVersion("B", "1.0.0", { shared = req("shared", ">=1.0.0 <1.3.0") }),
 			},
 			shared = {
-				namedVersion("shared", "2.0.0"),
+				namedVersion("shared", "1.5.0"),
+				namedVersion("shared", "1.2.0"),
 				namedVersion("shared", "1.0.0"),
 			},
 		}
 
-		assert.throwsWith("  >=2.0.0 <3.0.0  (required by A@1.1.0)", function()
-			solver.solve(universe, {
-				A = req("A", "^1.0.0"),
-				B = req("B", "^1.0.0"),
-			})
-		end)
+		local resolution = solver.solve(universe, {
+			A = req("A", "^1.0.0"),
+			B = req("B", "^1.0.0"),
+		})
+
+		assert.eq(resolution["A@1"].versionString, "1.0.0")
+		assert.eq(resolution["B@1"].versionString, "1.0.0")
+		assert.eq(resolution["shared@1"].versionString, "1.2.0")
 	end)
 
-	suite:case("greedyFailure_noBackPressureOnUpperFork", function(assert)
-		-- Limitation: the greedy solver has no back-pressure from deep transitive failures
-		-- up to earlier choices. It picks X@1.1.0 -> Y@2.0.0 -> Z@^5.0.0, then fails
-		-- because Z@1.0.0 does not satisfy ^5.0.0 — even though choosing X@1.0.0 at the
-		-- start would have led to Y@1.0.0 with no Z dependency at all.
-		-- FIXME(awe): A better algorithm would backtrack to X and retry with 1.0.0
+	suite:case("backtracksOnDeepTransitiveFailure", function(assert)
 		local universe: solver.Universe = {
 			X = {
 				namedVersion("X", "1.1.0", { Y = req("Y", "^2.0.0") }),
@@ -340,10 +305,457 @@ test.suite("solver.solve", function(suite)
 			},
 		}
 
-		assert.throwsWith("  >=5.0.0 <6.0.0  (required by Y@2.0.0)", function()
+		local resolution = solver.solve(universe, {
+			X = req("X", "^1.0.0"),
+		})
+
+		assert.eq(resolution["X@1"].versionString, "1.0.0")
+		assert.eq(resolution["Y@1"].versionString, "1.0.0")
+		assert.eq(resolution["Z@5"], nil)
+	end)
+
+	suite:case("handlesDeepDependencyChain", function(assert)
+		local universe: solver.Universe = {}
+		for i = 1, 100 do
+			local name = `p{i}`
+			local deps: { [string]: solver.Requirement } = {}
+			if i < 100 then
+				deps[`p{i + 1}`] = req(`p{i + 1}`, "^1.0.0")
+			end
+			universe[name] = { namedVersion(name, "1.0.0", deps) }
+		end
+
+		local resolution = solver.solve(universe, {
+			p1 = req("p1", "^1.0.0"),
+		})
+		assert.eq(resolution["p1@1"].versionString, "1.0.0")
+		assert.eq(resolution["p100@1"].versionString, "1.0.0")
+	end)
+
+	suite:case("reportsShallowConflict", function(assert)
+		local universe: solver.Universe = {
+			A = {
+				namedVersion("A", "2.0.0", { deep = req("deep", "^1.0.0") }),
+				namedVersion("A", "1.0.0", { deep = req("deep", "^1.0.0") }),
+			},
+			deep = {
+				namedVersion("deep", "1.0.0", { core = req("core", "^3.0.0") }),
+			},
+			core = {
+				namedVersion("core", "2.0.0"),
+			},
+		}
+		local ok, err = pcall(function()
 			solver.solve(universe, {
-				X = req("X", "^1.0.0"),
+				A = req("A", "^1.0.0"),
+				core = req("core", "^2.0.0"),
 			})
 		end)
+		assert.eq(ok, false)
+		assert.strContains(tostring(err), "version conflict for 'core'")
+	end)
+
+	suite:case("mrvPicksMostConstrainedFirst", function(assert)
+		-- 'forced' has exactly 1 satisfying candidate (=1.0.0) which depends on lib ^1.2.0.
+		-- 'flexible' has many candidates, and its latest (1.10.0) depends on lib ^1.0.0.
+		-- If MRV picks 'forced' first, lib gets constrained to ^1.2.0 early.
+		-- Then 'flexible' picks 1.10.0 whose lib ^1.0.0 merges into the same slot —
+		-- lib resolves to 1.5.0 (satisfies both ^1.2.0 and ^1.0.0).
+		-- If MRV were broken and picked 'flexible' first, the result would be the same
+		-- but would explore more branches. We verify the outcome is correct.
+		local universe: solver.Universe = {
+			forced = {
+				namedVersion("forced", "1.0.0", { lib = req("lib", "^1.2.0") }),
+			},
+			flexible = {},
+			lib = {
+				namedVersion("lib", "1.5.0"),
+				namedVersion("lib", "1.2.0"),
+				namedVersion("lib", "1.0.0"),
+			},
+		}
+		for i = 10, 1, -1 do
+			table.insert(universe.flexible, namedVersion("flexible", `1.{i}.0`, { lib = req("lib", "^1.0.0") }))
+		end
+
+		local resolution = solver.solve(universe, {
+			forced = req("forced", "=1.0.0"),
+			flexible = req("flexible", "^1.0.0"),
+		})
+		assert.eq(resolution["forced@1"].versionString, "1.0.0")
+		assert.eq(resolution["flexible@1"].versionString, "1.10.0")
+		-- lib must satisfy both ^1.2.0 (from forced) and ^1.0.0 (from flexible)
+		assert.eq(resolution["lib@1"].versionString, "1.5.0")
+	end)
+
+	suite:case("prereleaseExcludedByStableConstraint", function(assert)
+		local universe: solver.Universe = {
+			pkg = {
+				namedVersion("pkg", "1.1.0-alpha"),
+				namedVersion("pkg", "1.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			pkg = req("pkg", "^1.0.0"),
+		})
+		assert.eq(resolution["pkg@1"].versionString, "1.0.0")
+	end)
+
+	suite:case("prereleaseSelectedWhenConstraintOptsIn", function(assert)
+		local universe: solver.Universe = {
+			pkg = {
+				namedVersion("pkg", "1.0.0-beta"),
+				namedVersion("pkg", "1.0.0-alpha"),
+				namedVersion("pkg", "0.9.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			pkg = req("pkg", ">=1.0.0-alpha"),
+		})
+		assert.eq(resolution["pkg@1"].versionString, "1.0.0-beta")
+	end)
+
+	suite:case("prereleaseTransitiveDependency", function(assert)
+		local universe: solver.Universe = {
+			parent = {
+				namedVersion("parent", "1.0.0", { pkg = req("pkg", ">=2.0.0-rc.1") }),
+			},
+			pkg = {
+				namedVersion("pkg", "2.0.0-rc.2"),
+				namedVersion("pkg", "2.0.0-rc.1"),
+				namedVersion("pkg", "1.9.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			parent = req("parent", "^1.0.0"),
+		})
+		assert.eq(resolution["pkg@2"].versionString, "2.0.0-rc.2")
+	end)
+
+	suite:case("largeFanoutFindsIntersection", function(assert)
+		local universe: solver.Universe = {
+			a = { namedVersion("a", "1.0.0", { shared = req("shared", "^1.2.0") }) },
+			b = { namedVersion("b", "1.0.0", { shared = req("shared", ">=1.3.0") }) },
+			c = { namedVersion("c", "1.0.0", { shared = req("shared", "<1.6.0") }) },
+			d = { namedVersion("d", "1.0.0", { shared = req("shared", ">=1.4.0 <1.5.0") }) },
+			shared = {
+				namedVersion("shared", "1.6.0"),
+				namedVersion("shared", "1.5.0"),
+				namedVersion("shared", "1.4.0"),
+				namedVersion("shared", "1.3.0"),
+				namedVersion("shared", "1.2.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			a = req("a", "^1.0.0"),
+			b = req("b", "^1.0.0"),
+			c = req("c", "^1.0.0"),
+			d = req("d", "^1.0.0"),
+		})
+		assert.eq(resolution["shared@1"].versionString, "1.4.0")
+	end)
+
+	suite:case("largeFanoutMultiMajorCoexists", function(assert)
+		-- a requires shared ^1.0.0, b requires shared ^2.0.0
+		-- Under multi-major these coexist in different slots
+		local universe: solver.Universe = {
+			a = { namedVersion("a", "1.0.0", { shared = req("shared", "^1.0.0") }) },
+			b = { namedVersion("b", "1.0.0", { shared = req("shared", "^2.0.0") }) },
+			shared = {
+				namedVersion("shared", "2.5.0"),
+				namedVersion("shared", "2.0.0"),
+				namedVersion("shared", "1.5.0"),
+				namedVersion("shared", "1.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			a = req("a", "^1.0.0"),
+			b = req("b", "^1.0.0"),
+		})
+		assert.eq(resolution["shared@1"].versionString, "1.5.0")
+		assert.eq(resolution["shared@2"].versionString, "2.5.0")
+	end)
+
+	-- Multi-major specific tests
+
+	suite:case("multiMajorThreeSlots", function(assert)
+		local universe: solver.Universe = {
+			a = { namedVersion("a", "1.0.0", { shared = req("shared", "^1.0.0") }) },
+			b = { namedVersion("b", "1.0.0", { shared = req("shared", "^2.0.0") }) },
+			c = { namedVersion("c", "1.0.0", { shared = req("shared", "^3.0.0") }) },
+			shared = {
+				namedVersion("shared", "3.0.0"),
+				namedVersion("shared", "2.0.0"),
+				namedVersion("shared", "1.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			a = req("a", "^1.0.0"),
+			b = req("b", "^1.0.0"),
+			c = req("c", "^1.0.0"),
+		})
+		assert.eq(resolution["shared@1"].versionString, "1.0.0")
+		assert.eq(resolution["shared@2"].versionString, "2.0.0")
+		assert.eq(resolution["shared@3"].versionString, "3.0.0")
+	end)
+
+	suite:case("zeroMajorSlotsAreFiner", function(assert)
+		-- ^0.1.0 and ^0.2.0 land in different slots (0.1 vs 0.2)
+		local universe: solver.Universe = {
+			a = { namedVersion("a", "1.0.0", { lib = req("lib", "^0.1.0") }) },
+			b = { namedVersion("b", "1.0.0", { lib = req("lib", "^0.2.0") }) },
+			lib = {
+				namedVersion("lib", "0.2.5"),
+				namedVersion("lib", "0.1.9"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			a = req("a", "^1.0.0"),
+			b = req("b", "^1.0.0"),
+		})
+		assert.eq(resolution["lib@0.1"].versionString, "0.1.9")
+		assert.eq(resolution["lib@0.2"].versionString, "0.2.5")
+	end)
+
+	suite:case("sameSlotPicksHighest", function(assert)
+		local universe: solver.Universe = {
+			shared = {
+				namedVersion("shared", "1.5.0"),
+				namedVersion("shared", "1.3.0"),
+				namedVersion("shared", "1.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			shared = req("shared", "^1.0.0"),
+		})
+		assert.eq(resolution["shared@1"].versionString, "1.5.0")
+	end)
+
+	suite:case("broadConstraintPicksHighestSlot", function(assert)
+		-- >=1.0.0 has no upper bound; should pick highest available (3.0.0) and slot it as @3
+		local universe: solver.Universe = {
+			pkg = {
+				namedVersion("pkg", "3.0.0"),
+				namedVersion("pkg", "2.0.0"),
+				namedVersion("pkg", "1.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			pkg = req("pkg", ">=1.0.0"),
+		})
+		assert.eq(resolution["pkg@3"].versionString, "3.0.0")
+	end)
+
+	suite:case("unsatisfiableTransitiveSlotReportsConflict", function(assert)
+		-- B depends on A ^2.0.0, but no A@2.x exists in the universe.
+		-- The solver should report that A has no satisfying version.
+		local universe: solver.Universe = {
+			A = {
+				namedVersion("A", "1.0.0"),
+			},
+			B = {
+				namedVersion("B", "1.1.0", { A = req("A", "^2.0.0") }),
+				namedVersion("B", "1.0.0", { A = req("A", "^2.0.0") }),
+			},
+		}
+		local ok, err = pcall(function()
+			solver.solve(universe, {
+				A = req("A", "^1.0.0"),
+				B = req("B", "^1.0.0"),
+			})
+		end)
+		assert.eq(ok, false)
+		local errStr = tostring(err)
+		assert.strContains(errStr, "version conflict for 'A'")
+	end)
+
+	suite:case("staleConflictNotReportedAfterBacktrack", function(assert)
+		-- X@1.1.0 depends on Z ^2.0.0, but no Z@2.x exists.
+		-- The solver records a stuck conflict for Z, then backtracks X to 1.0.0.
+		-- X@1.0.0 has no deps and succeeds. The stale Z conflict must be cleared
+		-- so it doesn't surface as the error. If stuck weren't cleared, this would
+		-- erroneously throw "version conflict for 'Z'".
+		local universe: solver.Universe = {
+			X = {
+				namedVersion("X", "1.1.0", { Z = req("Z", "^2.0.0") }),
+				namedVersion("X", "1.0.0"),
+			},
+			Z = {
+				namedVersion("Z", "1.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			X = req("X", "^1.0.0"),
+		})
+		assert.eq(resolution["X@1"].versionString, "1.0.0")
+		assert.eq(resolution["Z@2"], nil)
+	end)
+
+	suite:case("indirectCircularDependencyShowsFullCycle", function(assert)
+		local universe: solver.Universe = {
+			a = {
+				namedVersion("a", "1.0.0", { b = req("b", "^1.0.0") }),
+			},
+			b = {
+				namedVersion("b", "1.0.0", { c = req("c", "^1.0.0") }),
+			},
+			c = {
+				namedVersion("c", "1.0.0", { a = req("a", "^1.0.0") }),
+			},
+		}
+		assert.throwsWith("circular dependency: a@1 -> b@1 -> c@1 -> a@1", function()
+			solver.solve(universe, {
+				a = req("a", "^1.0.0"),
+			})
+		end)
+	end)
+
+	suite:case("multiMajorBacktracking", function(assert)
+		-- X@1.1.0 needs shared ^2.0.0 AND foo ^1.0.0
+		-- foo@1.0.0 needs shared ^2.5.0 (only shared@2.0.0 available, not 2.5.0)
+		-- Must backtrack X to 1.0.0 which needs shared ^1.0.0 and no foo
+		local universe: solver.Universe = {
+			X = {
+				namedVersion("X", "1.1.0", {
+					shared = req("shared", "^2.0.0"),
+					foo = req("foo", "^1.0.0"),
+				}),
+				namedVersion("X", "1.0.0", { shared = req("shared", "^1.0.0") }),
+			},
+			foo = {
+				namedVersion("foo", "1.0.0", { shared = req("shared", "^2.5.0") }),
+			},
+			shared = {
+				namedVersion("shared", "2.0.0"),
+				namedVersion("shared", "1.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			X = req("X", "^1.0.0"),
+		})
+		assert.eq(resolution["X@1"].versionString, "1.0.0")
+		assert.eq(resolution["shared@1"].versionString, "1.0.0")
+	end)
+
+	-- Slot routing edge cases
+
+	suite:case("spanningRangePicksHighestSlot", function(assert)
+		-- >=1.0.0 <3.0.0 spans majors 1 and 2; should pick highest (2.5.0)
+		local universe: solver.Universe = {
+			pkg = {
+				namedVersion("pkg", "2.5.0"),
+				namedVersion("pkg", "1.9.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			pkg = req("pkg", ">=1.0.0 <3.0.0"),
+		})
+		assert.eq(resolution["pkg@2"].versionString, "2.5.0")
+	end)
+
+	suite:case("upperBoundOnlyPicksHighestSlot", function(assert)
+		-- <2.0.0 with no lower bound; should pick highest satisfying
+		local universe: solver.Universe = {
+			pkg = {
+				namedVersion("pkg", "2.5.0"),
+				namedVersion("pkg", "1.9.0"),
+				namedVersion("pkg", "1.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			pkg = req("pkg", "<2.0.0"),
+		})
+		assert.eq(resolution["pkg@1"].versionString, "1.9.0")
+	end)
+
+	suite:case("tildeConstraintSlotting", function(assert)
+		-- ~1.2.0 expands to >=1.2.0 <1.3.0; stays in slot @1
+		local universe: solver.Universe = {
+			pkg = {
+				namedVersion("pkg", "1.5.0"),
+				namedVersion("pkg", "1.2.5"),
+				namedVersion("pkg", "1.2.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			pkg = req("pkg", "~1.2.0"),
+		})
+		assert.eq(resolution["pkg@1"].versionString, "1.2.5")
+	end)
+
+	suite:case("zeroPatchSlotting", function(assert)
+		-- ^0.0.3 expands to =0.0.3; slot is @0.0.3
+		local universe: solver.Universe = {
+			pkg = {
+				namedVersion("pkg", "0.0.5"),
+				namedVersion("pkg", "0.0.3"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			pkg = req("pkg", "^0.0.3"),
+		})
+		assert.eq(resolution["pkg@0.0.3"].versionString, "0.0.3")
+	end)
+
+	suite:case("gtWithoutGeqPicksHighestSlot", function(assert)
+		-- >1.0.0 with no upper bound; slot is ambiguous, falls through to universe scan
+		local universe: solver.Universe = {
+			pkg = {
+				namedVersion("pkg", "3.0.0"),
+				namedVersion("pkg", "2.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			pkg = req("pkg", ">1.0.0"),
+		})
+		assert.eq(resolution["pkg@3"].versionString, "3.0.0")
+	end)
+
+	suite:case("wildcardPicksHighestSlot", function(assert)
+		-- * matches any non-prerelease; slot is ambiguous, resolved from universe
+		local universe: solver.Universe = {
+			pkg = {
+				namedVersion("pkg", "4.0.0"),
+				namedVersion("pkg", "2.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			pkg = req("pkg", "*"),
+		})
+		assert.eq(resolution["pkg@4"].versionString, "4.0.0")
+	end)
+
+	suite:case("exactConstraintSlotting", function(assert)
+		-- =2.3.1 goes directly to slot @2
+		local universe: solver.Universe = {
+			pkg = {
+				namedVersion("pkg", "3.0.0"),
+				namedVersion("pkg", "2.3.1"),
+				namedVersion("pkg", "1.0.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			pkg = req("pkg", "=2.3.1"),
+		})
+		assert.eq(resolution["pkg@2"].versionString, "2.3.1")
+	end)
+
+	suite:case("multiSlotWithSpanningTransitiveDep", function(assert)
+		-- parent needs lib >=1.0.0 <3.0.0 (spans two majors)
+		-- Should pick highest satisfying (2.0.0) and slot it correctly
+		local universe: solver.Universe = {
+			parent = {
+				namedVersion("parent", "1.0.0", { lib = req("lib", ">=1.0.0 <3.0.0") }),
+			},
+			lib = {
+				namedVersion("lib", "3.0.0"),
+				namedVersion("lib", "2.0.0"),
+				namedVersion("lib", "1.5.0"),
+			},
+		}
+		local resolution = solver.solve(universe, {
+			parent = req("parent", "^1.0.0"),
+		})
+		assert.eq(resolution["lib@2"].versionString, "2.0.0")
 	end)
 end)


### PR DESCRIPTION
This PR replaces the greedy BFS resolver with backtracking solver supporting multi-major versions
  
# Core loop
The solver repeatedly picks the next unresolved slot, selects the highest satisfying candidate, propagates its dependencies as new constraints, and advances. When a slot has zero satisfying candidates, it backtracks up the decision stack trying alternative versions at earlier decision points until it finds a viable path or exhausts all options.

## Behaviors
- Backtracking. When no candidate satisfies accumulated constraints, the solver unwinds the decision stack and tries alternatives at earlier decision levels.
- Multi-major coexistence. Versions are grouped into compatibility slots (pkg@1, pkg@2, pkg@0.1). Only one version per slot; different slots resolve independently. ^1.0.0 and ^2.0.0 of the same package no longer conflict.
- Allow circular dependencies. Resolver successfully resolves circular dependencies and does not report an error
- Conflict reporting. Names the conflicting package and lists all unsatisfiable constraints with their sources.

## Optimizations
- MRV heuristic. The slot with the fewest viable candidates is resolved first to fail fast and reduce backtracking.