### PR TITLE
Update create-pr-request version

### DIFF
--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -1,13 +1,9 @@
 name: Update Luau/Lute
 
-# on:
-#   schedule:
-#     - cron: "0 0 * * 6"
-#   workflow_dispatch:
-
 on:
-  pull_request:
-    branches: ["primary"]
+  schedule:
+    - cron: "0 0 * * 6"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -76,67 +72,67 @@ jobs:
         run: |
           echo "Luau is already up to date: ${{ steps.current-version.outputs.branch }}"
 
-  # update-lute:
-  #   runs-on: ubuntu-latest
-  #   needs: update-luau
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v6
+  update-lute:
+    runs-on: ubuntu-latest
+    needs: update-luau
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-  #     - name: Get latest Lute release
-  #       id: latest-release
-  #       run: |
-  #         # Fetch the latest release tag from luau-lang/lute
-  #         LATEST_LUTE=$(
-  #           curl -s https://api.github.com/repos/luau-lang/lute/releases \
-  #           | jq -r 'map(select(.draft | not))[0]?.tag_name'
-  #         )
-  #         echo "Latest Lute release: $LATEST_LUTE"
-  #         echo "tag=$LATEST_LUTE" >> $GITHUB_OUTPUT
+      - name: Get latest Lute release
+        id: latest-release
+        run: |
+          # Fetch the latest release tag from luau-lang/lute
+          LATEST_LUTE=$(
+            curl -s https://api.github.com/repos/luau-lang/lute/releases \
+            | jq -r 'map(select(.draft | not))[0]?.tag_name'
+          )
+          echo "Latest Lute release: $LATEST_LUTE"
+          echo "tag=$LATEST_LUTE" >> $GITHUB_OUTPUT
 
-  #         # rokit/foreman versions are SemVer and must not include a leading "v"
-  #         LATEST_LUTE_VERSION="${LATEST_LUTE#v}"
-  #         echo "Latest Lute version: $LATEST_LUTE_VERSION"
-  #         echo "version=$LATEST_LUTE_VERSION" >> $GITHUB_OUTPUT
+          # rokit/foreman versions are SemVer and must not include a leading "v"
+          LATEST_LUTE_VERSION="${LATEST_LUTE#v}"
+          echo "Latest Lute version: $LATEST_LUTE_VERSION"
+          echo "version=$LATEST_LUTE_VERSION" >> $GITHUB_OUTPUT
 
-  #     - name: Check current version
-  #       id: current-version
-  #       run: |
-  #         CURRENT_LUTE=$(grep '^lute = ' rokit.toml | sed -E 's/^lute = ".*@(.*)"/\1/')
-  #         echo "Current Lute version: $CURRENT_LUTE"
-  #         echo "lute=$CURRENT_LUTE" >> $GITHUB_OUTPUT
+      - name: Check current version
+        id: current-version
+        run: |
+          CURRENT_LUTE=$(grep '^lute = ' rokit.toml | sed -E 's/^lute = ".*@(.*)"/\1/')
+          echo "Current Lute version: $CURRENT_LUTE"
+          echo "lute=$CURRENT_LUTE" >> $GITHUB_OUTPUT
 
-  #     - name: Update version files
-  #       run: |
-  #         # Update lute version in rokit.toml and foreman.toml
-  #         if [ "${{ steps.current-version.outputs.lute }}" != "${{ steps.latest-release.outputs.version }}" ]; then
-  #           sed -i 's/^lute = "luau-lang\/lute@.*"/lute = "luau-lang\/lute@${{ steps.latest-release.outputs.version }}"/' rokit.toml
-  #           echo "Updated rokit.toml:"
-  #           cat rokit.toml
-  #           echo ""
-  #           sed -i 's/^lute = { github = "luau-lang\/lute", version = ".*" }/lute = { github = "luau-lang\/lute", version = "=${{ steps.latest-release.outputs.version }}" }/' foreman.toml
-  #           echo "Updated foreman.toml:"
-  #           cat foreman.toml
-  #         fi
+      - name: Update version files
+        run: |
+          # Update lute version in rokit.toml and foreman.toml
+          if [ "${{ steps.current-version.outputs.lute }}" != "${{ steps.latest-release.outputs.version }}" ]; then
+            sed -i 's/^lute = "luau-lang\/lute@.*"/lute = "luau-lang\/lute@${{ steps.latest-release.outputs.version }}"/' rokit.toml
+            echo "Updated rokit.toml:"
+            cat rokit.toml
+            echo ""
+            sed -i 's/^lute = { github = "luau-lang\/lute", version = ".*" }/lute = { github = "luau-lang\/lute", version = "=${{ steps.latest-release.outputs.version }}" }/' foreman.toml
+            echo "Updated foreman.toml:"
+            cat foreman.toml
+          fi
 
