### PR TITLE
Correctly serialize parametrized attributes and attribute lists

### DIFF
--- a/definitions/syntax/cst.luau
+++ b/definitions/syntax/cst.luau
@@ -543,8 +543,18 @@ export type CstAttributeParametrized = {
 	read closeParens: CstToken<")">,
 }
 
+-- A (possibly bracketed) list of comma-separated attributes
+export type CstAttributeList = {
+	read location: Span,
+	read kind: "attribute",
+	read tag: "list",
+	read atBracket: CstToken<"@[">,
+	read attributes: CstPunctuated<CstAttribute, ",">,
+	read closeBracket: CstToken<"]">,
+}
+
 --- Union of all attribute node types.
-export type CstAttribute = CstAttributeSimple | CstAttributeParametrized
+export type CstAttribute = CstAttributeSimple | CstAttributeParametrized | CstAttributeList
 
 --- A function declaration statement node.
 export type CstStatFunction = {

--- a/definitions/syntax/cst.luau
+++ b/definitions/syntax/cst.luau
@@ -524,12 +524,27 @@ export type CstStatCompoundAssign = {
 	read value: CstExpr,
 }
 
---- A function attribute node (`@checked`, `@native`, or `@deprecated`).
-export type CstAttribute = {
+--- A simple function attribute node (e.g., `@checked`, `@native`, `@deprecated`).
+export type CstAttributeSimple = {
 	read location: Span,
 	read kind: "attribute",
-	read name: CstToken<"@checked" | "@native" | "@deprecated">,
+	read tag: "simple",
+	read name: CstToken,
 }
+
+--- A parametrized function attribute node (e.g., `@[deprecated("reason")]`).
+export type CstAttributeParametrized = {
+	read location: Span,
+	read kind: "attribute",
+	read tag: "parametrized",
+	read name: CstToken,
+	read openParens: CstToken<"(">,
+	read arguments: CstPunctuated<CstExpr>,
+	read closeParens: CstToken<")">,
+}
+
+--- Union of all attribute node types.
+export type CstAttribute = CstAttributeSimple | CstAttributeParametrized
 
 --- A function declaration statement node.
 export type CstStatFunction = {

--- a/lute/std/libs/syntax/init.luau
+++ b/lute/std/libs/syntax/init.luau
@@ -119,6 +119,10 @@ export type CstStatAssign = cst.CstStatAssign
 
 export type CstStatCompoundAssign = cst.CstStatCompoundAssign
 
+export type CstAttributeSimple = cst.CstAttributeSimple
+
+export type CstAttributeParametrized = cst.CstAttributeParametrized
+
 export type CstAttribute = cst.CstAttribute
 
 export type CstStatFunction = cst.CstStatFunction

--- a/lute/std/libs/syntax/init.luau
+++ b/lute/std/libs/syntax/init.luau
@@ -123,6 +123,8 @@ export type CstAttributeSimple = cst.CstAttributeSimple
 
 export type CstAttributeParametrized = cst.CstAttributeParametrized
 
+export type CstAttributeList = cst.CstAttributeList
+
 export type CstAttribute = cst.CstAttribute
 
 export type CstStatFunction = cst.CstStatFunction

--- a/lute/std/libs/syntax/types/cst.luau
+++ b/lute/std/libs/syntax/types/cst.luau
@@ -100,6 +100,10 @@ export type CstStatAssign = cst.CstStatAssign
 
 export type CstStatCompoundAssign = cst.CstStatCompoundAssign
 
+export type CstAttributeSimple = cst.CstAttributeSimple
+
+export type CstAttributeParametrized = cst.CstAttributeParametrized
+
 export type CstAttribute = cst.CstAttribute
 
 export type CstStatFunction = cst.CstStatFunction

--- a/lute/std/libs/syntax/types/cst.luau
+++ b/lute/std/libs/syntax/types/cst.luau
@@ -104,6 +104,8 @@ export type CstAttributeSimple = cst.CstAttributeSimple
 
 export type CstAttributeParametrized = cst.CstAttributeParametrized
 
+export type CstAttributeList = cst.CstAttributeList
+
 export type CstAttribute = cst.CstAttribute
 
 export type CstStatFunction = cst.CstStatFunction

--- a/lute/std/libs/syntax/types/init.luau
+++ b/lute/std/libs/syntax/types/init.luau
@@ -101,6 +101,10 @@ export type CstStatAssign = cst.CstStatAssign
 
 export type CstStatCompoundAssign = cst.CstStatCompoundAssign
 
+export type CstAttributeSimple = cst.CstAttributeSimple
+
+export type CstAttributeParametrized = cst.CstAttributeParametrized
+
 export type CstAttribute = cst.CstAttribute
 
 export type CstStatFunction = cst.CstStatFunction

--- a/lute/std/libs/syntax/types/init.luau
+++ b/lute/std/libs/syntax/types/init.luau
@@ -105,6 +105,8 @@ export type CstAttributeSimple = cst.CstAttributeSimple
 
 export type CstAttributeParametrized = cst.CstAttributeParametrized
 
+export type CstAttributeList = cst.CstAttributeList
+
 export type CstAttribute = cst.CstAttribute
 
 export type CstStatFunction = cst.CstStatFunction

--- a/lute/std/libs/syntax/utils/init.luau
+++ b/lute/std/libs/syntax/utils/init.luau
@@ -309,6 +309,21 @@ function utils.isAttribute(n: types.CstNode): types.CstAttribute?
 	return if n.kind == "attribute" then n else nil
 end
 
+--- Returns `n` narrowed to `CstAttributeSimple` if it is a simple attribute node, or `nil` otherwise.
+function utils.isAttributeSimple(n: types.CstNode): types.CstAttributeSimple?
+	return if n.kind == "attribute" and n.tag == "simple" then n else nil
+end
+
+--- Returns `n` narrowed to `CstAttributeParametrized` if it is a parametrized attribute node, or `nil` otherwise.
+function utils.isAttributeParametrized(n: types.CstNode): types.CstAttributeParametrized?
+	return if n.kind == "attribute" and n.tag == "parametrized" then n else nil
+end
+
+--- Returns `n` narrowed to `CstAttributeList` if it is an attribute list node, or `nil` otherwise.
+function utils.isAttributeList(n: types.CstNode): types.CstAttributeList?
+	return if n.kind == "attribute" and n.tag == "list" then n else nil
+end
+
 --- Returns a `Replacement` that replaces the original node with the given content, preserving trivia.
 function utils.replacementWithTrivia(content: string): types.Replacement
 	return { content = content }

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -82,6 +82,8 @@ export type Visitor = {
 	visitLocal: (types.CstLocal) -> boolean,
 
 	visitAttribute: (types.CstAttribute) -> boolean,
+	visitSimpleAttribute: (types.CstAttributeSimple) -> boolean,
+	visitParametrizedAttribute: (types.CstAttributeParametrized) -> boolean,
 }
 
 local function alwaysVisit(...: types.CstNode)
@@ -160,6 +162,8 @@ local defaultVisitor: Visitor = {
 	visitLocal = alwaysVisit,
 
 	visitAttribute = alwaysVisit,
+	visitSimpleAttribute = alwaysVisit,
+	visitParametrizedAttribute = alwaysVisit,
 }
 
 local function exhaustiveMatch(value: never): never
@@ -482,9 +486,30 @@ local function visitExprBinary(node: types.CstExprBinary, visitor: Visitor)
 	end
 end
 
+local function visitSimpleAttribute(node: types.CstAttributeSimple, visitor: Visitor)
+	if visitor.visitSimpleAttribute(node) then
+		visitToken(node.name, visitor)
+	end
+end
+
+local function visitParametrizedAttribute(node: types.CstAttributeParametrized, visitor: Visitor)
+	if visitor.visitParametrizedAttribute(node) then
+		visitToken(node.name, visitor)
+		visitToken(node.openParens, visitor)
+		visitPunctuated(node.arguments, visitor, visitExpr)
+		visitToken(node.closeParens, visitor)
+	end
+end
+
 local function visitAttribute(node: types.CstAttribute, visitor: Visitor)
 	if visitor.visitAttribute(node) then
-		visitToken(node.name, visitor)
+		if node.tag == "simple" then
+			visitSimpleAttribute(node, visitor)
+		elseif node.tag == "parametrized" then
+			visitParametrizedAttribute(node, visitor)
+		else
+			exhaustiveMatch(node.tag)
+		end
 	end
 end
 
@@ -1088,6 +1113,8 @@ local function create(visit: ((types.CstNode) -> boolean)?): Visitor
 			visitExprVarargs = visit,
 
 			visitAttribute = visit,
+			visitSimpleAttribute = visit,
+			visitParametrizedAttribute = visit,
 		}
 	else
 		return table.clone(defaultVisitor)

--- a/lute/std/libs/syntax/visitor.luau
+++ b/lute/std/libs/syntax/visitor.luau
@@ -84,6 +84,7 @@ export type Visitor = {
 	visitAttribute: (types.CstAttribute) -> boolean,
 	visitSimpleAttribute: (types.CstAttributeSimple) -> boolean,
 	visitParametrizedAttribute: (types.CstAttributeParametrized) -> boolean,
+	visitAttributeList: (types.CstAttributeList) -> boolean,
 }
 
 local function alwaysVisit(...: types.CstNode)
@@ -164,6 +165,7 @@ local defaultVisitor: Visitor = {
 	visitAttribute = alwaysVisit,
 	visitSimpleAttribute = alwaysVisit,
 	visitParametrizedAttribute = alwaysVisit,
+	visitAttributeList = alwaysVisit,
 }
 
 local function exhaustiveMatch(value: never): never
@@ -501,12 +503,24 @@ local function visitParametrizedAttribute(node: types.CstAttributeParametrized, 
 	end
 end
 
-local function visitAttribute(node: types.CstAttribute, visitor: Visitor)
+local visitAttribute: (node: types.CstAttribute, visitor: Visitor) -> () = nil :: any
+
+local function visitAttributeList(node: types.CstAttributeList, visitor: Visitor)
+	if visitor.visitAttributeList(node) then
+		visitToken(node.atBracket, visitor)
+		visitPunctuated(node.attributes, visitor, visitAttribute)
+		visitToken(node.closeBracket, visitor)
+	end
+end
+
+visitAttribute = function(node: types.CstAttribute, visitor: Visitor)
 	if visitor.visitAttribute(node) then
 		if node.tag == "simple" then
 			visitSimpleAttribute(node, visitor)
 		elseif node.tag == "parametrized" then
 			visitParametrizedAttribute(node, visitor)
+		elseif node.tag == "list" then
+			visitAttributeList(node, visitor)
 		else
 			exhaustiveMatch(node.tag)
 		end
@@ -1115,6 +1129,7 @@ local function create(visit: ((types.CstNode) -> boolean)?): Visitor
 			visitAttribute = visit,
 			visitSimpleAttribute = visit,
 			visitParametrizedAttribute = visit,
+			visitAttributeList = visit,
 		}
 	else
 		return table.clone(defaultVisitor)

--- a/lute/syntax/src/parser.cpp
+++ b/lute/syntax/src/parser.cpp
@@ -618,15 +618,99 @@ struct AstSerialize : public Luau::AstVisitor
         }
     }
 
