### PR TITLE
Don't show empty paren in CLI help if no alias

### DIFF
--- a/batteries/cli.luau
+++ b/batteries/cli.luau
@@ -226,7 +226,11 @@ function cli.help(self: Parser, formatter: ((s: string) -> string)?): ()
 
 		local aliasStr = table.concat(argument.options.aliases or {}, ", ")
 		local reqStr = if argument.options.required then "(required) " else ""
-		print(fmt(string.format("  --%s (-%s) - %s%s", argument.name, aliasStr, reqStr, argument.options.help or "")))
+		print(
+			fmt(
+				`  --{argument.name}{if #aliasStr > 0 then ` (-{aliasStr})` else ""} - {reqStr}{argument.options.help or ""}`
+			)
+		)
 	end
 end
 

--- a/tests/batteries/cli/snapshots/help_no_alias_when_absent.snap
+++ b/tests/batteries/cli/snapshots/help_no_alias_when_absent.snap
@@ -1,0 +1,2 @@
+Usage:
+  --verbose - Enable verbose output

--- a/tests/batteries/cli/snapshots/help_no_alias_when_absent.snap.luau
+++ b/tests/batteries/cli/snapshots/help_no_alias_when_absent.snap.luau
@@ -1,0 +1,5 @@
+local cli = require("@batteries/cli")
+
+local p = cli.parser()
+p:add("verbose", "flag", { help = "Enable verbose output" })
+p:help()

--- a/tests/batteries/cli/snapshots/help_shows_alias.snap
+++ b/tests/batteries/cli/snapshots/help_shows_alias.snap
@@ -1,0 +1,2 @@
+Usage:
+  --verbose (-v) - Enable verbose output

--- a/tests/batteries/cli/snapshots/help_shows_alias.snap.luau
+++ b/tests/batteries/cli/snapshots/help_shows_alias.snap.luau
@@ -1,0 +1,5 @@
+local cli = require("@batteries/cli")
+
+local p = cli.parser()
+p:add("verbose", "flag", { aliases = { "v" }, help = "Enable verbose output" })
+p:help()

--- a/tests/batteries/cli/snapshots/help_shows_multiple_aliases.snap
+++ b/tests/batteries/cli/snapshots/help_shows_multiple_aliases.snap
@@ -1,0 +1,2 @@
+Usage:
+  --verbose (-v, V) - Enable verbose output

--- a/tests/batteries/cli/snapshots/help_shows_multiple_aliases.snap.luau
+++ b/tests/batteries/cli/snapshots/help_shows_multiple_aliases.snap.luau
@@ -1,0 +1,5 @@
+local cli = require("@batteries/cli")
+
+local p = cli.parser()
+p:add("verbose", "flag", { aliases = { "v", "V" }, help = "Enable verbose output" })
+p:help()


### PR DESCRIPTION
The CLI battery's `help` method was showing empty parens if an option didn't have any aliases. I added a check not to emit it if there is no alias, and snapshot tests documenting it.