### PR TITLE
Add breakpoints actually pausing execution

### DIFF
--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -214,7 +214,11 @@ void Target::installPendingBreakpoints(lua_State* L)
         {
             bool installed = installBreakpoint(L, bp);
             if (installed && launchConfig.onBreakpointInstall)
+            {
+                lock.unlock();
                 launchConfig.onBreakpointInstall(bp);
+                lock.lock();
+            }
         }
     }
 }
@@ -222,11 +226,10 @@ void Target::installPendingBreakpoints(lua_State* L)
 std::shared_ptr<Process> Target::launch(const std::vector<std::string>& args, LaunchConfig config)
 {
     // launch() cannot be called twice from the same target.
-    if (childRuntime != nullptr)
+    if (activeProcess != nullptr)
         return nullptr;
     childRuntime = std::make_shared<Runtime>(parentRuntime.reporter);
     setupState(*childRuntime, nullptr);
-
     launchConfig = config;
 
     std::ifstream file(sourcePath);
@@ -278,35 +281,36 @@ void Process::installBpHitCallback()
     cb->userdata = this;
     cb->debugbreak = [](lua_State* L, lua_Debug* ar)
     {
-        int line = ar->currentline;
-        lua_Debug info = {};
-        lua_getinfo(L, 0, "s", &info);
-
-        // TODO: this pause/resume mechanism assumes single co-routine runtime
         Process* process = static_cast<Process*>(lua_callbacks(L)->userdata);
+        // TODO: this pause/resume mechanism assumes single co-routine runtime
         process->resumeToken = getResumeToken(L);
+
+        lua_Debug info = {};
+        lua_getinfo(L, 0, "sl", &info);
+        int line = info.currentline;
+        if (!info.source)
+            process->runtime.reporter.reportError(Luau::format("breakpoint hit at line %d could not be find a runtime source", line));
         std::string source = info.source;
         std::optional<Breakpoint> bp = process->parentTarget.getBreakpointBySourceLine(source, line);
-        if (bp)
+        if (bp && bp->status == BreakpointStatus::Installed)
         {
-            if (bp->status == BreakpointStatus::Installed)
+            if (process->config.onBreakpointHit)
             {
-                // notify caller that we stopped
-                if (process->config.onBreakpointHit)
-                {
-                    process->config.onBreakpointHit(*process, bp.value());
-                }
-            }
-            else if (bp->status == BreakpointStatus::PendingUninstall)
-            {
-                process->continueProcess();
+                process->config.onBreakpointHit(*process, bp.value());
             }
         }
         else
         {
-            process->runtime.reporter.reportError(
-                Luau::format("breakpoint hit at line %d in %s could not be found in breakpoint map", line, source.c_str())
-            );
+            // it is normal to hit breakpoints that are pending uninstall but not normal
+            // to hit any other type of breakpoint
+            if (!bp || bp->status != BreakpointStatus::PendingUninstall)
+            {
+                process->runtime.reporter.reportError(
+                    Luau::format("breakpoint hit at line %d in %s could not be found in breakpoint map", line, source.c_str())
+                );
+            }
+            // this prevents us from hanging forever
+            process->continueProcess();
         }
     };
 }

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -298,9 +298,9 @@ void Process::installBpHitCallback()
         Process* process = static_cast<Process*>(lua_callbacks(L)->userdata);
         // TODO: this pause/resume mechanism assumes single co-routine runtime
         // We land on the same instruction after a continue() after hitting a bp so we basically don't do anything
-        if (process->continueRequested)
+        if (process->continueRequestedBp)
         {
-            process->continueRequested = false;
+            process->continueRequestedBp = false;
             return;
         }
         lua_Debug info = {};
@@ -316,6 +316,7 @@ void Process::installBpHitCallback()
         // Only stop execution on installed breakpoints; otherwise, don't stop.
         if (bp && bp->status == BreakpointStatus::Installed)
         {
+            process->bpHit = *bp;
             process->resumeToken = getResumeToken(L);
             lua_break(L);
             if (process->config.onBreakpointHit)
@@ -348,7 +349,16 @@ bool Process::continueProcess()
 {
     if (!resumeToken)
         return false;
-    continueRequested = true;
+    // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
+    if (bpHit)
+    {
+        // we need to check if our breakpoint is still currently installed after
+        // onBreakpointHit() callback
+        std::optional<Breakpoint> currentBp = parentTarget.getBreakpointById(bpHit->id);
+        if (currentBp && currentBp->status == BreakpointStatus::Installed)
+            continueRequestedBp = true;
+        bpHit = std::nullopt;
+    }
     resumeToken->complete(
         [](lua_State* L)
         {

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -23,9 +23,10 @@ Breakpoint::Breakpoint(int id, std::string sourcePath, int line, BreakpointStatu
 {
 }
 
-Target::Target(Runtime& runtime, std::string sourcePath)
-    : runtime(runtime)
+Target::Target(Runtime& parentRuntime, std::string sourcePath, std::function<void(const Breakpoint& bp)> onBreakpointInstall)
+    : parentRuntime(parentRuntime)
     , sourcePath(sourcePath)
+    , onBreakpointInstall(onBreakpointInstall)
     , loadedSources("")
 {
 }
@@ -35,7 +36,20 @@ Breakpoint Target::addBreakpoint(std::string sourcePath, int line)
     int id = currentBreakpointId;
     currentBreakpointId++;
     auto [it, _] = breakpoints.insert_or_assign(id, Breakpoint(id, sourcePath, line, BreakpointStatus::Pending));
-    installBreakpoint(runtime.GL, it->second);
+    if (childRuntime)
+        childRuntime->schedule(
+            [this, id]() mutable
+            {
+                auto it = breakpoints.find(id);
+                // check breakpoint has not been erased when this scheduled install has been fired
+                if (it != breakpoints.end())
+                {
+                    bool installed = installBreakpoint(childRuntime->GL, it->second);
+                    if (installed && onBreakpointInstall)
+                        onBreakpointInstall(it->second);
+                }
+            }
+        );
     return it->second;
 }
 
@@ -48,19 +62,25 @@ bool Target::removeBreakpoint(int bpId)
     if (bp.status == BreakpointStatus::Installed)
     {
         auto chunkRef = loadedSources.find(bp.sourcePath);
-        if (chunkRef)
+        if (chunkRef && childRuntime)
         {
-            (*chunkRef)->push(runtime.GL);
-            int removed_line = lua_breakpoint(runtime.GL, -1, bp.line, 0);
-            lua_pop(runtime.GL, 1);
+            (*chunkRef)->push(childRuntime->GL);
+            int removed_line = lua_breakpoint(childRuntime->GL, -1, bp.line, 0);
+            lua_pop(childRuntime->GL, 1);
             if (removed_line == -1)
-                runtime.reporter.reportError(
+                parentRuntime.reporter.reportError(
                     Luau::format("breakpoint %d installed at line %d in %s could not be removed", bp.id, bp.line, bp.sourcePath.c_str())
                 );
         }
+        else if (!childRuntime)
+        {
+            parentRuntime.reporter.reportError(
+                Luau::format("breakpoint %d installed at line %d in %s is missing a runtime", bp.id, bp.line, bp.sourcePath.c_str())
+            );
+        }
         else
         {
-            runtime.reporter.reportError(
+            parentRuntime.reporter.reportError(
                 Luau::format("breakpoint %d installed at line %d in %s is missing a loaded source", bp.id, bp.line, bp.sourcePath.c_str())
             );
         }
@@ -120,12 +140,19 @@ void Target::installPendingBreakpoints(lua_State* L)
     for (auto& [_, bp] : breakpoints)
     {
         if (bp.status == BreakpointStatus::Pending)
-            installBreakpoint(L, bp);
+        {
+            bool installed = installBreakpoint(L, bp);
+            if (installed && onBreakpointInstall)
+                onBreakpointInstall(bp);
+        }
     }
 }
 
 bool Target::launch(const std::vector<std::string>& args)
 {
+    childRuntime = std::make_shared<Runtime>(parentRuntime.reporter);
+    setupState(*childRuntime, nullptr);
+
     std::ifstream file(sourcePath);
     if (!file.is_open())
         return false;
@@ -134,15 +161,19 @@ bool Target::launch(const std::vector<std::string>& args)
     debugOptions.optimizationLevel = 1;
     debugOptions.debugLevel = 2;
     std::string bytecode = Luau::compile(source, debugOptions);
-    lua_State* thread = lua_newthread(runtime.GL);
+    lua_State* thread = lua_newthread(childRuntime->GL);
     luaL_sandboxthread(thread);
     luau_load(thread, sourcePath.c_str(), bytecode.c_str(), bytecode.size(), 0);
     loadedSources[sourcePath] = std::make_shared<Ref>(thread, -1);
     installPendingBreakpoints(thread);
     for (const std::string& arg : args)
         lua_pushstring(thread, arg.c_str());
-    runtime.runningThreads.push_back({true, getRefForThread(thread), static_cast<int>(args.size())});
-    lua_pop(runtime.GL, 1);
+    childRuntime->runningThreads.push_back({true, getRefForThread(thread), static_cast<int>(args.size())});
+    lua_pop(childRuntime->GL, 1);
+
+    // the runtime provides the guarantees that C++ continuations (such as already enqueued breakpoints to install)
+    // happen before the first Luau thread runs
+    childRuntime->runContinuously();
     return true;
 }
 } // namespace debug

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -280,7 +280,6 @@ Target& Process::getTarget()
 {
     return parentTarget;
 }
-
 void Process::installBpHitCallback()
 {
     lua_Callbacks* cb = lua_callbacks(runtime.GL);
@@ -289,33 +288,37 @@ void Process::installBpHitCallback()
     {
         Process* process = static_cast<Process*>(lua_callbacks(L)->userdata);
         // TODO: this pause/resume mechanism assumes single co-routine runtime
-        process->resumeToken = getResumeToken(L);
-
+        // We land on the same instruction after a continue() after hitting a bp so we basically don't do anything
+        if (process->continueRequested)
+        {
+            process->continueRequested = false;
+            return;
+        }
         lua_Debug info = {};
         lua_getinfo(L, 0, "sl", &info);
         int line = info.currentline;
         if (!info.source)
         {
-            process->runtime.reporter.reportError(Luau::format("breakpoint hit at line %d could not be find a runtime source", line));
+            process->runtime.reporter.reportError(Luau::format("breakpoint hit at line %d could not find a runtime source", line));
             return;
         }
         std::string source = info.source;
         std::optional<Breakpoint> bp = process->parentTarget.getBreakpointBySourceLine(source, line);
+        // Only stop execution on installed breakpoints; otherwise, don't stop.
         if (bp && bp->status == BreakpointStatus::Installed)
         {
+            process->resumeToken = getResumeToken(L);
+            lua_break(L);
             if (process->config.onBreakpointHit)
                 process->config.onBreakpointHit(*process, bp.value());
         }
-        else
+        else if (!bp || bp->status != BreakpointStatus::PendingUninstall)
         {
-            // it is normal to hit breakpoints that are pending uninstall but not normal
-            // to hit any other type of breakpoint
-            if (!bp || bp->status != BreakpointStatus::PendingUninstall)
-                process->runtime.reporter.reportError(
-                    Luau::format("breakpoint hit at line %d in %s could not be found in breakpoint map", line, source.c_str())
-                );
-            // this prevents us from hanging forever
-            process->continueProcess();
+            // It is normal to hit breakpoints that are pending uninstall but not normal
+            // to hit any other type of breakpoint so we error in those cases.
+            process->runtime.reporter.reportError(
+                Luau::format("breakpoint hit at line %d in %s could not be found in breakpoint map", line, source.c_str())
+            );
         }
     };
 }
@@ -336,6 +339,7 @@ bool Process::continueProcess()
 {
     if (!resumeToken)
         return false;
+    continueRequested = true;
     resumeToken->complete(
         [](lua_State* L)
         {

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -1,5 +1,7 @@
 #include "debugger.h"
 
+#include "lute/common.h"
+
 #include "Luau/Compiler.h"
 #include "Luau/DenseHash.h"
 #include "Luau/StringUtils.h"
@@ -7,10 +9,12 @@
 #include "lua.h"
 #include "lualib.h"
 
+#include <cstddef>
 #include <fstream>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -117,7 +121,7 @@ std::vector<Breakpoint> Target::getBreakpoints() const
     std::vector<Breakpoint> all;
     all.reserve(breakpoints.size());
     for (auto& [_, bp] : breakpoints)
-        all.push_back(bp);
+        all.emplace_back(bp);
     return all;
 }
 
@@ -128,7 +132,7 @@ std::vector<Breakpoint> Target::getBreakpointsByStatus(BreakpointStatus status) 
     statusBps.reserve(breakpoints.size());
     for (auto& [_, bp] : breakpoints)
         if (bp.status == status)
-            statusBps.push_back(bp);
+            statusBps.emplace_back(bp);
     return statusBps;
 }
 
@@ -218,28 +222,27 @@ bool Target::uninstallBreakpoint(lua_State* L, Breakpoint& bp)
     return true;
 }
 
-// This returns the list of installed and unisntalled vectors for use in callbacks
+// This returns the list of installed and uninstalled vectors for use in callbacks
 // later.
 std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> Target::modifyPendingBreakpoints(lua_State* L)
 {
-    std::vector<Breakpoint> installedBpsCallback, uninstalledBpsCallback;
+    std::vector<Breakpoint> installedBpsCallback;
+    std::vector<Breakpoint> uninstalledBpsCallback;
     std::vector<int> toErase;
     for (auto& [id, bp] : breakpoints)
     {
         if (bp.status == BreakpointStatus::PendingInstall)
         {
-            bool installed = installBreakpoint(L, bp);
-            if (installed && launchConfig.onBreakpointInstall)
-                installedBpsCallback.push_back(bp);
+            if (installBreakpoint(L, bp) && launchConfig.onBreakpointInstall)
+                installedBpsCallback.emplace_back(bp);
         }
         if (bp.status == BreakpointStatus::PendingUninstall)
         {
-            bool uninstalled = uninstallBreakpoint(L, bp);
-            if (uninstalled)
+            if (uninstallBreakpoint(L, bp))
             {
                 if (launchConfig.onBreakpointUninstall)
-                    uninstalledBpsCallback.push_back(bp);
-                toErase.push_back(bp.id);
+                    uninstalledBpsCallback.emplace_back(bp);
+                toErase.emplace_back(bp.id);
             }
         }
     }
@@ -250,47 +253,50 @@ std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> Target::modifyPendin
 
 bool Target::launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config)
 {
-    // launch() cannot be called twice from the same target.
-    std::unique_lock lock(targetMutex);
-    if (processThread != nullptr)
-        return false;
-    childRuntime = std::make_unique<Runtime>(parentRuntime.reporter);
-    setupState(*childRuntime, nullptr);
-    launchConfig = config;
-
-    std::ifstream file(sourcePath);
-    if (!file.is_open())
+    std::vector<Breakpoint> installedBps;
+    std::vector<Breakpoint> uninstalledBps;
     {
-        childRuntime.reset();
-        return false;
-    }
-    std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-    Luau::CompileOptions debugOptions = {};
-    debugOptions.optimizationLevel = 1;
-    debugOptions.debugLevel = 2;
-    std::string bytecode = Luau::compile(source, debugOptions);
-    lua_State* thread = lua_newthread(childRuntime->GL);
-    luaL_sandboxthread(thread);
-    luau_load(thread, sourcePath.c_str(), bytecode.c_str(), bytecode.size(), 0);
-    loadedSources[sourcePath] = std::make_shared<Ref>(thread, -1);
-    auto [installed, uninstalled] = modifyPendingBreakpoints(thread);
-    for (const std::string& arg : args)
-        lua_pushstring(thread, arg.c_str());
-    childRuntime->runningThreads.push_back({true, getRefForThread(thread), static_cast<int>(args.size())});
-    lua_pop(childRuntime->GL, 1);
+        std::lock_guard lock(targetMutex);
+        // launch() cannot be called twice from the same target.
+        LUTE_ASSERT(!launched);
+        childRuntime = std::make_unique<Runtime>(parentRuntime.reporter);
+        setupState(*childRuntime, nullptr);
+        launchConfig = config;
 
-    processThread = thread;
-    installBpHitCallback();
-    installExitCallback();
-    // All VM setup happens synchronously before runContinuously starts the background thread.
-    // The no-op schedule wakes the event loop so it picks up the queued thread.
-    paused = false;
-    childRuntime->schedule([]() {});
-    childRuntime->runContinuously();
-    lock.unlock();
-    for (auto& bp : installed)
+        std::ifstream file(sourcePath);
+        if (!file.is_open())
+        {
+            childRuntime.reset();
+            return false;
+        }
+        std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+        Luau::CompileOptions debugOptions = {};
+        debugOptions.optimizationLevel = 1;
+        debugOptions.debugLevel = 2;
+        std::string bytecode = Luau::compile(source, debugOptions);
+        lua_State* thread = lua_newthread(childRuntime->GL);
+        luaL_sandboxthread(thread);
+        luau_load(thread, sourcePath.c_str(), bytecode.c_str(), bytecode.size(), 0);
+        loadedSources[sourcePath] = std::make_shared<Ref>(thread, -1);
+        std::tie(installedBps, uninstalledBps) = modifyPendingBreakpoints(thread);
+        for (const std::string& arg : args)
+            lua_pushstring(thread, arg.c_str());
+        childRuntime->runningThreads.push_back({true, getRefForThread(thread), static_cast<int>(args.size())});
+        lua_pop(childRuntime->GL, 1);
+
+        scriptThread = thread;
+        installBpHitCallback();
+        installExitCallback();
+        // All VM setup happens synchronously before runContinuously starts the background thread.
+        // The no-op schedule wakes the event loop so it picks up the queued thread.
+        paused = false;
+        launched = true;
+        childRuntime->schedule([]() {});
+        childRuntime->runContinuously();
+    }
+    for (auto& bp : installedBps)
         launchConfig.onBreakpointInstall(bp);
-    for (auto& bp : uninstalled)
+    for (auto& bp : uninstalledBps)
         launchConfig.onBreakpointUninstall(bp);
     return true;
 }
@@ -301,7 +307,7 @@ void Target::installBpHitCallback()
     cb->userdata = this;
     cb->debugbreak = [](lua_State* L, lua_Debug* ar)
     {
-        Target* target = static_cast<Target*>(lua_callbacks(L)->userdata);
+        auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
         // TODO: this pause/resume mechanism assumes single co-routine runtime
         // We land on the same instruction after a continue() after hitting a bp so we basically don't do anything
         std::unique_lock lock(target->targetMutex);
@@ -327,7 +333,7 @@ void Target::installBpHitCallback()
             target->resumeToken = getResumeToken(L);
             target->paused = true;
             lua_break(L);
-            auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->processThread);
+            auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
             lock.unlock();
             if (target->launchConfig.onBreakpointHit)
                 target->launchConfig.onBreakpointHit(bp.value());
@@ -356,15 +362,15 @@ void Target::installExitCallback()
         if (launchConfig.onExit)
             launchConfig.onExit(status == LUA_OK);
     };
-    childRuntime->addThreadCompletionHandler(processThread, std::move(completion));
+    childRuntime->addThreadCompletionHandler(scriptThread, std::move(completion));
 }
 
 bool Target::continueProcess()
 {
+
     std::unique_lock lock(targetMutex);
     if (!paused || !resumeToken)
         return false;
-    ResumeToken token;
     // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
     if (bpHit)
     {
@@ -375,17 +381,14 @@ bool Target::continueProcess()
             continueRequestedBp = true;
         bpHit = std::nullopt;
     }
-    token = std::move(resumeToken);
-    paused = false;
-    lock.unlock();
-    // complete() holdes a continuation mutex that we want to avoid holding while holding targetMutex()
-    // so we do the move above.
-    token->complete(
+    resumeToken->complete(
         [](lua_State* L)
         {
             return 0;
         }
     );
+    resumeToken = nullptr;
+    paused = false;
     return true;
 }
 } // namespace debug

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -30,6 +30,14 @@ Target::Target(Runtime& parentRuntime)
 {
 }
 
+Target::~Target()
+{
+    // We want to stop the runtime so nothing runs while we are destroying the target but first
+    // we need to clear all sources (which are stored as refs in the runtme).
+    loadedSources.clear();
+    childRuntime.reset();
+}
+
 Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
 {
     std::optional<Breakpoint> preexistingBp = getBreakpointBySourceLine(sourcePath, line);

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -33,7 +33,7 @@ Target::Target(Runtime& parentRuntime)
 Target::~Target()
 {
     // We want to stop the runtime so nothing runs while we are destroying the target but first
-    // we need to clear all sources (which are stored as refs in the runtme).
+    // we need to clear all sources (which are stored as refs in the runtime).
     loadedSources.clear();
     childRuntime.reset();
 }
@@ -43,24 +43,24 @@ Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
     std::optional<Breakpoint> preexistingBp = getBreakpointBySourceLine(sourcePath, line);
     if (preexistingBp)
         return *preexistingBp;
+    std::unique_lock lock(breakpointsMutex);
     int id = currentBreakpointId;
     currentBreakpointId++;
-    std::unique_lock lock(breakpointsMutex);
-    auto [it, _] = breakpoints.insert_or_assign(id, Breakpoint(id, sourcePath, line, BreakpointStatus::PendingInstall));
+    auto [it, _] = breakpoints.insert_or_assign(id, Breakpoint{id, sourcePath, line, BreakpointStatus::PendingInstall});
     // We schedule breakpoint installs to happen async
     if (childRuntime)
         childRuntime->schedule(
             [this, id]()
             {
                 std::unique_lock lock(breakpointsMutex);
-                auto it = breakpoints.find(id);
                 // check breakpoint has not been erased when this scheduled install has been fired
-                if (it != breakpoints.end())
+                if (auto it = breakpoints.find(id); it != breakpoints.end())
                 {
                     bool installed = installBreakpoint(childRuntime->GL, it->second);
+                    Breakpoint bp = it->second;
                     lock.unlock();
                     if (installed && launchConfig.onBreakpointInstall)
-                        launchConfig.onBreakpointInstall(it->second);
+                        launchConfig.onBreakpointInstall(bp);
                 }
             }
         );
@@ -185,12 +185,17 @@ std::optional<Breakpoint> Target::getBreakpointById(int breakpointId) const
 std::optional<Breakpoint> Target::getBreakpointBySourceLine(std::string source, int line) const
 {
     std::unique_lock lock(breakpointsMutex);
-    for (const auto& [_, bp] : breakpoints)
-    {
-        if (bp.sourcePath == source && bp.line == line)
-            return bp;
-    }
-    return std::nullopt;
+    auto it = std::find_if(
+        breakpoints.begin(),
+        breakpoints.end(),
+        [&source, line](const std::pair<const int, Breakpoint>& entry)
+        {
+            return entry.second.sourcePath == source && entry.second.line == line;
+        }
+    );
+    if (it == breakpoints.end())
+        return std::nullopt;
+    return it->second;
 }
 
 bool Target::installBreakpoint(lua_State* L, Breakpoint& bp)
@@ -215,19 +220,19 @@ bool Target::installBreakpoint(lua_State* L, Breakpoint& bp)
 void Target::installPendingBreakpoints(lua_State* L)
 {
     std::unique_lock lock(breakpointsMutex);
+    std::vector<Breakpoint> needCallback;
     for (auto& [_, bp] : breakpoints)
     {
         if (bp.status == BreakpointStatus::PendingInstall)
         {
             bool installed = installBreakpoint(L, bp);
             if (installed && launchConfig.onBreakpointInstall)
-            {
-                lock.unlock();
-                launchConfig.onBreakpointInstall(bp);
-                lock.lock();
-            }
+                needCallback.push_back(bp);
         }
     }
+    lock.unlock();
+    for (auto& bp : needCallback)
+        launchConfig.onBreakpointInstall(bp);
 }
 
 std::shared_ptr<Process> Target::launch(const std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config)
@@ -235,13 +240,16 @@ std::shared_ptr<Process> Target::launch(const std::string sourcePath, const std:
     // launch() cannot be called twice from the same target.
     if (activeProcess != nullptr)
         return nullptr;
-    childRuntime = std::make_shared<Runtime>(parentRuntime.reporter);
+    childRuntime = std::make_unique<Runtime>(parentRuntime.reporter);
     setupState(*childRuntime, nullptr);
     launchConfig = config;
 
     std::ifstream file(sourcePath);
     if (!file.is_open())
+    {
+        childRuntime.reset();
         return nullptr;
+    }
     std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     Luau::CompileOptions debugOptions = {};
     debugOptions.optimizationLevel = 1;
@@ -280,6 +288,7 @@ Target& Process::getTarget()
 {
     return parentTarget;
 }
+
 void Process::installBpHitCallback()
 {
     lua_Callbacks* cb = lua_callbacks(runtime.GL);

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -235,7 +235,7 @@ void Target::installPendingBreakpoints(lua_State* L)
         launchConfig.onBreakpointInstall(bp);
 }
 
-std::shared_ptr<Process> Target::launch(const std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config)
+std::shared_ptr<Process> Target::launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config)
 {
     // launch() cannot be called twice from the same target.
     if (activeProcess != nullptr)
@@ -298,6 +298,7 @@ void Process::installBpHitCallback()
         Process* process = static_cast<Process*>(lua_callbacks(L)->userdata);
         // TODO: this pause/resume mechanism assumes single co-routine runtime
         // We land on the same instruction after a continue() after hitting a bp so we basically don't do anything
+        std::unique_lock lock(process->continueMutex);
         if (process->continueRequestedBp)
         {
             process->continueRequestedBp = false;
@@ -318,6 +319,7 @@ void Process::installBpHitCallback()
         {
             process->bpHit = *bp;
             process->resumeToken = getResumeToken(L);
+            lock.unlock();
             lua_break(L);
             if (process->config.onBreakpointHit)
                 process->config.onBreakpointHit(*process, bp.value());
@@ -347,6 +349,7 @@ void Process::installExitCallback()
 
 bool Process::continueProcess()
 {
+    std::unique_lock lock(continueMutex);
     if (!resumeToken)
         return false;
     // we are continuing on a breakpoint and so might need to flag continueRequestedBp.

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -52,8 +52,8 @@ Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
                 {
                     bool installed = installBreakpoint(childRuntime->GL, it->second);
                     lock.unlock();
-                    if (installed && onBreakpointInstall)
-                        onBreakpointInstall(it->second);
+                    if (installed && launchConfig.onBreakpointInstall)
+                        launchConfig.onBreakpointInstall(it->second);
                 }
             }
         );
@@ -124,8 +124,8 @@ bool Target::removeBreakpoint(int bpId)
                         return;
                     }
                     lock.unlock();
-                    if (onBreakpointUninstall)
-                        onBreakpointUninstall(bp);
+                    if (launchConfig.onBreakpointUninstall)
+                        launchConfig.onBreakpointUninstall(bp);
                 }
             );
         }
@@ -213,18 +213,13 @@ void Target::installPendingBreakpoints(lua_State* L)
         if (bp.status == BreakpointStatus::PendingInstall)
         {
             bool installed = installBreakpoint(L, bp);
-            if (installed && onBreakpointInstall)
-                onBreakpointInstall(bp);
+            if (installed && launchConfig.onBreakpointInstall)
+                launchConfig.onBreakpointInstall(bp);
         }
     }
 }
 
