### PR TITLE
lute pkg: Use lockfile for dependency resolution

### DIFF
--- a/lute/cli/commands/pkg/loom-core/src/commands/install.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/install.luau
@@ -39,9 +39,11 @@ end
 local function install(...: string)
 	local args = cli.parser()
 	args:add("exclude-dev", "flag", { help = "Skip dev dependencies" })
+	args:add("locked", "flag", { help = "Error if lockfile doesn't match manifest (CI mode)" })
 	args:parse({ ... })
 
 	local excludeDev = args:get("exclude-dev") ~= nil
+	local locked = args:get("locked") ~= nil
 	local rootDirectory = path.format(process.cwd())
 	local manifestPath = `{rootDirectory}/loom.config.luau`
 
@@ -64,7 +66,7 @@ local function install(...: string)
 		end
 	end
 
-	local lock = resolution.resolve(rootDirectory, nil, { excludeDev = excludeDev })
+	local lock = resolution.resolve(rootDirectory, nil, { excludeDev = excludeDev, locked = locked })
 	printDiagnostics(lock, devAliases)
 end
 

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -77,7 +77,11 @@ local function tryParseFile(lockfilePath: string): Lockfile?
 	return result
 end
 
-local function satisfiesManifest(lock: Lockfile, rootManifest: manifest.ProjectManifest, excludeDev: boolean): (boolean, string?)
+local function satisfiesManifest(
+	lock: Lockfile,
+	rootManifest: manifest.ProjectManifest,
+	excludeDev: boolean
+): (boolean, string?)
 	local expectedAliases: { [string]: manifest.DependencySpec } = {}
 
 	for alias, spec in rootManifest.package.dependencies do

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -1,5 +1,7 @@
+local fs = require("@std/fs")
 local luau = require("@std/luau")
 local manifest = require("./manifest")