-    void serializeAttributes(Luau::AstArray<Luau::AstAttr*>& attrs, size_t nrec = 0)
+    void serializeAttributeList(const Luau::AstArray<Luau::AstAttr*>& attrs, const Luau::CstAttrList& attrList, size_t& attrIndex)
     {
-        lua_rawcheckstack(L, 2);
-        lua_createtable(L, attrs.size, nrec);
+        LUTE_ASSERT(attrIndex < attrs.size);
 
-        for (size_t i = 0; i < attrs.size; i++)
+        lua_rawcheckstack(L, 4);
+        lua_createtable(L, 0, preambleSize + 3); // atBracket, attributes, closeBracket
+
+        withLocation(Luau::Location{attrList.atBracketPosition, attrList.closeBracketPosition});
+
+        lua_pushstring(L, "attribute");
+        lua_setfield(L, -2, "kind");
+
+        lua_pushstring(L, "list");
+        lua_setfield(L, -2, "tag");
+
+        LUTE_ASSERT(attrList.atBracketPosition.hasValue());
+        serializeToken(attrList.atBracketPosition, "@[");
+        lua_setfield(L, -2, "atBracket");
+
+        size_t lastAttrIndex = attrIndex + attrList.commaPositions.size + 1;
+        LUTE_ASSERT(lastAttrIndex <= attrs.size);
+
+        lua_createtable(L, attrList.commaPositions.size + 1, 1);
+
+        // separators
+        lua_createtable(L, attrList.commaPositions.size, 0);
+
+        size_t numAttrs = attrList.commaPositions.size + 1;
+        for (size_t i = 0; i < numAttrs; i++)
         {
-            serializeAttribute(attrs.data[i]);
-            lua_rawseti(L, -2, i + 1);
+            serializeAttribute(attrs.data[attrIndex]);
+            attrIndex++;
+            lua_rawseti(L, -3, static_cast<int>(i) + 1);
+
+            if (i < attrList.commaPositions.size)
+            {
+                serializeToken(attrList.commaPositions.data[i], ",");
+                lua_rawseti(L, -2, static_cast<int>(i) + 1);
+            }
+        }
+
+        lua_setfield(L, -2, "separators");
+
+        luaL_getmetatable(L, kCstPunctuatedType);
+        lua_setmetatable(L, -2);
+
+        lua_setfield(L, -2, "attributes");
+
+        LUTE_ASSERT(attrList.closeBracketPosition.hasValue());
+        serializeToken(attrList.closeBracketPosition, "]");
+        lua_setfield(L, -2, "closeBracket");
+    }
+
+    void serializeAttributes(Luau::AstArray<Luau::AstAttr*>& attrs, const Luau::AstArray<Luau::CstAttrList*>& attrLists)
+    {
+        LUTE_ASSERT(attrs.size >= attrLists.size);
+
+        lua_rawcheckstack(L, 2);
+        lua_createtable(L, attrLists.size, 0);
+
+        size_t attrIndex = 0;
+        size_t attrListIndex = 0;
+        size_t serializedArrIndex = 1;
+
+        for (; attrIndex < attrs.size;)
+        {
+            if (attrListIndex == attrLists.size)
+                break;
+
+            const Luau::AstAttr* attr = attrs.data[attrIndex];
+            const Luau::CstAttrList* attrList = attrLists.data[attrListIndex];
+
+            if (attr->location.begin < attrList->atBracketPosition)
+            {
+                serializeAttribute(attrs.data[attrIndex]);
+                lua_rawseti(L, -2, serializedArrIndex);
+                serializedArrIndex++;
+                attrIndex++;
+            }
+            else
+            {
+                serializeAttributeList(attrs, *attrList, attrIndex);
+                lua_rawseti(L, -2, serializedArrIndex);
+                serializedArrIndex++;
+                attrListIndex++;
+            }
+        }
+
+        for (; attrIndex < attrs.size; attrIndex++)
+        {
+            serializeAttribute(attrs.data[attrIndex]);
+            lua_rawseti(L, -2, serializedArrIndex);
+            serializedArrIndex++;
         }
     }
 
