### PR TITLE
`lute pkg`: refactor resolution in terms of modular helpers

### DIFF
--- a/lute/cli/commands/pkg/loom-core/src/commands/install.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/install.luau
@@ -40,10 +40,10 @@ local function install(...: string)
 	args:add("exclude-dev", "flag", { help = "Skip dev dependencies" })
 	args:parse({ ... })
 
-	local excludeDev = args:get("exclude-dev") ~= nil
 	local rootDirectory = path.format(process.cwd())
-
 	local rootManifest = manifest.parseFile(rootDirectory)
+
+	local excludeDev = args:get("exclude-dev") ~= nil
 	local devAliases: { [string]: boolean } = {}
 
 	for _, depSpec in rootManifest.package.dependencies do
@@ -51,6 +51,7 @@ local function install(...: string)
 			error("Registry dependencies are not yet supported by the install command")
 		end
 	end
+
 	if not excludeDev then
 		for alias, depSpec in rootManifest.package.devDependencies do
 			if depSpec.sourceKind == "registry" then

--- a/lute/cli/commands/pkg/loom-core/src/commands/install.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/install.luau
@@ -1,5 +1,4 @@
 local cli = require("@batteries/cli")
-local fs = require("@std/fs")
 local lockfile = require("../lockfile")
 local manifest = require("../manifest")
 local resolution = require("../resolution")
@@ -43,29 +42,27 @@ local function install(...: string)
 
 	local excludeDev = args:get("exclude-dev") ~= nil
 	local rootDirectory = path.format(process.cwd())
-	local manifestPath = `{rootDirectory}/loom.config.luau`
 
+	local rootManifest = manifest.parseFile(rootDirectory)
 	local devAliases: { [string]: boolean } = {}
 
-	if fs.exists(manifestPath) then
-		local rootManifest = manifest.parseFile(manifestPath)
-		for _, depSpec in rootManifest.package.dependencies do
+	for _, depSpec in rootManifest.package.dependencies do
+		if depSpec.sourceKind == "registry" then
+			error("Registry dependencies are not yet supported by the install command")
+		end
+	end
+	if not excludeDev then
+		for alias, depSpec in rootManifest.package.devDependencies do
 			if depSpec.sourceKind == "registry" then
 				error("Registry dependencies are not yet supported by the install command")
 			end
-		end
-		if not excludeDev then
-			for alias, depSpec in rootManifest.package.devDependencies do
-				if depSpec.sourceKind == "registry" then
-					error("Registry dependencies are not yet supported by the install command")
-				end
-				devAliases[alias] = true
-			end
+			devAliases[alias] = true
 		end
 	end
 
 	local lock = resolution.resolve(rootDirectory, nil, { excludeDev = excludeDev })
 	printDiagnostics(lock, devAliases)
+	lockfile.writeFile(lock, rootDirectory)
 end
 
 return install

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -1,5 +1,7 @@
+local fs = require("@std/fs")
 local luau = require("@std/luau")
 local manifest = require("./manifest")
+local pp = require("@batteries/pp")
 
 export type LockfileDependency = {
 	read name: string,
@@ -59,11 +61,31 @@ local function parseLockfile(t: any): Lockfile
 	return table.freeze(t)
 end
 
-local function parseFile(lockfilePath: string): Lockfile
+local function resolvePath(directory: string): string
+	return `{directory}/loom.lock.luau`
+end
+
+local function parseFile(directory: string): Lockfile
+	local lockfilePath = resolvePath(directory)
+	if not fs.exists(lockfilePath) then
+		error(`Lockfile not found at: {lockfilePath}`)
+	end
 	local t = luau.loadModule(lockfilePath)
 	return parseLockfile(t)
 end
 
+local function renderLockfile(lock: Lockfile): string
+	return `return {pp(lock)}\n`
+end
+
+local function writeFile(lock: Lockfile, directory: string)
+	local lockfilePath = resolvePath(directory)
+	fs.writeStringToFile(lockfilePath, renderLockfile(lock))
+end
+
 return {
 	parseFile = parseFile,
+	writeFile = writeFile,
+	resolvePath = resolvePath,
+	renderLockfile = renderLockfile,
 }

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -74,18 +74,12 @@ local function parseFile(directory: string): Lockfile
 	return parseLockfile(t)
 end
 
-local function renderLockfile(lock: Lockfile): string
-	return `return {pp(lock)}\n`
-end
-
 local function writeFile(lock: Lockfile, directory: string)
 	local lockfilePath = resolvePath(directory)
-	fs.writeStringToFile(lockfilePath, renderLockfile(lock))
+	fs.writeStringToFile(lockfilePath, `return {pp(lock)}\n`)
 end
 
 return {
 	parseFile = parseFile,
 	writeFile = writeFile,
-	resolvePath = resolvePath,
-	renderLockfile = renderLockfile,
 }

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -1,3 +1,4 @@
+local fs = require("@std/fs")
 local luau = require("@std/luau")
 
 export type SourceKind = "path" | "github" | "registry"
@@ -130,7 +131,15 @@ local function parseManifest(t: unknown): ProjectManifest
 	})
 end
 
