### PR TITLE
infra: `lute pkg` tests should be owned by `@luau-lang/lute-pkg-maintainers`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 
 # Package management
 /lute/cli/commands/pkg/ @luau-lang/lute-pkg-maintainers
+/tests/cli/pkg/ @luau-lang/lute-pkg-maintainers


### PR DESCRIPTION
This PR sets the code owners for `tests/cli/pkg` to also be `lute-pkg-maintainers`.