@@ -1061,7 +1145,7 @@ struct AstSerialize : public Luau::AstVisitor
             lua_setfield(L, -2, "attributes");
             break;
         case NothingSerialized:
-            serializeAttributes(node->attributes);
+            serializeAttributes(node->attributes, cstNode->attrLists);
             lua_setfield(L, -2, "attributes");
 
             serializeToken(cstNode->functionKeywordPosition, "function");
@@ -1741,7 +1825,7 @@ struct AstSerialize : public Luau::AstVisitor
         const auto cstNode = lookupCstNode<Luau::CstStatFunction>(node);
 
         // Serialization needs to happen in program-lexical order, so we serialize attributes and function keyword first
-        serializeAttributes(node->func->attributes);
+        serializeAttributes(node->func->attributes, cstNode->attrLists);
 
         serializeToken(cstNode->functionKeywordPosition, "function");
 
@@ -1759,10 +1843,10 @@ struct AstSerialize : public Luau::AstVisitor
 
         serializeNodePreamble(node, "localfunction", "stat");
 
-        // Serialization needs to happen in program-lexical order, so we serialize attributes and function keyword before the func expr
-        serializeAttributes(node->func->attributes);
-
         const auto cstNode = lookupCstNode<Luau::CstStatLocalFunction>(node);