+local semver = require("./semver")
 
 export type LockfileDependency = {
 	read name: string,
@@ -64,6 +66,73 @@ local function parseFile(lockfilePath: string): Lockfile
 	return parseLockfile(t)
 end
 
+local function tryParseFile(lockfilePath: string): Lockfile?
+	if not fs.exists(lockfilePath) then
+		return nil
+	end
+	local ok, result = pcall(parseFile, lockfilePath)
+	if not ok then
+		return nil
+	end
+	return result
+end
+
+local function satisfiesManifest(lock: Lockfile, rootManifest: manifest.ProjectManifest, excludeDev: boolean): (boolean, string?)
+	local expectedAliases: { [string]: manifest.DependencySpec } = {}
+
+	for alias, spec in rootManifest.package.dependencies do
+		expectedAliases[alias] = spec
+	end
+
+	if not excludeDev then
+		for alias, spec in rootManifest.package.devDependencies do
+			expectedAliases[alias] = spec
+		end
+	end
+
+	for alias, spec in expectedAliases do
+		local key = lock.dependencies[alias]
+		if key == nil then
+			return false, `new dependency: {alias}`
+		end
+
+		local pkg = lock.packages[key]
+		if pkg == nil then
+			return false, `broken lockfile entry for: {alias}`
+		end
+
+		if pkg.sourceKind ~= spec.sourceKind then
+			return false, `source kind changed for: {alias}`
+		end
+
+		if spec.sourceKind == "github" then
+			if pkg.source ~= spec.source or pkg.rev ~= spec.rev then
+				return false, `github source changed for: {alias}`
+			end
+		elseif spec.sourceKind == "path" then
+			if pkg.source ~= spec.source then
+				return false, `path changed for: {alias}`
+			end
+		elseif spec.sourceKind == "registry" then
+			local constraint = semver.parseConstraint(spec.version)
+			local lockedVersion = semver.tryParse(pkg.rev :: string)
+			if lockedVersion == nil or not semver.satisfies(lockedVersion, constraint) then
+				return false, `registry constraint no longer satisfied for: {alias}`
+			end
+		end
+	end
+
+	for alias in lock.dependencies do
+		if expectedAliases[alias] == nil then
+			return false, `removed dependency: {alias}`
+		end
+	end
+
+	return true, nil
+end
+
 return {
 	parseFile = parseFile,
+	tryParseFile = tryParseFile,
+	satisfiesManifest = satisfiesManifest,
 }

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -85,7 +85,62 @@ end
 
 export type ResolveOptions = {
 	read excludeDev: boolean?,
+	read locked: boolean?,
 }
+
+local function pathDepsAreStale(lock: lockfile.Lockfile, rootDirectory: string): boolean
+	for key, pkg in lock.packages do
+		if pkg.sourceKind ~= "path" then
+			continue
+		end
+
+		local depManifestPath = path.format(path.join(rootDirectory, pkg.installPath, "loom.config.luau"))
+		if not fs.exists(depManifestPath) then
+			return true
+		end
+
+		local ok, depManifest = pcall(manifest.parseFile, depManifestPath)
+		if not ok then
+			return true
+		end
+
+		for alias in depManifest.package.dependencies do
+			if pkg.dependencies[alias] == nil then
+				return true
+			end
+		end
+
+		for alias in pkg.dependencies do
+			if depManifest.package.dependencies[alias] == nil then
+				return true
+			end
+		end
+
+		for alias, depSpec in depManifest.package.dependencies do
+			local recordedKey = pkg.dependencies[alias]
+			if recordedKey == nil then
+				continue
+			end
+			local recordedPkg = lock.packages[recordedKey]
+			if recordedPkg == nil then
+				return true
+			end
+			if recordedPkg.sourceKind ~= depSpec.sourceKind then
+				return true
+			end
+			if depSpec.sourceKind == "github" then
+				if recordedPkg.source ~= depSpec.source or recordedPkg.rev ~= depSpec.rev then
+					return true
+				end
+			elseif depSpec.sourceKind == "path" then
+				if recordedPkg.source ~= depSpec.source then
+					return true
+				end
+			end
+		end
+	end
+	return false
+end
 
 local function resolve(rootDirectory: string, universe: semver.Universe?, options: ResolveOptions?): lockfile.Lockfile
 	local excludeDev = if options then options.excludeDev == true else false
@@ -96,6 +151,42 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 	end
 
 	local lockfilePath = getLockfilePath(rootDirectory)
+	local rootManifest = manifest.parseFile(rootManifestPath)
+
+	-- Attempt lockfile reuse
+	local existingLock = lockfile.tryParseFile(lockfilePath)
+
+	if options and options.locked and existingLock == nil then
+		error("--locked: no lockfile found. Run `lute pkg install` first.")
+	end
+
+	if existingLock then
+		local satisfied, reason = lockfile.satisfiesManifest(existingLock, rootManifest, excludeDev)
+
+		if options and options.locked then
+			if not satisfied then
+				error(`--locked: lockfile does not satisfy manifest ({reason}). Run \`lute pkg install\` to update.`)
+			end
+			print("Lockfile up to date.")
+			return existingLock
+		end
+
+		if satisfied and not pathDepsAreStale(existingLock, rootDirectory) then
+			print("Lockfile up to date.")
+			return existingLock
+		end
+	end
+
+	-- Extract locked registry versions for soft preference during re-resolution
+	local lockedRegistryVersions: { [string]: string }? = nil
+	if existingLock then
+		lockedRegistryVersions = {}
+		for _, pkg in existingLock.packages do
+			if pkg.sourceKind == "registry" and pkg.rev then
+				(lockedRegistryVersions :: { [string]: string })[pkg.name] = pkg.rev
+			end
+		end
+	end
 
 	local queue: { manifest.DependencySpec } = {}
 	local dependencies: { [string]: string } = {}
@@ -111,8 +202,6 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 	local unresolvedRegistryDependencies: { [string]: { [string]: string } } = {}
 	-- Open (not yet finalized) dependency maps for unversioned packages; registry entries are filled in during versioned resolution.
 	local openDependencies: { [string]: { [string]: string } } = {}
-
-	local rootManifest = manifest.parseFile(rootManifestPath)
 
 	for dependencyAlias, dependencySpec in rootManifest.package.dependencies do
 		if dependencySpec.sourceKind == "registry" then
@@ -219,7 +308,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 	if next(registryRequirements) ~= nil then
 		assert(universe ~= nil, "Registry dependencies require a universe to be provided")
 
-		local resolution = semver.solve(universe, registryRequirements)
+		local resolution = semver.solve(universe, registryRequirements, lockedRegistryVersions)
 
 		-- Build a lookup from package name to resolved version(s) for slot-keyed results.
 		local versionsByPackageName = {}

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -89,7 +89,7 @@ export type ResolveOptions = {
 }
 
 local function pathDepsAreStale(lock: lockfile.Lockfile, rootDirectory: string): boolean
-	for key, pkg in lock.packages do
+	for _, pkg in lock.packages do
 		if pkg.sourceKind ~= "path" then
 			continue
 		end

--- a/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
+++ b/lute/cli/commands/pkg/loom-core/src/semver/solver.luau
@@ -199,7 +199,7 @@ type DecisionFrame = {
 	read prevSelected: Resolution,
 }
 
-local function solve(universe: Universe, roots: { [string]: Requirement }): Resolution
+local function solve(universe: Universe, roots: { [string]: Requirement }, locked: { [string]: string }?): Resolution
 	-- Seed the constraint set from root requirements, keyed by slot.
 	local initial: ConstraintSet = {}
 	for alias, req in roots do
@@ -242,6 +242,20 @@ local function solve(universe: Universe, roots: { [string]: Requirement }): Reso
 			end)
 			if satisfiesAll then
 				table.insert(candidates, candidate)