-  #     - name: Create Pull Request
-  #       if: steps.current-version.outputs.lute != steps.latest-release.outputs.version
-  #       uses: luau-lang/create-pull-request@v7
-  #       with:
-  #         commit-message: "chore: update dependencies"
-  #         title: "Update Lute to ${{ steps.latest-release.outputs.tag }}"
-  #         body: |
-  #           ${{ format('**Lute**: Updated from `{0}` to `{1}`', steps.current-version.outputs.lute, steps.latest-release.outputs.version)}}
+      - name: Create Pull Request
+        if: steps.current-version.outputs.lute != steps.latest-release.outputs.version
+        uses: luau-lang/create-pull-request@v7
+        with:
+          commit-message: "chore: update dependencies"
+          title: "Update Lute to ${{ steps.latest-release.outputs.tag }}"
+          body: |
+            ${{ format('**Lute**: Updated from `{0}` to `{1}`', steps.current-version.outputs.lute, steps.latest-release.outputs.version)}}
 
-  #           **Release Notes:**
-  #           ${{ format('https://github.com/luau-lang/lute/releases/tag/{0}', steps.latest-release.outputs.tag)}}
+            **Release Notes:**
+            ${{ format('https://github.com/luau-lang/lute/releases/tag/{0}', steps.latest-release.outputs.tag)}}
 