+
+        // Serialization needs to happen in program-lexical order, so we serialize attributes and function keyword before the func expr
+        serializeAttributes(node->func->attributes, cstNode->attrLists);
 
         serializeToken(cstNode->localKeywordPosition, "local");
         lua_setfield(L, -3, "localKeyword");

--- a/lute/syntax/src/parser.cpp
+++ b/lute/syntax/src/parser.cpp
@@ -720,16 +720,41 @@ struct AstSerialize : public Luau::AstVisitor
 
     void serializeAttribute(Luau::AstAttr* node)
     {
-        lua_rawcheckstack(L, 2);
-        lua_createtable(L, 0, preambleSize); // location, kind, token
+        Luau::CstNode** cstNode = cstNodeMap.find(node);
+        LUTE_ASSERT(cstNode);
 
-        serializeToken(node->location.begin, ("@" + std::string(node->name.value)).c_str());
-        lua_setfield(L, -2, "name");
+        if (const Luau::CstParametrizedAttr* cstParametrized = (*cstNode)->as<Luau::CstParametrizedAttr>())
+        {
+            lua_rawcheckstack(L, 2);
+            lua_createtable(L, 0, preambleSize + 4); // name, openParens, arguments, closeParens
 
-        lua_pushstring(L, "attribute");
-        lua_setfield(L, -2, "kind");
+            serializeNodePreamble(node, "parametrized", "attribute");
 
-        withLocation(node->location);
+            serializeToken(node->location.begin, (std::string(node->name.value)).c_str());
+            lua_setfield(L, -2, "name");
+
+            serializeToken(cstParametrized->openParenPosition, "(");
+            lua_setfield(L, -2, "openParens");
+
+            serializePunctuated(node->args, cstParametrized->argsCommaPositions, ",");
+            lua_setfield(L, -2, "arguments");
+
+            serializeToken(cstParametrized->closeParenPosition, ")");
+            lua_setfield(L, -2, "closeParens");
+        }
+        else
+        {
+            const Luau::CstAttr* cstSimple = (*cstNode)->as<Luau::CstAttr>();
+            LUTE_ASSERT(cstSimple);
+
+            lua_rawcheckstack(L, 2);
+            lua_createtable(L, 0, preambleSize + 1); // location, kind, tag, name
+
+            serializeNodePreamble(node, "simple", "attribute");
+
+            serializeToken(node->location.begin, (cstSimple->hasAt ? "@" + std::string(node->name.value) : std::string(node->name.value)).c_str());
+            lua_setfield(L, -2, "name");
+        }
     }
 
     void serializeEof(Luau::Position eofPosition)

