### PR TITLE
lute pkg: add dev dependencies 

### DIFF
--- a/lute/cli/commands/pkg/init.luau
+++ b/lute/cli/commands/pkg/init.luau
@@ -30,7 +30,7 @@ local function main(...: string)
 	local command = args[1]
 
 	if command == "install" then
-		install()
+		install(table.unpack(args, 2))
 	elseif command == "auth" then
 		authenticate(table.unpack(args, 2))
 	else

--- a/lute/cli/commands/pkg/loom-core/src/commands/install.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/install.luau
@@ -1,3 +1,4 @@
+local cli = require("@batteries/cli")
 local fs = require("@std/fs")
 local lockfile = require("../lockfile")
 local manifest = require("../manifest")
@@ -5,14 +6,24 @@ local resolution = require("../resolution")
 local path = require("@std/path")
 local process = require("@std/process")
 
-local function printDiagnostics(lock: lockfile.Lockfile)
+local function printDiagnostics(lock: lockfile.Lockfile, devAliases: { [string]: boolean })
 	local depCount = 0
-	for _ in lock.dependencies do
-		depCount += 1
+	local devCount = 0
+	for alias in lock.dependencies do
+		if devAliases[alias] then
+			devCount += 1
+		else
+			depCount += 1
+		end
 	end
-	print(`Resolved {depCount} package(s).`)
 
-	for _, key in lock.dependencies do
+	if devCount > 0 then
+		print(`Resolved {depCount + devCount} package(s) ({devCount} dev).`)
+	else
+		print(`Resolved {depCount} package(s).`)
+	end
+
+	for alias, key in lock.dependencies do
 		local transitive = 0
 		local pkg = lock.packages[key]
 		if pkg then
@@ -20,13 +31,21 @@ local function printDiagnostics(lock: lockfile.Lockfile)
 				transitive += 1
 			end
 		end
-		print(`  {key} ({pkg.sourceKind}, {transitive} dep(s))`)
+		local suffix = if devAliases[alias] then " [dev]" else ""
+		print(`  {key} ({pkg.sourceKind}, {transitive} dep(s)){suffix}`)
 	end
 end
 
-local function install()
+local function install(...: string)
+	local args = cli.parser()
+	args:add("no-dev", "flag", { help = "Skip dev dependencies" })
+	args:parse({ ... })
+
+	local excludeDev = args:get("no-dev") == true
 	local rootDirectory = path.format(process.cwd())
 	local manifestPath = `{rootDirectory}/loom.config.luau`
+
+	local devAliases: { [string]: boolean } = {}
 
 	if fs.exists(manifestPath) then
 		local rootManifest = manifest.parseFile(manifestPath)
@@ -35,10 +54,18 @@ local function install()
 				error("Registry dependencies are not yet supported by the install command")
 			end
 		end
+		if not excludeDev then
+			for alias, depSpec in rootManifest.package.devDependencies do
+				if depSpec.sourceKind == "registry" then
+					error("Registry dependencies are not yet supported by the install command")
+				end
+				devAliases[alias] = true
+			end
+		end
 	end
 
-	local lock = resolution.resolve(rootDirectory, nil)
-	printDiagnostics(lock)
+	local lock = resolution.resolve(rootDirectory, nil, { excludeDev = excludeDev })
+	printDiagnostics(lock, devAliases)
 end
 
 return install

--- a/lute/cli/commands/pkg/loom-core/src/commands/install.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/install.luau
@@ -38,10 +38,10 @@ end
 
 local function install(...: string)
 	local args = cli.parser()
-	args:add("no-dev", "flag", { help = "Skip dev dependencies" })
+	args:add("exclude-dev", "flag", { help = "Skip dev dependencies" })
 	args:parse({ ... })
 
-	local excludeDev = args:get("no-dev") == true
+	local excludeDev = args:get("exclude-dev") ~= nil
 	local rootDirectory = path.format(process.cwd())
 	local manifestPath = `{rootDirectory}/loom.config.luau`
 

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -82,7 +82,10 @@ local function parseDependencyMap(raw: any, sectionName: string): { [string]: De
 				rev = spec.rev,
 			})
 		elseif spec.sourceKind == "registry" then
