### PR TITLE
Update actions to support Node.js 24 following Node.js 20 deprecation

### DIFF
--- a/.github/actions/setup-and-build/action.yml
+++ b/.github/actions/setup-and-build/action.yml
@@ -69,7 +69,7 @@ runs:
       uses: luau-lang/setup-nasm@v1
 
     - name: Cache extern folder
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: cache-extern
       with:
         path: extern
@@ -86,7 +86,7 @@ runs:
         ccache -z
 
     - name: Restore ccache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       id: cache-ccache
       with:
         path: .ccache
@@ -130,7 +130,7 @@ runs:
 
     - name: Save ccache
       if: github.ref_name == 'primary'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: .ccache
         key: ccache-${{ runner.os }}-${{ inputs.options }}-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             echo "proceed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup and Build Lute
         id: build_lute
@@ -113,7 +113,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup and Build C++ Unit Tests
         id: build_tests
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install tools
         uses: Roblox/setup-foreman@v3
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup and Build Lute
         id: build_lute
@@ -161,7 +161,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
 
       - name: Install dependencies
         run: npm install
@@ -175,7 +175,7 @@ jobs:
 
       - name: Upload docs artifact
         id: deployment
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist/
 
@@ -184,7 +184,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup and Build Lute
         id: build_lute
@@ -203,7 +203,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup and Build Lute
         id: build_lute

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup and Build Lute
         id: build_lute
@@ -24,7 +24,7 @@ jobs:
           use-bootstrap: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
 
       - name: Install dependencies
         run: npm install
@@ -38,7 +38,7 @@ jobs:
 
       - name: Upload docs artifact
         id: deployment
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs/.vitepress/dist/
   
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
 
@@ -102,7 +102,7 @@ jobs:
           install-system-deps: ${{ matrix.container && 'false' || 'true' }}
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           path: ${{ steps.build_lute.outputs.exe_path }}
           name: ${{ matrix.artifact_name }}
@@ -119,7 +119,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch }}
           sparse-checkout: CMakeBuild/get_version.cmake
@@ -129,7 +129,7 @@ jobs:
         run: echo "LUTE_VERSION_SUFFIX=nightly.$(date +%Y%m%d)" >> "$GITHUB_ENV"
 
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get latest Luau release
         id: latest-release
@@ -76,7 +76,7 @@ jobs:
     needs: update-luau
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get latest Lute release
         id: latest-release


### PR DESCRIPTION
Fixing warnings in github actions (see [nightly release](https://github.com/luau-lang/lute/actions/runs/27659029838)) following the Node.js 20 deprecation. The only remaining is `Roblox/setup-foreman@v3` because there isn't a newer version available 

Tested by running a nightly release! https://github.com/luau-lang/lute/actions/runs/27712327753