-local function parseFile(manifestPath: string): ProjectManifest
+local function resolvePath(directory: string): string
+	return `{directory}/loom.config.luau`
+end
+
+local function parseFile(directory: string): ProjectManifest
+	local manifestPath = resolvePath(directory)
+	if not fs.exists(manifestPath) then
+		error(`Manifest file not found: {manifestPath}`)
+	end
 	local manifestTable = luau.loadModule(manifestPath)
 	return parseManifest(manifestTable)
 end
@@ -139,4 +148,5 @@ return {
 	isSourceKind = isSourceKind,
 	parseSourceKind = parseSourceKind,
 	parseFile = parseFile,
+	resolvePath = resolvePath,
 }

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -148,5 +148,4 @@ return {
 	isSourceKind = isSourceKind,
 	parseSourceKind = parseSourceKind,
 	parseFile = parseFile,
-	resolvePath = resolvePath,
 }

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -199,9 +199,6 @@ local function processSpecQueue(
 	return packages
 end
 
--- Solve all collected registry requirements in one pass and stitch the resolved
--- versions into the package graph: emit one packages entry per resolved version,
--- and back-patch every fixup's alias table with the concrete `name@version` key.
 local function solveRegistryRequirements(
 	packages: { [string]: lockfile.LockfileDependency },
 	registry: RegistryContext,

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -230,7 +230,7 @@ local function solveRegistryRequirements(
 			source = registry.sources[name] or name,
 			sourceKind = "registry" :: "registry",
 			installPath = store.toStorePath(key),
-			dependencies = transitiveDependencies,
+			dependencies = table.freeze(transitiveDependencies),
 		})
 	end
 
@@ -277,7 +277,11 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 	end
 
 	for _, pkg in packages do
-		table.freeze(pkg.dependencies)
+		if pkg.sourceKind ~= "registry" then
+			table.freeze(pkg.dependencies)
+		elseif not table.isfrozen(pkg.dependencies) then
+			error("Registry package dependencies are not frozen")
+		end
 	end
 
 	table.freeze(packages)

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -6,21 +6,21 @@ local path = require("@std/path")
 local semver = require("./semver")
 local store = require("./store")
 
-type RegistryFixup = {
-	read aliases: { [string]: string },
+type RegistryPatch = {
+	read parentAliases: { [string]: string },
 	read alias: string,
 	read name: string,
 }
 
 type RegistryContext = {
-	read fixups: { RegistryFixup },
+	read patches: { RegistryPatch },
 	read requirements: { [string]: semver.Requirement },
 	read sources: { [string]: string },
 }
 
 local function createRegistryContext(): RegistryContext
 	return table.freeze({
-		fixups = {},
+		patches = {},
 		requirements = {},
 		sources = {},
 	})
@@ -141,8 +141,8 @@ local function enqueueDependencies(
 				aliasedAs = if dependencyAlias ~= dependencySpec.name then dependencyAlias else nil,
 			}
 			registry.sources[dependencySpec.name] = dependencySpec.source
-			table.insert(registry.fixups, {
-				aliases = aliases,
+			table.insert(registry.patches, {
+				parentAliases = aliases,
 				alias = dependencyAlias,
 				name = dependencySpec.name,
 			})
@@ -234,10 +234,10 @@ local function solveRegistryRequirements(
 		})
 	end
 
-	for _, fix in registry.fixups do
-		local pkgVersion = versionsByPackageName[fix.name]
-		assert(pkgVersion ~= nil, `Solver did not resolve registry dependency '{fix.name}'`)
-		fix.aliases[fix.alias] = `{fix.name}@{pkgVersion.versionString}`
+	for _, patch in registry.patches do
+		local pkgVersion = versionsByPackageName[patch.name]
+		assert(pkgVersion ~= nil, `Solver did not resolve registry dependency '{patch.name}'`)
+		patch.parentAliases[patch.alias] = `{patch.name}@{pkgVersion.versionString}`
 	end
 end
 

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -1,18 +1,29 @@
 local fs = require("@std/fs")
 local github = require("./github")
 local lockfile = require("./lockfile")
-local path = require("@std/path")
-local pp = require("@batteries/pp")
 local manifest = require("./manifest")
+local path = require("@std/path")
 local semver = require("./semver")
 local store = require("./store")
 
-local function getManifestPath(directory: string): string
-	return `{directory}/loom.config.luau`
-end
+type RegistryFixup = {
+	read aliases: { [string]: string },
+	read alias: string,
+	read name: string,
+}
 
-local function getLockfilePath(directory: string): string
-	return `{directory}/loom.lock.luau`
+type RegistryContext = {
+	read fixups: { RegistryFixup },
+	read requirements: { [string]: semver.Requirement },
+	read sources: { [string]: string },
+}
+
+local function createRegistryContext(): RegistryContext
+	return table.freeze({
+		fixups = {},
+		requirements = {},
+		sources = {},
+	})
 end
 
 local function getKey(spec: manifest.DependencySpec): string
@@ -56,9 +67,9 @@ local function normalizePathDependency(
 
 	return table.freeze({
 		name = spec.name,
-		sourceKind = "path",
+		sourceKind = "path" :: "path",
 		source = path.format(path.relative(rootDirectory, sourcePath)),
-	}) :: manifest.PathDependencySpec
+	})
 end
 
 local function fetchSource(spec: manifest.DependencySpec, rootDirectory: string): string
@@ -87,121 +98,87 @@ export type ResolveOptions = {
 	read excludeDev: boolean?,
 }
 
-local function resolve(rootDirectory: string, universe: semver.Universe?, options: ResolveOptions?): lockfile.Lockfile
-	local excludeDev = if options then options.excludeDev == true else false
+local function shouldProcess(
+	spec: manifest.DependencySpec,
+	packages: { [string]: lockfile.LockfileDependency }
+): boolean
+	local key = getKey(spec)
 
-	local rootManifestPath = getManifestPath(rootDirectory)
-	if not fs.exists(rootManifestPath) then
-		error(`Manifest file not found: {rootManifestPath}`)
+	if packages[key] then
+		if hasConflict(packages[key], spec) then
+			error(
+				`Source mismatch for package '{spec.name}':\n`
+					.. `  resolved: {packages[key].source} ({packages[key].sourceKind})\n`
+					.. `  incoming: {spec.source} ({spec.sourceKind})\n`
+					.. `Both resolve to '{key}' but from different sources.`
+			)
+		else
+			-- Already resolved at this exact version — deduplicate
+			return false
+		end
 	end
 
-	local lockfilePath = getLockfilePath(rootDirectory)
+	return true
+end
 
-	local queue: { manifest.DependencySpec } = {}
-	local dependencies: { [string]: string } = {}
-	local packages: { [string]: lockfile.LockfileDependency } = {}
-
-	-- All registry solver inputs: root-level dependencies keyed by alias, transitive by "{pkgKey}:{dependencyAlias}".
-	local registryRequirements: { [string]: semver.Requirement } = {}
-	local registrySources: { [string]: string } = {}
-
-	-- Root aliases that need a resolved key written back into `dependencies` after solving.
-	local rootRegistryAliases: { string } = {}
-	-- Per-package registry aliases that need keys written into their dependency table after solving.
-	local unresolvedRegistryDependencies: { [string]: { [string]: string } } = {}
-	-- Open (not yet finalized) dependency maps for unversioned packages; registry entries are filled in during versioned resolution.
-	local openDependencies: { [string]: { [string]: string } } = {}
-
-	local rootManifest = manifest.parseFile(rootManifestPath)
-
-	for dependencyAlias, dependencySpec in rootManifest.package.dependencies do
+local function enqueueDependencies(
+	queue: { manifest.DependencySpec },
+	registry: RegistryContext,
+	dependencies: { [string]: manifest.DependencySpec },
+	installPath: string,
+	rootDirectory: string,
+	requiredBy: string,
+	existingAliases: { [string]: string }?
+): { [string]: string }
+	local aliases: { [string]: string } = existingAliases or {}
+	for dependencyAlias, dependencySpec in dependencies do
 		if dependencySpec.sourceKind == "registry" then
-			registryRequirements[dependencyAlias] = {
+			local sourceKey = `{requiredBy}:{dependencyAlias}`
+			registry.requirements[sourceKey] = {
 				name = dependencySpec.name,
 				constraint = semver.parseConstraint(dependencySpec.version),
-				requiredBy = rootManifest.package.name,
+				requiredBy = requiredBy,
 				aliasedAs = if dependencyAlias ~= dependencySpec.name then dependencyAlias else nil,
 			}
+			registry.sources[dependencySpec.name] = dependencySpec.source
+			table.insert(registry.fixups, {
+				aliases = aliases,
+				alias = dependencyAlias,
+				name = dependencySpec.name,
+			})
+		else
+			local normalized = normalizePathDependency(dependencySpec, installPath, rootDirectory)
+			aliases[dependencyAlias] = getKey(normalized)
+			table.insert(queue, normalized)
+		end
+	end
+	return aliases
+end
 
-			registrySources[dependencySpec.name] = dependencySpec.source
-			table.insert(rootRegistryAliases, dependencyAlias)
+local function processSpecQueue(
+	queue: { manifest.DependencySpec },
+	registry: RegistryContext,
+	rootDirectory: string
+): { [string]: lockfile.LockfileDependency }
+	local packages: { [string]: lockfile.LockfileDependency } = {}
+
+	for _, spec in queue do
+		if not shouldProcess(spec, packages) then
 			continue
 		end
 
-		dependencies[dependencyAlias] = getKey(dependencySpec)
-		table.insert(queue, dependencySpec)
-	end
-
-	if not excludeDev then
-		for dependencyAlias, dependencySpec in rootManifest.package.devDependencies do
-			if dependencySpec.sourceKind == "registry" then
-				registryRequirements[dependencyAlias] = {
-					name = dependencySpec.name,
-					constraint = semver.parseConstraint(dependencySpec.version),
-					requiredBy = rootManifest.package.name,
-					aliasedAs = if dependencyAlias ~= dependencySpec.name then dependencyAlias else nil,
-				}
-
-				registrySources[dependencySpec.name] = dependencySpec.source
-				table.insert(rootRegistryAliases, dependencyAlias)
-				continue
-			end
-
-			dependencies[dependencyAlias] = getKey(dependencySpec)
-			table.insert(queue, dependencySpec)
-		end
-	end
-
-	for _, spec in queue do
-		local key = getKey(spec)
-
-		if packages[key] then
-			if hasConflict(packages[key], spec) then
-				error(
-					`Source mismatch for package '{spec.name}':\n`
-						.. `  resolved: {packages[key].source} ({packages[key].sourceKind})\n`
-						.. `  incoming: {spec.source} ({spec.sourceKind})\n`
-						.. `Both resolve to '{key}' but from different sources.`
-				)
-			else
-				-- Already resolved at this exact version — deduplicate
-				continue
-			end
-		end
-
-		local transitiveDependencies: { [string]: string } = {}
-		openDependencies[key] = transitiveDependencies
-
 		local installPath = fetchSource(spec, rootDirectory)
+		local dependencyManifest = manifest.parseFile(installPath)
 
-		local nestedManifestPath = getManifestPath(installPath)
-		if fs.exists(nestedManifestPath) then
-			local dependencyManifest = manifest.parseFile(nestedManifestPath)
-			for dependencyAlias, dependencySpec in dependencyManifest.package.dependencies do
-				local normalizedSpec = normalizePathDependency(dependencySpec, installPath, rootDirectory)
-
-				if normalizedSpec.sourceKind == "registry" then
-					registryRequirements[`{key}:{dependencyAlias}`] = {
-						name = normalizedSpec.name,
-						constraint = semver.parseConstraint(normalizedSpec.version),
-						requiredBy = key,
-						aliasedAs = if dependencyAlias ~= normalizedSpec.name then dependencyAlias else nil,
-					}
-
-					registrySources[normalizedSpec.name] = normalizedSpec.source
-
-					if not unresolvedRegistryDependencies[key] then
-						unresolvedRegistryDependencies[key] = {}
-					end
-
-					unresolvedRegistryDependencies[key][dependencyAlias] = normalizedSpec.name
-					continue
-				end
-
-				transitiveDependencies[dependencyAlias] = getKey(normalizedSpec)
-				table.insert(queue, normalizedSpec)
-			end
-		end
+		local key = getKey(spec)
+		local transitiveDependencies = enqueueDependencies(
+			queue,
+			registry,
+			dependencyManifest.package.dependencies,
+			installPath,
+			rootDirectory,
+			key
+		)
 
 		packages[key] = table.freeze({
 			name = spec.name,
@@ -215,75 +192,105 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 		})
 	end
 
-	-- Versioned dependency resolution: solve registry dependencies and stitch them into the package graph.
-	if next(registryRequirements) ~= nil then
-		assert(universe ~= nil, "Registry dependencies require a universe to be provided")
+	-- "destroy" queue
+	table.clear(queue)
+	table.freeze(queue)
 
-		local resolution = semver.solve(universe, registryRequirements)
+	return packages
+end
 
-		-- Build a lookup from package name to resolved version(s) for slot-keyed results.
-		local versionsByPackageName = {}
-		for _, pkgVersion in resolution do
-			versionsByPackageName[pkgVersion.name] = pkgVersion
-		end
+-- Solve all collected registry requirements in one pass and stitch the resolved
+-- versions into the package graph: emit one packages entry per resolved version,
+-- and back-patch every fixup's alias table with the concrete `name@version` key.
+local function solveRegistryRequirements(
+	packages: { [string]: lockfile.LockfileDependency },
+	registry: RegistryContext,
+	universe: semver.Universe
+)
+	local resolution = semver.solve(universe, registry.requirements)
 
-		for _, pkgVersion in resolution do
-			local name = pkgVersion.name
-			local key = `{name}@{pkgVersion.versionString}`
-
-			local transitiveDependencies: { [string]: string } = {}
-			for alias, dependency in pkgVersion.dependencies do
-				local resolvedVersion = versionsByPackageName[dependency.name]
-				assert(resolvedVersion ~= nil, `Solver produced an incomplete resolution: missing '{dependency.name}'`)
-
-				transitiveDependencies[alias] = `{dependency.name}@{resolvedVersion.versionString}`
-			end
-
-			packages[key] = table.freeze({
-				name = name,
-				rev = pkgVersion.versionString,
-				source = registrySources[name] or name,
-				sourceKind = "registry" :: "registry",
-				installPath = store.toStorePath(key),
-				dependencies = table.freeze(transitiveDependencies),
-			})
-		end
-
-		-- Fill in pending registry dependency keys directly into the unversioned packages' dependency tables.
-		for pkgKey, unresolvedAliases in unresolvedRegistryDependencies do
-			local packageDependencies = openDependencies[pkgKey]
-			for dependencyAlias, registryName in unresolvedAliases do
-				local pkgVersion = versionsByPackageName[registryName]
-				assert(pkgVersion ~= nil, `Solver did not resolve transitive registry dependency '{registryName}'`)
-				packageDependencies[dependencyAlias] = `{registryName}@{pkgVersion.versionString}`
-			end
-		end
-
-		-- Write root-level registry dependency aliases now that versions are resolved.
-		for _, alias in rootRegistryAliases do
-			local req = registryRequirements[alias]
-			local pkgVersion = versionsByPackageName[req.name]
-			assert(pkgVersion ~= nil, `Solver did not resolve root dependency '{req.name}'`)
-			dependencies[alias] = `{req.name}@{pkgVersion.versionString}`
-		end
+	-- Solver returns slot-keyed entries; build a name lookup for dependency stitching.
+	local versionsByPackageName: { [string]: semver.PackageVersion } = {}
+	for _, pkgVersion in resolution do
+		versionsByPackageName[pkgVersion.name] = pkgVersion
 	end
 
-	for _, packageDependencies in openDependencies do
-		table.freeze(packageDependencies)
+	for _, pkgVersion in resolution do
+		local name = pkgVersion.name
+		local key = `{name}@{pkgVersion.versionString}`
+
+		local transitiveDependencies: { [string]: string } = {}
+		for alias, dependency in pkgVersion.dependencies do
+			local resolvedVersion = versionsByPackageName[dependency.name]
+			assert(resolvedVersion ~= nil, `Solver produced an incomplete resolution: missing '{dependency.name}'`)
+
+			transitiveDependencies[alias] = `{dependency.name}@{resolvedVersion.versionString}`
+		end
+
+		packages[key] = table.freeze({
+			name = name,
+			rev = pkgVersion.versionString,
+			source = registry.sources[name] or name,
+			sourceKind = "registry" :: "registry",
+			installPath = store.toStorePath(key),
+			dependencies = transitiveDependencies,
+		})
+	end
+
+	for _, fix in registry.fixups do
+		local pkgVersion = versionsByPackageName[fix.name]
+		assert(pkgVersion ~= nil, `Solver did not resolve registry dependency '{fix.name}'`)
+		fix.aliases[fix.alias] = `{fix.name}@{pkgVersion.versionString}`
+	end
+end
+
+local function resolve(rootDirectory: string, universe: semver.Universe?, options: ResolveOptions?): lockfile.Lockfile
+	local excludeDev = if options then options.excludeDev == true else false
+
+	local queue: { manifest.DependencySpec } = {}
+	local registry = createRegistryContext()
+
+	local rootManifest = manifest.parseFile(rootDirectory)
+
+	local dependencies = enqueueDependencies(
+		queue,
+		registry,
+		rootManifest.package.dependencies,
+		rootDirectory,
+		rootDirectory,
+		rootManifest.package.name
+	)
+	if not excludeDev then
+		enqueueDependencies(
+			queue,
+			registry,
+			rootManifest.package.devDependencies,
+			rootDirectory,
+			rootDirectory,
+			rootManifest.package.name,
+			dependencies
+		)
+	end
+
+	local packages = processSpecQueue(queue, registry, rootDirectory)
+
+	if next(registry.requirements) ~= nil then
+		assert(universe ~= nil, "Registry dependencies require a universe to be provided")
+		solveRegistryRequirements(packages, registry, universe)
+	end
+
+	for _, pkg in packages do
+		table.freeze(pkg.dependencies)
 	end
 
 	table.freeze(packages)
 	table.freeze(dependencies)
 
-	local lock: lockfile.Lockfile = table.freeze({
+	return table.freeze({
 		version = 3,
 		packages = packages,
 		dependencies = dependencies,
 	})
-
-	fs.writeStringToFile(lockfilePath, `return {pp(lock)}\n`)
-
-	return lock
 end
 
 return {

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -280,7 +280,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 		if pkg.sourceKind ~= "registry" then
 			table.freeze(pkg.dependencies)
 		elseif not table.isfrozen(pkg.dependencies) then
-			error("Registry package dependencies are not frozen")
+			error("Registry package dependencies should be frozen")
 		end
 	end
 

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -3,6 +3,7 @@ local path = require("@std/path")
 local system = require("@std/system")
 local test = require("@std/test")
 
+local lockfile = require("@commands/pkg/loom-core/src/lockfile")
 local resolution = require("@commands/pkg/loom-core/src/resolution")
 local parser = require("@commands/pkg/loom-core/src/semver/parser")
 local solver = require("@commands/pkg/loom-core/src/semver/solver")
@@ -462,7 +463,8 @@ test.suite("RegistryResolution", function(suite)
 			},
 		}
 
-		resolution.resolve(path.format(workingDirectory), universe)
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+		lockfile.writeFile(lock, path.format(workingDirectory))
 
 		local lockfilePath = path.join(workingDirectory, "loom.lock.luau")
 		assert.that(fs.exists(lockfilePath))
@@ -820,7 +822,8 @@ test.suite("DevDependencies", function(suite)
 			},]]
 		)
 
-		resolution.resolve(path.format(workingDirectory), nil)
+		local lock = resolution.resolve(path.format(workingDirectory), nil)
+		lockfile.writeFile(lock, path.format(workingDirectory))
 
 		local lockfilePath = path.join(workingDirectory, "loom.lock.luau")
 		local content = fs.readFileToString(lockfilePath)

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -505,7 +505,7 @@ test.suite("DevDependencies", function(suite)
 		assert.eq(lock.packages["testlib"], {
 			name = "testlib",
 			sourceKind = "path",
-			source = "./testlib",
+			source = "testlib",
 			installPath = "testlib",
 			dependencies = {},
 		})
@@ -547,7 +547,7 @@ test.suite("DevDependencies", function(suite)
 		assert.eq(lock.packages["lib"], {
 			name = "lib",
 			sourceKind = "path",
-			source = "./lib",
+			source = "lib",
 			installPath = "lib",
 			dependencies = {},
 		})
@@ -745,7 +745,7 @@ test.suite("DevDependencies", function(suite)
 		assert.eq(lock.packages["lib"], {
 			name = "lib",
 			sourceKind = "path",
-			source = "./lib",
+			source = "lib",
 			installPath = "lib",
 			dependencies = {},
 		})


### PR DESCRIPTION
Refactors lute's dependency resolution implementation to be slightly more modular with semantically named functions. My intention/hope is to make the code easier to read and extend.

One issue that this refactor caught was https://github.com/luau-lang/lute/pull/1194 did not use the same path-spec normalization helper, which was caught with unit tests after the refactor correct this.