-			assert(typeof(spec.version) == "string", `Expected 'version' field for registry dependency '{name}' in {sectionName}`)
+			assert(
+				typeof(spec.version) == "string",
+				`Expected 'version' field for registry dependency '{name}' in {sectionName}`
+			)
 			result[name] = table.freeze({
 				name = spec.name or name,
 				sourceKind = "registry" :: "registry",
@@ -114,10 +117,7 @@ local function parseManifest(t: unknown): ProjectManifest
 	local devDependencies = parseDependencyMap((pkg :: any).dev_dependencies, "dev_dependencies")
 
 	for alias in devDependencies do
-		assert(
-			dependencies[alias] == nil,
-			`Alias '{alias}' appears in both dependencies and dev_dependencies`
-		)
+		assert(dependencies[alias] == nil, `Alias '{alias}' appears in both dependencies and dev_dependencies`)
 	end
 
 	return table.freeze({

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -27,7 +27,8 @@ export type DependencySpec = PathDependencySpec | GitHubDependencySpec | Registr
 export type PackageManifest = {
 	read name: string,
 	read version: string,
-	read dependencies: { [string]: DependencySpec }, -- maps alias to dependency spec
+	read dependencies: { [string]: DependencySpec },
+	read devDependencies: { [string]: DependencySpec },
 }
 
 export type ProjectManifest = {
@@ -46,6 +47,54 @@ local function parseSourceKind(s: unknown): SourceKind?
 	return s :: SourceKind
 end
 
+local function parseDependencyMap(raw: any, sectionName: string): { [string]: DependencySpec }
+	local result: { [string]: DependencySpec } = {}
+	if raw == nil then
+		return table.freeze(result)
+	end
+
+	for name, spec in raw do
+		assert(
+			spec.name == nil or typeof(spec.name) == "string",
+			`Optional 'name' field in dependency spec for '{name}' in {sectionName} expected to be a string`
+		)
+		assert(
+			isSourceKind(spec.sourceKind),
+			`Expected 'sourceKind' to be 'path', 'github', or 'registry' in dependency spec for '{name}' in {sectionName}, got '{spec.sourceKind}'`
+		)
+		assert(
+			spec.source ~= nil and typeof(spec.source) == "string",
+			`Expected 'source' field in dependency spec for '{name}' in {sectionName}`
+		)
+
+		if spec.sourceKind == "path" then
+			result[name] = table.freeze({
+				name = spec.name or name,
+				sourceKind = "path" :: "path",
+				source = spec.source,
+			})
+		elseif spec.sourceKind == "github" then
+			assert(typeof(spec.rev) == "string", `Expected 'rev' field for github dependency '{name}' in {sectionName}`)
+			result[name] = table.freeze({
+				name = spec.name or name,
+				sourceKind = "github" :: "github",
+				source = spec.source,
+				rev = spec.rev,
+			})
+		elseif spec.sourceKind == "registry" then
+			assert(typeof(spec.version) == "string", `Expected 'version' field for registry dependency '{name}' in {sectionName}`)
+			result[name] = table.freeze({
+				name = spec.name or name,
+				sourceKind = "registry" :: "registry",
+				source = spec.source,
+				version = spec.version,
+			})
+		end
+	end
+
+	return table.freeze(result)
+end
+
 -- TODO: We should do proper error handling because this is user input.
 local function parseManifest(t: unknown): ProjectManifest
 	assert(t ~= nil and typeof(t) == "table", "Expected a table")
@@ -61,49 +110,14 @@ local function parseManifest(t: unknown): ProjectManifest
 		"Expected 'version' field in package manifest"
 	)
 
-	local dependencies: { [string]: DependencySpec } = {}
-	-- FIXME(Luau): Luau currently refines `pkg` to have `dependencies` based on this check, but
-	-- also produces a type error for the access _in_ the condition without the cast here.
-	if (pkg :: any).dependencies ~= nil then
-		for name, spec in pkg.dependencies do
-			assert(
-				spec.name == nil or typeof(spec.name) == "string",
-				`Optional 'name' field in dependency spec for '{name}' expected to be a string`
-			)
-			assert(
-				isSourceKind(spec.sourceKind),
-				`Expected 'sourceKind' to be 'path', 'github', or 'registry' in dependency spec for '{name}', got '{spec.sourceKind}'`
-			)
-			assert(
-				spec.source ~= nil and typeof(spec.source) == "string",
-				`Expected 'source' field in dependency spec for '{name}'`
-			)
+	local dependencies = parseDependencyMap((pkg :: any).dependencies, "dependencies")
+	local devDependencies = parseDependencyMap((pkg :: any).dev_dependencies, "dev_dependencies")
 
-			if spec.sourceKind == "path" then
-				dependencies[name] = table.freeze({
-					name = spec.name or name,
-					sourceKind = "path" :: "path",
-					source = spec.source,
-				})
-			elseif spec.sourceKind == "github" then
-				assert(typeof(spec.rev) == "string", `Expected 'rev' field for github dependency '{name}'`)
-				dependencies[name] = table.freeze({
-					name = spec.name or name, -- use the optional name if provided, otherwise use the alias
-					sourceKind = "github" :: "github",
-					source = spec.source,
-					rev = spec.rev,
-				})
-			elseif spec.sourceKind == "registry" then
-				assert(typeof(spec.version) == "string", `Expected 'version' field for registry dependency '{name}'`)
-				dependencies[name] = table.freeze({
-					name = spec.name or name,
-					sourceKind = "registry" :: "registry",
-					source = spec.source,
-					version = spec.version,
-				})
-			end
-		end
-		table.freeze(dependencies)
+	for alias in devDependencies do
+		assert(
+			dependencies[alias] == nil,
+			`Alias '{alias}' appears in both dependencies and dev_dependencies`
+		)
 	end
 
 	return table.freeze({
@@ -111,6 +125,7 @@ local function parseManifest(t: unknown): ProjectManifest
 			name = pkg.name,
 			version = pkg.version,
 			dependencies = dependencies,
+			devDependencies = devDependencies,
 		}),
 	})
 end

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -83,7 +83,13 @@ local function fetchSource(spec: manifest.DependencySpec, rootDirectory: string)
 	end
 end
 
-local function resolve(rootDirectory: string, universe: semver.Universe?): lockfile.Lockfile
+export type ResolveOptions = {
+	read excludeDev: boolean?,
+}
+
+local function resolve(rootDirectory: string, universe: semver.Universe?, options: ResolveOptions?): lockfile.Lockfile
+	local excludeDev = if options then options.excludeDev == true else false
+
 	local rootManifestPath = getManifestPath(rootDirectory)
 	if not fs.exists(rootManifestPath) then
 		error(`Manifest file not found: {rootManifestPath}`)
@@ -124,6 +130,26 @@ local function resolve(rootDirectory: string, universe: semver.Universe?): lockf
 
 		dependencies[dependencyAlias] = getKey(dependencySpec)
 		table.insert(queue, dependencySpec)
+	end
+
+	if not excludeDev then
+		for dependencyAlias, dependencySpec in rootManifest.package.devDependencies do
+			if dependencySpec.sourceKind == "registry" then
+				registryRequirements[dependencyAlias] = {
+					name = dependencySpec.name,
+					constraint = semver.parseConstraint(dependencySpec.version),
+					requiredBy = rootManifest.package.name,
+					aliasedAs = if dependencyAlias ~= dependencySpec.name then dependencyAlias else nil,
+				}
+
+				registrySources[dependencySpec.name] = dependencySpec.source
+				table.insert(rootRegistryAliases, dependencyAlias)
+				continue
+			end
+
+			dependencies[dependencyAlias] = getKey(dependencySpec)
+			table.insert(queue, dependencySpec)
+		end
 	end
 
 	for _, spec in queue do

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -10,10 +10,15 @@ local solver = require("@commands/pkg/loom-core/src/semver/solver")
 local temporaryDirectory = system.tmpdir()
 local workingDirectory = path.join(temporaryDirectory, "lute-pkg-registry")
 
-local function writeConfig(dir: path.Path, name: string, deps: string)
+local function writeConfig(dir: path.Path, name: string, deps: string, devDeps: string?)
+	local sections = `\t\tdependencies = \{{deps}\n\t\t}`
+	if devDeps then
+		sections ..= `,\n\t\tdev_dependencies = \{{devDeps}\n\t\t}`
+	end
+
 	fs.writeStringToFile(
 		path.join(dir, "loom.config.luau"),
-		`return \{\n\tpackage = \{\n\t\tname = "{name}",\n\t\tversion = "0.0.0",\n\t\tdependencies = \{{deps}\n\t\t},\n\t},\n}\n`
+		`return \{\n\tpackage = \{\n\t\tname = "{name}",\n\t\tversion = "0.0.0",\n{sections},\n\t},\n}\n`
 	)
 end
 
@@ -465,5 +470,360 @@ test.suite("RegistryResolution", function(suite)
 		local content = fs.readFileToString(lockfilePath)
 		assert.strContains(content, '"registry"')
 		assert.strContains(content, "citrus@1.0.0")
+	end)
+end)
+
+test.suite("DevDependencies", function(suite)
+	suite:beforeEach(function()
+		if fs.exists(workingDirectory) then
+			fs.removeDirectory(workingDirectory, { recursive = true })
+		end
+		fs.createDirectory(workingDirectory)
+	end)
+
+	suite:case("devDependenciesResolvedForRoot", function(assert)
+		local devDir = path.join(workingDirectory, "testlib")
+		fs.createDirectory(devDir)
+		writeConfig(devDir, "testlib", "")
+		writeConfig(
+			workingDirectory,
+			"root",
+			"",
+			[[
+
+			testlib = {
+				sourceKind = "path",
+				source = "./testlib",
+			},]]
+		)
+
+		local lock = resolution.resolve(path.format(workingDirectory), nil)
+
+		assert.eq(lock.dependencies.testlib, "testlib")
+		assert.eq(lock.packages["testlib"], {
+			name = "testlib",
+			sourceKind = "path",
+			source = "./testlib",
+			installPath = "testlib",
+			dependencies = {},
+		})
+	end)
+
+	suite:case("devDependenciesOfTransitivePathDepsExcluded", function(assert)
+		local libDir = path.join(workingDirectory, "lib")
+		fs.createDirectory(libDir)
+
+		local libDevDir = path.join(libDir, "libtest")
+		fs.createDirectory(libDevDir)
+		writeConfig(libDevDir, "libtest", "")
+
+		writeConfig(
+			libDir,
+			"lib",
+			"",
+			[[
+
+			libtest = {
+				sourceKind = "path",
+				source = "./libtest",
+			},]]
+		)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]]
+		)
+
+		local lock = resolution.resolve(path.format(workingDirectory), nil)
+
+		assert.eq(lock.dependencies.lib, "lib")
+		assert.eq(lock.packages["lib"], {
+			name = "lib",
+			sourceKind = "path",
+			source = "./lib",
+			installPath = "lib",
+			dependencies = {},
+		})
+		assert.eq(lock.packages["libtest"], nil)
+		assert.eq(lock.dependencies.libtest, nil)
+	end)
+
+	suite:case("devDependenciesOfTransitiveRegistryDepsExcluded", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]]
+		)
+
+		-- mocklib exists in the universe but is never required — verifies the solver
+		-- only resolves what's actually reachable through prod dependency edges
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+			mocklib = {
+				namedVersion("mocklib", "2.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+
+		assert.eq(lock.dependencies.citrus, "citrus@1.0.0")
+		assert.eq(lock.packages["citrus@1.0.0"], {
+			name = "citrus",
+			rev = "1.0.0",
+			source = "citrus",
+			sourceKind = "registry",
+			installPath = "@pkg/citrus@1.0.0",
+			dependencies = {},
+		})
+		assert.eq(lock.packages["mocklib@2.0.0"], nil)
+		assert.eq(lock.dependencies.mocklib, nil)
+	end)
+
+	suite:case("devAndProdShareTransitiveDep", function(assert)
+		local sharedDir = path.join(workingDirectory, "shared")
+		fs.createDirectory(sharedDir)
+		writeConfig(sharedDir, "shared", "")
+
+		local libDir = path.join(workingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfig(
+			libDir,
+			"lib",
+			[[
+
+			shared = {
+				sourceKind = "path",
+				source = "../shared",
+			},]]
+		)
+
+		local testDir = path.join(workingDirectory, "testlib")
+		fs.createDirectory(testDir)
+		writeConfig(
+			testDir,
+			"testlib",
+			[[
+
+			shared = {
+				sourceKind = "path",
+				source = "../shared",
+			},]]
+		)
+
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]],
+			[[
+
+			testlib = {
+				sourceKind = "path",
+				source = "./testlib",
+			},]]
+		)
+
+		local lock = resolution.resolve(path.format(workingDirectory), nil)
+
+		assert.eq(lock.dependencies.lib, "lib")
+		assert.eq(lock.dependencies.testlib, "testlib")
+		assert.eq(lock.packages["shared"], {
+			name = "shared",
+			sourceKind = "path",
+			source = "shared",
+			installPath = "shared",
+			dependencies = {},
+		})
+		assert.eq(lock.packages["lib"].dependencies.shared, "shared")
+		assert.eq(lock.packages["testlib"].dependencies.shared, "shared")
+	end)
+
+	suite:case("devRegistryDependencyResolved", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			"",
+			[[
+
+			testing = {
+				sourceKind = "registry",
+				source = "testing",
+				version = "^1.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			testing = {
+				namedVersion("testing", "1.2.0"),
+				namedVersion("testing", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+
+		assert.eq(lock.dependencies.testing, "testing@1.2.0")
+		assert.eq(lock.packages["testing@1.2.0"], {
+			name = "testing",
+			rev = "1.2.0",
+			source = "testing",
+			sourceKind = "registry",
+			installPath = "@pkg/testing@1.2.0",
+			dependencies = {},
+		})
+	end)
+
+	suite:case("excludeDevSkipsDevDeps", function(assert)
+		local devDir = path.join(workingDirectory, "testlib")
+		fs.createDirectory(devDir)
+		writeConfig(devDir, "testlib", "")
+		writeConfig(
+			workingDirectory,
+			"root",
+			"",
+			[[
+
+			testlib = {
+				sourceKind = "path",
+				source = "./testlib",
+			},]]
+		)
+
+		local lock = resolution.resolve(path.format(workingDirectory), nil, { excludeDev = true })
+
+		assert.eq(lock.dependencies.testlib, nil)
+		assert.eq(lock.packages["testlib"], nil)
+	end)
+
+	suite:case("excludeDevKeepsProdDeps", function(assert)
+		local libDir = path.join(workingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfig(libDir, "lib", "")
+
+		local devDir = path.join(workingDirectory, "testlib")
+		fs.createDirectory(devDir)
+		writeConfig(devDir, "testlib", "")
+
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]],
+			[[
+
+			testlib = {
+				sourceKind = "path",
+				source = "./testlib",
+			},]]
+		)
+
+		local lock = resolution.resolve(path.format(workingDirectory), nil, { excludeDev = true })
+
+		assert.eq(lock.dependencies.lib, "lib")
+		assert.eq(lock.packages["lib"], {
+			name = "lib",
+			sourceKind = "path",
+			source = "./lib",
+			installPath = "lib",
+			dependencies = {},
+		})
+		assert.eq(lock.dependencies.testlib, nil)
+		assert.eq(lock.packages["testlib"], nil)
+	end)
+
+	suite:case("excludeDevSkipsRegistryDevDeps", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			"",
+			[[
+
+			testing = {
+				sourceKind = "registry",
+				source = "testing",
+				version = "^1.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			testing = {
+				namedVersion("testing", "1.2.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe, { excludeDev = true })
+
+		assert.eq(lock.dependencies.testing, nil)
+		assert.eq(lock.packages["testing@1.2.0"], nil)
+	end)
+
+	suite:case("duplicateAliasAcrossSectionsErrors", function(assert)
+		local libDir = path.join(workingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfig(libDir, "lib", "")
+
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]],
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]]
+		)
+
+		assert.throwsWith("Alias 'lib' appears in both dependencies and dev_dependencies", function()
+			resolution.resolve(path.format(workingDirectory), nil)
+		end)
+	end)
+
+	suite:case("lockfileVersionRemainsThree", function(assert)
+		local devDir = path.join(workingDirectory, "testlib")
+		fs.createDirectory(devDir)
+		writeConfig(devDir, "testlib", "")
+		writeConfig(
+			workingDirectory,
+			"root",
+			"",
+			[[
+
+			testlib = {
+				sourceKind = "path",
+				source = "./testlib",
+			},]]
+		)
+
+		resolution.resolve(path.format(workingDirectory), nil)
+
+		local lockfilePath = path.join(workingDirectory, "loom.lock.luau")
+		local content = fs.readFileToString(lockfilePath)
+		assert.strContains(content, "version = 3")
 	end)
 end)


### PR DESCRIPTION
 ## Summary

  - Adds dev_dependencies section to loom.config.luau manifest format
  - Dev dependencies are resolved for the root project only — transitive packages' dev dependencies are ignored (i.e. not included in index information on publish)
  - Supports --exclude-dev flag on lute pkg install to exclude dev dependencies
  - No lockfile distinction: Dev and prod deps share the same dependencies map in the lockfile. At install/link time, the manifest 
  - Single solver pass: Dev and prod deps are resolved together so shared transitive deps unify to one version.
  - Duplicate alias validation: An alias appearing in both dependencies and dev_dependencies is an error at parse time.