### PR TITLE
infra: upgrade curl to 8.21.0

### DIFF
--- a/extern/curl.tune
+++ b/extern/curl.tune
@@ -1,5 +1,5 @@
 [dependency]
 name = "curl"
 remote = "https://github.com/curl/curl.git"
-branch = "curl-8_20_0"
-revision = "a05f34973e6c4bb629d018f7cb51487be1c904d8"
+branch = "curl-8_21_0"
+revision = "68720b4837284335b2d63cb358f8f6ce65f5bc55"


### PR DESCRIPTION
@jkelaty-rbx's investigations into networking hangs on Windows (#1178) seem to be pointing to something going wrong with the DNS resolver in curl. I see that v8.20.0 had some changes to the DNS resolver, and v8.21.0 has further ones. It's possible that we're hitting some bugs there, so I'd like to see if we can keep the DNS resolution asynchronous by just upgrading to the latest curl release.