-std::shared_ptr<Process> Target::launch(
-    const std::vector<std::string>& args,
-    std::function<void(const Breakpoint& bp)> onBreakpointInstall,
-    std::function<void(const Breakpoint& bp)> onBreakpointUninstall,
-    std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit
-)
+std::shared_ptr<Process> Target::launch(const std::vector<std::string>& args, LaunchConfig config)
 {
     // launch() cannot be called twice from the same target.
     if (childRuntime != nullptr)
@@ -232,8 +227,7 @@ std::shared_ptr<Process> Target::launch(
     childRuntime = std::make_shared<Runtime>(parentRuntime.reporter);
     setupState(*childRuntime, nullptr);
 
-    this->onBreakpointInstall = onBreakpointInstall;
-    this->onBreakpointUninstall = onBreakpointUninstall;
+    launchConfig = config;
 
     std::ifstream file(sourcePath);
     if (!file.is_open())
@@ -250,10 +244,12 @@ std::shared_ptr<Process> Target::launch(
     installPendingBreakpoints(thread);
     for (const std::string& arg : args)
         lua_pushstring(thread, arg.c_str());
+
+    auto process = std::make_shared<Process>(thread, *this, config);
+    activeProcess = process;
     childRuntime->runningThreads.push_back({true, getRefForThread(thread), static_cast<int>(args.size())});
     lua_pop(childRuntime->GL, 1);
 
-    auto process = std::make_shared<Process>(*childRuntime, *this, onBreakpointHit);
     // All VM setup happens synchronously before runContinuously starts the background thread.
     // The no-op schedule wakes the event loop so it picks up the queued thread.
     childRuntime->schedule([]() {});
@@ -261,12 +257,14 @@ std::shared_ptr<Process> Target::launch(
     return process;
 }
 
-Process::Process(Runtime& runtime, Target& parentTarget, std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit)
-    : runtime(runtime)
+Process::Process(lua_State* thread, Target& parentTarget, LaunchConfig config)
+    : thread(thread)
+    , runtime(*getRuntime(thread))
     , parentTarget(parentTarget)
-    , onBreakpointHit(onBreakpointHit)
+    , config(std::move(config))
 {
     installBpHitCallback();
+    installExitCallback();
 }
 
 Target& Process::getTarget()
@@ -284,23 +282,45 @@ void Process::installBpHitCallback()
         lua_Debug info = {};
         lua_getinfo(L, 0, "s", &info);
 
+        // TODO: this pause/resume mechanism assumes single co-routine runtime
         Process* process = static_cast<Process*>(lua_callbacks(L)->userdata);
         process->resumeToken = getResumeToken(L);
         std::string source = info.source;
         std::optional<Breakpoint> bp = process->parentTarget.getBreakpointBySourceLine(source, line);
-        if (bp && bp->status == BreakpointStatus::Installed)
+        if (bp)
         {
-            // notify caller that we stopped
-            if (process->onBreakpointHit)
+            if (bp->status == BreakpointStatus::Installed)
             {
-                process->onBreakpointHit(*process, bp.value());
+                // notify caller that we stopped
+                if (process->config.onBreakpointHit)
+                {
+                    process->config.onBreakpointHit(*process, bp.value());
+                }
+            }
+            else if (bp->status == BreakpointStatus::PendingUninstall)
+            {
+                process->continueProcess();
             }
         }
         else
         {
-            // TODO: some error report
+            process->runtime.reporter.reportError(
+                Luau::format("breakpoint hit at line %d in %s could not be found in breakpoint map", line, source.c_str())
+            );
         }
     };
+}
+
+// TODO: this exit handler assumes single coroutine runtime
+void Process::installExitCallback()
+{
+    ThreadCompletionHandler completion;
+    completion.onFinish = [this](lua_State* L, int status)
+    {
+        if (config.onExit)
+            config.onExit(status == LUA_OK);
+    };
+    runtime.addThreadCompletionHandler(thread, std::move(completion));
 }
 
 bool Process::continueProcess()

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -40,36 +40,30 @@ Target::~Target()
 
 Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
 {
-    std::optional<Breakpoint> preexistingBp = getBreakpointBySourceLine(sourcePath, line);
+    std::unique_lock lock(targetMutex);
+    std::optional<Breakpoint> preexistingBp = getBreakpointBySourceLineHelper(sourcePath, line);
     if (preexistingBp)
         return *preexistingBp;
-    std::unique_lock lock(breakpointsMutex);
     int id = currentBreakpointId;
     currentBreakpointId++;
     auto [it, _] = breakpoints.insert_or_assign(id, Breakpoint{id, sourcePath, line, BreakpointStatus::PendingInstall});
-    // We schedule breakpoint installs to happen async
-    if (childRuntime)
-        childRuntime->schedule(
-            [this, id]()
-            {
-                std::unique_lock lock(breakpointsMutex);
-                // check breakpoint has not been erased when this scheduled install has been fired
-                if (auto it = breakpoints.find(id); it != breakpoints.end())
-                {
-                    bool installed = installBreakpoint(childRuntime->GL, it->second);
-                    Breakpoint bp = it->second;
-                    lock.unlock();
-                    if (installed && launchConfig.onBreakpointInstall)
-                        launchConfig.onBreakpointInstall(bp);
-                }
-            }
-        );
+    // We schedule breakpoint installs to happen when the runtime exists and we are paused. Otherwise,
+    // they are scheduled for pending installs.
+    if (childRuntime && paused)
+    {
+        bool installed = installBreakpoint(childRuntime->GL, it->second);
+        Breakpoint bpCopy = it->second;
+        lock.unlock();
+        if (installed && launchConfig.onBreakpointInstall)
+            launchConfig.onBreakpointInstall(bpCopy);
+        return bpCopy;
+    }
     return it->second;
 }
 
 bool Target::removeBreakpoint(int bpId)
 {
-    std::unique_lock lock(breakpointsMutex);
+    std::unique_lock lock(targetMutex);
     auto it = breakpoints.find(bpId);
     if (it == breakpoints.end())
         return false;
@@ -83,58 +77,23 @@ bool Target::removeBreakpoint(int bpId)
         // We schedule breakpoint uninstalls to happen async
         if (childRuntime)
         {
-            bp.status = BreakpointStatus::PendingUninstall;
-            childRuntime->schedule(
-                [this, bp]()
+            if (!paused)
+            {
+                bp.status = BreakpointStatus::PendingUninstall;
+            }
+            else
+            {
+                bool successful = uninstallBreakpoint(childRuntime->GL, bp);
+                if (!successful)
                 {
-                    std::unique_lock lock(breakpointsMutex);
-                    auto it = breakpoints.find(bp.id);
-                    if (it == breakpoints.end())
-                    {
-                        parentRuntime.reporter.reportError(
-                            Luau::format(
-                                "breakpoint %d installed at line %d in %s that is queued for uninstall is missing in breakpoint map",
-                                bp.id,
-                                bp.line,
-                                bp.sourcePath.c_str()
-                            )
-                        );
-                        return;
-                    }
-                    breakpoints.erase(it);
-                    auto chunkRef = loadedSources.find(bp.sourcePath);
-                    if (!chunkRef)
-                    {
-                        parentRuntime.reporter.reportError(
-                            Luau::format(
-                                "breakpoint %d installed at line %d in %s that is queued for uninstall is missing a loaded source",
-                                bp.id,
-                                bp.line,
-                                bp.sourcePath.c_str()
-                            )
-                        );
-                        return;
-                    }
-                    (*chunkRef)->push(childRuntime->GL);
-                    int removed_line = lua_breakpoint(childRuntime->GL, -1, bp.line, 0);
-                    lua_pop(childRuntime->GL, 1);
-                    if (removed_line == -1)
-                    {
-                        parentRuntime.reporter.reportError(
-                            Luau::format(
-                                "breakpoint %d installed at line %d in %s that is queued for uninstall could not be removed",
-                                bp.id,
-                                bp.line,
-                                bp.sourcePath.c_str()
-                            )
-                        );
-                        return;
-                    }
-                    lock.unlock();
-                    if (launchConfig.onBreakpointUninstall)
-                        launchConfig.onBreakpointUninstall(bp);
+                    return false;
                 }
-            );
+                Breakpoint bpCopy = bp;
+                breakpoints.erase(it);
+                lock.unlock();
+                if (launchConfig.onBreakpointUninstall)
+                    launchConfig.onBreakpointUninstall(bpCopy);
+            }
         }
         else
         {
@@ -154,7 +113,7 @@ bool Target::removeBreakpoint(int bpId)
 
 std::vector<Breakpoint> Target::getBreakpoints() const
 {
-    std::unique_lock lock(breakpointsMutex);
+    std::unique_lock lock(targetMutex);
     std::vector<Breakpoint> all;
     all.reserve(breakpoints.size());
     for (auto& [_, bp] : breakpoints)
@@ -164,7 +123,7 @@ std::vector<Breakpoint> Target::getBreakpoints() const
 
 std::vector<Breakpoint> Target::getBreakpointsByStatus(BreakpointStatus status) const
 {
-    std::unique_lock lock(breakpointsMutex);
+    std::unique_lock lock(targetMutex);
     std::vector<Breakpoint> statusBps;
     statusBps.reserve(breakpoints.size());
     for (auto& [_, bp] : breakpoints)
@@ -173,18 +132,22 @@ std::vector<Breakpoint> Target::getBreakpointsByStatus(BreakpointStatus status) 
     return statusBps;
 }
 
-std::optional<Breakpoint> Target::getBreakpointById(int breakpointId) const
+std::optional<Breakpoint> Target::getBreakpointByIdHelper(int breakpointId) const
 {
-    std::unique_lock lock(breakpointsMutex);
     auto it = breakpoints.find(breakpointId);
     if (it != breakpoints.end())
         return it->second;
     return std::nullopt;
 }
 
-std::optional<Breakpoint> Target::getBreakpointBySourceLine(std::string source, int line) const
+std::optional<Breakpoint> Target::getBreakpointById(int breakpointId) const
 {
-    std::unique_lock lock(breakpointsMutex);
+    std::unique_lock lock(targetMutex);
+    return getBreakpointByIdHelper(breakpointId);
+}
+
+std::optional<Breakpoint> Target::getBreakpointBySourceLineHelper(std::string source, int line) const
+{
     auto it = std::find_if(
         breakpoints.begin(),
         breakpoints.end(),
@@ -196,6 +159,12 @@ std::optional<Breakpoint> Target::getBreakpointBySourceLine(std::string source, 
     if (it == breakpoints.end())
         return std::nullopt;
     return it->second;
+}
+
+std::optional<Breakpoint> Target::getBreakpointBySourceLine(std::string source, int line) const
+{
+    std::unique_lock lock(targetMutex);
+    return getBreakpointBySourceLineHelper(source, line);
 }
 
 bool Target::installBreakpoint(lua_State* L, Breakpoint& bp)
@@ -217,29 +186,74 @@ bool Target::installBreakpoint(lua_State* L, Breakpoint& bp)
     return true;
 }
 
-void Target::installPendingBreakpoints(lua_State* L)
+// uninstallBreakpoint does not actually remove from the breakpoint map
+// to prevent issues with map iteration so callers should remember to do this.
+bool Target::uninstallBreakpoint(lua_State* L, Breakpoint& bp)
 {
-    std::unique_lock lock(breakpointsMutex);
-    std::vector<Breakpoint> needCallback;
-    for (auto& [_, bp] : breakpoints)
+    auto chunkRef = loadedSources.find(bp.sourcePath);
+    if (!chunkRef)
+    {
+        parentRuntime.reporter.reportError(
+            Luau::format(
+                "breakpoint %d installed at line %d in %s that is queued for uninstall is missing a loaded source",
+                bp.id,
+                bp.line,
+                bp.sourcePath.c_str()
+            )
+        );
+        return false;
+    }
+    (*chunkRef)->push(L);
+    int removed_line = lua_breakpoint(L, -1, bp.line, 0);
+    lua_pop(L, 1);
+    if (removed_line == -1)
+    {
+        parentRuntime.reporter.reportError(
+            Luau::format(
+                "breakpoint %d installed at line %d in %s that is queued for uninstall could not be removed", bp.id, bp.line, bp.sourcePath.c_str()
+            )
+        );
+        return false;
+    }
+    return true;
+}
+
+// This returns the list of installed and unisntalled vectors for use in callbacks
+// later.
+std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> Target::modifyPendingBreakpoints(lua_State* L)
+{
+    std::vector<Breakpoint> installedBpsCallback, uninstalledBpsCallback;
+    std::vector<int> toErase;
+    for (auto& [id, bp] : breakpoints)
     {
         if (bp.status == BreakpointStatus::PendingInstall)
         {
             bool installed = installBreakpoint(L, bp);
             if (installed && launchConfig.onBreakpointInstall)
-                needCallback.push_back(bp);
+                installedBpsCallback.push_back(bp);
+        }
+        if (bp.status == BreakpointStatus::PendingUninstall)
+        {
+            bool uninstalled = uninstallBreakpoint(L, bp);
+            if (uninstalled)
+            {
+                if (launchConfig.onBreakpointUninstall)
+                    uninstalledBpsCallback.push_back(bp);
+                toErase.push_back(bp.id);
+            }
         }
     }
-    lock.unlock();
-    for (auto& bp : needCallback)
-        launchConfig.onBreakpointInstall(bp);
+    for (int id : toErase)
+        breakpoints.erase(id);
+    return {installedBpsCallback, uninstalledBpsCallback};
 }
 
-std::shared_ptr<Process> Target::launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config)
+bool Target::launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config)
 {
     // launch() cannot be called twice from the same target.
-    if (activeProcess != nullptr)
-        return nullptr;
+    std::unique_lock lock(targetMutex);
+    if (processThread != nullptr)
+        return false;
     childRuntime = std::make_unique<Runtime>(parentRuntime.reporter);
     setupState(*childRuntime, nullptr);
     launchConfig = config;
@@ -248,7 +262,7 @@ std::shared_ptr<Process> Target::launch(const std::string& sourcePath, const std
     if (!file.is_open())
     {
         childRuntime.reset();
-        return nullptr;
+        return false;
     }
     std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     Luau::CompileOptions debugOptions = {};
@@ -259,49 +273,41 @@ std::shared_ptr<Process> Target::launch(const std::string& sourcePath, const std
     luaL_sandboxthread(thread);
     luau_load(thread, sourcePath.c_str(), bytecode.c_str(), bytecode.size(), 0);
     loadedSources[sourcePath] = std::make_shared<Ref>(thread, -1);
-    installPendingBreakpoints(thread);
+    auto [installed, uninstalled] = modifyPendingBreakpoints(thread);
     for (const std::string& arg : args)
         lua_pushstring(thread, arg.c_str());
     childRuntime->runningThreads.push_back({true, getRefForThread(thread), static_cast<int>(args.size())});
     lua_pop(childRuntime->GL, 1);
 
-    std::shared_ptr<Process> process = std::make_shared<Process>(thread, *this, config);
-    activeProcess = process;
-    // All VM setup happens synchronously before runContinuously starts the background thread.
-    // The no-op schedule wakes the event loop so it picks up the queued thread.
-    childRuntime->schedule([]() {});
-    childRuntime->runContinuously();
-    return process;
-}
-
-Process::Process(lua_State* thread, Target& parentTarget, LaunchConfig config)
-    : thread(thread)
-    , runtime(*getRuntime(thread))
-    , parentTarget(parentTarget)
-    , config(std::move(config))
-{
+    processThread = thread;
     installBpHitCallback();
     installExitCallback();
+    // All VM setup happens synchronously before runContinuously starts the background thread.
+    // The no-op schedule wakes the event loop so it picks up the queued thread.
+    paused = false;
+    childRuntime->schedule([]() {});
+    childRuntime->runContinuously();
+    lock.unlock();
+    for (auto& bp : installed)
+        launchConfig.onBreakpointInstall(bp);
+    for (auto& bp : uninstalled)
+        launchConfig.onBreakpointUninstall(bp);
+    return true;
 }
 
-Target& Process::getTarget()
+void Target::installBpHitCallback()
 {
-    return parentTarget;
-}
-
-void Process::installBpHitCallback()
-{
-    lua_Callbacks* cb = lua_callbacks(runtime.GL);
+    lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
     cb->userdata = this;
     cb->debugbreak = [](lua_State* L, lua_Debug* ar)
     {
-        Process* process = static_cast<Process*>(lua_callbacks(L)->userdata);
+        Target* target = static_cast<Target*>(lua_callbacks(L)->userdata);
         // TODO: this pause/resume mechanism assumes single co-routine runtime
         // We land on the same instruction after a continue() after hitting a bp so we basically don't do anything
-        std::unique_lock lock(process->continueMutex);
-        if (process->continueRequestedBp)
+        std::unique_lock lock(target->targetMutex);
+        if (target->continueRequestedBp)
         {
-            process->continueRequestedBp = false;
+            target->continueRequestedBp = false;
             return;
         }
         lua_Debug info = {};
@@ -309,26 +315,32 @@ void Process::installBpHitCallback()
         int line = info.currentline;
         if (!info.source)
         {
-            process->runtime.reporter.reportError(Luau::format("breakpoint hit at line %d could not find a runtime source", line));
+            target->parentRuntime.reporter.reportError(Luau::format("breakpoint hit at line %d could not find a runtime source", line));
             return;
         }
         std::string source = info.source;
-        std::optional<Breakpoint> bp = process->parentTarget.getBreakpointBySourceLine(source, line);
+        std::optional<Breakpoint> bp = target->getBreakpointBySourceLineHelper(source, line);
         // Only stop execution on installed breakpoints; otherwise, don't stop.
         if (bp && bp->status == BreakpointStatus::Installed)
         {
-            process->bpHit = *bp;
-            process->resumeToken = getResumeToken(L);
-            lock.unlock();
+            target->bpHit = *bp;
+            target->resumeToken = getResumeToken(L);
+            target->paused = true;
             lua_break(L);
-            if (process->config.onBreakpointHit)
-                process->config.onBreakpointHit(*process, bp.value());
+            auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->processThread);
+            lock.unlock();
+            if (target->launchConfig.onBreakpointHit)
+                target->launchConfig.onBreakpointHit(bp.value());
+            for (auto& bp : installed)
+                target->launchConfig.onBreakpointInstall(bp);
+            for (auto& bp : uninstalled)
+                target->launchConfig.onBreakpointUninstall(bp);
         }
         else if (!bp || bp->status != BreakpointStatus::PendingUninstall)
         {
             // It is normal to hit breakpoints that are pending uninstall but not normal
             // to hit any other type of breakpoint so we error in those cases.
-            process->runtime.reporter.reportError(
+            target->parentRuntime.reporter.reportError(
                 Luau::format("breakpoint hit at line %d in %s could not be found in breakpoint map", line, source.c_str())
             );
         }
@@ -336,21 +348,21 @@ void Process::installBpHitCallback()
 }
 
 // TODO: this exit handler assumes single coroutine runtime
-void Process::installExitCallback()
+void Target::installExitCallback()
 {
     ThreadCompletionHandler completion;
     completion.onFinish = [this](lua_State* L, int status)
     {
-        if (config.onExit)
-            config.onExit(status == LUA_OK);
+        if (launchConfig.onExit)
+            launchConfig.onExit(status == LUA_OK);
     };
-    runtime.addThreadCompletionHandler(thread, std::move(completion));
+    childRuntime->addThreadCompletionHandler(processThread, std::move(completion));
 }
 
-bool Process::continueProcess()
+bool Target::continueProcess()
 {
-    std::unique_lock lock(continueMutex);
-    if (!resumeToken)
+    std::unique_lock lock(targetMutex);
+    if (!paused || !resumeToken)
         return false;
     ResumeToken token;
     // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
@@ -358,14 +370,15 @@ bool Process::continueProcess()
     {
         // we need to check if our breakpoint is still currently installed after
         // onBreakpointHit() callback
-        std::optional<Breakpoint> currentBp = parentTarget.getBreakpointById(bpHit->id);
+        std::optional<Breakpoint> currentBp = getBreakpointByIdHelper(bpHit->id);
         if (currentBp && currentBp->status == BreakpointStatus::Installed)
             continueRequestedBp = true;
         bpHit = std::nullopt;
     }
     token = std::move(resumeToken);
+    paused = false;
     lock.unlock();
-    // complete() holdes a continuation mutex that we want to avoid holding while holding continueMutex
+    // complete() holdes a continuation mutex that we want to avoid holding while holding targetMutex()
     // so we do the move above.
     token->complete(
         [](lua_State* L)

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -43,7 +43,7 @@ Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
     // We schedule breakpoint installs to happen async
     if (childRuntime)
         childRuntime->schedule(
-            [this, id]() mutable
+            [this, id]()
             {
                 std::unique_lock lock(breakpointsMutex);
                 auto it = breakpoints.find(id);
@@ -78,7 +78,7 @@ bool Target::removeBreakpoint(int bpId)
         {
             bp.status = BreakpointStatus::PendingUninstall;
             childRuntime->schedule(
-                [this, bp]() mutable
+                [this, bp]()
                 {
                     std::unique_lock lock(breakpointsMutex);
                     auto it = breakpoints.find(bp.id);
@@ -247,12 +247,11 @@ std::shared_ptr<Process> Target::launch(const std::vector<std::string>& args, La
     installPendingBreakpoints(thread);
     for (const std::string& arg : args)
         lua_pushstring(thread, arg.c_str());
-
-    auto process = std::make_shared<Process>(thread, *this, config);
-    activeProcess = process;
     childRuntime->runningThreads.push_back({true, getRefForThread(thread), static_cast<int>(args.size())});
     lua_pop(childRuntime->GL, 1);
 
+    std::shared_ptr<Process> process = std::make_shared<Process>(thread, *this, config);
+    activeProcess = process;
     // All VM setup happens synchronously before runContinuously starts the background thread.
     // The no-op schedule wakes the event loop so it picks up the queued thread.
     childRuntime->schedule([]() {});
@@ -288,27 +287,25 @@ void Process::installBpHitCallback()
         lua_Debug info = {};
         lua_getinfo(L, 0, "sl", &info);
         int line = info.currentline;
-        if (!info.source)
+        if (!info.source) {
             process->runtime.reporter.reportError(Luau::format("breakpoint hit at line %d could not be find a runtime source", line));
+            return;
+        }
         std::string source = info.source;
         std::optional<Breakpoint> bp = process->parentTarget.getBreakpointBySourceLine(source, line);
         if (bp && bp->status == BreakpointStatus::Installed)
         {
             if (process->config.onBreakpointHit)
-            {
                 process->config.onBreakpointHit(*process, bp.value());
-            }
         }
         else
         {
             // it is normal to hit breakpoints that are pending uninstall but not normal
             // to hit any other type of breakpoint
             if (!bp || bp->status != BreakpointStatus::PendingUninstall)
-            {
                 process->runtime.reporter.reportError(
                     Luau::format("breakpoint hit at line %d in %s could not be found in breakpoint map", line, source.c_str())
                 );
-            }
             // this prevents us from hanging forever
             process->continueProcess();
         }

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -352,6 +352,7 @@ bool Process::continueProcess()
     std::unique_lock lock(continueMutex);
     if (!resumeToken)
         return false;
+    ResumeToken token;
     // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
     if (bpHit)
     {
@@ -362,13 +363,16 @@ bool Process::continueProcess()
             continueRequestedBp = true;
         bpHit = std::nullopt;
     }
-    resumeToken->complete(
+    token = std::move(resumeToken);
+    lock.unlock();
+    // complete() holdes a continuation mutex that we want to avoid holding while holding continueMutex
+    // so we do the move above.
+    token->complete(
         [](lua_State* L)
         {
             return 0;
         }
     );
-    resumeToken = nullptr;
     return true;
 }
 } // namespace debug

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -8,6 +8,7 @@
 #include "lualib.h"
 
 #include <fstream>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -23,10 +24,9 @@ Breakpoint::Breakpoint(int id, std::string sourcePath, int line, BreakpointStatu
 {
 }
 
-Target::Target(Runtime& parentRuntime, std::string sourcePath, std::function<void(const Breakpoint& bp)> onBreakpointInstall)
+Target::Target(Runtime& parentRuntime, std::string sourcePath)
     : parentRuntime(parentRuntime)
     , sourcePath(sourcePath)
-    , onBreakpointInstall(onBreakpointInstall)
     , loadedSources("")
 {
 }
@@ -35,11 +35,13 @@ Breakpoint Target::addBreakpoint(std::string sourcePath, int line)
 {
     int id = currentBreakpointId;
     currentBreakpointId++;
-    auto [it, _] = breakpoints.insert_or_assign(id, Breakpoint(id, sourcePath, line, BreakpointStatus::Pending));
+    std::unique_lock lock(breakpointsMutex);
+    auto [it, _] = breakpoints.insert_or_assign(id, Breakpoint(id, sourcePath, line, BreakpointStatus::PendingInstall));
     if (childRuntime)
         childRuntime->schedule(
             [this, id]() mutable
             {
+                std::unique_lock lock(breakpointsMutex);
                 auto it = breakpoints.find(id);
                 // check breakpoint has not been erased when this scheduled install has been fired
                 if (it != breakpoints.end())
@@ -55,42 +57,77 @@ Breakpoint Target::addBreakpoint(std::string sourcePath, int line)
 
 bool Target::removeBreakpoint(int bpId)
 {
+    std::unique_lock lock(breakpointsMutex);
     auto it = breakpoints.find(bpId);
     if (it == breakpoints.end())
         return false;
     Breakpoint& bp = it->second;
-    if (bp.status == BreakpointStatus::Installed)
+    if (bp.status == BreakpointStatus::PendingUninstall)
     {
-        auto chunkRef = loadedSources.find(bp.sourcePath);
-        if (chunkRef && childRuntime)
+        return false;
+    }
+    else if (bp.status == BreakpointStatus::Installed)
+    {
+        if (childRuntime)
         {
-            (*chunkRef)->push(childRuntime->GL);
-            int removed_line = lua_breakpoint(childRuntime->GL, -1, bp.line, 0);
-            lua_pop(childRuntime->GL, 1);
-            if (removed_line == -1)
-                parentRuntime.reporter.reportError(
-                    Luau::format("breakpoint %d installed at line %d in %s could not be removed", bp.id, bp.line, bp.sourcePath.c_str())
-                );
-        }
-        else if (!childRuntime)
-        {
-            parentRuntime.reporter.reportError(
-                Luau::format("breakpoint %d installed at line %d in %s is missing a runtime", bp.id, bp.line, bp.sourcePath.c_str())
+            bp.status = BreakpointStatus::PendingUninstall;
+            childRuntime->schedule(
+                [this, bp]() mutable
+                {
+                    std::unique_lock lock(breakpointsMutex);
+                    auto it = breakpoints.find(bp.id);
+                    if (it == breakpoints.end())
+                    {
+                        parentRuntime.reporter.reportError(
+                            Luau::format(
+                                "breakpoint %d installed at line %d in %s is missing in breakpoint map", bp.id, bp.line, bp.sourcePath.c_str()
+                            )
+                        );
+                        return;
+                    }
+                    breakpoints.erase(it);
+                    auto chunkRef = loadedSources.find(bp.sourcePath);
+                    if (!chunkRef)
+                    {
+                        parentRuntime.reporter.reportError(
+                            Luau::format("breakpoint %d installed at line %d in %s is missing a loaded source", bp.id, bp.line, bp.sourcePath.c_str())
+                        );
+                        return;
+                    }
+                    (*chunkRef)->push(childRuntime->GL);
+                    int removed_line = lua_breakpoint(childRuntime->GL, -1, bp.line, 0);
+                    lua_pop(childRuntime->GL, 1);
+                    if (removed_line == -1)
+                    {
+                        parentRuntime.reporter.reportError(
+                            Luau::format("breakpoint %d installed at line %d in %s could not be removed", bp.id, bp.line, bp.sourcePath.c_str())
+                        );
+                        return;
+                    }
+                    if (onBreakpointUninstall)
+                        onBreakpointUninstall(bp);
+                }
             );
         }
         else
         {
             parentRuntime.reporter.reportError(
-                Luau::format("breakpoint %d installed at line %d in %s is missing a loaded source", bp.id, bp.line, bp.sourcePath.c_str())
+                Luau::format("breakpoint %d installed at line %d in %s is missing a runtime", bp.id, bp.line, bp.sourcePath.c_str())
             );
         }
     }
-    breakpoints.erase(it);
+    else
+    {
+        // We can simply erase breakpoints that are pending or invalid
+        // since they can never be hit.
+        breakpoints.erase(it);
+    }
     return true;
 }
 
 std::vector<Breakpoint> Target::getBreakpoints() const
 {
+    std::unique_lock lock(breakpointsMutex);
     std::vector<Breakpoint> all;
     all.reserve(breakpoints.size());
     for (auto& [_, bp] : breakpoints)
@@ -100,6 +137,7 @@ std::vector<Breakpoint> Target::getBreakpoints() const
 
 std::vector<Breakpoint> Target::getBreakpointsByStatus(BreakpointStatus status) const
 {
+    std::unique_lock lock(breakpointsMutex);
     std::vector<Breakpoint> statusBps;
     statusBps.reserve(breakpoints.size());
     for (auto& [_, bp] : breakpoints)
@@ -110,9 +148,21 @@ std::vector<Breakpoint> Target::getBreakpointsByStatus(BreakpointStatus status) 
 
 std::optional<Breakpoint> Target::getBreakpointById(int breakpointId) const
 {
+    std::unique_lock lock(breakpointsMutex);
     auto it = breakpoints.find(breakpointId);
     if (it != breakpoints.end())
         return it->second;
+    return std::nullopt;
+}
+
+std::optional<Breakpoint> Target::getBreakpointBySourceLine(std::string source, int line) const
+{
+    std::unique_lock lock(breakpointsMutex);
+    for (const auto& [_, bp] : breakpoints)
+    {
+        if (bp.sourcePath == source && bp.line == line)
+            return bp;
+    }
     return std::nullopt;
 }
 
@@ -137,9 +187,10 @@ bool Target::installBreakpoint(lua_State* L, Breakpoint& bp)
 
 void Target::installPendingBreakpoints(lua_State* L)
 {
+    std::unique_lock lock(breakpointsMutex);
     for (auto& [_, bp] : breakpoints)
     {
-        if (bp.status == BreakpointStatus::Pending)
+        if (bp.status == BreakpointStatus::PendingInstall)
         {
             bool installed = installBreakpoint(L, bp);
             if (installed && onBreakpointInstall)
@@ -148,14 +199,25 @@ void Target::installPendingBreakpoints(lua_State* L)
     }
 }
 
-bool Target::launch(const std::vector<std::string>& args)
+std::shared_ptr<Process> Target::launch(
+    const std::vector<std::string>& args,
+    std::function<void(const Breakpoint& bp)> onBreakpointInstall,
+    std::function<void(const Breakpoint& bp)> onBreakpointUninstall,
+    std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit
+)
 {
+    // launch() cannot be called twice from the same target.
+    if (childRuntime != nullptr)
+        return nullptr;
     childRuntime = std::make_shared<Runtime>(parentRuntime.reporter);
     setupState(*childRuntime, nullptr);
 
+    this->onBreakpointInstall = onBreakpointInstall;
+    this->onBreakpointUninstall = onBreakpointUninstall;
+
     std::ifstream file(sourcePath);
     if (!file.is_open())
-        return false;
+        return nullptr;
     std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
     Luau::CompileOptions debugOptions = {};
     debugOptions.optimizationLevel = 1;
@@ -171,9 +233,67 @@ bool Target::launch(const std::vector<std::string>& args)
     childRuntime->runningThreads.push_back({true, getRefForThread(thread), static_cast<int>(args.size())});
     lua_pop(childRuntime->GL, 1);
 
-    // the runtime provides the guarantees that C++ continuations (such as already enqueued breakpoints to install)
-    // happen before the first Luau thread runs
+    auto process = std::make_shared<Process>(*childRuntime, *this, onBreakpointHit);
+    // All VM setup happens synchronously before runContinuously starts the background thread.
+    // The no-op schedule wakes the event loop so it picks up the queued thread.
+    childRuntime->schedule([]() {});
     childRuntime->runContinuously();
+    return process;
+}
+
+Process::Process(Runtime& runtime, Target& parentTarget, std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit)
+    : runtime(runtime)
+    , parentTarget(parentTarget)
+    , onBreakpointHit(onBreakpointHit)
+{
+    installBpHitCallback();
+}
+
+Target& Process::getTarget()
+{
+    return parentTarget;
+}
+
+void Process::installBpHitCallback()
+{
+    lua_Callbacks* cb = lua_callbacks(runtime.GL);
+    cb->userdata = this;
+    cb->debugbreak = [](lua_State* L, lua_Debug* ar)
+    {
+        int line = ar->currentline;
+        lua_Debug info = {};
+        lua_getinfo(L, 0, "s", &info);
+
+        Process* process = static_cast<Process*>(lua_callbacks(L)->userdata);
+        process->resumeToken = getResumeToken(L);
+        std::string source = info.source;
+        std::optional<Breakpoint> bp = process->parentTarget.getBreakpointBySourceLine(source, line);
+        if (bp)
+        {
+            // notify caller that we stopped
+            if (process->onBreakpointHit)
+            {
+                process->onBreakpointHit(*process, bp.value());
+            }
+        }
+        else
+        {
+            // TODO: some error report
+        }
+    };
+}
+
+bool Process::continueProcess()
+{
+    if (!resumeToken)
+        return false;
+    resumeToken->complete(
+        [](lua_State* L)
+        {
+            return 0;
+        }
+    );
+    resumeToken = nullptr;
     return true;
 }
 } // namespace debug

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -24,9 +24,8 @@ Breakpoint::Breakpoint(int id, std::string sourcePath, int line, BreakpointStatu
 {
 }
 
-Target::Target(Runtime& parentRuntime, std::string sourcePath)
+Target::Target(Runtime& parentRuntime)
     : parentRuntime(parentRuntime)
-    , sourcePath(sourcePath)
     , loadedSources("")
 {
 }
@@ -223,7 +222,7 @@ void Target::installPendingBreakpoints(lua_State* L)
     }
 }
 
-std::shared_ptr<Process> Target::launch(const std::vector<std::string>& args, LaunchConfig config)
+std::shared_ptr<Process> Target::launch(const std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config)
 {
     // launch() cannot be called twice from the same target.
     if (activeProcess != nullptr)
@@ -287,7 +286,8 @@ void Process::installBpHitCallback()
         lua_Debug info = {};
         lua_getinfo(L, 0, "sl", &info);
         int line = info.currentline;
-        if (!info.source) {
+        if (!info.source)
+        {
             process->runtime.reporter.reportError(Luau::format("breakpoint hit at line %d could not be find a runtime source", line));
             return;
         }

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -31,10 +31,10 @@ Target::Target(Runtime& parentRuntime, std::string sourcePath)
 {
 }
 
-Breakpoint Target::addBreakpoint(std::string sourcePath, int line)
+Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
 {
     std::optional<Breakpoint> preexistingBp = getBreakpointBySourceLine(sourcePath, line);
-    if(preexistingBp)
+    if (preexistingBp)
         return *preexistingBp;
     int id = currentBreakpointId;
     currentBreakpointId++;

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -33,10 +33,14 @@ Target::Target(Runtime& parentRuntime, std::string sourcePath)
 
 Breakpoint Target::addBreakpoint(std::string sourcePath, int line)
 {
+    std::optional<Breakpoint> preexistingBp = getBreakpointBySourceLine(sourcePath, line);
+    if(preexistingBp)
+        return *preexistingBp;
     int id = currentBreakpointId;
     currentBreakpointId++;
     std::unique_lock lock(breakpointsMutex);
     auto [it, _] = breakpoints.insert_or_assign(id, Breakpoint(id, sourcePath, line, BreakpointStatus::PendingInstall));
+    // We schedule breakpoint installs to happen async
     if (childRuntime)
         childRuntime->schedule(
             [this, id]() mutable
@@ -47,6 +51,7 @@ Breakpoint Target::addBreakpoint(std::string sourcePath, int line)
                 if (it != breakpoints.end())
                 {
                     bool installed = installBreakpoint(childRuntime->GL, it->second);
+                    lock.unlock();
                     if (installed && onBreakpointInstall)
                         onBreakpointInstall(it->second);
                 }
@@ -68,6 +73,7 @@ bool Target::removeBreakpoint(int bpId)
     }
     else if (bp.status == BreakpointStatus::Installed)
     {
+        // We schedule breakpoint uninstalls to happen async
         if (childRuntime)
         {
             bp.status = BreakpointStatus::PendingUninstall;
@@ -80,7 +86,10 @@ bool Target::removeBreakpoint(int bpId)
                     {
                         parentRuntime.reporter.reportError(
                             Luau::format(
-                                "breakpoint %d installed at line %d in %s is missing in breakpoint map", bp.id, bp.line, bp.sourcePath.c_str()
+                                "breakpoint %d installed at line %d in %s that is queued for uninstall is missing in breakpoint map",
+                                bp.id,
+                                bp.line,
+                                bp.sourcePath.c_str()
                             )
                         );
                         return;
@@ -90,7 +99,12 @@ bool Target::removeBreakpoint(int bpId)
                     if (!chunkRef)
                     {
                         parentRuntime.reporter.reportError(
-                            Luau::format("breakpoint %d installed at line %d in %s is missing a loaded source", bp.id, bp.line, bp.sourcePath.c_str())
+                            Luau::format(
+                                "breakpoint %d installed at line %d in %s that is queued for uninstall is missing a loaded source",
+                                bp.id,
+                                bp.line,
+                                bp.sourcePath.c_str()
+                            )
                         );
                         return;
                     }
@@ -100,10 +114,16 @@ bool Target::removeBreakpoint(int bpId)
                     if (removed_line == -1)
                     {
                         parentRuntime.reporter.reportError(
-                            Luau::format("breakpoint %d installed at line %d in %s could not be removed", bp.id, bp.line, bp.sourcePath.c_str())
+                            Luau::format(
+                                "breakpoint %d installed at line %d in %s that is queued for uninstall could not be removed",
+                                bp.id,
+                                bp.line,
+                                bp.sourcePath.c_str()
+                            )
                         );
                         return;
                     }
+                    lock.unlock();
                     if (onBreakpointUninstall)
                         onBreakpointUninstall(bp);
                 }
@@ -268,7 +288,7 @@ void Process::installBpHitCallback()
         process->resumeToken = getResumeToken(L);
         std::string source = info.source;
         std::optional<Breakpoint> bp = process->parentTarget.getBreakpointBySourceLine(source, line);
-        if (bp)
+        if (bp && bp->status == BreakpointStatus::Installed)
         {
             // notify caller that we stopped
             if (process->onBreakpointHit)

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -33,13 +33,11 @@ struct Breakpoint
     explicit Breakpoint(int id, std::string sourcePath, int line, BreakpointStatus status);
 };
 
-struct Process;
-
 struct LaunchConfig
 {
     std::function<void(const Breakpoint& bp)> onBreakpointInstall;
     std::function<void(const Breakpoint& bp)> onBreakpointUninstall;
-    std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit;
+    std::function<void(const Breakpoint& bp)> onBreakpointHit;
     std::function<void(bool success)> onExit;
 };
 
@@ -67,45 +65,38 @@ struct Target
     std::optional<Breakpoint> getBreakpointById(int breakpointId) const;
     std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
 
-    std::shared_ptr<Process> launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
+    // For processes:
+    bool launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
+    bool continueProcess();
 
 private:
+    // targetMutex protects the entire Target, which basically serializes calls into it
+    // This is ok because we are not looking for high performance but rather correctness.
+    mutable std::mutex targetMutex;
+
     Runtime& parentRuntime;
     std::unique_ptr<Runtime> childRuntime;
 
-    // breakpointsMutex protects currentBreakpointId and breakpoints itself.
-    // for deadlock concerns, mutexes in the Process object should always be locked before
-    // locking the breakpointsMutex. We should never take a Process object lock while already owning breakpointsMutex.
-    mutable std::mutex breakpointsMutex;
     int currentBreakpointId = 0;
+    bool paused = true;
     std::unordered_map<int, Breakpoint> breakpoints; // breakpoint id -> breakpoint object (this is unordered_map to support erase)
-
-    std::shared_ptr<Process> activeProcess;
+    bool continueRequestedBp = false;
+    std::optional<Breakpoint> bpHit;
+    ResumeToken resumeToken;
     LaunchConfig launchConfig;
 
     Luau::DenseHashMap<std::string, std::shared_ptr<Ref>> loadedSources; // source path -> reference to chunk
 
+    // thread for our running process
+    lua_State* processThread = nullptr;
+
+    // private methods are meant for internal calls, so these don't lock targetMutex
+    std::optional<Breakpoint> getBreakpointBySourceLineHelper(std::string source, int line) const;
+    std::optional<Breakpoint> getBreakpointByIdHelper(int breakpointId) const;
+
     bool installBreakpoint(lua_State* L, Breakpoint& bp);
-    void installPendingBreakpoints(lua_State* L);
-};
-
-struct Process
-{
-    explicit Process(lua_State* thread, Target& parentTarget, LaunchConfig config);
-    Target& getTarget();
-    bool continueProcess();
-
-private:
-    lua_State* thread;
-    Runtime& runtime;
-    Target& parentTarget;
-    LaunchConfig config;
-
-    // continueMutex protects continueRequestedBp, resumeToken, and bpHit
-    mutable std::mutex continueMutex;
-    bool continueRequestedBp = false;
-    std::optional<Breakpoint> bpHit;
-    ResumeToken resumeToken;
+    bool uninstallBreakpoint(lua_State* L, Breakpoint& bp);
+    std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> modifyPendingBreakpoints(lua_State* L);
 
     void installBpHitCallback();
     void installExitCallback();

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -71,11 +71,12 @@ struct Target
 
 private:
     Runtime& parentRuntime;
-    std::shared_ptr<Runtime> childRuntime;
+    std::unique_ptr<Runtime> childRuntime;
 
+    // breakpointsMutex protects currentBreakpointId and breakpoints itself
+    mutable std::mutex breakpointsMutex;
     int currentBreakpointId = 0;
     std::unordered_map<int, Breakpoint> breakpoints; // breakpoint id -> breakpoint object (this is unordered_map to support erase)
-    mutable std::mutex breakpointsMutex;
 
     std::shared_ptr<Process> activeProcess;
     LaunchConfig launchConfig;
@@ -91,7 +92,7 @@ struct Process
     explicit Process(lua_State* thread, Target& parentTarget, LaunchConfig config);
     Target& getTarget();
     bool continueProcess();
-    int getCurrentLine() const;
+
 private:
     lua_State* thread;
     Runtime& runtime;

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -65,12 +65,13 @@ struct Target
     std::optional<Breakpoint> getBreakpointById(int breakpointId) const;
     std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
 
-    // For processes:
+    // For actively running scripts:
     bool launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
     bool continueProcess();
 
 private:
-    // targetMutex protects the entire Target, which basically serializes calls into it
+    // targetMutex protects the entire Target, since Target can be accessed from the main thread
+    // and the child runtime thread (i.e. in your debugbreak breakpoint callback).
     // This is ok because we are not looking for high performance but rather correctness.
     mutable std::mutex targetMutex;
 
@@ -79,6 +80,7 @@ private:
 
     int currentBreakpointId = 0;
     bool paused = true;
+    bool launched = false;
     std::unordered_map<int, Breakpoint> breakpoints; // breakpoint id -> breakpoint object (this is unordered_map to support erase)
     bool continueRequestedBp = false;
     std::optional<Breakpoint> bpHit;

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -4,6 +4,7 @@
 
 #include "Luau/DenseHash.h"
 
+#include <functional>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -31,7 +32,7 @@ struct Breakpoint
 
 struct Target
 {
-    explicit Target(Runtime& runtime, std::string sourcePath);
+    explicit Target(Runtime& parentRuntime, std::string sourcePath, std::function<void(const Breakpoint& bp)> onBreakpointInstall = {});
 
     // Setting breakpoints is a two step process. We add them to our Target. If they
     // involve a source that has already been loaded by the VM, we attempt to install that
@@ -39,6 +40,11 @@ struct Target
     // We do this because clients may 1) configure breakpoints before launching executables
     // 2) we load sources dynamically with @require that a client may want to debug.
     // TODO: implement 2 and add some callback when breakpoints get installed
+    //
+    // Guarantees for when breakpoints are installed:
+    // Any breakpoint that is placed when the target process is paused (including before launch) and that
+    // have a loaded source are guaranteed to be installed after the process is resumed. Breakpoints placed on a loaded source
+    // when the target script is running may not be installed until the next time that script is paused.
     Breakpoint addBreakpoint(std::string sourcePath, int line);
     bool removeBreakpoint(int bpId);
 
@@ -49,11 +55,13 @@ struct Target
     bool launch(const std::vector<std::string>& args);
 
 private:
-    Runtime& runtime;
+    Runtime& parentRuntime;
+    std::shared_ptr<Runtime> childRuntime;
     std::string sourcePath;
 
     int currentBreakpointId = 0;
     std::unordered_map<int, Breakpoint> breakpoints; // breakpoint id -> breakpoint object (this is unordered_map to support erase)
+    std::function<void(const Breakpoint& bp)> onBreakpointInstall;
 
     Luau::DenseHashMap<std::string, std::shared_ptr<Ref>> loadedSources; // source path -> reference to chunk
 

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -50,7 +50,7 @@ struct Target
     // Any breakpoint that is placed when the target process is paused (including before launch) and that
     // have a loaded source are guaranteed to be installed before the process is resumed. Breakpoints placed on a loaded source
     // when the target script is running may not be installed until the next time that script is paused.
-    Breakpoint addBreakpoint(std::string sourcePath, int line);
+    Breakpoint setBreakpoint(std::string sourcePath, int line);
     bool removeBreakpoint(int bpId);
 
     std::vector<Breakpoint> getBreakpoints() const;

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -91,13 +91,14 @@ struct Process
     explicit Process(lua_State* thread, Target& parentTarget, LaunchConfig config);
     Target& getTarget();
     bool continueProcess();
-
+    int getCurrentLine() const;
 private:
     lua_State* thread;
     Runtime& runtime;
     Target& parentTarget;
     ResumeToken resumeToken;
     LaunchConfig config;
+    bool continueRequested = false;
 
     void installBpHitCallback();
     void installExitCallback();

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -5,18 +5,21 @@
 #include "Luau/DenseHash.h"
 
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 struct lua_State;
+struct lua_Debug;
 
 namespace debug
 {
 enum class BreakpointStatus
 {
-    Pending,
+    PendingInstall,
+    PendingUninstall,
     Installed,
     Invalid,
 };
@@ -30,20 +33,22 @@ struct Breakpoint
     explicit Breakpoint(int id, std::string sourcePath, int line, BreakpointStatus status);
 };
 
+struct Process;
+
 struct Target
 {
-    explicit Target(Runtime& parentRuntime, std::string sourcePath, std::function<void(const Breakpoint& bp)> onBreakpointInstall = {});
+    explicit Target(Runtime& parentRuntime, std::string sourcePath);
 
     // Setting breakpoints is a two step process. We add them to our Target. If they
     // involve a source that has already been loaded by the VM, we attempt to install that
     // breakpoint. Otherwise, it exists as a pending breakpoint until new sources are loaded.
     // We do this because clients may 1) configure breakpoints before launching executables
     // 2) we load sources dynamically with @require that a client may want to debug.
-    // TODO: implement 2 and add some callback when breakpoints get installed
+    // TODO: implement 2
     //
     // Guarantees for when breakpoints are installed:
     // Any breakpoint that is placed when the target process is paused (including before launch) and that
-    // have a loaded source are guaranteed to be installed after the process is resumed. Breakpoints placed on a loaded source
+    // have a loaded source are guaranteed to be installed before the process is resumed. Breakpoints placed on a loaded source
     // when the target script is running may not be installed until the next time that script is paused.
     Breakpoint addBreakpoint(std::string sourcePath, int line);
     bool removeBreakpoint(int bpId);
@@ -51,8 +56,14 @@ struct Target
     std::vector<Breakpoint> getBreakpoints() const;
     std::vector<Breakpoint> getBreakpointsByStatus(BreakpointStatus status) const;
     std::optional<Breakpoint> getBreakpointById(int breakpointId) const;
+    std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
 
-    bool launch(const std::vector<std::string>& args);
+    std::shared_ptr<Process> launch(
+        const std::vector<std::string>& args,
+        std::function<void(const Breakpoint& bp)> onBreakpointInstall = {},
+        std::function<void(const Breakpoint& bp)> onBreakpointUninstall = {},
+        std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit = {}
+    );
 
 private:
     Runtime& parentRuntime;
@@ -61,7 +72,10 @@ private:
 
     int currentBreakpointId = 0;
     std::unordered_map<int, Breakpoint> breakpoints; // breakpoint id -> breakpoint object (this is unordered_map to support erase)
+    mutable std::mutex breakpointsMutex;
+
     std::function<void(const Breakpoint& bp)> onBreakpointInstall;
+    std::function<void(const Breakpoint& bp)> onBreakpointUninstall;
 
     Luau::DenseHashMap<std::string, std::shared_ptr<Ref>> loadedSources; // source path -> reference to chunk
 
@@ -69,4 +83,18 @@ private:
     void installPendingBreakpoints(lua_State* L);
 };
 
+struct Process
+{
+    explicit Process(Runtime& runtime, Target& parentTarget, std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit);
+    Target& getTarget();
+    bool continueProcess();
+
+private:
+    Runtime& runtime;
+    Target& parentTarget;
+    ResumeToken resumeToken;
+
+    std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit;
+    void installBpHitCallback();
+};
 } // namespace debug

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -46,6 +46,7 @@ struct LaunchConfig
 struct Target
 {
     explicit Target(Runtime& parentRuntime);
+    ~Target();
 
     // Setting breakpoints is a two step process. We add them to our Target. If they
     // involve a source that has already been loaded by the VM, we attempt to install that

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -99,7 +99,8 @@ private:
     Target& parentTarget;
     ResumeToken resumeToken;
     LaunchConfig config;
-    bool continueRequested = false;
+    bool continueRequestedBp = false;
+    std::optional<Breakpoint> bpHit;
 
     void installBpHitCallback();
     void installExitCallback();

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -67,13 +67,15 @@ struct Target
     std::optional<Breakpoint> getBreakpointById(int breakpointId) const;
     std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
 
-    std::shared_ptr<Process> launch(std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
+    std::shared_ptr<Process> launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
 
 private:
     Runtime& parentRuntime;
     std::unique_ptr<Runtime> childRuntime;
 
-    // breakpointsMutex protects currentBreakpointId and breakpoints itself
+    // breakpointsMutex protects currentBreakpointId and breakpoints itself.
+    // for deadlock concerns, mutexes in the Process object should always be locked before
+    // locking the breakpointsMutex. We should never take a Process object lock while already owning breakpointsMutex.
     mutable std::mutex breakpointsMutex;
     int currentBreakpointId = 0;
     std::unordered_map<int, Breakpoint> breakpoints; // breakpoint id -> breakpoint object (this is unordered_map to support erase)
@@ -97,10 +99,13 @@ private:
     lua_State* thread;
     Runtime& runtime;
     Target& parentTarget;
-    ResumeToken resumeToken;
     LaunchConfig config;
+
+    // continueMutex protects continueRequestedBp, resumeToken, and bpHit
+    mutable std::mutex continueMutex;
     bool continueRequestedBp = false;
     std::optional<Breakpoint> bpHit;
+    ResumeToken resumeToken;
 
     void installBpHitCallback();
     void installExitCallback();

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -35,6 +35,14 @@ struct Breakpoint
 
 struct Process;
 
+struct LaunchConfig
+{
+    std::function<void(const Breakpoint& bp)> onBreakpointInstall;
+    std::function<void(const Breakpoint& bp)> onBreakpointUninstall;
+    std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit;
+    std::function<void(bool success)> onExit;
+};
+
 struct Target
 {
     explicit Target(Runtime& parentRuntime, std::string sourcePath);
@@ -58,12 +66,7 @@ struct Target
     std::optional<Breakpoint> getBreakpointById(int breakpointId) const;
     std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
 
-    std::shared_ptr<Process> launch(
-        const std::vector<std::string>& args,
-        std::function<void(const Breakpoint& bp)> onBreakpointInstall = {},
-        std::function<void(const Breakpoint& bp)> onBreakpointUninstall = {},
-        std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit = {}
-    );
+    std::shared_ptr<Process> launch(const std::vector<std::string>& args, LaunchConfig config = {});
 
 private:
     Runtime& parentRuntime;
@@ -74,8 +77,8 @@ private:
     std::unordered_map<int, Breakpoint> breakpoints; // breakpoint id -> breakpoint object (this is unordered_map to support erase)
     mutable std::mutex breakpointsMutex;
 
-    std::function<void(const Breakpoint& bp)> onBreakpointInstall;
-    std::function<void(const Breakpoint& bp)> onBreakpointUninstall;
+    std::shared_ptr<Process> activeProcess;
+    LaunchConfig launchConfig;
 
     Luau::DenseHashMap<std::string, std::shared_ptr<Ref>> loadedSources; // source path -> reference to chunk
 
@@ -85,16 +88,18 @@ private:
 
 struct Process
 {
-    explicit Process(Runtime& runtime, Target& parentTarget, std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit);
+    explicit Process(lua_State* thread, Target& parentTarget, LaunchConfig config);
     Target& getTarget();
     bool continueProcess();
 
 private:
+    lua_State* thread;
     Runtime& runtime;
     Target& parentTarget;
     ResumeToken resumeToken;
+    LaunchConfig config;
 
-    std::function<void(Process& process, const Breakpoint& bp)> onBreakpointHit;
     void installBpHitCallback();
+    void installExitCallback();
 };
 } // namespace debug

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -45,7 +45,7 @@ struct LaunchConfig
 
 struct Target
 {
-    explicit Target(Runtime& parentRuntime, std::string sourcePath);
+    explicit Target(Runtime& parentRuntime);
 
     // Setting breakpoints is a two step process. We add them to our Target. If they
     // involve a source that has already been loaded by the VM, we attempt to install that
@@ -66,12 +66,11 @@ struct Target
     std::optional<Breakpoint> getBreakpointById(int breakpointId) const;
     std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
 
-    std::shared_ptr<Process> launch(const std::vector<std::string>& args, LaunchConfig config = {});
+    std::shared_ptr<Process> launch(std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
 
 private:
     Runtime& parentRuntime;
     std::shared_ptr<Runtime> childRuntime;
-    std::string sourcePath;
 
     int currentBreakpointId = 0;
     std::unordered_map<int, Breakpoint> breakpoints; // breakpoint id -> breakpoint object (this is unordered_map to support erase)

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -71,7 +71,7 @@ struct Target
 
 private:
     // targetMutex protects the entire Target, since Target can be accessed from the main thread
-    // and the child runtime thread (i.e. in your debugbreak breakpoint callback).
+    // and the child runtime thread (i.e. in the debugbreak breakpoint callback).
     // This is ok because we are not looking for high performance but rather correctness.
     mutable std::mutex targetMutex;
 
@@ -89,8 +89,8 @@ private:
 
     Luau::DenseHashMap<std::string, std::shared_ptr<Ref>> loadedSources; // source path -> reference to chunk
 
-    // thread for our running process
-    lua_State* processThread = nullptr;
+    // thread for our launched script
+    lua_State* scriptThread = nullptr;
 
     // private methods are meant for internal calls, so these don't lock targetMutex
     std::optional<Breakpoint> getBreakpointBySourceLineHelper(std::string source, int line) const;

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -126,7 +126,7 @@ RuntimeStep Runtime::runOnce()
     else
         status = lua_resume(L, nullptr, next.argumentCount);
 
-    if (status == LUA_YIELD || status == LUA_BREAK)
+    if (status == LUA_YIELD)
     {
         return StepSuccess{L};
     }

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -126,7 +126,7 @@ RuntimeStep Runtime::runOnce()
     else
         status = lua_resume(L, nullptr, next.argumentCount);
 
-    if (status == LUA_YIELD)
+    if (status == LUA_YIELD || status == LUA_BREAK)
     {
         return StepSuccess{L};
     }

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -55,7 +55,11 @@ TEST_SUITE("Debug")
             CHECK(continuedProcess);
         };
 
-        std::shared_ptr<debug::Process> process = target.launch({}, onBreakpointInstall, nullptr, onBreakpointHit);
+        debug::LaunchConfig config;
+        config.onBreakpointInstall = onBreakpointInstall;
+        config.onBreakpointHit = onBreakpointHit;
+
+        std::shared_ptr<debug::Process> process = target.launch({}, config);
         CHECK(process);
 
         // check breakpoints after launch
@@ -148,7 +152,10 @@ TEST_SUITE("Debug")
             CHECK(continuedProcess);
         };
 
-        std::shared_ptr<debug::Process> process = target.launch({}, nullptr, onBreakpointUninstall, onBreakpointHit);
+        debug::LaunchConfig config;
+        config.onBreakpointUninstall = onBreakpointUninstall;
+        config.onBreakpointHit = onBreakpointHit;
+        std::shared_ptr<debug::Process> process = target.launch({}, config);
         CHECK(process);
         std::optional<debug::Breakpoint> postLaunch = target.getBreakpointById(bp3.id);
         REQUIRE(postLaunch.has_value());
@@ -156,15 +163,56 @@ TEST_SUITE("Debug")
 
         bool removedBp3 = target.removeBreakpoint(bp3.id);
         CHECK(removedBp3);
-        REQUIRE(!target.getBreakpointById(bp3.id).has_value());
+        CHECK(!target.getBreakpointById(bp3.id).has_value());
 
         // check installed breakpoint is actually uninstalled
         REQUIRE(bp2Future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         CHECK(numUninstalledBps == 1);
-        REQUIRE(!target.getBreakpointById(bp2.id).has_value());
+        CHECK(!target.getBreakpointById(bp2.id).has_value());
 
         // check cannot remove never added breakpoint
         bool cannotRemove = target.removeBreakpoint(100);
         CHECK(!cannotRemove);
+    }
+
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_hitBreakpoint")
+    {
+        std::string fixturePath = getDebugFixturePath("loop.luau");
+        debug::Target target(*runtime, fixturePath);
+
+        // check removing pending breakpoint
+        debug::Breakpoint bp1 = target.setBreakpoint(fixturePath, 4);
+        debug::Breakpoint bp2 = target.setBreakpoint(fixturePath, 6);
+
+        int hitBp1 = 0, hitBp2 = 0;
+        std::function<void(debug::Process & process, const debug::Breakpoint& bp)> onBreakpointHit =
+            [bp1, bp2, &hitBp1, &hitBp2](debug::Process& process, const debug::Breakpoint& hitBp)
+        {
+            if (hitBp.id == bp1.id)
+            {
+                hitBp1++;
+            }
+            if (hitBp.id == bp2.id)
+            {
+                hitBp2++;
+            }
+            process.continueProcess();
+        };
+
+        std::promise<bool> exitPromise;
+        std::future<bool> exitFuture = exitPromise.get_future();
+
+        debug::LaunchConfig config;
+        config.onBreakpointHit = onBreakpointHit;
+        config.onExit = [&exitPromise](bool success)
+        {
+            exitPromise.set_value(success);
+        };
+        target.launch({}, config);
+
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        CHECK(exitFuture.get() == true);
+        CHECK(hitBp1 == 5);
+        CHECK(hitBp2 == 25);
     }
 }

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -9,7 +9,7 @@ TEST_SUITE("Debug")
     TEST_CASE_FIXTURE(DebugFixture, "Debug_setBreakpoint")
     {
         std::string fixturePath = getDebugFixturePath("simple.luau");
-        debug::Target target(*runtime, fixturePath);
+        debug::Target target(*runtime);
 
         // valid breakpoint
         debug::Breakpoint bp = target.setBreakpoint(fixturePath, 2);
@@ -58,7 +58,7 @@ TEST_SUITE("Debug")
         config.onBreakpointInstall = onBreakpointInstall;
         config.onBreakpointHit = onBreakpointHit;
 
-        std::shared_ptr<debug::Process> process = target.launch({}, config);
+        std::shared_ptr<debug::Process> process = target.launch(fixturePath, {}, config);
         REQUIRE((bool)(process));
 
         // check breakpoints after launch
@@ -103,7 +103,7 @@ TEST_SUITE("Debug")
     TEST_CASE_FIXTURE(DebugFixture, "Debug_removeBreakpoint")
     {
         std::string fixturePath = getDebugFixturePath("simple.luau");
-        debug::Target target(*runtime, fixturePath);
+        debug::Target target(*runtime);
 
         // check removing pending breakpoint
         debug::Breakpoint bp = target.setBreakpoint(fixturePath, 2);
@@ -155,7 +155,7 @@ TEST_SUITE("Debug")
 
         config.onBreakpointUninstall = onBreakpointUninstall;
         config.onBreakpointHit = onBreakpointHit;
-        std::shared_ptr<debug::Process> process = target.launch({}, config);
+        std::shared_ptr<debug::Process> process = target.launch(fixturePath, {}, config);
         REQUIRE((bool)(process));
         std::optional<debug::Breakpoint> postLaunch = target.getBreakpointById(bp3.id);
         REQUIRE(postLaunch.has_value());
@@ -182,7 +182,7 @@ TEST_SUITE("Debug")
     TEST_CASE_FIXTURE(DebugFixture, "Debug_hitBreakpoint")
     {
         std::string fixturePath = getDebugFixturePath("loop.luau");
-        debug::Target target(*runtime, fixturePath);
+        debug::Target target(*runtime);
 
         // check removing pending breakpoint
         debug::Breakpoint bp1 = target.setBreakpoint(fixturePath, 4);
@@ -200,7 +200,7 @@ TEST_SUITE("Debug")
         };
 
         config.onBreakpointHit = onBreakpointHit;
-        target.launch({}, config);
+        target.launch(fixturePath, {}, config);
 
         // wait until script is finished
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -126,10 +126,10 @@ TEST_SUITE("Debug")
         int numUninstalledBps = 0;
         std::promise<debug::Breakpoint> bp2Promise;
         std::future<debug::Breakpoint> bp2Future = bp2Promise.get_future();
-        std::function<void(const debug::Breakpoint& bp)> onBreakpointUninstall = [&numUninstalledBps, &bp2Promise](const debug::Breakpoint& bp)
+        std::function<void(const debug::Breakpoint& bp)> onBreakpointUninstall = [&numUninstalledBps, &bp2Promise, &bp2](const debug::Breakpoint& bp)
         {
             numUninstalledBps++;
-            if (bp.id == 1)
+            if (bp.id == bp2.id)
                 bp2Promise.set_value(bp);
         };
 

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -9,17 +9,7 @@ TEST_SUITE("Debug")
     TEST_CASE_FIXTURE(DebugFixture, "Debug_addBreakpoint")
     {
         std::string fixturePath = getDebugFixturePath("simple.luau");
-
-        std::promise<debug::Breakpoint> bp4Promise;
-        std::future<debug::Breakpoint> bp4Future = bp4Promise.get_future();
-
-        std::function<void(const debug::Breakpoint& bp)> onBreakpointInstall = [&bp4Promise](const debug::Breakpoint& bp)
-        {
-            if (bp.id == 3)
-                bp4Promise.set_value(bp);
-        };
-
-        debug::Target target(*runtime, fixturePath, onBreakpointInstall);
+        debug::Target target(*runtime, fixturePath);
 
         // valid breakpoint
         debug::Breakpoint bp = target.addBreakpoint(fixturePath, 2);
@@ -32,17 +22,17 @@ TEST_SUITE("Debug")
         CHECK(bp.id == 0);
         CHECK(bp.sourcePath == fixturePath);
         CHECK(bp.line == 2);
-        CHECK(bp.status == debug::BreakpointStatus::Pending);
+        CHECK(bp.status == debug::BreakpointStatus::PendingInstall);
 
         CHECK(bp2.id == 1);
         CHECK(bp2.sourcePath == fixturePath);
         CHECK(bp2.line == 100);
-        CHECK(bp2.status == debug::BreakpointStatus::Pending);
+        CHECK(bp2.status == debug::BreakpointStatus::PendingInstall);
 
         CHECK(bp3.id == 2);
         CHECK(bp3.sourcePath == fixturePath);
         CHECK(bp3.line == 3);
-        CHECK(bp3.status == debug::BreakpointStatus::Pending);
+        CHECK(bp3.status == debug::BreakpointStatus::PendingInstall);
 
         std::optional<debug::Breakpoint> found = target.getBreakpointById(0);
         REQUIRE(found.has_value());
@@ -50,12 +40,27 @@ TEST_SUITE("Debug")
         found = target.getBreakpointById(999);
         REQUIRE(!found.has_value());
 
-        bool launched = target.launch({});
-        CHECK(launched == true);
+        std::promise<debug::Breakpoint> bp4Promise;
+        std::future<debug::Breakpoint> bp4Future = bp4Promise.get_future();
+        std::function<void(const debug::Breakpoint& bp)> onBreakpointInstall = [&bp4Promise](const debug::Breakpoint& bp)
+        {
+            if (bp.id == 3)
+                bp4Promise.set_value(bp);
+        };
+
+        std::function<void(debug::Process & process, const debug::Breakpoint& bp)> onBreakpointHit =
+            [](debug::Process& process, const debug::Breakpoint& bp)
+        {
+            bool continuedProcess = process.continueProcess();
+            CHECK(continuedProcess);
+        };
+
+        std::shared_ptr<debug::Process> process = target.launch({}, onBreakpointInstall, nullptr, onBreakpointHit);
+        CHECK(process);
 
         // check breakpoints after launch
         CHECK(target.getBreakpoints().size() == 3);
-        CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::Pending).size() == 0);
+        CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::PendingInstall).size() == 0);
         CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::Installed).size() == 2);
         CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::Invalid).size() == 1);
 
@@ -74,7 +79,7 @@ TEST_SUITE("Debug")
         CHECK(postLaunch->status == debug::BreakpointStatus::Installed);
         CHECK(postLaunch->line == 4);
 
-        // check that adding breakpoints after launch should be immediately installed
+        // check that adding breakpoints after launch should be installed at some point
         debug::Breakpoint bp4 = target.addBreakpoint(fixturePath, 2);
         REQUIRE(bp4Future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         debug::Breakpoint installedBp4 = bp4Future.get();
@@ -94,7 +99,7 @@ TEST_SUITE("Debug")
 
         std::optional<debug::Breakpoint> preLaunch = target.getBreakpointById(bp.id);
         REQUIRE(preLaunch.has_value());
-        CHECK(preLaunch->status == debug::BreakpointStatus::Pending);
+        CHECK(preLaunch->status == debug::BreakpointStatus::PendingInstall);
 
         bool removedBp1 = target.removeBreakpoint(bp.id);
         CHECK(removedBp1);
@@ -105,26 +110,52 @@ TEST_SUITE("Debug")
         debug::Breakpoint bp2 = target.addBreakpoint(fixturePath, 3);
         debug::Breakpoint bp3 = target.addBreakpoint(fixturePath, 100);
         CHECK(target.getBreakpoints().size() == 2);
-        bool launched = target.launch({});
-        CHECK(launched == true);
 
-        std::optional<debug::Breakpoint> postLaunch = target.getBreakpointById(bp2.id);
-        REQUIRE(postLaunch.has_value());
-        CHECK(postLaunch->status == debug::BreakpointStatus::Installed);
+        // We can do things like trigger breakpoint removals when our breakpoint is paused.
+        int numUninstalledBps = 0;
+        std::promise<debug::Breakpoint> bp2Promise;
+        std::future<debug::Breakpoint> bp2Future = bp2Promise.get_future();
+        std::function<void(const debug::Breakpoint& bp)> onBreakpointUninstall = [&numUninstalledBps, &bp2Promise](const debug::Breakpoint& bp)
+        {
+            numUninstalledBps++;
+            if (bp.id == 1)
+            {
+                bp2Promise.set_value(bp);
+            }
+        };
 
-        bool removedBp2 = target.removeBreakpoint(bp2.id);
-        CHECK(removedBp2);
-        REQUIRE(!target.getBreakpointById(bp2.id).has_value());
-        CHECK(target.getBreakpoints().size() == 1);
+        std::function<void(debug::Process & process, const debug::Breakpoint& bp)> onBreakpointHit =
+            [](debug::Process& process, const debug::Breakpoint& bp)
+        {
+            debug::Target& target = process.getTarget();
+            std::optional<debug::Breakpoint> postLaunch = target.getBreakpointById(bp.id);
+            REQUIRE(postLaunch.has_value());
+            CHECK(postLaunch->status == debug::BreakpointStatus::Installed);
 
-        postLaunch = target.getBreakpointById(bp3.id);
+            bool removedBp2 = target.removeBreakpoint(bp.id);
+            CHECK(removedBp2);
+            std::optional<debug::Breakpoint> postRemoval = target.getBreakpointById(bp.id);
+            REQUIRE(postRemoval.has_value());
+            CHECK(postRemoval->status == debug::BreakpointStatus::PendingUninstall);
+
+            bool continuedProcess = process.continueProcess();
+            CHECK(continuedProcess);
+        };
+
+        std::shared_ptr<debug::Process> process = target.launch({}, nullptr, onBreakpointUninstall, onBreakpointHit);
+        CHECK(process);
+        std::optional<debug::Breakpoint> postLaunch = target.getBreakpointById(bp3.id);
         REQUIRE(postLaunch.has_value());
         CHECK(postLaunch->status == debug::BreakpointStatus::Invalid);
 
         bool removedBp3 = target.removeBreakpoint(bp3.id);
         CHECK(removedBp3);
         REQUIRE(!target.getBreakpointById(bp3.id).has_value());
-        CHECK(target.getBreakpoints().size() == 0);
+
+        // check installed breakpoint is actually uninstalled
+        REQUIRE(bp2Future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        CHECK(numUninstalledBps == 1);
+        REQUIRE(!target.getBreakpointById(bp2.id).has_value());
 
         // check cannot remove never added breakpoint
         bool cannotRemove = target.removeBreakpoint(100);

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -1,5 +1,6 @@
 #include <chrono>
 #include <future>
+#include <thread>
 
 #include "debugfixture.h"
 #include "doctest.h"
@@ -42,7 +43,7 @@ TEST_SUITE("Debug")
 
         std::promise<debug::Breakpoint> bp4Promise;
         std::future<debug::Breakpoint> bp4Future = bp4Promise.get_future();
-        std::function<void(const debug::Breakpoint& bp)> onBreakpointInstall = [&bp4Promise](const debug::Breakpoint& bp)
+        std::function<void(const debug::Breakpoint& bp)> onBreakpointInstall = [&](const debug::Breakpoint& bp)
         {
             if (bp.id == 3)
                 bp4Promise.set_value(bp);
@@ -126,7 +127,7 @@ TEST_SUITE("Debug")
         int numUninstalledBps = 0;
         std::promise<debug::Breakpoint> bp2Promise;
         std::future<debug::Breakpoint> bp2Future = bp2Promise.get_future();
-        std::function<void(const debug::Breakpoint& bp)> onBreakpointUninstall = [&numUninstalledBps, &bp2Promise, &bp2](const debug::Breakpoint& bp)
+        std::function<void(const debug::Breakpoint& bp)> onBreakpointUninstall = [&](const debug::Breakpoint& bp)
         {
             numUninstalledBps++;
             if (bp.id == bp2.id)
@@ -190,7 +191,7 @@ TEST_SUITE("Debug")
 
         int hitBp1 = 0, hitBp2 = 0;
         std::function<void(debug::Process & process, const debug::Breakpoint& bp)> onBreakpointHit =
-            [bp1, bp2, &hitBp1, &hitBp2](debug::Process& process, const debug::Breakpoint& hitBp)
+            [&](debug::Process& process, const debug::Breakpoint& hitBp)
         {
             if (hitBp.id == bp1.id)
                 hitBp1++;
@@ -207,5 +208,50 @@ TEST_SUITE("Debug")
         CHECK(exitFuture.get() == true);
         CHECK(hitBp1 == 5);
         CHECK(hitBp2 == 25);
+    }
+
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_pausesOnBreakpoint")
+    {
+        std::string fixturePath = getDebugFixturePath("simple.luau");
+        debug::Target target(*runtime);
+        debug::Breakpoint bp1 = target.setBreakpoint(fixturePath, 1);
+        debug::Breakpoint bp2 = target.setBreakpoint(fixturePath, 2);
+
+
+        std::promise<void> hitPromise1;
+        std::future<void> hitFuture1 = hitPromise1.get_future();
+        std::promise<void> hitPromise2;
+        std::future<void> hitFuture2 = hitPromise2.get_future();
+
+        config.onBreakpointHit = [&](debug::Process& process, const debug::Breakpoint& bp)
+        {
+            if (bp.id == bp1.id)
+                hitPromise1.set_value();
+            else if (bp.id == bp2.id)
+                hitPromise2.set_value();
+        };
+
+        std::shared_ptr<debug::Process> process = target.launch(fixturePath, {}, config);
+        REQUIRE((bool)(process));
+        // check we have hit the breakpoint 1
+        REQUIRE(hitFuture1.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+        // check that we actually stopped at the breakpoint by having not hit the next breakpoint
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        REQUIRE(hitFuture2.wait_for(std::chrono::seconds(0)) == std::future_status::timeout);
+
+        // continue execution
+        bool continuedProcess = process->continueProcess();
+        CHECK(continuedProcess);
+
+        // check we have hit the breakpoint 2
+        REQUIRE(hitFuture2.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+        // check that we actually stopped at the breakpoint by having not hit the exit
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(0)) == std::future_status::timeout);
+
+        // continue execution
+        continuedProcess = process->continueProcess();
+        CHECK(continuedProcess);
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }
 }

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -5,6 +5,15 @@
 #include "debugfixture.h"
 #include "doctest.h"
 
+static void checkBreakpoint(debug::Target& target, int id, debug::BreakpointStatus status, int line)
+{
+    auto foundBp = target.getBreakpointById(id);
+    REQUIRE(foundBp.has_value());
+    CHECK(foundBp->id == id);
+    CHECK(foundBp->status == status);
+    CHECK(foundBp->line == line);
+}
+
 TEST_SUITE("Debug")
 {
     TEST_CASE_FIXTURE(DebugFixture, "Debug_setBreakpoint")
@@ -21,24 +30,13 @@ TEST_SUITE("Debug")
 
         // check breakpoints before launch
         CHECK(bp.id == 0);
-        CHECK(bp.sourcePath == fixturePath);
-        CHECK(bp.line == 2);
-        CHECK(bp.status == debug::BreakpointStatus::PendingInstall);
-
+        checkBreakpoint(target, bp.id, debug::BreakpointStatus::PendingInstall, 2);
         CHECK(bp2.id == 1);
-        CHECK(bp2.sourcePath == fixturePath);
-        CHECK(bp2.line == 100);
-        CHECK(bp2.status == debug::BreakpointStatus::PendingInstall);
-
+        checkBreakpoint(target, bp2.id, debug::BreakpointStatus::PendingInstall, 100);
         CHECK(bp3.id == 2);
-        CHECK(bp3.sourcePath == fixturePath);
-        CHECK(bp3.line == 3);
-        CHECK(bp3.status == debug::BreakpointStatus::PendingInstall);
+        checkBreakpoint(target, bp3.id, debug::BreakpointStatus::PendingInstall, 3);
 
-        std::optional<debug::Breakpoint> found = target.getBreakpointById(0);
-        REQUIRE(found.has_value());
-        CHECK(found->id == 0);
-        found = target.getBreakpointById(999);
+        std::optional<debug::Breakpoint> found = target.getBreakpointById(999);
         REQUIRE(!found.has_value());
 
         std::promise<debug::Breakpoint> bp4Promise;
@@ -68,34 +66,22 @@ TEST_SUITE("Debug")
         CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::Installed).size() == 2);
         CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::Invalid).size() == 1);
 
-        std::optional<debug::Breakpoint> postLaunch = target.getBreakpointById(0);
-        REQUIRE(postLaunch.has_value());
-        CHECK(postLaunch->status == debug::BreakpointStatus::Installed);
-        CHECK(postLaunch->line == 2);
 
-        postLaunch = target.getBreakpointById(1);
-        REQUIRE(postLaunch.has_value());
-        CHECK(postLaunch->status == debug::BreakpointStatus::Invalid);
-        CHECK(postLaunch->line == -1);
-
-        postLaunch = target.getBreakpointById(2);
-        REQUIRE(postLaunch.has_value());
-        CHECK(postLaunch->status == debug::BreakpointStatus::Installed);
-        CHECK(postLaunch->line == 4);
+        checkBreakpoint(target, bp.id, debug::BreakpointStatus::Installed, 2);
+        checkBreakpoint(target, bp2.id, debug::BreakpointStatus::Invalid, -1);
+        checkBreakpoint(target, bp3.id, debug::BreakpointStatus::Installed, 4);
 
         // check that adding breakpoints after launch should be installed at some point
         debug::Breakpoint bp4 = target.setBreakpoint(fixturePath, 1);
         REQUIRE(bp4Future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         debug::Breakpoint installedBp4 = bp4Future.get();
-        CHECK(installedBp4.status == debug::BreakpointStatus::Installed);
-        CHECK(installedBp4.line == 1);
-        CHECK(installedBp4.id == 3);
+        CHECK(bp4.id == 3);
+        checkBreakpoint(target, bp4.id, debug::BreakpointStatus::Installed, 1);
 
         // check that setting breakpoints at same breakpoint returns same id
         debug::Breakpoint bp5 = target.setBreakpoint(fixturePath, 2);
-        CHECK(bp5.status == debug::BreakpointStatus::Installed);
         CHECK(bp5.id == 0);
-        CHECK(bp5.line == 2);
+        checkBreakpoint(target, bp5.id, debug::BreakpointStatus::Installed, 2);
 
         // wait until script is finished to call destructors
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
@@ -140,15 +126,11 @@ TEST_SUITE("Debug")
             [](debug::Process& process, const debug::Breakpoint& bp)
         {
             debug::Target& target = process.getTarget();
-            std::optional<debug::Breakpoint> postLaunch = target.getBreakpointById(bp.id);
-            REQUIRE(postLaunch.has_value());
-            CHECK(postLaunch->status == debug::BreakpointStatus::Installed);
+            checkBreakpoint(target, bp.id, debug::BreakpointStatus::Installed, bp.line);
 
             bool removedBp2 = target.removeBreakpoint(bp.id);
             CHECK(removedBp2);
-            std::optional<debug::Breakpoint> postRemoval = target.getBreakpointById(bp.id);
-            REQUIRE(postRemoval.has_value());
-            CHECK(postRemoval->status == debug::BreakpointStatus::PendingUninstall);
+            checkBreakpoint(target, bp.id, debug::BreakpointStatus::PendingUninstall, bp.line);
 
             bool continuedProcess = process.continueProcess();
             CHECK(continuedProcess);
@@ -158,10 +140,8 @@ TEST_SUITE("Debug")
         config.onBreakpointHit = onBreakpointHit;
         std::shared_ptr<debug::Process> process = target.launch(fixturePath, {}, config);
         REQUIRE((bool)(process));
-        std::optional<debug::Breakpoint> postLaunch = target.getBreakpointById(bp3.id);
-        REQUIRE(postLaunch.has_value());
-        CHECK(postLaunch->status == debug::BreakpointStatus::Invalid);
 
+        checkBreakpoint(target, bp3.id, debug::BreakpointStatus::Invalid, -1);
         // check invalid breakpoint is installed instantenously
         bool removedBp3 = target.removeBreakpoint(bp3.id);
         CHECK(removedBp3);

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -55,7 +55,6 @@ TEST_SUITE("Debug")
             CHECK(continuedProcess);
         };
 
-        debug::LaunchConfig config;
         config.onBreakpointInstall = onBreakpointInstall;
         config.onBreakpointHit = onBreakpointHit;
 
@@ -96,6 +95,8 @@ TEST_SUITE("Debug")
         CHECK(bp5.status == debug::BreakpointStatus::Installed);
         CHECK(bp5.id == 0);
         CHECK(bp5.line == 2);
+
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }
 
     TEST_CASE_FIXTURE(DebugFixture, "Debug_removeBreakpoint")
@@ -152,7 +153,6 @@ TEST_SUITE("Debug")
             CHECK(continuedProcess);
         };
 
-        debug::LaunchConfig config;
         config.onBreakpointUninstall = onBreakpointUninstall;
         config.onBreakpointHit = onBreakpointHit;
         std::shared_ptr<debug::Process> process = target.launch({}, config);
@@ -173,6 +173,8 @@ TEST_SUITE("Debug")
         // check cannot remove never added breakpoint
         bool cannotRemove = target.removeBreakpoint(100);
         CHECK(!cannotRemove);
+
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }
 
     TEST_CASE_FIXTURE(DebugFixture, "Debug_hitBreakpoint")
@@ -199,15 +201,7 @@ TEST_SUITE("Debug")
             process.continueProcess();
         };
 
-        std::promise<bool> exitPromise;
-        std::future<bool> exitFuture = exitPromise.get_future();
-
-        debug::LaunchConfig config;
         config.onBreakpointHit = onBreakpointHit;
-        config.onExit = [&exitPromise](bool success)
-        {
-            exitPromise.set_value(success);
-        };
         target.launch({}, config);
 
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -1,3 +1,6 @@
+#include <chrono>
+#include <future>
+
 #include "debugfixture.h"
 #include "doctest.h"
 
@@ -6,7 +9,17 @@ TEST_SUITE("Debug")
     TEST_CASE_FIXTURE(DebugFixture, "Debug_addBreakpoint")
     {
         std::string fixturePath = getDebugFixturePath("simple.luau");
-        debug::Target target(*runtime, fixturePath);
+
+        std::promise<debug::Breakpoint> bp4Promise;
+        std::future<debug::Breakpoint> bp4Future = bp4Promise.get_future();
+
+        std::function<void(const debug::Breakpoint& bp)> onBreakpointInstall = [&bp4Promise](const debug::Breakpoint& bp)
+        {
+            if (bp.id == 3)
+                bp4Promise.set_value(bp);
+        };
+
+        debug::Target target(*runtime, fixturePath, onBreakpointInstall);
 
         // valid breakpoint
         debug::Breakpoint bp = target.addBreakpoint(fixturePath, 2);
@@ -63,10 +76,11 @@ TEST_SUITE("Debug")
 
         // check that adding breakpoints after launch should be immediately installed
         debug::Breakpoint bp4 = target.addBreakpoint(fixturePath, 2);
-        CHECK(target.getBreakpoints().size() == 4);
-        CHECK(bp4.status == debug::BreakpointStatus::Installed);
-        CHECK(bp4.line == 2);
-        CHECK(bp4.id == 3);
+        REQUIRE(bp4Future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        debug::Breakpoint installedBp4 = bp4Future.get();
+        CHECK(installedBp4.status == debug::BreakpointStatus::Installed);
+        CHECK(installedBp4.line == 2);
+        CHECK(installedBp4.id == 3);
     }
 
     TEST_CASE_FIXTURE(DebugFixture, "Debug_removeBreakpoint")

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -80,11 +80,11 @@ TEST_SUITE("Debug")
         CHECK(postLaunch->line == 4);
 
         // check that adding breakpoints after launch should be installed at some point
-        debug::Breakpoint bp4 = target.addBreakpoint(fixturePath, 2);
+        debug::Breakpoint bp4 = target.addBreakpoint(fixturePath, 1);
         REQUIRE(bp4Future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         debug::Breakpoint installedBp4 = bp4Future.get();
         CHECK(installedBp4.status == debug::BreakpointStatus::Installed);
-        CHECK(installedBp4.line == 2);
+        CHECK(installedBp4.line == 1);
         CHECK(installedBp4.id == 3);
     }
 

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -60,7 +60,7 @@ TEST_SUITE("Debug")
         config.onBreakpointHit = onBreakpointHit;
 
         std::shared_ptr<debug::Process> process = target.launch({}, config);
-        REQUIRE(process != nullptr);
+        REQUIRE((bool)(process));
 
         // check breakpoints after launch
         CHECK(target.getBreakpoints().size() == 3);
@@ -156,7 +156,7 @@ TEST_SUITE("Debug")
         config.onBreakpointUninstall = onBreakpointUninstall;
         config.onBreakpointHit = onBreakpointHit;
         std::shared_ptr<debug::Process> process = target.launch({}, config);
-        REQUIRE(process != nullptr);
+        REQUIRE((bool)(process));
         std::optional<debug::Breakpoint> postLaunch = target.getBreakpointById(bp3.id);
         REQUIRE(postLaunch.has_value());
         CHECK(postLaunch->status == debug::BreakpointStatus::Invalid);

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -6,17 +6,17 @@
 
 TEST_SUITE("Debug")
 {
-    TEST_CASE_FIXTURE(DebugFixture, "Debug_addBreakpoint")
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_setBreakpoint")
     {
         std::string fixturePath = getDebugFixturePath("simple.luau");
         debug::Target target(*runtime, fixturePath);
 
         // valid breakpoint
-        debug::Breakpoint bp = target.addBreakpoint(fixturePath, 2);
+        debug::Breakpoint bp = target.setBreakpoint(fixturePath, 2);
         // invalid breakpoint
-        debug::Breakpoint bp2 = target.addBreakpoint(fixturePath, 100);
+        debug::Breakpoint bp2 = target.setBreakpoint(fixturePath, 100);
         // breakpoint that will be moved on installation due to whitespace
-        debug::Breakpoint bp3 = target.addBreakpoint(fixturePath, 3);
+        debug::Breakpoint bp3 = target.setBreakpoint(fixturePath, 3);
 
         // check breakpoints before launch
         CHECK(bp.id == 0);
@@ -80,12 +80,18 @@ TEST_SUITE("Debug")
         CHECK(postLaunch->line == 4);
 
         // check that adding breakpoints after launch should be installed at some point
-        debug::Breakpoint bp4 = target.addBreakpoint(fixturePath, 1);
+        debug::Breakpoint bp4 = target.setBreakpoint(fixturePath, 1);
         REQUIRE(bp4Future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         debug::Breakpoint installedBp4 = bp4Future.get();
         CHECK(installedBp4.status == debug::BreakpointStatus::Installed);
         CHECK(installedBp4.line == 1);
         CHECK(installedBp4.id == 3);
+
+        // check that setting breakpoints at same breakpoint returns same id
+        debug::Breakpoint bp5 = target.setBreakpoint(fixturePath, 2);
+        CHECK(bp5.status == debug::BreakpointStatus::Installed);
+        CHECK(bp5.id == 0);
+        CHECK(bp5.line == 2);
     }
 
     TEST_CASE_FIXTURE(DebugFixture, "Debug_removeBreakpoint")
@@ -94,7 +100,7 @@ TEST_SUITE("Debug")
         debug::Target target(*runtime, fixturePath);
 
         // check removing pending breakpoint
-        debug::Breakpoint bp = target.addBreakpoint(fixturePath, 2);
+        debug::Breakpoint bp = target.setBreakpoint(fixturePath, 2);
         CHECK(target.getBreakpoints().size() == 1);
 
         std::optional<debug::Breakpoint> preLaunch = target.getBreakpointById(bp.id);
@@ -107,8 +113,8 @@ TEST_SUITE("Debug")
         CHECK(target.getBreakpoints().size() == 0);
 
         // check removing installed breakpoints and invalid breakpoints
-        debug::Breakpoint bp2 = target.addBreakpoint(fixturePath, 3);
-        debug::Breakpoint bp3 = target.addBreakpoint(fixturePath, 100);
+        debug::Breakpoint bp2 = target.setBreakpoint(fixturePath, 3);
+        debug::Breakpoint bp3 = target.setBreakpoint(fixturePath, 100);
         CHECK(target.getBreakpoints().size() == 2);
 
         // We can do things like trigger breakpoint removals when our breakpoint is paused.

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -48,18 +48,17 @@ TEST_SUITE("Debug")
                 bp4Promise.set_value();
         };
 
-        std::function<void(debug::Process & process, const debug::Breakpoint& bp)> onBreakpointHit =
-            [](debug::Process& process, const debug::Breakpoint& bp)
+        std::function<void(const debug::Breakpoint& bp)> onBreakpointHit = [&](const debug::Breakpoint& bp)
         {
-            bool continuedProcess = process.continueProcess();
+            bool continuedProcess = target.continueProcess();
             CHECK(continuedProcess);
         };
 
         config.onBreakpointInstall = onBreakpointInstall;
         config.onBreakpointHit = onBreakpointHit;
 
-        std::shared_ptr<debug::Process> process = target.launch(fixturePath, {}, config);
-        REQUIRE((bool)(process));
+        bool launched = target.launch(fixturePath, {}, config);
+        CHECK(launched);
 
         // check breakpoints before launch are immediately installed after launch
         CHECK(target.getBreakpoints().size() == 3);
@@ -115,24 +114,22 @@ TEST_SUITE("Debug")
 
         // trigger breakpoint removals when our breakpoint is hit (thus, the execution is currently paused
         // and we can see changes to it being pending uninstall)
-        std::function<void(debug::Process & process, const debug::Breakpoint& bp)> onBreakpointHit =
-            [](debug::Process& process, const debug::Breakpoint& bp)
+        std::function<void(const debug::Breakpoint& bp)> onBreakpointHit = [&](const debug::Breakpoint& bp)
         {
-            debug::Target& target = process.getTarget();
             checkBreakpoint(target, bp.id, debug::BreakpointStatus::Installed, bp.line);
 
             bool removedBp2 = target.removeBreakpoint(bp.id);
             CHECK(removedBp2);
-            checkBreakpoint(target, bp.id, debug::BreakpointStatus::PendingUninstall, bp.line);
+            REQUIRE(!target.getBreakpointById(bp.id).has_value());
 
-            bool continuedProcess = process.continueProcess();
+            bool continuedProcess = target.continueProcess();
             CHECK(continuedProcess);
         };
 
         config.onBreakpointUninstall = onBreakpointUninstall;
         config.onBreakpointHit = onBreakpointHit;
-        std::shared_ptr<debug::Process> process = target.launch(fixturePath, {}, config);
-        REQUIRE((bool)(process));
+        bool launched = target.launch(fixturePath, {}, config);
+        CHECK(launched);
 
         checkBreakpoint(target, bp3.id, debug::BreakpointStatus::Invalid, -1);
         // check invalid breakpoint is installed instantenously
@@ -164,8 +161,7 @@ TEST_SUITE("Debug")
         debug::Breakpoint bp3 = target.setBreakpoint(fixturePath, 7);
         int hitBp1 = 0, hitBp2 = 0, hitBp3 = 0;
 
-        std::function<void(debug::Process & process, const debug::Breakpoint& bp)> onBreakpointHit =
-            [&](debug::Process& process, const debug::Breakpoint& hitBp)
+        std::function<void(const debug::Breakpoint& bp)> onBreakpointHit = [&](const debug::Breakpoint& hitBp)
         {
             if (hitBp.id == bp1.id)
                 hitBp1++;
@@ -176,7 +172,7 @@ TEST_SUITE("Debug")
                 hitBp3++;
                 target.removeBreakpoint(bp3.id);
             }
-            process.continueProcess();
+            target.continueProcess();
         };
 
         config.onBreakpointHit = onBreakpointHit;
@@ -202,7 +198,7 @@ TEST_SUITE("Debug")
         std::promise<void> hitPromise2;
         std::future<void> hitFuture2 = hitPromise2.get_future();
 
-        config.onBreakpointHit = [&](debug::Process& process, const debug::Breakpoint& bp)
+        config.onBreakpointHit = [&](const debug::Breakpoint& bp)
         {
             if (bp.id == bp1.id)
                 hitPromise1.set_value();
@@ -210,8 +206,8 @@ TEST_SUITE("Debug")
                 hitPromise2.set_value();
         };
 
-        std::shared_ptr<debug::Process> process = target.launch(fixturePath, {}, config);
-        REQUIRE((bool)(process));
+        bool launched = target.launch(fixturePath, {}, config);
+        CHECK(launched);
         // check we have hit the breakpoint 1
         REQUIRE(hitFuture1.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
         // check that we actually stopped at the breakpoint by having not hit the next breakpoint
@@ -219,7 +215,7 @@ TEST_SUITE("Debug")
         REQUIRE(hitFuture2.wait_for(std::chrono::seconds(0)) == std::future_status::timeout);
 
         // continue execution
-        bool continuedProcess = process->continueProcess();
+        bool continuedProcess = target.continueProcess();
         CHECK(continuedProcess);
 
         // check we have hit the breakpoint 2
@@ -229,7 +225,7 @@ TEST_SUITE("Debug")
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(0)) == std::future_status::timeout);
 
         // continue execution
-        continuedProcess = process->continueProcess();
+        continuedProcess = target.continueProcess();
         CHECK(continuedProcess);
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -5,7 +5,9 @@
 #include "debugfixture.h"
 #include "doctest.h"
 
-static void checkBreakpoint(debug::Target& target, int id, debug::BreakpointStatus status, int line)
+using namespace debug;
+
+static void checkBreakpoint(Target& target, int id, BreakpointStatus status, int line)
 {
     auto foundBp = target.getBreakpointById(id);
     REQUIRE(foundBp.has_value());
@@ -19,36 +21,36 @@ TEST_SUITE("Debug")
     TEST_CASE_FIXTURE(DebugFixture, "Debug_setBreakpoint")
     {
         std::string fixturePath = getDebugFixturePath("simple.luau");
-        debug::Target target(*runtime);
+        Target target(*runtime);
 
         // valid breakpoint
-        debug::Breakpoint bp = target.setBreakpoint(fixturePath, 2);
+        Breakpoint bp = target.setBreakpoint(fixturePath, 2);
         // invalid breakpoint
-        debug::Breakpoint bp2 = target.setBreakpoint(fixturePath, 100);
+        Breakpoint bp2 = target.setBreakpoint(fixturePath, 100);
         // breakpoint that will be moved on installation due to whitespace
-        debug::Breakpoint bp3 = target.setBreakpoint(fixturePath, 3);
+        Breakpoint bp3 = target.setBreakpoint(fixturePath, 3);
 
         // check breakpoints before launch
         CHECK(bp.id == 0);
-        checkBreakpoint(target, bp.id, debug::BreakpointStatus::PendingInstall, 2);
+        checkBreakpoint(target, bp.id, BreakpointStatus::PendingInstall, 2);
         CHECK(bp2.id == 1);
-        checkBreakpoint(target, bp2.id, debug::BreakpointStatus::PendingInstall, 100);
+        checkBreakpoint(target, bp2.id, BreakpointStatus::PendingInstall, 100);
         CHECK(bp3.id == 2);
-        checkBreakpoint(target, bp3.id, debug::BreakpointStatus::PendingInstall, 3);
+        checkBreakpoint(target, bp3.id, BreakpointStatus::PendingInstall, 3);
 
         // check cannot find not-set breakpoint
-        std::optional<debug::Breakpoint> found = target.getBreakpointById(999);
+        std::optional<Breakpoint> found = target.getBreakpointById(999);
         REQUIRE(!found.has_value());
 
         std::promise<void> bp4Promise;
         std::future<void> bp4Future = bp4Promise.get_future();
-        std::function<void(const debug::Breakpoint& bp)> onBreakpointInstall = [&](const debug::Breakpoint& bp)
+        std::function<void(const Breakpoint& bp)> onBreakpointInstall = [&](const Breakpoint& bp)
         {
             if (bp.id == 3)
                 bp4Promise.set_value();
         };
 
-        std::function<void(const debug::Breakpoint& bp)> onBreakpointHit = [&](const debug::Breakpoint& bp)
+        std::function<void(const Breakpoint& bp)> onBreakpointHit = [&](const Breakpoint& bp)
         {
             bool continuedProcess = target.continueProcess();
             CHECK(continuedProcess);
@@ -62,22 +64,22 @@ TEST_SUITE("Debug")
 
         // check breakpoints before launch are immediately installed after launch
         CHECK(target.getBreakpoints().size() == 3);
-        CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::PendingInstall).size() == 0);
-        CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::Installed).size() == 2);
-        CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::Invalid).size() == 1);
-        checkBreakpoint(target, bp.id, debug::BreakpointStatus::Installed, 2);
-        checkBreakpoint(target, bp2.id, debug::BreakpointStatus::Invalid, -1);
-        checkBreakpoint(target, bp3.id, debug::BreakpointStatus::Installed, 4);
+        CHECK(target.getBreakpointsByStatus(BreakpointStatus::PendingInstall).size() == 0);
+        CHECK(target.getBreakpointsByStatus(BreakpointStatus::Installed).size() == 2);
+        CHECK(target.getBreakpointsByStatus(BreakpointStatus::Invalid).size() == 1);
+        checkBreakpoint(target, bp.id, BreakpointStatus::Installed, 2);
+        checkBreakpoint(target, bp2.id, BreakpointStatus::Invalid, -1);
+        checkBreakpoint(target, bp3.id, BreakpointStatus::Installed, 4);
 
         // check that adding breakpoints after launch should be installed at some point
-        debug::Breakpoint bp4 = target.setBreakpoint(fixturePath, 1);
+        Breakpoint bp4 = target.setBreakpoint(fixturePath, 1);
         REQUIRE(bp4Future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
-        checkBreakpoint(target, bp4.id, debug::BreakpointStatus::Installed, 1);
+        checkBreakpoint(target, bp4.id, BreakpointStatus::Installed, 1);
 
         // check that setting breakpoints at same breakpoint returns same id
-        debug::Breakpoint bp5 = target.setBreakpoint(fixturePath, 2);
+        Breakpoint bp5 = target.setBreakpoint(fixturePath, 2);
         CHECK(bp5.id == 0);
-        checkBreakpoint(target, bp5.id, debug::BreakpointStatus::Installed, 2);
+        checkBreakpoint(target, bp5.id, BreakpointStatus::Installed, 2);
 
         // wait until script is finished to call destructors
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
@@ -86,26 +88,26 @@ TEST_SUITE("Debug")
     TEST_CASE_FIXTURE(DebugFixture, "Debug_removeBreakpoint")
     {
         std::string fixturePath = getDebugFixturePath("simple.luau");
-        debug::Target target(*runtime);
+        Target target(*runtime);
 
         // check removing pending breakpoint
-        debug::Breakpoint bp = target.setBreakpoint(fixturePath, 2);
+        Breakpoint bp = target.setBreakpoint(fixturePath, 2);
         CHECK(target.getBreakpoints().size() == 1);
-        checkBreakpoint(target, bp.id, debug::BreakpointStatus::PendingInstall, 2);
+        checkBreakpoint(target, bp.id, BreakpointStatus::PendingInstall, 2);
         bool removedBp1 = target.removeBreakpoint(bp.id);
         CHECK(removedBp1);
         REQUIRE(!target.getBreakpointById(bp.id).has_value());
         CHECK(target.getBreakpoints().size() == 0);
 
         // check removing installed breakpoints and invalid breakpoints
-        debug::Breakpoint bp2 = target.setBreakpoint(fixturePath, 3);
-        debug::Breakpoint bp3 = target.setBreakpoint(fixturePath, 100);
+        Breakpoint bp2 = target.setBreakpoint(fixturePath, 3);
+        Breakpoint bp3 = target.setBreakpoint(fixturePath, 100);
         CHECK(target.getBreakpoints().size() == 2);
 
         int numUninstalledBps = 0;
         std::promise<void> bp2Promise;
         std::future<void> bp2Future = bp2Promise.get_future();
-        std::function<void(const debug::Breakpoint& bp)> onBreakpointUninstall = [&](const debug::Breakpoint& bp)
+        std::function<void(const Breakpoint& bp)> onBreakpointUninstall = [&](const Breakpoint& bp)
         {
             numUninstalledBps++;
             if (bp.id == bp2.id)
@@ -114,9 +116,9 @@ TEST_SUITE("Debug")
 
         // trigger breakpoint removals when our breakpoint is hit (thus, the execution is currently paused
         // and we can see changes to it being pending uninstall)
-        std::function<void(const debug::Breakpoint& bp)> onBreakpointHit = [&](const debug::Breakpoint& bp)
+        std::function<void(const Breakpoint& bp)> onBreakpointHit = [&](const Breakpoint& bp)
         {
-            checkBreakpoint(target, bp.id, debug::BreakpointStatus::Installed, bp.line);
+            checkBreakpoint(target, bp.id, BreakpointStatus::Installed, bp.line);
 
             bool removedBp2 = target.removeBreakpoint(bp.id);
             CHECK(removedBp2);
@@ -131,7 +133,7 @@ TEST_SUITE("Debug")
         bool launched = target.launch(fixturePath, {}, config);
         CHECK(launched);
 
-        checkBreakpoint(target, bp3.id, debug::BreakpointStatus::Invalid, -1);
+        checkBreakpoint(target, bp3.id, BreakpointStatus::Invalid, -1);
         // check invalid breakpoint is installed instantenously
         bool removedBp3 = target.removeBreakpoint(bp3.id);
         CHECK(removedBp3);
@@ -153,15 +155,15 @@ TEST_SUITE("Debug")
     TEST_CASE_FIXTURE(DebugFixture, "Debug_hitBreakpoint")
     {
         std::string fixturePath = getDebugFixturePath("loop.luau");
-        debug::Target target(*runtime);
+        Target target(*runtime);
 
-        debug::Breakpoint bp1 = target.setBreakpoint(fixturePath, 4);
-        debug::Breakpoint bp2 = target.setBreakpoint(fixturePath, 6);
+        Breakpoint bp1 = target.setBreakpoint(fixturePath, 4);
+        Breakpoint bp2 = target.setBreakpoint(fixturePath, 6);
         // bp3 checks that removing a breakpoint makes sure that breakpoint is never hit again
-        debug::Breakpoint bp3 = target.setBreakpoint(fixturePath, 7);
+        Breakpoint bp3 = target.setBreakpoint(fixturePath, 7);
         int hitBp1 = 0, hitBp2 = 0, hitBp3 = 0;
 
-        std::function<void(const debug::Breakpoint& bp)> onBreakpointHit = [&](const debug::Breakpoint& hitBp)
+        std::function<void(const Breakpoint& bp)> onBreakpointHit = [&](const Breakpoint& hitBp)
         {
             if (hitBp.id == bp1.id)
                 hitBp1++;
@@ -189,16 +191,16 @@ TEST_SUITE("Debug")
     TEST_CASE_FIXTURE(DebugFixture, "Debug_pausesOnBreakpoint")
     {
         std::string fixturePath = getDebugFixturePath("simple.luau");
-        debug::Target target(*runtime);
-        debug::Breakpoint bp1 = target.setBreakpoint(fixturePath, 1);
-        debug::Breakpoint bp2 = target.setBreakpoint(fixturePath, 2);
+        Target target(*runtime);
+        Breakpoint bp1 = target.setBreakpoint(fixturePath, 1);
+        Breakpoint bp2 = target.setBreakpoint(fixturePath, 2);
 
         std::promise<void> hitPromise1;
         std::future<void> hitFuture1 = hitPromise1.get_future();
         std::promise<void> hitPromise2;
         std::future<void> hitFuture2 = hitPromise2.get_future();
 
-        config.onBreakpointHit = [&](const debug::Breakpoint& bp)
+        config.onBreakpointHit = [&](const Breakpoint& bp)
         {
             if (bp.id == bp1.id)
                 hitPromise1.set_value();

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -96,6 +96,7 @@ TEST_SUITE("Debug")
         CHECK(bp5.id == 0);
         CHECK(bp5.line == 2);
 
+        // wait until script is finished to call destructors
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }
 
@@ -122,7 +123,6 @@ TEST_SUITE("Debug")
         debug::Breakpoint bp3 = target.setBreakpoint(fixturePath, 100);
         CHECK(target.getBreakpoints().size() == 2);
 
-        // We can do things like trigger breakpoint removals when our breakpoint is paused.
         int numUninstalledBps = 0;
         std::promise<debug::Breakpoint> bp2Promise;
         std::future<debug::Breakpoint> bp2Future = bp2Promise.get_future();
@@ -130,11 +130,11 @@ TEST_SUITE("Debug")
         {
             numUninstalledBps++;
             if (bp.id == 1)
-            {
                 bp2Promise.set_value(bp);
-            }
         };
 
+        // trigger breakpoint removals when our breakpoint is hit (thus, the execution is currently paused
+        // and we can see changes to it being pending uninstall)
         std::function<void(debug::Process & process, const debug::Breakpoint& bp)> onBreakpointHit =
             [](debug::Process& process, const debug::Breakpoint& bp)
         {
@@ -161,6 +161,7 @@ TEST_SUITE("Debug")
         REQUIRE(postLaunch.has_value());
         CHECK(postLaunch->status == debug::BreakpointStatus::Invalid);
 
+        // check invalid breakpoint is installed instantenously
         bool removedBp3 = target.removeBreakpoint(bp3.id);
         CHECK(removedBp3);
         CHECK(!target.getBreakpointById(bp3.id).has_value());
@@ -174,6 +175,7 @@ TEST_SUITE("Debug")
         bool cannotRemove = target.removeBreakpoint(100);
         CHECK(!cannotRemove);
 
+        // wait until script is finished to call destructors
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }
 
@@ -191,19 +193,16 @@ TEST_SUITE("Debug")
             [bp1, bp2, &hitBp1, &hitBp2](debug::Process& process, const debug::Breakpoint& hitBp)
         {
             if (hitBp.id == bp1.id)
-            {
                 hitBp1++;
-            }
             if (hitBp.id == bp2.id)
-            {
                 hitBp2++;
-            }
             process.continueProcess();
         };
 
         config.onBreakpointHit = onBreakpointHit;
         target.launch({}, config);
 
+        // wait until script is finished
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         CHECK(exitFuture.get() == true);
         CHECK(hitBp1 == 5);

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -36,15 +36,16 @@ TEST_SUITE("Debug")
         CHECK(bp3.id == 2);
         checkBreakpoint(target, bp3.id, debug::BreakpointStatus::PendingInstall, 3);
 
+        // check cannot find not-set breakpoint
         std::optional<debug::Breakpoint> found = target.getBreakpointById(999);
         REQUIRE(!found.has_value());
 
-        std::promise<debug::Breakpoint> bp4Promise;
-        std::future<debug::Breakpoint> bp4Future = bp4Promise.get_future();
+        std::promise<void> bp4Promise;
+        std::future<void> bp4Future = bp4Promise.get_future();
         std::function<void(const debug::Breakpoint& bp)> onBreakpointInstall = [&](const debug::Breakpoint& bp)
         {
             if (bp.id == 3)
-                bp4Promise.set_value(bp);
+                bp4Promise.set_value();
         };
 
         std::function<void(debug::Process & process, const debug::Breakpoint& bp)> onBreakpointHit =
@@ -60,13 +61,11 @@ TEST_SUITE("Debug")
         std::shared_ptr<debug::Process> process = target.launch(fixturePath, {}, config);
         REQUIRE((bool)(process));
 
-        // check breakpoints after launch
+        // check breakpoints before launch are immediately installed after launch
         CHECK(target.getBreakpoints().size() == 3);
         CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::PendingInstall).size() == 0);
         CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::Installed).size() == 2);
         CHECK(target.getBreakpointsByStatus(debug::BreakpointStatus::Invalid).size() == 1);
-
-
         checkBreakpoint(target, bp.id, debug::BreakpointStatus::Installed, 2);
         checkBreakpoint(target, bp2.id, debug::BreakpointStatus::Invalid, -1);
         checkBreakpoint(target, bp3.id, debug::BreakpointStatus::Installed, 4);
@@ -74,8 +73,6 @@ TEST_SUITE("Debug")
         // check that adding breakpoints after launch should be installed at some point
         debug::Breakpoint bp4 = target.setBreakpoint(fixturePath, 1);
         REQUIRE(bp4Future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
-        debug::Breakpoint installedBp4 = bp4Future.get();
-        CHECK(bp4.id == 3);
         checkBreakpoint(target, bp4.id, debug::BreakpointStatus::Installed, 1);
 
         // check that setting breakpoints at same breakpoint returns same id
@@ -95,11 +92,7 @@ TEST_SUITE("Debug")
         // check removing pending breakpoint
         debug::Breakpoint bp = target.setBreakpoint(fixturePath, 2);
         CHECK(target.getBreakpoints().size() == 1);
-
-        std::optional<debug::Breakpoint> preLaunch = target.getBreakpointById(bp.id);
-        REQUIRE(preLaunch.has_value());
-        CHECK(preLaunch->status == debug::BreakpointStatus::PendingInstall);
-
+        checkBreakpoint(target, bp.id, debug::BreakpointStatus::PendingInstall, 2);
         bool removedBp1 = target.removeBreakpoint(bp.id);
         CHECK(removedBp1);
         REQUIRE(!target.getBreakpointById(bp.id).has_value());
@@ -111,13 +104,13 @@ TEST_SUITE("Debug")
         CHECK(target.getBreakpoints().size() == 2);
 
         int numUninstalledBps = 0;
-        std::promise<debug::Breakpoint> bp2Promise;
-        std::future<debug::Breakpoint> bp2Future = bp2Promise.get_future();
+        std::promise<void> bp2Promise;
+        std::future<void> bp2Future = bp2Promise.get_future();
         std::function<void(const debug::Breakpoint& bp)> onBreakpointUninstall = [&](const debug::Breakpoint& bp)
         {
             numUninstalledBps++;
             if (bp.id == bp2.id)
-                bp2Promise.set_value(bp);
+                bp2Promise.set_value();
         };
 
         // trigger breakpoint removals when our breakpoint is hit (thus, the execution is currently paused
@@ -147,7 +140,7 @@ TEST_SUITE("Debug")
         CHECK(removedBp3);
         CHECK(!target.getBreakpointById(bp3.id).has_value());
 
-        // check installed breakpoint is actually uninstalled
+        // check installed breakpoint is actually uninstalled by hitting the breakpoint
         REQUIRE(bp2Future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         CHECK(numUninstalledBps == 1);
         CHECK(!target.getBreakpointById(bp2.id).has_value());
@@ -165,11 +158,12 @@ TEST_SUITE("Debug")
         std::string fixturePath = getDebugFixturePath("loop.luau");
         debug::Target target(*runtime);
 
-        // check removing pending breakpoint
         debug::Breakpoint bp1 = target.setBreakpoint(fixturePath, 4);
         debug::Breakpoint bp2 = target.setBreakpoint(fixturePath, 6);
+        // bp3 checks that removing a breakpoint makes sure that breakpoint is never hit again
+        debug::Breakpoint bp3 = target.setBreakpoint(fixturePath, 7);
+        int hitBp1 = 0, hitBp2 = 0, hitBp3 = 0;
 
-        int hitBp1 = 0, hitBp2 = 0;
         std::function<void(debug::Process & process, const debug::Breakpoint& bp)> onBreakpointHit =
             [&](debug::Process& process, const debug::Breakpoint& hitBp)
         {
@@ -177,6 +171,11 @@ TEST_SUITE("Debug")
                 hitBp1++;
             if (hitBp.id == bp2.id)
                 hitBp2++;
+            if (hitBp.id == bp3.id)
+            {
+                hitBp3++;
+                target.removeBreakpoint(bp3.id);
+            }
             process.continueProcess();
         };
 
@@ -188,6 +187,7 @@ TEST_SUITE("Debug")
         CHECK(exitFuture.get() == true);
         CHECK(hitBp1 == 5);
         CHECK(hitBp2 == 25);
+        CHECK(hitBp3 == 1);
     }
 
     TEST_CASE_FIXTURE(DebugFixture, "Debug_pausesOnBreakpoint")
@@ -196,7 +196,6 @@ TEST_SUITE("Debug")
         debug::Target target(*runtime);
         debug::Breakpoint bp1 = target.setBreakpoint(fixturePath, 1);
         debug::Breakpoint bp2 = target.setBreakpoint(fixturePath, 2);
-
 
         std::promise<void> hitPromise1;
         std::future<void> hitFuture1 = hitPromise1.get_future();

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -60,7 +60,7 @@ TEST_SUITE("Debug")
         config.onBreakpointHit = onBreakpointHit;
 
         std::shared_ptr<debug::Process> process = target.launch({}, config);
-        CHECK(process);
+        REQUIRE(process != nullptr);
 
         // check breakpoints after launch
         CHECK(target.getBreakpoints().size() == 3);
@@ -156,7 +156,7 @@ TEST_SUITE("Debug")
         config.onBreakpointUninstall = onBreakpointUninstall;
         config.onBreakpointHit = onBreakpointHit;
         std::shared_ptr<debug::Process> process = target.launch({}, config);
-        CHECK(process);
+        REQUIRE(process != nullptr);
         std::optional<debug::Breakpoint> postLaunch = target.getBreakpointById(bp3.id);
         REQUIRE(postLaunch.has_value());
         CHECK(postLaunch->status == debug::BreakpointStatus::Invalid);

--- a/tests/src/debug/loop.luau
+++ b/tests/src/debug/loop.luau
@@ -1,0 +1,8 @@
+local step1 = 0
+local step2 = 0
+for _ = 1, 5 do
+    step1 = step1 + 1
+    for _ = 1, 5 do
+        step2 = step2 + 1
+    end
+end

--- a/tests/src/debug/loop.luau
+++ b/tests/src/debug/loop.luau
@@ -4,5 +4,6 @@ for _ = 1, 5 do
 	_step1 = _step1 + 1
 	for _ = 1, 5 do
 		_step2 = _step2 + 1
+		_step2 = _step2 + 1
 	end
 end

--- a/tests/src/debug/loop.luau
+++ b/tests/src/debug/loop.luau
@@ -1,8 +1,8 @@
 local step1 = 0
 local step2 = 0
 for _ = 1, 5 do
-    step1 = step1 + 1
-    for _ = 1, 5 do
-        step2 = step2 + 1
-    end
+	step1 = step1 + 1
+	for _ = 1, 5 do
+		step2 = step2 + 1
+	end
 end

--- a/tests/src/debug/loop.luau
+++ b/tests/src/debug/loop.luau
@@ -1,8 +1,8 @@
-local step1 = 0
-local step2 = 0
+local _step1 = 0
+local _step2 = 0
 for _ = 1, 5 do
-	step1 = step1 + 1
+	_step1 = _step1 + 1
 	for _ = 1, 5 do
-		step2 = step2 + 1
+		_step2 = _step2 + 1
 	end
 end

--- a/tests/src/debugfixture.cpp
+++ b/tests/src/debugfixture.cpp
@@ -15,4 +15,9 @@ DebugFixture::DebugFixture()
     : runtime(std::make_unique<Runtime>(getReporter()))
 {
     setupState(*runtime, nullptr);
+    exitFuture = exitPromise.get_future();
+    config.onExit = [this](bool success)
+    {
+        exitPromise.set_value(success);
+    };
 }

--- a/tests/src/debugfixture.h
+++ b/tests/src/debugfixture.h
@@ -2,6 +2,7 @@
 
 #include "lute/runtime.h"
 
+#include <future>
 #include <string>
 
 #include "debugger.h"
@@ -14,4 +15,9 @@ class DebugFixture : public LuteFixture
 public:
     DebugFixture();
     std::unique_ptr<Runtime> runtime;
+    std::future<bool> exitFuture;
+    debug::LaunchConfig config;
+
+private:
+    std::promise<bool> exitPromise;
 };


### PR DESCRIPTION
This PR makes breakpoints actually functional but in order to do we need to add many features under the hood
* as mentioned here https://github.com/luau-lang/lute/pull/1202#pullrequestreview-4603646302, we need to run the child debuggee process in a separate VM.
* as a side effect of the above change, we need to instead schedule operations (such as adding and removing breakpoints) onto the child VM, which effectively makes them async
* we add some callbacks when breakpoints are installed or un-installed, and when program execution terminates, and when a breakpoint is hit
* we add a `continue()` to resume program execution

Caveats:
* most of this code relies on the debugged script (`exit` and `continue`) being single coroutine. Multi-coroutines execution will be handled in future PRs.