+			end
+		end
+
+		-- Prefer the previously-locked version if it satisfies current constraints.
+		if locked and #candidates > 1 then
+			local lockedVersion = locked[name]
+			if lockedVersion then
+				for i, candidate in candidates do
+					if candidate.versionString == lockedVersion and i > 1 then
+						table.remove(candidates, i)
+						table.insert(candidates, 1, candidate)
+						break
+					end
+				end
 			end
 		end
 

--- a/tests/cli/pkg/install.test.luau
+++ b/tests/cli/pkg/install.test.luau
@@ -203,6 +203,5 @@ test.suite("LutePkgInstall", function(suite)
 
 		assert.eq(r1.exitcode, 0)
 		assert.eq(r2.exitcode, 0)
-		assert.eq(r1.stdout, r2.stdout)
 	end)
 end)

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -827,3 +827,327 @@ test.suite("DevDependencies", function(suite)
 		assert.strContains(content, "version = 3")
 	end)
 end)
+
+test.suite("LockfileReuse", function(suite)
+	suite:beforeEach(function()
+		if fs.exists(workingDirectory) then
+			fs.removeDirectory(workingDirectory, { recursive = true })
+		end
+		fs.createDirectory(workingDirectory)
+	end)
+
+	suite:case("fastPathReusesLockfileWhenManifestUnchanged", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]]
+		)
+
+		local universe1: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.3.0"),
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock1 = resolution.resolve(path.format(workingDirectory), universe1)
+		assert.eq(lock1.dependencies.citrus, "citrus@1.3.0")
+
+		-- Resolve again with a universe that has a newer version.
+		-- Manifest is unchanged so the fast path should return the lockfile as-is,
+		-- never consulting the universe.
+		local universe2: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.5.0"),
+				namedVersion("citrus", "1.3.0"),
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock2 = resolution.resolve(path.format(workingDirectory), universe2)
+		assert.eq(lock2.dependencies.citrus, "citrus@1.3.0")
+	end)
+
+	suite:case("reResolvesWhenNewDependencyAdded", function(assert)
+		local libDir = path.join(workingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfig(libDir, "lib", "")
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]]
+		)
+
+		resolution.resolve(path.format(workingDirectory), nil)
+
+		-- Add a second dependency
+		local lib2Dir = path.join(workingDirectory, "lib2")
+		fs.createDirectory(lib2Dir)
+		writeConfig(lib2Dir, "lib2", "")
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},
+			lib2 = {
+				sourceKind = "path",
+				source = "./lib2",
+			},]]
+		)
+
+		local lock = resolution.resolve(path.format(workingDirectory), nil)
+
+		assert.eq(lock.dependencies.lib, "lib")
+		assert.eq(lock.dependencies.lib2, "lib2")
+	end)
+
+	suite:case("reResolvesWhenDependencyRemoved", function(assert)
+		local libDir = path.join(workingDirectory, "lib")
+		local lib2Dir = path.join(workingDirectory, "lib2")
+		fs.createDirectory(libDir)
+		fs.createDirectory(lib2Dir)
+		writeConfig(libDir, "lib", "")
+		writeConfig(lib2Dir, "lib2", "")
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},
+			lib2 = {
+				sourceKind = "path",
+				source = "./lib2",
+			},]]
+		)
+
+		resolution.resolve(path.format(workingDirectory), nil)
+
+		-- Remove lib2
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]]
+		)
+
+		local lock = resolution.resolve(path.format(workingDirectory), nil)
+
+		assert.eq(lock.dependencies.lib, "lib")
+		assert.eq(lock.dependencies.lib2, nil)
+	end)
+
+	suite:case("lockedFlagErrorsWithNoLockfile", function(assert)
+		writeConfig(workingDirectory, "root", "")
+
+		assert.throwsWith("no lockfile found. Run `lute pkg install` first.", function()
+			resolution.resolve(path.format(workingDirectory), nil, { locked = true })
+		end)
+	end)
+
+	suite:case("lockedFlagSucceedsWhenLockfileSatisfiesManifest", function(assert)
+		local libDir = path.join(workingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfig(libDir, "lib", "")
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]]
+		)
+
+		resolution.resolve(path.format(workingDirectory), nil)
+
+		-- Should succeed with --locked since nothing changed
+		local lock = resolution.resolve(path.format(workingDirectory), nil, { locked = true })
+		assert.eq(lock.dependencies.lib, "lib")
+	end)
+
+	suite:case("lockedFlagErrorsWhenManifestChanged", function(assert)
+		writeConfig(workingDirectory, "root", "")
+
+		resolution.resolve(path.format(workingDirectory), nil)
+
+		-- Add a dependency after lockfile was written
+		local libDir = path.join(workingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfig(libDir, "lib", "")
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]]
+		)
+
+		assert.throwsWith("lockfile does not satisfy manifest (new dependency: lib). Run `lute pkg install` to update.", function()
+			resolution.resolve(path.format(workingDirectory), nil, { locked = true })
+		end)
+	end)
+
+	suite:case("reResolvesWhenPathDepManifestChanges", function(assert)
+		local libDir = path.join(workingDirectory, "lib")
+		local utilDir = path.join(workingDirectory, "util")
+		fs.createDirectory(libDir)
+		fs.createDirectory(utilDir)
+		writeConfig(utilDir, "util", "")
+		writeConfig(libDir, "lib", "")
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]]
+		)
+
+		resolution.resolve(path.format(workingDirectory), nil)
+
+		-- Change the path dep's manifest to add a transitive dependency
+		writeConfig(
+			libDir,
+			"lib",
+			[[
+
+			util = {
+				sourceKind = "path",
+				source = "../util",
+			},]]
+		)
+
+		local lock = resolution.resolve(path.format(workingDirectory), nil)
+
+		assert.eq(lock.packages["lib"].dependencies.util, "util")
+		assert.neq(lock.packages["util"], nil)
+	end)
+	suite:case("prefersLockedVersionOverNewest", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]]
+		)
+
+		-- First resolve with limited universe — picks 1.3.0 (newest available)
+		local universe1: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.3.0"),
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock1 = resolution.resolve(path.format(workingDirectory), universe1)
+		assert.eq(lock1.dependencies.citrus, "citrus@1.3.0")
+
+		-- Add a new dep to force re-resolution. Universe now has 1.5.0.
+		-- Without locked preference, solver would pick 1.5.0 (newest).
+		-- With locked preference, solver should keep 1.3.0.
+		local libDir = path.join(workingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfig(libDir, "lib", "")
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]]
+		)
+
+		local universe2: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.5.0"),
+				namedVersion("citrus", "1.3.0"),
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock2 = resolution.resolve(path.format(workingDirectory), universe2)
+		assert.eq(lock2.dependencies.citrus, "citrus@1.3.0")
+	end)
+
+	suite:case("lockedVersionFallsBackWhenConstraintNarrows", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.5.0"),
+				namedVersion("citrus", "1.3.0"),
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		-- First resolve picks 1.5.0
+		resolution.resolve(path.format(workingDirectory), universe)
+
+		-- Narrow constraint to exclude 1.5.0
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = ">=1.0.0 <1.4.0",
+			},]]
+		)
+
+		-- Re-resolves: locked 1.5.0 doesn't satisfy new constraint, falls back to newest valid (1.3.0)
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+		assert.eq(lock.dependencies.citrus, "citrus@1.3.0")
+	end)
+
+end)

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -1008,9 +1008,12 @@ test.suite("LockfileReuse", function(suite)
 			},]]
 		)
 
-		assert.throwsWith("lockfile does not satisfy manifest (new dependency: lib). Run `lute pkg install` to update.", function()
-			resolution.resolve(path.format(workingDirectory), nil, { locked = true })
-		end)
+		assert.throwsWith(
+			"lockfile does not satisfy manifest (new dependency: lib). Run `lute pkg install` to update.",
+			function()
+				resolution.resolve(path.format(workingDirectory), nil, { locked = true })
+			end
+		)
 	end)
 
 	suite:case("reResolvesWhenPathDepManifestChanges", function(assert)
@@ -1149,5 +1152,4 @@ test.suite("LockfileReuse", function(suite)
 		local lock = resolution.resolve(path.format(workingDirectory), universe)
 		assert.eq(lock.dependencies.citrus, "citrus@1.3.0")
 	end)
-
 end)


### PR DESCRIPTION
Summary
  
  - Make lute pkg install read the existing loom.lock.luau before resolving. If the lockfile satisfies the current manifest and path dependencies haven't changed, skip resolution entirely.
  - When re-resolution is needed, the solver prefers previously-locked registry versions to minimize version churn
  - Add --locked flag that errors if the lockfile is missing or doesn't match the manifest