### PR TITLE
loom: use GitHub's zipball api to preserve auth for private repos

### DIFF
--- a/lute/cli/commands/pkg/loom-core/src/github.luau
+++ b/lute/cli/commands/pkg/loom-core/src/github.luau
@@ -91,7 +91,11 @@ local function downloadFromGitHubArchive(url: string): string
 end
 
 local function installPackage(source: string, rev: string, installPath: string): ()
-	local url = `{source}/archive/{rev}.zip`
+	local owner, repo = string.match(source, "^https?://github%.com/([^/]+)/([^/]+)")
+	if not owner or not repo then
+		error(`Unsupported GitHub source URL: {source}`)
+	end
+	local url = `https://api.github.com/repos/{owner}/{repo}/zipball/{rev}`
 	local zipArchive = downloadFromGitHubArchive(url)
 
 	local safeName = rev:gsub("[^%w%-_.]", "-")

--- a/lute/cli/commands/pkg/loom-core/src/github.luau
+++ b/lute/cli/commands/pkg/loom-core/src/github.luau
@@ -76,7 +76,9 @@ local function installZipArchive(content: string, installPath: string)
 end
 
 local function downloadFromGitHubArchive(url: string): string
-	local headers = {}
+	local headers = {
+		["User-Agent"] = "lute-pkg",
+	}
 
 	local token = getGithubAuthenticationToken()
 	if token ~= nil and token ~= "" then

--- a/lute/cli/commands/pkg/loom-core/src/github.luau
+++ b/lute/cli/commands/pkg/loom-core/src/github.luau
@@ -75,7 +75,7 @@ local function installZipArchive(content: string, installPath: string)
 	end)
 end
 
-local function downloadFromGitHubArchive(url: string): string
+local function downloadFromGitHub(url: string): string
 	local headers = {
 		["User-Agent"] = "lute-pkg",
 	}
@@ -98,7 +98,7 @@ local function installPackage(source: string, rev: string, installPath: string):
 		error(`Unsupported GitHub source URL: {source}`)
 	end
 	local url = `https://api.github.com/repos/{owner}/{repo}/zipball/{rev}`
-	local zipArchive = downloadFromGitHubArchive(url)
+	local zipArchive = downloadFromGitHub(url)
 
 	local safeName = rev:gsub("[^%w%-_.]", "-")
 	local tempDir = path.format(path.join(system.tmpdir(), `lute-pkg-install-{safeName}`))


### PR DESCRIPTION
The github web archive url redirects across hosts before serving the download. The http clients drops the Authorization header on cross-host redirects, so the download lands unauthenticated and 404s on private repos. The zipball api endpoint redirects to a short-lived, pre-authorized download URL that doesn't depend on the header surviving the redirect.