### PR TITLE
Add option to disable the use of vendored libraries

### DIFF
--- a/CMakeBuild/uSockets.cmake
+++ b/CMakeBuild/uSockets.cmake
@@ -7,13 +7,6 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 set(USOCKETS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extern/uSockets)
 
-# Include directories
-include_directories(${USOCKETS_SOURCE_DIR}/src)
-include_directories(${USOCKETS_SOURCE_DIR}/src/eventing)
-include_directories(${USOCKETS_SOURCE_DIR}/src/crypto)
-include_directories(${USOCKETS_SOURCE_DIR}/src/io_uring)
-include_directories(${LIBUV_INCLUDE_DIR})
-
 # Source files
 file(GLOB USOCKETS_SOURCES
     ${USOCKETS_SOURCE_DIR}/src/*.c
@@ -26,6 +19,9 @@ file(GLOB USOCKETS_SOURCES
 # Add the uSockets library
 add_library(uSockets STATIC ${USOCKETS_SOURCES})
 
+# Include directories
+target_include_directories(uSockets PUBLIC ${USOCKETS_SOURCE_DIR}/src)
+
 # Set C++17 standard for uSockets target (only affects .cpp files)
 target_compile_features(uSockets PRIVATE cxx_std_17)
 
@@ -37,15 +33,15 @@ if(MSVC)
     target_compile_options(uSockets PRIVATE /GL-)
 endif()
 
+option(WITH_OPENSSL "Build with OpenSSL support" OFF)
 option(WITH_BORINGSSL "Build with BoringSSL support" OFF)
 option(WITH_WOLFSSL "Build with WolfSSL support" OFF)
 option(WITH_LIBUV "Build with libuv support" ON)
 option(WITH_ASAN "Build with AddressSanitizer support" OFF)
 
-if(WITH_BORINGSSL)
-    target_include_directories(uSockets PRIVATE ${BORINGSSL_INCLUDE_DIR})
-    target_compile_definitions(uSockets PRIVATE LIBUS_USE_OPENSSL)
-    target_link_libraries(uSockets PRIVATE ssl crypto)
+if(WITH_OPENSSL OR WITH_BORINGSSL)
+  target_link_libraries(uSockets PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+  target_compile_definitions(uSockets PRIVATE LIBUS_USE_OPENSSL)
 endif()
 
 if(WITH_WOLFSSL)
@@ -57,8 +53,7 @@ endif()
 
 if(WITH_LIBUV)
     target_compile_definitions(uSockets PRIVATE LIBUS_USE_LIBUV)
-    target_include_directories(uSockets PRIVATE ${LIBUV_INCLUDE_DIR})
-    target_link_libraries(uSockets PRIVATE ${LIBUV_LIBRARY})
+    target_link_libraries(uSockets PRIVATE libuv::libuv)
 endif()
 
 if(WITH_ASAN)

--- a/CMakeBuild/uWebSockets.cmake
+++ b/CMakeBuild/uWebSockets.cmake
@@ -3,13 +3,11 @@ project(uWebSockets LANGUAGES C CXX)
 
 set(UWEBSOCKETS_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/extern/uWebSockets)
 
-# Include directories
-include_directories(${UWEBSOCKETS_SOURCE_DIR}/src)
-include_directories(${UWEBSOCKETS_SOURCE_DIR}/uSockets/src)
-include_directories(${LIBUV_INCLUDE_DIR})
-
 # Add the uWebSockets interface library
 add_library(uWS INTERFACE)
+
+# Include directories
+target_include_directories(uWS INTERFACE ${UWEBSOCKETS_SOURCE_DIR}/src)
 
 # Set C++20 standard for uWS target
 target_compile_features(uWS INTERFACE cxx_std_20)
@@ -40,8 +38,7 @@ if(WITH_LIBDEFLATE)
 endif()
 
 if(WITH_ZLIB)
-    target_include_directories(uWS INTERFACE ${ZLIB_INCLUDE_DIRS})
-    target_link_libraries(uWS INTERFACE ${ZLIB_LIBRARIES})
+    target_link_libraries(uWS INTERFACE ZLIB::ZLIB)
 else()
     target_compile_definitions(uWS INTERFACE UWS_NO_ZLIB)
 endif()
@@ -69,8 +66,7 @@ elseif(WITH_WOLFSSL)
 endif()
 
 if(WITH_LIBUV)
-    target_include_directories(uWS INTERFACE ${LIBUV_INCLUDE_DIR})
-    target_link_libraries(uWS INTERFACE ${LIBUV_LIBRARY})
+    target_link_libraries(uWS INTERFACE libuv::libuv)
 endif()
 
 if(WITH_ASIO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,11 @@ if(LUTE_EXTERN_C)
     set(LUAU_EXTERN_C ON)
 endif()
 
+option(LUTE_NO_VENDOR "Don't vendor dependencies" OFF)
+if (LUTE_NO_VENDOR)
+    find_package(PkgConfig REQUIRED)
+endif()
+
 # luau setup
 set(LUAU_BUILD_CLI OFF)
 set(LUAU_BUILD_TESTS OFF)
@@ -89,49 +94,43 @@ set(LUAU_BUILD_TESTS OFF)
 add_subdirectory(extern/luau)
 
 # libuv setup
-set(LIBUV_BUILD_SHARED OFF)
-set(BUILD_SHARED_LIBS OFF) # why does an option for LIBUV_BUILD_SHARED exist separately
-set(LIBUV_BUILD_TESTS OFF)
-set(LIBUV_BUILD_BENCH OFF)
-add_subdirectory(extern/libuv)
+if (LUTE_NO_VENDOR)
+    pkg_check_modules(LIBUV REQUIRED IMPORTED_TARGET libuv)
+    add_library(libuv::libuv ALIAS PkgConfig::LIBUV)
+else()
+    set(LIBUV_BUILD_SHARED OFF)
+    set(BUILD_SHARED_LIBS OFF) # why does an option for LIBUV_BUILD_SHARED exist separately
+    set(LIBUV_BUILD_TESTS OFF)
+    set(LIBUV_BUILD_BENCH OFF)
+    add_subdirectory(extern/libuv)
+endif()
 
 # Define libuv include directory here, before it's needed by other subdirectories
 set(LIBUV_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/libuv/include)
 
 # zlib setup
-#
-set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "Do not build examples" FORCE)
-set(ZLIB_BUILD_TESTING OFF CACHE BOOL "Do not build zlib tests" FORCE)
-set(ZLIB_BUILD_SHARED OFF CACHE BOOL "Do not build shared zlib" FORCE)
-set(ZLIB_BUILD_STATIC ON CACHE BOOL "Build static zlib" FORCE)
-set(ZLIB_INSTALL OFF CACHE BOOL "Do not install zlib" FORCE)
-set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static zlib" FORCE)
-add_subdirectory(extern/zlib)
-if(TARGET zlibstatic AND NOT TARGET ZLIB::ZLIB)
-    add_library(ZLIB::ZLIB INTERFACE IMPORTED GLOBAL)
-    target_link_libraries(ZLIB::ZLIB INTERFACE "$<BUILD_INTERFACE:zlibstatic>")
-endif()
-
-set(ZLIB_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/extern/zlib")
-
-if(MSVC)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstaticd.lib" CACHE FILEPATH "" FORCE)
-    else()
-        set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/zlibstatic.lib" CACHE FILEPATH "" FORCE)
-    endif()
+if (LUTE_NO_VENDOR)
+    find_package(ZLIB REQUIRED)
 else()
-    set(ZLIB_LIBRARY "${ZLIB_OUTPUT_DIR}/libz.a" CACHE FILEPATH "" FORCE)
+    set(ZLIB_BUILD_EXAMPLES OFF CACHE BOOL "Do not build examples" FORCE)
+    set(ZLIB_BUILD_TESTING OFF CACHE BOOL "Do not build zlib tests" FORCE)
+    set(ZLIB_BUILD_SHARED OFF CACHE BOOL "Do not build shared zlib" FORCE)
+    set(ZLIB_BUILD_STATIC ON CACHE BOOL "Build static zlib" FORCE)
+    set(ZLIB_INSTALL OFF CACHE BOOL "Do not install zlib" FORCE)
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static zlib" FORCE)
+    add_subdirectory(extern/zlib)
+    if(TARGET zlibstatic AND NOT TARGET ZLIB::ZLIB)
+        add_library(ZLIB::ZLIB INTERFACE IMPORTED GLOBAL)
+        target_link_libraries(ZLIB::ZLIB INTERFACE "$<BUILD_INTERFACE:zlibstatic>")
+    endif()
 endif()
-set(ZLIB_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/zlib;${ZLIB_OUTPUT_DIR} CACHE PATH "" FORCE)
-set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR} CACHE STRING "" FORCE)
-set(ZLIB_LIBRARIES ZLIB::ZLIB CACHE STRING "" FORCE)
 
 # boringssl setup
 set(BUILD_TESTING OFF)
 add_subdirectory(extern/boringssl)
 set(BORINGSSL_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/extern/boringssl")
 set(BORINGSSL_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/boringssl/include)
+find_package(OpenSSL REQUIRED)
 
 # Suppress frame-size warnings in boringssl when sanitizers are enabled
 if (LUTE_ENABLE_SANITIZERS AND NOT MSVC)
@@ -153,68 +152,77 @@ endif()
 
 # curl setup
 
-set(USE_LIBIDN2 OFF)
-set(USE_NGHTTP2 OFF)
-set(CURL_USE_LIBPSL OFF)
-set(CURL_USE_LIBSSH2 OFF)
-set(CURL_ZLIB ON)
-SET(CURL_ZSTD OFF CACHE STRING "Disable ZSTD" FORCE)
-set(CURL_BROTLI OFF CACHE STRING "Disable brotli support" FORCE)
-set(CURL_ENABLE_SSL ON)
-set(CURL_USE_OPENSSL ON)
-set(BUILD_EXAMPLES OFF)
-set(BUILD_CURL_EXE OFF)
-set(BUILD_SHARED_LIBS OFF)
-set(BUILD_STATIC_LIBS ON)
-set(CURL_ENABLE_EXPORT_TARGET OFF)
-
-# curl's OpenSSL-family probes run in nested try-compile projects, where the
-# in-tree ZLIB::ZLIB target is not visible. These are false for BoringSSL.
-set(HAVE_DES_ECB_ENCRYPT "" CACHE INTERNAL "curl BoringSSL feature probe")
-set(HAVE_SSL_SET0_WBIO "" CACHE INTERNAL "curl BoringSSL feature probe")
-set(HAVE_OPENSSL_SRP "" CACHE INTERNAL "curl BoringSSL feature probe")
-
-# lute/net only speaks HTTP/HTTPS/WebSocket.
-set(CURL_DISABLE_FTP    ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_TFTP   ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_FILE   ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_DICT   ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_TELNET ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_LDAP   ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_LDAPS  ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_SMB    ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_SMTP   ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_IMAP   ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_POP3   ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_GOPHER ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_RTSP   ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_MQTT   ON CACHE BOOL "" FORCE)
-set(CURL_DISABLE_IPFS   ON CACHE BOOL "" FORCE)
-
-# One more set of DISABLES. We might need to re-enable these at some point
-# if we need the features they provide
-set(CURL_DISABLE_AWS            ON  CACHE BOOL "" FORCE)
-set(CURL_DISABLE_INSTALL        ON  CACHE BOOL "" FORCE)
-set(ENABLE_UNIX_SOCKETS         OFF CACHE BOOL "" FORCE)
-
-set(HAVE_BORINGSSL ON)
-add_subdirectory(extern/curl)
+if (LUTE_NO_VENDOR)
+    find_package(CURL REQUIRED)
+else()
+    set(USE_LIBIDN2 OFF)
+    set(USE_NGHTTP2 OFF)
+    set(CURL_USE_LIBPSL OFF)
+    set(CURL_USE_LIBSSH2 OFF)
+    set(CURL_ZLIB ON)
+    SET(CURL_ZSTD OFF CACHE STRING "Disable ZSTD" FORCE)
+    set(CURL_BROTLI OFF CACHE STRING "Disable brotli support" FORCE)
+    set(CURL_ENABLE_SSL ON)
+    set(CURL_USE_OPENSSL ON)
+    set(BUILD_EXAMPLES OFF)
+    set(BUILD_CURL_EXE OFF)
+    set(BUILD_SHARED_LIBS OFF)
+    set(BUILD_STATIC_LIBS ON)
+    set(CURL_ENABLE_EXPORT_TARGET OFF)
+    
+    # curl's OpenSSL-family probes run in nested try-compile projects, where the
+    # in-tree ZLIB::ZLIB target is not visible. These are false for BoringSSL.
+    set(HAVE_DES_ECB_ENCRYPT "" CACHE INTERNAL "curl BoringSSL feature probe")
+    set(HAVE_SSL_SET0_WBIO "" CACHE INTERNAL "curl BoringSSL feature probe")
+    set(HAVE_OPENSSL_SRP "" CACHE INTERNAL "curl BoringSSL feature probe")
+    
+    # lute/net only speaks HTTP/HTTPS/WebSocket.
+    set(CURL_DISABLE_FTP    ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_TFTP   ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_FILE   ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_DICT   ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_TELNET ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_LDAP   ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_LDAPS  ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_SMB    ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_SMTP   ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_IMAP   ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_POP3   ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_GOPHER ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_RTSP   ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_MQTT   ON CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_IPFS   ON CACHE BOOL "" FORCE)
+    
+    # One more set of DISABLES. We might need to re-enable these at some point
+    # if we need the features they provide
+    set(CURL_DISABLE_AWS            ON  CACHE BOOL "" FORCE)
+    set(CURL_DISABLE_INSTALL        ON  CACHE BOOL "" FORCE)
+    set(ENABLE_UNIX_SOCKETS         OFF CACHE BOOL "" FORCE)
+    
+    set(HAVE_BORINGSSL ON)
+    add_subdirectory(extern/curl)
+endif()
 
 # uWebSockets setup
-set(WITH_BORINGSSL ON)
+if (LUTE_NO_VENDOR)
+    set(WITH_OPENSSL ON)
+else()
+    set(WITH_BORINGSSL ON)
+endif()
 set(WITH_LIBUV ON)
 set(WITH_ZLIB ON)
 
 # Set the correct libuv library name for uWebSockets
-set(LIBUV_LIBRARY uv_a)
 include(uSockets)
 include(uWebSockets)
 
-# Define include directories for uWebSockets and uSockets
-set(UWEBSOCKETS_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/extern/uWebSockets/src)
-
 # libsodium for `pwhash`
-include(libsodium)
+if (LUTE_NO_VENDOR)
+    pkg_check_modules(SODIUM REQUIRED IMPORTED_TARGET libsodium)
+    add_library(sodium ALIAS PkgConfig::SODIUM)
+else()
+    include(libsodium)
+endif()
 
 # Lute
 set(LUTE_OPTIONS)

--- a/lute/batteries/CMakeLists.txt
+++ b/lute/batteries/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
     target_compile_features(Lute.Batteries PUBLIC cxx_std_17)
     target_include_directories(Lute.Batteries PUBLIC include generated)
 endif()
-target_link_libraries(Lute.Batteries PRIVATE uv_a)
+target_link_libraries(Lute.Batteries PRIVATE libuv::libuv)
 target_compile_options(Lute.Batteries PRIVATE ${LUTE_OPTIONS})
 
 set(BATTERIES_GENERATED_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")

--- a/lute/cli/CMakeLists.txt
+++ b/lute/cli/CMakeLists.txt
@@ -54,8 +54,8 @@ target_sources(Lute.CLI.lib PRIVATE
 )
 
 target_compile_features(Lute.CLI.lib PUBLIC cxx_std_17)
-target_include_directories(Lute.CLI.lib PUBLIC include ${CLI_GENERATED_INCLUDE_DIR} ${ZLIB_INCLUDE_DIR})
-target_link_libraries(Lute.CLI.lib PRIVATE Luau.Common Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Luau Lute.Process Lute.Require Lute.Runtime Luau.CLI.lib Lute.Common zlibstatic)
+target_include_directories(Lute.CLI.lib PUBLIC include ${CLI_GENERATED_INCLUDE_DIR})
+target_link_libraries(Lute.CLI.lib PRIVATE Luau.Common Luau.Compiler Luau.Config Luau.CodeGen Luau.Analysis Luau.VM Lute.CLI.Commands Lute.Luau Lute.Process Lute.Require Lute.Runtime Luau.CLI.lib Lute.Common ZLIB::ZLIB)
 target_compile_options(Lute.CLI.lib PRIVATE ${LUTE_OPTIONS})
 
 add_executable(Lute.CLI)

--- a/lute/common/CMakeLists.txt
+++ b/lute/common/CMakeLists.txt
@@ -11,7 +11,7 @@ target_sources(Lute.Common PRIVATE
 
 target_compile_features(Lute.Common PUBLIC cxx_std_17)
 target_include_directories(Lute.Common PUBLIC include)
-target_link_libraries(Lute.Common PRIVATE Luau.CLI.lib Luau.Common)
+target_link_libraries(Lute.Common PRIVATE Luau.CLI.lib PUBLIC Luau.VM Luau.Common)
 target_compile_options(Lute.Common PRIVATE ${LUTE_OPTIONS})
 
 if(LUTE_EXTERN_C)

--- a/lute/crypto/CMakeLists.txt
+++ b/lute/crypto/CMakeLists.txt
@@ -7,6 +7,6 @@ target_sources(Lute.Crypto PRIVATE
 )
 
 target_compile_features(Lute.Crypto PUBLIC cxx_std_17)
-target_include_directories(Lute.Crypto PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Crypto PRIVATE Lute.Runtime Luau.VM uv_a ssl crypto sodium)
+target_include_directories(Lute.Crypto PUBLIC "include")
+target_link_libraries(Lute.Crypto PRIVATE Lute.Runtime libuv::libuv ssl crypto sodium PUBLIC Lute.Common)
 target_compile_options(Lute.Crypto PRIVATE ${LUTE_OPTIONS})

--- a/lute/fs/CMakeLists.txt
+++ b/lute/fs/CMakeLists.txt
@@ -9,6 +9,6 @@ target_sources(Lute.Fs PRIVATE
 )
 
 target_compile_features(Lute.Fs PUBLIC cxx_std_17)
-target_include_directories(Lute.Fs PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Fs PRIVATE Lute.Common Lute.Runtime Lute.Time Luau.VM uv_a)
+target_include_directories(Lute.Fs PUBLIC "include")
+target_link_libraries(Lute.Fs PRIVATE Lute.Runtime Lute.Time libuv::libuv PUBLIC Lute.Common)
 target_compile_options(Lute.Fs PRIVATE ${LUTE_OPTIONS})

--- a/lute/io/CMakeLists.txt
+++ b/lute/io/CMakeLists.txt
@@ -7,6 +7,6 @@ target_sources(Lute.IO PRIVATE
 )
 
 target_compile_features(Lute.IO PUBLIC cxx_std_17)
-target_include_directories(Lute.IO PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.IO PRIVATE Lute.Runtime Luau.VM uv_a)
+target_include_directories(Lute.IO PUBLIC "include")
+target_link_libraries(Lute.IO PRIVATE Lute.Runtime libuv::libuv PUBLIC Lute.Common)
 target_compile_options(Lute.IO PRIVATE ${LUTE_OPTIONS})

--- a/lute/luau/CMakeLists.txt
+++ b/lute/luau/CMakeLists.txt
@@ -15,6 +15,6 @@ target_sources(Lute.Luau PRIVATE
 )
 
 target_compile_features(Lute.Luau PUBLIC cxx_std_17)
-target_include_directories(Lute.Luau PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Luau PRIVATE Lute.Common Lute.Require Lute.Runtime Lute.Syntax uv_a Luau.Analysis Luau.Ast Luau.Compiler Luau.CLI.lib Luau.Require Luau.VM)
+target_include_directories(Lute.Luau PUBLIC "include")
+target_link_libraries(Lute.Luau PRIVATE Lute.Require Lute.Runtime Lute.Syntax libuv::libuv Luau.Analysis Luau.Ast Luau.Compiler Luau.CLI.lib Luau.Require PUBLIC Lute.Common)
 target_compile_options(Lute.Luau PRIVATE ${LUTE_OPTIONS})

--- a/lute/net/CMakeLists.txt
+++ b/lute/net/CMakeLists.txt
@@ -15,6 +15,6 @@ target_sources(Lute.Net PRIVATE
 )
 
 target_compile_features(Lute.Net PUBLIC cxx_std_17)
-target_include_directories(Lute.Net PUBLIC "include" ${LIBUV_INCLUDE_DIR} ${UWEBSOCKETS_INCLUDE_DIR})
-target_link_libraries(Lute.Net PRIVATE Lute.Common Lute.Runtime Luau.VM uv_a libcurl uWS zlibstatic)
+target_include_directories(Lute.Net PUBLIC "include")
+target_link_libraries(Lute.Net PRIVATE Lute.Runtime libuv::libuv CURL::libcurl uWS ZLIB::ZLIB PUBLIC Lute.Common)
 target_compile_options(Lute.Net PRIVATE ${LUTE_OPTIONS})

--- a/lute/process/CMakeLists.txt
+++ b/lute/process/CMakeLists.txt
@@ -11,6 +11,6 @@ target_sources(Lute.Process PRIVATE
 )
 
 target_compile_features(Lute.Process PUBLIC cxx_std_17)
-target_include_directories(Lute.Process PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Process PRIVATE Lute.Common Lute.Runtime Luau.VM uv_a)
+target_include_directories(Lute.Process PUBLIC "include")
+target_link_libraries(Lute.Process PRIVATE Lute.Runtime libuv::libuv PUBLIC Lute.Common)
 target_compile_options(Lute.Process PRIVATE ${LUTE_OPTIONS})

--- a/lute/require/CMakeLists.txt
+++ b/lute/require/CMakeLists.txt
@@ -30,5 +30,5 @@ target_sources(Lute.Require PRIVATE
 
 target_compile_features(Lute.Require PUBLIC cxx_std_17)
 target_include_directories(Lute.Require PUBLIC include)
-target_link_libraries(Lute.Require PUBLIC Luau.Require Luau.Compiler PRIVATE Luau.CLI.lib Luau.CodeGen Lute.Common Lute.Std Lute.CLI.Commands Lute.Batteries Lute.Std Lute.Lute Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Syntax Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Runtime Lute.Debug)
+target_link_libraries(Lute.Require PUBLIC Lute.Common Luau.Require Luau.Compiler Luau.Common PRIVATE Luau.CLI.lib Luau.CodeGen Lute.Common Lute.Std Lute.CLI.Commands Lute.Batteries Lute.Std Lute.Lute Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Syntax Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Runtime Lute.Debug)
 target_compile_options(Lute.Require PRIVATE ${LUTE_OPTIONS})

--- a/lute/runtime/CMakeLists.txt
+++ b/lute/runtime/CMakeLists.txt
@@ -15,7 +15,6 @@ target_sources(Lute.Runtime PRIVATE
 )
 
 target_compile_features(Lute.Runtime PUBLIC cxx_std_17)
-target_include_directories(Lute.Runtime PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Runtime PUBLIC Lute.Common)
-target_link_libraries(Lute.Runtime PRIVATE Luau.Require Luau.Compiler Luau.VM uv_a)
+target_include_directories(Lute.Runtime PUBLIC "include")
+target_link_libraries(Lute.Runtime PRIVATE Luau.Require Luau.Compiler PUBLIC libuv::libuv Luau.Common Lute.Common)
 target_compile_options(Lute.Runtime PRIVATE ${LUTE_OPTIONS})

--- a/lute/std/CMakeLists.txt
+++ b/lute/std/CMakeLists.txt
@@ -16,5 +16,5 @@ endif()
 
 target_compile_features(Lute.Std PUBLIC cxx_std_17)
 target_include_directories(Lute.Std PUBLIC "include")
-target_link_libraries(Lute.Std PRIVATE Lute.Runtime Luau.VM uv_a)
+target_link_libraries(Lute.Std PRIVATE Lute.Runtime Luau.VM libuv::libuv)
 target_compile_options(Lute.Std PRIVATE ${LUTE_OPTIONS})

--- a/lute/system/CMakeLists.txt
+++ b/lute/system/CMakeLists.txt
@@ -7,6 +7,6 @@ target_sources(Lute.System PRIVATE
 )
 
 target_compile_features(Lute.System PUBLIC cxx_std_17)
-target_include_directories(Lute.System PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.System PRIVATE Lute.Runtime Luau.VM uv_a)
+target_include_directories(Lute.System PUBLIC "include")
+target_link_libraries(Lute.System PRIVATE Lute.Runtime libuv::libuv PUBLIC Lute.Common)
 target_compile_options(Lute.System PRIVATE ${LUTE_OPTIONS})

--- a/lute/task/CMakeLists.txt
+++ b/lute/task/CMakeLists.txt
@@ -7,6 +7,6 @@ target_sources(Lute.Task PRIVATE
 )
 
 target_compile_features(Lute.Task PUBLIC cxx_std_17)
-target_include_directories(Lute.Task PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Task PRIVATE Lute.Runtime Lute.Common Lute.Time Luau.VM uv_a)
+target_include_directories(Lute.Task PUBLIC "include")
+target_link_libraries(Lute.Task PRIVATE Lute.Runtime Lute.Time libuv::libuv PUBLIC Lute.Common)
 target_compile_options(Lute.Task PRIVATE ${LUTE_OPTIONS})

--- a/lute/time/CMakeLists.txt
+++ b/lute/time/CMakeLists.txt
@@ -7,6 +7,6 @@ target_sources(Lute.Time PRIVATE
 )
 
 target_compile_features(Lute.Time PUBLIC cxx_std_17)
-target_include_directories(Lute.Time PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.Time PRIVATE Lute.Runtime Luau.VM uv_a)
+target_include_directories(Lute.Time PUBLIC "include")
+target_link_libraries(Lute.Time PRIVATE Lute.Runtime libuv::libuv PUBLIC Lute.Common)
 target_compile_options(Lute.Time PRIVATE ${LUTE_OPTIONS})

--- a/lute/vm/CMakeLists.txt
+++ b/lute/vm/CMakeLists.txt
@@ -9,6 +9,6 @@ target_sources(Lute.VM PRIVATE
 )
 
 target_compile_features(Lute.VM PUBLIC cxx_std_17)
-target_include_directories(Lute.VM PUBLIC "include" ${LIBUV_INCLUDE_DIR})
-target_link_libraries(Lute.VM PRIVATE Lute.Require Lute.Runtime Luau.CodeGen Luau.VM Luau.Require uv_a)
+target_include_directories(Lute.VM PUBLIC "include")
+target_link_libraries(Lute.VM PRIVATE Lute.Require Lute.Runtime Luau.Require Luau.CodeGen libuv::libuv PUBLIC Lute.Common)
 target_compile_options(Lute.VM PRIVATE ${LUTE_OPTIONS})


### PR DESCRIPTION
Adds a `LUTE_NO_VENDOR` build option that will use the system libraries instead of statically linking to vendored libraries in `extern`, except for uSockets and uWebSockets which will still be vendored and built with Lute.

This is useful for packaging Lute for Linux package repositories, as they generally prefer to avoid vendoring dependencies. (e.g. https://github.com/NixOS/nixpkgs/pull/511134#discussion_r3198005901)

When the option is enabled, OpenSSL will be used instead of BoringSSL, however this required some changes to Lute's crypto library because OpenSSL does not have `EVP_blake2b256`.