--- a/tests/parserExamples/.styluaignore
+++ b/tests/parserExamples/.styluaignore
@@ -1,1 +1,2 @@
 explicit-generic-instantiation-1.luau
+attributes-2.luau

--- a/tests/parserExamples/attributes-2.luau
+++ b/tests/parserExamples/attributes-2.luau
@@ -1,0 +1,14 @@
+-- lute-lint-global-ignore(unused_variable)
+@[native]
+local function foo() end
+
+@[deprecated({ reason = "use bar instead" })]
+function bar() end
+
+@[native, deprecated({ reason = "old" })]
+local function baz() end
+
+@native @[deprecated({ reason = "old" })]
+function qux() end
+
+local x = @[native] function() end

--- a/tests/std/syntax/parser.test.luau
+++ b/tests/std/syntax/parser.test.luau
@@ -191,8 +191,94 @@ test.suite("Parser", function(suite)
 			assert.eq(l.tag, "localfunction")
 
 			local lf = l :: syntax.CstStatLocalFunction
-			assert.eq(lf.func.attributes[1].name.text, subcase.attr)
+			assert.eq((lf.func.attributes[1] :: syntax.CstAttributeSimple).name.text, subcase.attr)
 		end
+	end)
+
+	suite:case("canParseParametrizedAttributes", function(assert)
+		local block = parser.parseBlock([[
+			@[deprecated({ reason = "reason" })]
+			function foo() end
+		]])
+		assert.eq(#block.statements, 1)
+
+		local funcStat = block.statements[1] :: syntax.CstStatFunction
+		assert.eq(funcStat.tag, "function")
+		assert.eq(#funcStat.func.attributes, 1)
+
+		local attrList = funcStat.func.attributes[1] :: any
+		assert.eq(attrList.kind, "attribute")
+		assert.eq(attrList.tag, "list")
+		assert.eq(attrList.atBracket.text, "@[")
+		assert.eq(attrList.closeBracket.text, "]")
+		assert.eq(#attrList.attributes, 1)
+
+		local attr = attrList.attributes[1]
+		assert.eq(attr.tag, "parametrized")
+		assert.eq(attr.kind, "attribute")
+		assert.eq(attr.name.text, "deprecated")
+		assert.eq(attr.openParens.text, "(")
+		assert.eq(#attr.arguments, 1)
+		assert.eq(attr.arguments[1].tag, "table")
+		assert.eq(attr.closeParens.text, ")")
+	end)
+
+	suite:case("canParseAttributeList", function(assert)
+		local block = parser.parseBlock([[
+			@[native, checked]
+			function foo() end
+		]])
+		assert.eq(#block.statements, 1)
+
+		local funcStat = block.statements[1] :: syntax.CstStatFunction
+		assert.eq(#funcStat.func.attributes, 1)
+
+		local attrList = funcStat.func.attributes[1] :: any
+		assert.eq(attrList.kind, "attribute")
+		assert.eq(attrList.tag, "list")
+		assert.eq(attrList.atBracket.text, "@[")
+		assert.eq(attrList.closeBracket.text, "]")
+		assert.eq(#attrList.attributes, 2)
+
+		local attr1 = attrList.attributes[1]
+		assert.eq(attr1.tag, "simple")
+		assert.eq(attr1.kind, "attribute")
+		assert.eq(attr1.name.text, "native")
+
+		local attr2 = attrList.attributes[2]
+		assert.eq(attr2.tag, "simple")
+		assert.eq(attr2.kind, "attribute")
+		assert.eq(attr2.name.text, "checked")
+
+		assert.neq(attrList.attributes.separators[1], nil)
+		assert.eq((attrList.attributes.separators[1] :: syntax.CstToken<",">).text, ",")
+	end)
+
+	suite:case("canParseMixedAttributes", function(assert)
+		local block = parser.parseBlock([[
+			@native @[deprecated({ reason = "reason" })]
+			function foo() end
+		]])
+		assert.eq(#block.statements, 1)
+
+		local funcStat = block.statements[1] :: syntax.CstStatFunction
+		assert.eq(#funcStat.func.attributes, 2)
+
+		local simpleAttr = funcStat.func.attributes[1] :: syntax.CstAttributeSimple
+		assert.eq(simpleAttr.tag, "simple")
+		assert.eq(simpleAttr.kind, "attribute")
+		assert.eq(simpleAttr.name.text, "@native")
+
+		local attrList = funcStat.func.attributes[2] :: syntax.CstAttributeList
+		assert.eq(attrList.kind, "attribute")
+		assert.eq(attrList.tag, "list")
+		assert.eq(#attrList.attributes, 1)
+
+		local paramAttr = attrList.attributes[1] :: syntax.CstAttributeParametrized
+		assert.eq(paramAttr.tag, "parametrized")
+		assert.eq(paramAttr.kind, "attribute")
+		assert.eq(paramAttr.name.text, "deprecated")
+		assert.eq(#paramAttr.arguments, 1)
 	end)
 end)
 
@@ -852,9 +938,9 @@ test.suite("parse", function(suite)
 		local funcStat = block.statements[1] :: syntax.CstStatFunction
 		assert.eq(funcStat.tag, "function")
 		assert.eq(#funcStat.func.attributes, 3)
-		assert.eq((funcStat.func.attributes[1] :: syntax.CstAttribute).name.text, "@checked")
-		assert.eq((funcStat.func.attributes[2] :: syntax.CstAttribute).name.text, "@native")
-		assert.eq((funcStat.func.attributes[3] :: syntax.CstAttribute).name.text, "@deprecated")
+		assert.eq((funcStat.func.attributes[1] :: syntax.CstAttributeSimple).name.text, "@checked")
+		assert.eq((funcStat.func.attributes[2] :: syntax.CstAttributeSimple).name.text, "@native")
+		assert.eq((funcStat.func.attributes[3] :: syntax.CstAttributeSimple).name.text, "@deprecated")
 		assert.eq(funcStat.func.functionKeyword.text, "function")
 		assert.eq(funcStat.name.tag, "global")
 		assert.eq((funcStat.name :: syntax.CstExprGlobal).name.text, "add")

--- a/tests/std/syntax/snapshots/printer/attributeListTrivia.in
+++ b/tests/std/syntax/snapshots/printer/attributeListTrivia.in
@@ -1,0 +1,4 @@
+-- hello
+@[native]
+function foo() return end
+-- world

--- a/tests/std/syntax/snapshots/printer/attributeListTrivia.snap
+++ b/tests/std/syntax/snapshots/printer/attributeListTrivia.snap
@@ -1,0 +1,4 @@
+-- hello
+replaced
+function foo() return end
+-- world

--- a/tests/std/syntax/snapshots/printer/attributeListTrivia.snap.luau
+++ b/tests/std/syntax/snapshots/printer/attributeListTrivia.snap.luau
@@ -1,0 +1,9 @@
+local query = require("@std/syntax/query")
+local syntaxUtils = require("@std/syntax/utils")
+local util = require("./util")
+
+util.printReplacement("attributeListTrivia", function(cst)
+	return query.findAllFromRoot(cst, syntaxUtils.isAttributeList):replace(function()
+		return "replaced"
+	end)
+end)

--- a/tests/std/syntax/snapshots/printer/parametrizedAttributeTrivia.in
+++ b/tests/std/syntax/snapshots/printer/parametrizedAttributeTrivia.in
@@ -1,0 +1,5 @@
+-- hello
+@[
+deprecated({ reason = "reason" })]
+function foo() return end
+-- world

--- a/tests/std/syntax/snapshots/printer/parametrizedAttributeTrivia.snap
+++ b/tests/std/syntax/snapshots/printer/parametrizedAttributeTrivia.snap
@@ -1,0 +1,5 @@
+-- hello
+@[
+replaced]
+function foo() return end
+-- world

--- a/tests/std/syntax/snapshots/printer/parametrizedAttributeTrivia.snap.luau
+++ b/tests/std/syntax/snapshots/printer/parametrizedAttributeTrivia.snap.luau
@@ -1,0 +1,9 @@
+local query = require("@std/syntax/query")
+local syntaxUtils = require("@std/syntax/utils")
+local util = require("./util")
+
+util.printReplacement("parametrizedAttributeTrivia", function(cst)
+	return query.findAllFromRoot(cst, syntaxUtils.isAttributeParametrized):replace(function()
+		return "replaced"
+	end)
+end)


### PR DESCRIPTION
This PR renames the existing `CstAttribute` node type to `CstAttributeSimple`, and adds `CstAttributeParametrized` and `CstAttributeList`.

Addresses #1076.