### PR TITLE
infra: add a CODEOWNERS file to set up review groups

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Default
+* @luau-lang/lute-contrib
+
+# GitHub configuration
+/.github/ @luau-lang/lute-maintainers
+
+# Package management
+/lute/cli/pkg/ @luau-lang/lute-pkg-maintainers


### PR DESCRIPTION
We'd like to have a little bit more structure for code ownership and review groups going forward, and so I've set up some GitHub teams, and moved folks into them. This PR adds a `CODEOWNERS` file that reflects the currently desired review structure.