-  #           ---
-  #           *This PR was automatically created by the [Update Luau workflow](https://github.com/${{ github.repository }}/actions/workflows/update-prs.yml)*
-  #         branch: update-lute
-  #         delete-branch: true
+            ---
+            *This PR was automatically created by the [Update Luau workflow](https://github.com/${{ github.repository }}/actions/workflows/update-prs.yml)*
+          branch: update-lute
+          delete-branch: true
 
-  #     - name: No update needed
-  #       if: steps.current-version.outputs.lute == steps.latest-release.outputs.version
-  #       run: |
-  #         echo "Lute is already up to date: ${{ steps.current-version.outputs.lute }}"
+      - name: No update needed
+        if: steps.current-version.outputs.lute == steps.latest-release.outputs.version
+        run: |
+          echo "Lute is already up to date: ${{ steps.current-version.outputs.lute }}"

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -69,6 +69,7 @@ jobs:
             *This PR was automatically created by the [Update Luau workflow](https://github.com/${{ github.repository }}/actions/workflows/update-prs.yml)*
           branch: update-luau
           delete-branch: true
+          base: primary
 
       - name: No update needed
         if: steps.current-version.outputs.branch == steps.latest-release.outputs.tag

--- a/.github/workflows/update-prs.yml
+++ b/.github/workflows/update-prs.yml
@@ -1,9 +1,13 @@
 name: Update Luau/Lute
 
+# on:
+#   schedule:
+#     - cron: "0 0 * * 6"
+#   workflow_dispatch:
+
 on:
-  schedule:
-    - cron: '0 0 * * 6'
-  workflow_dispatch:
+  pull_request:
+    branches: ["primary"]
 
 permissions:
   contents: write
@@ -12,7 +16,7 @@ permissions:
 jobs:
   update-luau:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -24,7 +28,7 @@ jobs:
           LATEST_TAG=$(curl -s https://api.github.com/repos/luau-lang/luau/releases/latest | jq -r '.tag_name')
           echo "Latest Luau release: $LATEST_TAG"
           echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-          
+
           # Fetch the commit hash for this tag
           COMMIT_HASH=$(curl -s https://api.github.com/repos/luau-lang/luau/git/ref/tags/$LATEST_TAG | jq -r '.object.sha')
           echo "Commit hash: $COMMIT_HASH"
@@ -36,7 +40,7 @@ jobs:
           CURRENT_BRANCH=$(grep '^branch' extern/luau.tune | sed -E 's/^branch *= *"(.*)"/\1/')
           echo "Current Luau version: $CURRENT_BRANCH"
           echo "branch=$CURRENT_BRANCH" >> $GITHUB_OUTPUT
-          
+
       - name: Update version files
         if: steps.current-version.outputs.branch != steps.latest-release.outputs.tag
         run: |
@@ -51,7 +55,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.current-version.outputs.branch != steps.latest-release.outputs.tag
-        uses: luau-lang/create-pull-request@v7
+        uses: luau-lang/create-pull-request@v7.0.9
         with:
           commit-message: "chore: update dependencies"
           title: "Update Luau to ${{ steps.latest-release.outputs.tag }}"
@@ -60,7 +64,7 @@ jobs:
 
             **Release Notes:**
             ${{ format('https://github.com/luau-lang/luau/releases/tag/{0}', steps.latest-release.outputs.tag) }}
-            
+
             ---
             *This PR was automatically created by the [Update Luau workflow](https://github.com/${{ github.repository }}/actions/workflows/update-prs.yml)*
           branch: update-luau
@@ -71,67 +75,67 @@ jobs:
         run: |
           echo "Luau is already up to date: ${{ steps.current-version.outputs.branch }}"
 
-  update-lute:
-    runs-on: ubuntu-latest
-    needs: update-luau
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+  # update-lute:
+  #   runs-on: ubuntu-latest
+  #   needs: update-luau
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v6
 
-      - name: Get latest Lute release
-        id: latest-release
-        run: |
-          # Fetch the latest release tag from luau-lang/lute
-          LATEST_LUTE=$(
-            curl -s https://api.github.com/repos/luau-lang/lute/releases \
-            | jq -r 'map(select(.draft | not))[0]?.tag_name'
-          )
-          echo "Latest Lute release: $LATEST_LUTE"
-          echo "tag=$LATEST_LUTE" >> $GITHUB_OUTPUT
+  #     - name: Get latest Lute release
+  #       id: latest-release
+  #       run: |
+  #         # Fetch the latest release tag from luau-lang/lute
+  #         LATEST_LUTE=$(
+  #           curl -s https://api.github.com/repos/luau-lang/lute/releases \
+  #           | jq -r 'map(select(.draft | not))[0]?.tag_name'
+  #         )
+  #         echo "Latest Lute release: $LATEST_LUTE"
+  #         echo "tag=$LATEST_LUTE" >> $GITHUB_OUTPUT
 
-          # rokit/foreman versions are SemVer and must not include a leading "v"
-          LATEST_LUTE_VERSION="${LATEST_LUTE#v}"
-          echo "Latest Lute version: $LATEST_LUTE_VERSION"
-          echo "version=$LATEST_LUTE_VERSION" >> $GITHUB_OUTPUT
+  #         # rokit/foreman versions are SemVer and must not include a leading "v"
+  #         LATEST_LUTE_VERSION="${LATEST_LUTE#v}"
+  #         echo "Latest Lute version: $LATEST_LUTE_VERSION"
+  #         echo "version=$LATEST_LUTE_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Check current version
-        id: current-version
-        run: |
-          CURRENT_LUTE=$(grep '^lute = ' rokit.toml | sed -E 's/^lute = ".*@(.*)"/\1/')
-          echo "Current Lute version: $CURRENT_LUTE"
-          echo "lute=$CURRENT_LUTE" >> $GITHUB_OUTPUT
+  #     - name: Check current version
+  #       id: current-version
+  #       run: |
+  #         CURRENT_LUTE=$(grep '^lute = ' rokit.toml | sed -E 's/^lute = ".*@(.*)"/\1/')
+  #         echo "Current Lute version: $CURRENT_LUTE"
+  #         echo "lute=$CURRENT_LUTE" >> $GITHUB_OUTPUT
 
-      - name: Update version files
-        run: |
-          # Update lute version in rokit.toml and foreman.toml
-          if [ "${{ steps.current-version.outputs.lute }}" != "${{ steps.latest-release.outputs.version }}" ]; then
-            sed -i 's/^lute = "luau-lang\/lute@.*"/lute = "luau-lang\/lute@${{ steps.latest-release.outputs.version }}"/' rokit.toml
-            echo "Updated rokit.toml:"
-            cat rokit.toml
-            echo ""
-            sed -i 's/^lute = { github = "luau-lang\/lute", version = ".*" }/lute = { github = "luau-lang\/lute", version = "=${{ steps.latest-release.outputs.version }}" }/' foreman.toml
-            echo "Updated foreman.toml:"
-            cat foreman.toml
-          fi
+  #     - name: Update version files
+  #       run: |
+  #         # Update lute version in rokit.toml and foreman.toml
+  #         if [ "${{ steps.current-version.outputs.lute }}" != "${{ steps.latest-release.outputs.version }}" ]; then
+  #           sed -i 's/^lute = "luau-lang\/lute@.*"/lute = "luau-lang\/lute@${{ steps.latest-release.outputs.version }}"/' rokit.toml
+  #           echo "Updated rokit.toml:"
+  #           cat rokit.toml
+  #           echo ""
+  #           sed -i 's/^lute = { github = "luau-lang\/lute", version = ".*" }/lute = { github = "luau-lang\/lute", version = "=${{ steps.latest-release.outputs.version }}" }/' foreman.toml
+  #           echo "Updated foreman.toml:"
+  #           cat foreman.toml
+  #         fi
 
-      - name: Create Pull Request
-        if: steps.current-version.outputs.lute != steps.latest-release.outputs.version
-        uses: luau-lang/create-pull-request@v7
-        with:
-          commit-message: "chore: update dependencies"
-          title: "Update Lute to ${{ steps.latest-release.outputs.tag }}"
-          body: |
-            ${{ format('**Lute**: Updated from `{0}` to `{1}`', steps.current-version.outputs.lute, steps.latest-release.outputs.version)}}
-            
-            **Release Notes:**
-            ${{ format('https://github.com/luau-lang/lute/releases/tag/{0}', steps.latest-release.outputs.tag)}}
-            
-            ---
-            *This PR was automatically created by the [Update Luau workflow](https://github.com/${{ github.repository }}/actions/workflows/update-prs.yml)*
-          branch: update-lute
-          delete-branch: true
+  #     - name: Create Pull Request
+  #       if: steps.current-version.outputs.lute != steps.latest-release.outputs.version
+  #       uses: luau-lang/create-pull-request@v7
+  #       with:
+  #         commit-message: "chore: update dependencies"
+  #         title: "Update Lute to ${{ steps.latest-release.outputs.tag }}"
+  #         body: |
+  #           ${{ format('**Lute**: Updated from `{0}` to `{1}`', steps.current-version.outputs.lute, steps.latest-release.outputs.version)}}
 
-      - name: No update needed
-        if: steps.current-version.outputs.lute == steps.latest-release.outputs.version
-        run: |
-          echo "Lute is already up to date: ${{ steps.current-version.outputs.lute }}"
+  #           **Release Notes:**
+  #           ${{ format('https://github.com/luau-lang/lute/releases/tag/{0}', steps.latest-release.outputs.tag)}}
+
+  #           ---
+  #           *This PR was automatically created by the [Update Luau workflow](https://github.com/${{ github.repository }}/actions/workflows/update-prs.yml)*
+  #         branch: update-lute
+  #         delete-branch: true
+
+  #     - name: No update needed
+  #       if: steps.current-version.outputs.lute == steps.latest-release.outputs.version
+  #       run: |
+  #         echo "Lute is already up to date: ${{ steps.current-version.outputs.lute }}"


### PR DESCRIPTION
Our update luau/lute job started failing with 
```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/luau-lang/lute/': The requested URL returned error: 400
```

After some Googling, it turns out that `create-pull-request@v7` is incompatible with `actions/checkout@v6`, and that we should use at least [v7.0.9](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.9) instead. I synced our fork of `create-pull-request` to the upstream, including tags, and bumped the version we use in the create Luau/Lute job. While testing I had to add a base branch argument which I kept since it doesn't hurt.