### PR TITLE
infra: fix path to pkg command for CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 /.github/ @luau-lang/lute-maintainers
 
 # Package management
-/lute/cli/pkg/ @luau-lang/lute-pkg-maintainers
+/lute/cli/commands/pkg/ @luau-lang/lute-pkg-maintainers


### PR DESCRIPTION
I mistakenly got the path wrong for the `lute pkg` command in CODEOWNERS. We should fix that.