### PR TITLE
lute pkg: add overrides

### DIFF
--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -187,4 +187,5 @@ return {
 	parseFile = parseFile,
 	tryParseFile = tryParseFile,
 	satisfiesManifest = satisfiesManifest,
+	serializeOverrides = serializeOverrides,
 }

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -101,10 +101,7 @@ local function serializeOverrides(overrides: { [string]: manifest.DependencySpec
 	return result
 end
 
-local function overridesMatch(
-	locked: { [string]: string }?,
-	current: { [string]: string }
-): (boolean, string?)
+local function overridesMatch(locked: { [string]: string }?, current: { [string]: string }): (boolean, string?)
 	for name, value in current do
 		if locked == nil or locked[name] ~= value then
 			return false, `override changed: {name}`

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -42,7 +42,7 @@ end
 
 local function parseLockfile(t: any): Lockfile
 	assert(t ~= nil and typeof(t) == "table", "Expected lockfile to be a table")
-	assert(t.version == 3 or t.version == 4, `Unsupported lockfile version: {t.version}`)
+	assert(t.version == 3, `Unsupported lockfile version: {t.version}`)
 	assert(typeof(t.packages) == "table", "Expected 'packages' field in lockfile")
 	assert(typeof(t.dependencies) == "table", "Expected 'dependencies' field in lockfile")
 

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -119,6 +119,13 @@ local function overridesMatch(locked: { [string]: string }?, current: { [string]
 	return true, nil
 end
 
+local function getEffectiveRootSpec(
+	spec: manifest.DependencySpec,
+	overrides: { [string]: manifest.DependencySpec }
+): manifest.DependencySpec
+	return overrides[spec.name] or spec
+end
+
 local function satisfiesManifest(
 	lock: Lockfile,
 	rootManifest: manifest.ProjectManifest,
@@ -137,6 +144,8 @@ local function satisfiesManifest(
 	end
 
 	for alias, spec in expectedAliases do
+		spec = getEffectiveRootSpec(spec, rootManifest.overrides)
+
 		local key = lock.dependencies[alias]
 		if key == nil then
 			return false, `new dependency: {alias}`

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -16,6 +16,7 @@ export type Lockfile = {
 	read version: number,
 	read packages: { [string]: LockfileDependency },
 	read dependencies: { [string]: string },
+	read overrides: { [string]: string }?,
 }
 
 local function validatePackageEntry(key: string, entry: any)
@@ -41,7 +42,7 @@ end
 
 local function parseLockfile(t: any): Lockfile
 	assert(t ~= nil and typeof(t) == "table", "Expected lockfile to be a table")
-	assert(t.version == 3, `Unsupported lockfile version: {t.version}`)
+	assert(t.version == 3 or t.version == 4, `Unsupported lockfile version: {t.version}`)
 	assert(typeof(t.packages) == "table", "Expected 'packages' field in lockfile")
 	assert(typeof(t.dependencies) == "table", "Expected 'dependencies' field in lockfile")
 
@@ -57,6 +58,15 @@ local function parseLockfile(t: any): Lockfile
 		assert(t.packages[key] ~= nil, `Dependency '{alias}' references package '{key}' which is not in packages`)
 	end
 	table.freeze(t.dependencies)
+
+	if t.overrides ~= nil then
+		assert(typeof(t.overrides) == "table", "Expected 'overrides' field to be a table")
+		for name, value in t.overrides do
+			assert(typeof(name) == "string", "Expected override key to be a string")
+			assert(typeof(value) == "string", "Expected override value to be a string")
+		end
+		table.freeze(t.overrides)
+	end
 
 	return table.freeze(t)
 end
@@ -75,6 +85,41 @@ local function tryParseFile(lockfilePath: string): Lockfile?
 		return nil
 	end
 	return result
+end
+
+local function serializeOverrides(overrides: { [string]: manifest.DependencySpec }): { [string]: string }
+	local result: { [string]: string } = {}
+	for name, spec in overrides do
+		if spec.sourceKind == "registry" then
+			result[name] = spec.version
+		elseif spec.sourceKind == "path" then
+			result[name] = `path:{spec.source}`
+		elseif spec.sourceKind == "github" then
+			result[name] = `github:{spec.source}@{spec.rev}`
+		end
+	end
+	return result
+end
+
+local function overridesMatch(
+	locked: { [string]: string }?,
+	current: { [string]: string }
+): (boolean, string?)
+	for name, value in current do
+		if locked == nil or locked[name] ~= value then
+			return false, `override changed: {name}`
+		end
+	end
+
+	if locked then
+		for name in locked do
+			if current[name] == nil then
+				return false, `override removed: {name}`
+			end
+		end
+	end
+
+	return true, nil
 end
 
 local function satisfiesManifest(
@@ -130,6 +175,12 @@ local function satisfiesManifest(
 		if expectedAliases[alias] == nil then
 			return false, `removed dependency: {alias}`
 		end
+	end
+
+	local currentOverrides = serializeOverrides(rootManifest.overrides)
+	local overridesOk, overridesReason = overridesMatch(lock.overrides, currentOverrides)
+	if not overridesOk then
+		return false, overridesReason
 	end
 
 	return true, nil

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -33,6 +33,7 @@ export type PackageManifest = {
 
 export type ProjectManifest = {
 	read package: PackageManifest,
+	read overrides: { [string]: DependencySpec },
 }
 
 local function isSourceKind(s: unknown): boolean
@@ -120,6 +121,8 @@ local function parseManifest(t: unknown): ProjectManifest
 		assert(dependencies[alias] == nil, `Alias '{alias}' appears in both dependencies and dev_dependencies`)
 	end
 
+	local overrides = parseDependencyMap((t :: any).overrides, "overrides")
+
 	return table.freeze({
 		package = table.freeze({
 			name = pkg.name,
@@ -127,6 +130,7 @@ local function parseManifest(t: unknown): ProjectManifest
 			dependencies = dependencies,
 			devDependencies = devDependencies,
 		}),
+		overrides = overrides,
 	})
 end
 

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -96,19 +96,6 @@ local function removeRequirementsForPackage(registryRequirements: { [string]: se
 	end
 end
 
-local function serializeOverrides(overrides: { [string]: manifest.DependencySpec }): { [string]: string }
-	local result: { [string]: string } = {}
-	for name, spec in overrides do
-		if spec.sourceKind == "registry" then
-			result[name] = spec.version
-		elseif spec.sourceKind == "path" then
-			result[name] = `path:{spec.source}`
-		elseif spec.sourceKind == "github" then
-			result[name] = `github:{spec.source}@{spec.rev}`
-		end
-	end
-	return result
-end
 
 local function buildEffectiveUniverse(
 	universe: semver.Universe,
@@ -137,7 +124,7 @@ local function buildEffectiveUniverse(
 			end
 			assert(
 				#filtered > 0,
-				`Override constrains '{pkgName}' to {overrides[pkgName].version}, but no matching version exists in the registry`
+				`Override constrains '{pkgName}' to {semver.formatConstraint(registryOverrides[pkgName])}, but no matching version exists in the registry`
 			)
 			effective[pkgName] = filtered
 		elseif sourceOverrideNames[pkgName] then
@@ -568,7 +555,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 	table.freeze(packages)
 	table.freeze(dependencies)
 
-	local serializedOverrides = serializeOverrides(overrides)
+	local serializedOverrides = lockfile.serializeOverrides(overrides)
 	local frozenOverrides: { [string]: string }? = if next(serializedOverrides)
 		then table.freeze(serializedOverrides)
 		else nil

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -88,11 +88,58 @@ export type ResolveOptions = {
 	read locked: boolean?,
 }
 
+type RootRegistryAlias = {
+	read alias: string,
+	read name: string,
+}
+
 local function removeRequirementsForPackage(registryRequirements: { [string]: semver.Requirement }, packageName: string)
 	for reqKey, req in registryRequirements do
 		if req.name == packageName then
 			registryRequirements[reqKey] = nil
 		end
+	end
+end
+
+local function collectSourcePackageDependencies(
+	key: string,
+	installPath: string,
+	rootDirectory: string,
+	transitiveDependencies: { [string]: string },
+	queue: { manifest.DependencySpec },
+	registryRequirements: { [string]: semver.Requirement },
+	registrySources: { [string]: string },
+	unresolvedRegistryDependencies: { [string]: { [string]: string } }
+)
+	local nestedManifestPath = getManifestPath(installPath)
+	if not fs.exists(nestedManifestPath) then
+		return
+	end
+
+	local dependencyManifest = manifest.parseFile(nestedManifestPath)
+	for dependencyAlias, dependencySpec in dependencyManifest.package.dependencies do
+		local normalizedSpec = normalizePathDependency(dependencySpec, installPath, rootDirectory)
+
+		if normalizedSpec.sourceKind == "registry" then
+			registryRequirements[`{key}:{dependencyAlias}`] = {
+				name = normalizedSpec.name,
+				constraint = semver.parseConstraint(normalizedSpec.version),
+				requiredBy = key,
+				aliasedAs = if dependencyAlias ~= normalizedSpec.name then dependencyAlias else nil,
+			}
+
+			registrySources[normalizedSpec.name] = normalizedSpec.source
+
+			if not unresolvedRegistryDependencies[key] then
+				unresolvedRegistryDependencies[key] = {}
+			end
+
+			unresolvedRegistryDependencies[key][dependencyAlias] = normalizedSpec.name
+			continue
+		end
+
+		transitiveDependencies[dependencyAlias] = getKey(normalizedSpec)
+		table.insert(queue, normalizedSpec)
 	end
 end
 
@@ -167,13 +214,18 @@ local function buildEffectiveUniverse(
 	return effective, sourceOverridedDeps
 end
 
-local function pathDepsAreStale(lock: lockfile.Lockfile, rootDirectory: string): boolean
+local function pathDepsAreStale(
+	lock: lockfile.Lockfile,
+	rootDirectory: string,
+	overrides: { [string]: manifest.DependencySpec }
+): boolean
 	for _, pkg in lock.packages do
 		if pkg.sourceKind ~= "path" then
 			continue
 		end
 
-		local depManifestPath = path.format(path.join(rootDirectory, pkg.installPath, "loom.config.luau"))
+		local packageInstallPath = path.format(path.join(rootDirectory, pkg.installPath))
+		local depManifestPath = path.format(path.join(packageInstallPath, "loom.config.luau"))
 		if not fs.exists(depManifestPath) then
 			return true
 		end
@@ -196,6 +248,12 @@ local function pathDepsAreStale(lock: lockfile.Lockfile, rootDirectory: string):
 		end
 
 		for alias, depSpec in depManifest.package.dependencies do
+			local ok, normalizedDepSpec = pcall(normalizePathDependency, depSpec, packageInstallPath, rootDirectory)
+			if not ok then
+				return true
+			end
+			depSpec = overrides[(normalizedDepSpec :: manifest.DependencySpec).name] or normalizedDepSpec
+
 			local recordedKey = pkg.dependencies[alias]
 			if recordedKey == nil then
 				continue
@@ -250,7 +308,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 			return existingLock
 		end
 
-		if satisfied and not pathDepsAreStale(existingLock, rootDirectory) then
+		if satisfied and not pathDepsAreStale(existingLock, rootDirectory, rootManifest.overrides) then
 			print("Lockfile up to date.")
 			return existingLock
 		end
@@ -281,11 +339,62 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 	local registrySources: { [string]: string } = {}
 
 	-- Root aliases that need a resolved key written back into `dependencies` after solving.
-	local rootRegistryAliases: { string } = {}
+	local rootRegistryAliases: { RootRegistryAlias } = {}
 	-- Per-package registry aliases that need keys written into their dependency table after solving.
 	local unresolvedRegistryDependencies: { [string]: { [string]: string } } = {}
 	-- Open (not yet finalized) dependency maps for unversioned packages; registry entries are filled in during versioned resolution.
 	local openDependencies: { [string]: { [string]: string } } = {}
+	local queueIndex = 1
+
+	local function processSourceQueue()
+		while queueIndex <= #queue do
+			local spec = queue[queueIndex]
+			queueIndex += 1
+
+			local key = getKey(spec)
+
+			if packages[key] then
+				if hasConflict(packages[key], spec) then
+					error(
+						`Source mismatch for package '{spec.name}':\n`
+							.. `  resolved: {packages[key].source} ({packages[key].sourceKind})\n`
+							.. `  incoming: {spec.source} ({spec.sourceKind})\n`
+							.. `Both resolve to '{key}' but from different sources.`
+					)
+				else
+					-- Already resolved at this exact version — deduplicate
+					continue
+				end
+			end
+
+			local transitiveDependencies: { [string]: string } = {}
+			openDependencies[key] = transitiveDependencies
+
+			local installPath = fetchSource(spec, rootDirectory)
+
+			collectSourcePackageDependencies(
+				key,
+				installPath,
+				rootDirectory,
+				transitiveDependencies,
+				queue,
+				registryRequirements,
+				registrySources,
+				unresolvedRegistryDependencies
+			)
+
+			packages[key] = table.freeze({
+				name = spec.name,
+				rev = if spec.sourceKind == "github" then spec.rev else nil,
+				source = spec.source,
+				sourceKind = spec.sourceKind,
+				installPath = if spec.sourceKind == "path"
+					then path.format(path.relative(rootDirectory, installPath))
+					else store.toStorePath(key),
+				dependencies = transitiveDependencies,
+			})
+		end
+	end
 
 	for dependencyAlias, dependencySpec in rootManifest.package.dependencies do
 		if dependencySpec.sourceKind == "registry" then
@@ -297,7 +406,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 			}
 
 			registrySources[dependencySpec.name] = dependencySpec.source
-			table.insert(rootRegistryAliases, dependencyAlias)
+			table.insert(rootRegistryAliases, { alias = dependencyAlias, name = dependencySpec.name })
 			continue
 		end
 
@@ -316,7 +425,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 				}
 
 				registrySources[dependencySpec.name] = dependencySpec.source
-				table.insert(rootRegistryAliases, dependencyAlias)
+				table.insert(rootRegistryAliases, { alias = dependencyAlias, name = dependencySpec.name })
 				continue
 			end
 
@@ -325,68 +434,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 		end
 	end
 
-	for _, spec in queue do
-		local key = getKey(spec)
-
-		if packages[key] then
-			if hasConflict(packages[key], spec) then
-				error(
-					`Source mismatch for package '{spec.name}':\n`
-						.. `  resolved: {packages[key].source} ({packages[key].sourceKind})\n`
-						.. `  incoming: {spec.source} ({spec.sourceKind})\n`
-						.. `Both resolve to '{key}' but from different sources.`
-				)
-			else
-				-- Already resolved at this exact version — deduplicate
-				continue
-			end
-		end
-
-		local transitiveDependencies: { [string]: string } = {}
-		openDependencies[key] = transitiveDependencies
-
-		local installPath = fetchSource(spec, rootDirectory)
-
-		local nestedManifestPath = getManifestPath(installPath)
-		if fs.exists(nestedManifestPath) then
-			local dependencyManifest = manifest.parseFile(nestedManifestPath)
-			for dependencyAlias, dependencySpec in dependencyManifest.package.dependencies do
-				local normalizedSpec = normalizePathDependency(dependencySpec, installPath, rootDirectory)
-
-				if normalizedSpec.sourceKind == "registry" then
-					registryRequirements[`{key}:{dependencyAlias}`] = {
-						name = normalizedSpec.name,
-						constraint = semver.parseConstraint(normalizedSpec.version),
-						requiredBy = key,
-						aliasedAs = if dependencyAlias ~= normalizedSpec.name then dependencyAlias else nil,
-					}
-
-					registrySources[normalizedSpec.name] = normalizedSpec.source
-
-					if not unresolvedRegistryDependencies[key] then
-						unresolvedRegistryDependencies[key] = {}
-					end
-
-					unresolvedRegistryDependencies[key][dependencyAlias] = normalizedSpec.name
-					continue
-				end
-
-				transitiveDependencies[dependencyAlias] = getKey(normalizedSpec)
-				table.insert(queue, normalizedSpec)
-			end
-		end
-
-		packages[key] = table.freeze({
-			name = spec.name,
-			rev = if spec.sourceKind == "github" then spec.rev else nil,
-			source = spec.source,
-			sourceKind = spec.sourceKind,
-			installPath = if spec.sourceKind == "path"
-				then path.format(path.relative(rootDirectory, installPath))
-				else store.toStorePath(key),
-			dependencies = transitiveDependencies,
-		})
-	end
+	processSourceQueue()
 
 	-- Apply overrides: version pins replace constraints; source overrides redirect to path/github.
 	local overrides = rootManifest.overrides
@@ -424,8 +472,9 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 
 			-- Alias was removed from registryRequirements by the override; write override key directly.
 			for i = #rootRegistryAliases, 1, -1 do
-				if registryRequirements[rootRegistryAliases[i]] == nil then
-					dependencies[rootRegistryAliases[i]] = overrideKey
+				local rootAlias = rootRegistryAliases[i]
+				if rootAlias.name == overrideName then
+					dependencies[rootAlias.alias] = overrideKey
 					table.remove(rootRegistryAliases, i)
 				end
 			end
@@ -435,30 +484,16 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 				openDependencies[overrideKey] = transitiveDependencies
 
 				local installPath = fetchSource(overrideSpec, rootDirectory)
-				local nestedManifestPath = getManifestPath(installPath)
-				if fs.exists(nestedManifestPath) then
-					local dependencyManifest = manifest.parseFile(nestedManifestPath)
-					for dependencyAlias, dependencySpec in dependencyManifest.package.dependencies do
-						local normalizedSpec = normalizePathDependency(dependencySpec, installPath, rootDirectory)
-
-						if normalizedSpec.sourceKind == "registry" then
-							registryRequirements[`{overrideKey}:{dependencyAlias}`] = {
-								name = normalizedSpec.name,
-								constraint = semver.parseConstraint(normalizedSpec.version),
-								requiredBy = overrideKey,
-								aliasedAs = if dependencyAlias ~= normalizedSpec.name then dependencyAlias else nil,
-							}
-							registrySources[normalizedSpec.name] = normalizedSpec.source
-							if not unresolvedRegistryDependencies[overrideKey] then
-								unresolvedRegistryDependencies[overrideKey] = {}
-							end
-							unresolvedRegistryDependencies[overrideKey][dependencyAlias] = normalizedSpec.name
-							continue
-						end
-
-						transitiveDependencies[dependencyAlias] = getKey(normalizedSpec)
-					end
-				end
+				collectSourcePackageDependencies(
+					overrideKey,
+					installPath,
+					rootDirectory,
+					transitiveDependencies,
+					queue,
+					registryRequirements,
+					registrySources,
+					unresolvedRegistryDependencies
+				)
 
 				packages[overrideKey] = table.freeze({
 					name = overrideSpec.name,
@@ -473,6 +508,8 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 			end
 		end
 	end
+
+	processSourceQueue()
 
 	-- Build a modified universe that respects overrides.
 	local effectiveUniverse = universe
@@ -536,14 +573,14 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 		end
 
 		-- Write root-level registry dependency aliases now that versions are resolved.
-		for _, alias in rootRegistryAliases do
-			local req = registryRequirements[alias] or overriddenPackages[alias]
+		for _, rootAlias in rootRegistryAliases do
+			local req = registryRequirements[rootAlias.alias] or overriddenPackages[rootAlias.name]
 			if req == nil then
 				continue
 			end
 			local pkgVersion = versionsByPackageName[req.name]
 			assert(pkgVersion ~= nil, `Solver did not resolve root dependency '{req.name}'`)
-			dependencies[alias] = `{req.name}@{pkgVersion.versionString}`
+			dependencies[rootAlias.alias] = `{req.name}@{pkgVersion.versionString}`
 		end
 	end
 

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -117,11 +117,11 @@ local function buildEffectiveUniverse(
 	universe: semver.Universe,
 	overrides: { [string]: manifest.DependencySpec }
 ): (semver.Universe, { [string]: { [string]: string } })
-	local registryOverrides: { [string]: string } = {}
+	local registryOverrides: { [string]: semver.Constraint } = {}
 	local sourceOverrideNames: { [string]: boolean } = {}
 	for name, spec in overrides do
 		if spec.sourceKind == "registry" then
-			registryOverrides[name] = spec.version
+			registryOverrides[name] = semver.parseConstraint(spec.version)
 		else
 			sourceOverrideNames[name] = true
 		end
@@ -132,14 +132,14 @@ local function buildEffectiveUniverse(
 
 	for pkgName, versions in universe do
 		if registryOverrides[pkgName] then
-			effective[pkgName] = {}
+			local filtered: { semver.PackageVersion } = {}
 			for _, v in versions do
-				if v.versionString == registryOverrides[pkgName] then
-					effective[pkgName] = { v }
-					break
+				if semver.satisfies(v.version, registryOverrides[pkgName]) then
+					table.insert(filtered, v)
 				end
 			end
-			assert(#effective[pkgName] > 0, `Override pins '{pkgName}' to version {registryOverrides[pkgName]}, but that version does not exist in the registry`)
+			assert(#filtered > 0, `Override constrains '{pkgName}' to {overrides[pkgName].version}, but no matching version exists in the registry`)
+			effective[pkgName] = filtered
 		elseif sourceOverrideNames[pkgName] then
 			continue
 		else
@@ -150,7 +150,7 @@ local function buildEffectiveUniverse(
 					if registryOverrides[dep.name] then
 						newDeps[alias] = table.freeze({
 							name = dep.name,
-							constraint = semver.parseConstraint(`={registryOverrides[dep.name]}`),
+							constraint = registryOverrides[dep.name],
 							requiredBy = dep.requiredBy,
 							aliasedAs = dep.aliasedAs,
 						})
@@ -409,7 +409,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 		if overrideSpec.sourceKind == "registry" then
 			local overrideReq = {
 				name = overrideName,
-				constraint = semver.parseConstraint(`={overrideSpec.version}`),
+				constraint = semver.parseConstraint(overrideSpec.version),
 				requiredBy = "override",
 			}
 			registryRequirements[`override:{overrideName}`] = overrideReq

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -88,6 +88,96 @@ export type ResolveOptions = {
 	read locked: boolean?,
 }
 
+local function removeRequirementsForPackage(
+	registryRequirements: { [string]: semver.Requirement },
+	packageName: string
+)
+	for reqKey, req in registryRequirements do
+		if req.name == packageName then
+			registryRequirements[reqKey] = nil
+		end
+	end
+end
+
+local function serializeOverrides(overrides: { [string]: manifest.DependencySpec }): { [string]: string }
+	local result: { [string]: string } = {}
+	for name, spec in overrides do
+		if spec.sourceKind == "registry" then
+			result[name] = spec.version
+		elseif spec.sourceKind == "path" then
+			result[name] = `path:{spec.source}`
+		elseif spec.sourceKind == "github" then
+			result[name] = `github:{spec.source}@{spec.rev}`
+		end
+	end
+	return result
+end
+
+local function buildEffectiveUniverse(
+	universe: semver.Universe,
+	overrides: { [string]: manifest.DependencySpec }
+): (semver.Universe, { [string]: { [string]: string } })
+	local registryOverrides: { [string]: string } = {}
+	local sourceOverrideNames: { [string]: boolean } = {}
+	for name, spec in overrides do
+		if spec.sourceKind == "registry" then
+			registryOverrides[name] = spec.version
+		else
+			sourceOverrideNames[name] = true
+		end
+	end
+
+	local effective: semver.Universe = {}
+	local sourceOverridedDeps: { [string]: { [string]: string } } = {}
+
+	for pkgName, versions in universe do
+		if registryOverrides[pkgName] then
+			effective[pkgName] = {}
+			for _, v in versions do
+				if v.versionString == registryOverrides[pkgName] then
+					effective[pkgName] = { v }
+					break
+				end
+			end
+			assert(#effective[pkgName] > 0, `Override pins '{pkgName}' to version {registryOverrides[pkgName]}, but that version does not exist in the registry`)
+		elseif sourceOverrideNames[pkgName] then
+			continue
+		else
+			local rewritten: { semver.PackageVersion } = {}
+			for _, v in versions do
+				local newDeps: { [string]: semver.Requirement } = {}
+				for alias, dep in v.dependencies do
+					if registryOverrides[dep.name] then
+						newDeps[alias] = table.freeze({
+							name = dep.name,
+							constraint = semver.parseConstraint(`={registryOverrides[dep.name]}`),
+							requiredBy = dep.requiredBy,
+							aliasedAs = dep.aliasedAs,
+						})
+					elseif sourceOverrideNames[dep.name] then
+						local vKey = `{v.name}@{v.versionString}`
+						if not sourceOverridedDeps[vKey] then
+							sourceOverridedDeps[vKey] = {}
+						end
+						sourceOverridedDeps[vKey][alias] = dep.name
+					else
+						newDeps[alias] = dep
+					end
+				end
+				table.insert(rewritten, table.freeze({
+					name = v.name,
+					version = v.version,
+					versionString = v.versionString,
+					dependencies = table.freeze(newDeps),
+				}))
+			end
+			effective[pkgName] = rewritten
+		end
+	end
+
+	return effective, sourceOverridedDeps
+end
+
 local function pathDepsAreStale(lock: lockfile.Lockfile, rootDirectory: string): boolean
 	for _, pkg in lock.packages do
 		if pkg.sourceKind ~= "path" then
@@ -177,12 +267,17 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 		end
 	end
 
-	-- Extract locked registry versions for soft preference during re-resolution
+	-- Extract locked registry versions for soft preference during re-resolution.
+	-- Skip packages that were previously overridden — removing an override should unlock the version.
 	local lockedRegistryVersions: { [string]: string }? = nil
 	if existingLock then
 		lockedRegistryVersions = {}
+		local previousOverrides = existingLock.overrides
 		for _, pkg in existingLock.packages do
 			if pkg.sourceKind == "registry" and pkg.rev then
+				if previousOverrides and previousOverrides[pkg.name] then
+					continue
+				end
 				(lockedRegistryVersions :: { [string]: string })[pkg.name] = pkg.rev
 			end
 		end
@@ -304,11 +399,104 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 		})
 	end
 
+	-- Apply overrides: version pins replace constraints; source overrides redirect to path/github.
+	local overrides = rootManifest.overrides
+	local overriddenPackages: { [string]: semver.Requirement } = {}
+
+	for overrideName, overrideSpec in overrides do
+		removeRequirementsForPackage(registryRequirements, overrideName)
+
+		if overrideSpec.sourceKind == "registry" then
+			local overrideReq = {
+				name = overrideName,
+				constraint = semver.parseConstraint(`={overrideSpec.version}`),
+				requiredBy = "override",
+			}
+			registryRequirements[`override:{overrideName}`] = overrideReq
+			overriddenPackages[overrideName] = overrideReq
+
+			if not registrySources[overrideName] then
+				registrySources[overrideName] = overrideSpec.source
+			end
+		else
+			local overrideKey = getKey(overrideSpec)
+
+			for pkgKey, unresolvedAliases in unresolvedRegistryDependencies do
+				for depAlias, registryName in unresolvedAliases do
+					if registryName == overrideName then
+						local packageDependencies = openDependencies[pkgKey]
+						if packageDependencies then
+							packageDependencies[depAlias] = overrideKey
+						end
+						unresolvedAliases[depAlias] = nil
+					end
+				end
+			end
+
+			-- Alias was removed from registryRequirements by the override; write override key directly.
+			for i = #rootRegistryAliases, 1, -1 do
+				if registryRequirements[rootRegistryAliases[i]] == nil then
+					dependencies[rootRegistryAliases[i]] = overrideKey
+					table.remove(rootRegistryAliases, i)
+				end
+			end
+
+			if not packages[overrideKey] then
+				local transitiveDependencies: { [string]: string } = {}
+				openDependencies[overrideKey] = transitiveDependencies
+
+				local installPath = fetchSource(overrideSpec, rootDirectory)
+				local nestedManifestPath = getManifestPath(installPath)
+				if fs.exists(nestedManifestPath) then
+					local dependencyManifest = manifest.parseFile(nestedManifestPath)
+					for dependencyAlias, dependencySpec in dependencyManifest.package.dependencies do
+						local normalizedSpec = normalizePathDependency(dependencySpec, installPath, rootDirectory)
+
+						if normalizedSpec.sourceKind == "registry" then
+							registryRequirements[`{overrideKey}:{dependencyAlias}`] = {
+								name = normalizedSpec.name,
+								constraint = semver.parseConstraint(normalizedSpec.version),
+								requiredBy = overrideKey,
+								aliasedAs = if dependencyAlias ~= normalizedSpec.name then dependencyAlias else nil,
+							}
+							registrySources[normalizedSpec.name] = normalizedSpec.source
+							if not unresolvedRegistryDependencies[overrideKey] then
+								unresolvedRegistryDependencies[overrideKey] = {}
+							end
+							unresolvedRegistryDependencies[overrideKey][dependencyAlias] = normalizedSpec.name
+							continue
+						end
+
+						transitiveDependencies[dependencyAlias] = getKey(normalizedSpec)
+					end
+				end
+
+				packages[overrideKey] = table.freeze({
+					name = overrideSpec.name,
+					rev = if overrideSpec.sourceKind == "github" then overrideSpec.rev else nil,
+					source = overrideSpec.source,
+					sourceKind = overrideSpec.sourceKind,
+					installPath = if overrideSpec.sourceKind == "path"
+						then path.format(path.relative(rootDirectory, installPath))
+						else store.toStorePath(overrideKey),
+					dependencies = transitiveDependencies,
+				})
+			end
+		end
+	end
+
+	-- Build a modified universe that respects overrides.
+	local effectiveUniverse = universe
+	local sourceOverridedDeps: { [string]: { [string]: string } } = {}
+	if universe ~= nil and next(overrides) ~= nil then
+		effectiveUniverse, sourceOverridedDeps = buildEffectiveUniverse(universe, overrides)
+	end
+
 	-- Versioned dependency resolution: solve registry dependencies and stitch them into the package graph.
 	if next(registryRequirements) ~= nil then
-		assert(universe ~= nil, "Registry dependencies require a universe to be provided")
+		assert(effectiveUniverse ~= nil, "Registry dependencies require a universe to be provided")
 
-		local resolution = semver.solve(universe, registryRequirements, lockedRegistryVersions)
+		local resolution = semver.solve(effectiveUniverse, registryRequirements, lockedRegistryVersions)
 
 		-- Build a lookup from package name to resolved version(s) for slot-keyed results.
 		local versionsByPackageName = {}
@@ -326,6 +514,16 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 				assert(resolvedVersion ~= nil, `Solver produced an incomplete resolution: missing '{dependency.name}'`)
 
 				transitiveDependencies[alias] = `{dependency.name}@{resolvedVersion.versionString}`
+			end
+
+			-- Add back dependencies that were stripped for source overrides.
+			if sourceOverridedDeps[key] then
+				for alias, overriddenName in sourceOverridedDeps[key] do
+					local overrideSpec = overrides[overriddenName]
+					if overrideSpec then
+						transitiveDependencies[alias] = getKey(overrideSpec)
+					end
+				end
 			end
 
 			packages[key] = table.freeze({
@@ -350,7 +548,10 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 
 		-- Write root-level registry dependency aliases now that versions are resolved.
 		for _, alias in rootRegistryAliases do
-			local req = registryRequirements[alias]
+			local req = registryRequirements[alias] or overriddenPackages[alias]
+			if req == nil then
+				continue
+			end
 			local pkgVersion = versionsByPackageName[req.name]
 			assert(pkgVersion ~= nil, `Solver did not resolve root dependency '{req.name}'`)
 			dependencies[alias] = `{req.name}@{pkgVersion.versionString}`
@@ -364,10 +565,16 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 	table.freeze(packages)
 	table.freeze(dependencies)
 
+	local serializedOverrides = serializeOverrides(overrides)
+	local frozenOverrides: { [string]: string }? = if next(serializedOverrides)
+		then table.freeze(serializedOverrides)
+		else nil
+
 	local lock: lockfile.Lockfile = table.freeze({
-		version = 3,
+		version = if frozenOverrides then 4 else 3,
 		packages = packages,
 		dependencies = dependencies,
+		overrides = frozenOverrides,
 	})
 
 	fs.writeStringToFile(lockfilePath, `return {pp(lock)}\n`)

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -597,7 +597,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 		else nil
 
 	local lock: lockfile.Lockfile = table.freeze({
-		version = if frozenOverrides then 4 else 3,
+		version = 3,
 		packages = packages,
 		dependencies = dependencies,
 		overrides = frozenOverrides,

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -96,7 +96,6 @@ local function removeRequirementsForPackage(registryRequirements: { [string]: se
 	end
 end
 
-
 local function buildEffectiveUniverse(
 	universe: semver.Universe,
 	overrides: { [string]: manifest.DependencySpec }

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -88,10 +88,7 @@ export type ResolveOptions = {
 	read locked: boolean?,
 }
 
-local function removeRequirementsForPackage(
-	registryRequirements: { [string]: semver.Requirement },
-	packageName: string
-)
+local function removeRequirementsForPackage(registryRequirements: { [string]: semver.Requirement }, packageName: string)
 	for reqKey, req in registryRequirements do
 		if req.name == packageName then
 			registryRequirements[reqKey] = nil
@@ -138,7 +135,10 @@ local function buildEffectiveUniverse(
 					table.insert(filtered, v)
 				end
 			end
-			assert(#filtered > 0, `Override constrains '{pkgName}' to {overrides[pkgName].version}, but no matching version exists in the registry`)
+			assert(
+				#filtered > 0,
+				`Override constrains '{pkgName}' to {overrides[pkgName].version}, but no matching version exists in the registry`
+			)
 			effective[pkgName] = filtered
 		elseif sourceOverrideNames[pkgName] then
 			continue
@@ -164,12 +164,15 @@ local function buildEffectiveUniverse(
 						newDeps[alias] = dep
 					end
 				end
-				table.insert(rewritten, table.freeze({
-					name = v.name,
-					version = v.version,
-					versionString = v.versionString,
-					dependencies = table.freeze(newDeps),
-				}))
+				table.insert(
+					rewritten,
+					table.freeze({
+						name = v.name,
+						version = v.version,
+						versionString = v.versionString,
+						dependencies = table.freeze(newDeps),
+					})
+				)
 			end
 			effective[pkgName] = rewritten
 		end

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -1322,6 +1322,204 @@ test.suite("Overrides", function(suite)
 		assert.eq(lock.packages["lemon@1.0.0"].dependencies.citrus, "citrus")
 	end)
 
+	suite:case("sourceOverridePathResolvesNestedPathDeps", function(assert)
+		local sharedDir = path.join(workingDirectory, "shared")
+		fs.createDirectory(sharedDir)
+		writeConfig(sharedDir, "shared", "")
+
+		local overrideDir = path.join(workingDirectory, "citrus-fork")
+		fs.createDirectory(overrideDir)
+		writeConfig(
+			overrideDir,
+			"citrus",
+			[[
+
+			shared = {
+				sourceKind = "path",
+				source = "../shared",
+			},]]
+		)
+
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lemon = {
+				sourceKind = "registry",
+				source = "lemon",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "path",
+				source = "./citrus-fork",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			lemon = {
+				namedVersion("lemon", "1.0.0", { citrus = req("citrus", "^2.0.0") }),
+			},
+			citrus = {
+				namedVersion("citrus", "2.1.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+
+		assert.eq(lock.packages.citrus.dependencies.shared, "shared")
+		assert.eq(lock.packages.shared.name, "shared")
+		assert.eq(lock.packages.shared.sourceKind, "path")
+
+		local reused = resolution.resolve(path.format(workingDirectory), nil)
+		assert.eq(reused.packages.citrus.dependencies.shared, "shared")
+	end)
+
+	suite:case("directRegistryOverrideOutsideOriginalRangeReusesLockfile", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "2.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "2.0.0"),
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		resolution.resolve(path.format(workingDirectory), universe)
+		local lock = resolution.resolve(path.format(workingDirectory), universe, { locked = true })
+
+		assert.eq(lock.dependencies.citrus, "citrus@2.0.0")
+	end)
+
+	suite:case("directSourceOverrideReusesLockfile", function(assert)
+		local overrideDir = path.join(workingDirectory, "citrus-fork")
+		fs.createDirectory(overrideDir)
+		writeConfig(overrideDir, "citrus", "")
+
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "path",
+				source = "./citrus-fork",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		resolution.resolve(path.format(workingDirectory), universe)
+		local lock = resolution.resolve(path.format(workingDirectory), universe, { locked = true })
+
+		assert.eq(lock.dependencies.citrus, "citrus")
+		assert.eq(lock.packages.citrus.sourceKind, "path")
+	end)
+
+	suite:case("registryOverrideWorksForAliasedDirectDep", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			localCitrus = {
+				sourceKind = "registry",
+				name = "citrus",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "2.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "2.0.0"),
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+
+		assert.eq(lock.dependencies.localCitrus, "citrus@2.0.0")
+	end)
+
+	suite:case("sourceOverrideWorksForAliasedDirectDep", function(assert)
+		local overrideDir = path.join(workingDirectory, "citrus-fork")
+		fs.createDirectory(overrideDir)
+		writeConfig(overrideDir, "citrus", "")
+
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			localCitrus = {
+				sourceKind = "registry",
+				name = "citrus",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "path",
+				source = "./citrus-fork",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+
+		assert.eq(lock.dependencies.localCitrus, "citrus")
+		assert.eq(lock.packages.citrus.sourceKind, "path")
+	end)
+
 	suite:case("lockfileIncludesOverrideFingerprint", function(assert)
 		writeConfig(
 			workingDirectory,

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -1554,7 +1554,7 @@ test.suite("Overrides", function(suite)
 		assert.eq((lock.overrides :: any).citrus, "2.0.0")
 	end)
 
-	suite:case("lockfileVersionIsFourWithOverrides", function(assert)
+	suite:case("lockfileVersionIsThreeWithOverrides", function(assert)
 		writeConfig(
 			workingDirectory,
 			"root",
@@ -1572,29 +1572,6 @@ test.suite("Overrides", function(suite)
 				sourceKind = "registry",
 				source = "citrus",
 				version = "1.0.0",
-			},]]
-		)
-
-		local universe: solver.Universe = {
-			citrus = {
-				namedVersion("citrus", "1.0.0"),
-			},
-		}
-
-		local lock = resolution.resolve(path.format(workingDirectory), universe)
-		assert.eq(lock.version, 4)
-	end)
-
-	suite:case("lockfileVersionIsThreeWithoutOverrides", function(assert)
-		writeConfig(
-			workingDirectory,
-			"root",
-			[[
-
-			citrus = {
-				sourceKind = "registry",
-				source = "citrus",
-				version = "^1.0.0",
 			},]]
 		)
 

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -1206,6 +1206,47 @@ test.suite("Overrides", function(suite)
 		assert.eq(lock.packages["lemon@1.0.0"].dependencies.citrus, "citrus@3.0.0")
 	end)
 
+	suite:case("versionRangeOverrideSelectsBestMatch", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lemon = {
+				sourceKind = "registry",
+				source = "lemon",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^3.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			lemon = {
+				namedVersion("lemon", "1.0.0", { citrus = req("citrus", "^2.0.0") }),
+			},
+			citrus = {
+				namedVersion("citrus", "3.2.0"),
+				namedVersion("citrus", "3.1.0"),
+				namedVersion("citrus", "3.0.0"),
+				namedVersion("citrus", "2.1.0"),
+				namedVersion("citrus", "2.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+
+		assert.eq(lock.packages["citrus@3.2.0"].name, "citrus")
+		assert.eq(lock.packages["citrus@2.1.0"], nil)
+		assert.eq(lock.packages["lemon@1.0.0"].dependencies.citrus, "citrus@3.2.0")
+	end)
+
 	suite:case("versionPinWorksForDirectDep", function(assert)
 		writeConfig(
 			workingDirectory,

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -10,15 +10,20 @@ local solver = require("@commands/pkg/loom-core/src/semver/solver")
 local temporaryDirectory = system.tmpdir()
 local workingDirectory = path.join(temporaryDirectory, "lute-pkg-registry")
 
-local function writeConfig(dir: path.Path, name: string, deps: string, devDeps: string?)
+local function writeConfig(dir: path.Path, name: string, deps: string, devDeps: string?, overrides: string?)
 	local sections = `\t\tdependencies = \{{deps}\n\t\t}`
 	if devDeps then
 		sections ..= `,\n\t\tdev_dependencies = \{{devDeps}\n\t\t}`
 	end
 
+	local overridesSection = ""
+	if overrides then
+		overridesSection = `\n\toverrides = \{{overrides}\n\t},`
+	end
+
 	fs.writeStringToFile(
 		path.join(dir, "loom.config.luau"),
-		`return \{\n\tpackage = \{\n\t\tname = "{name}",\n\t\tversion = "0.0.0",\n{sections},\n\t},\n}\n`
+		`return \{\n\tpackage = \{\n\t\tname = "{name}",\n\t\tversion = "0.0.0",\n{sections},\n\t},{overridesSection}\n}\n`
 	)
 end
 
@@ -1151,5 +1156,361 @@ test.suite("LockfileReuse", function(suite)
 		-- Re-resolves: locked 1.5.0 doesn't satisfy new constraint, falls back to newest valid (1.3.0)
 		local lock = resolution.resolve(path.format(workingDirectory), universe)
 		assert.eq(lock.dependencies.citrus, "citrus@1.3.0")
+	end)
+end)
+
+test.suite("Overrides", function(suite)
+	suite:beforeEach(function()
+		if fs.exists(workingDirectory) then
+			fs.removeDirectory(workingDirectory, { recursive = true })
+		end
+		fs.createDirectory(workingDirectory)
+	end)
+
+	suite:case("versionPinForcesExactVersion", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lemon = {
+				sourceKind = "registry",
+				source = "lemon",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "3.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			lemon = {
+				namedVersion("lemon", "1.0.0", { citrus = req("citrus", "^2.0.0") }),
+			},
+			citrus = {
+				namedVersion("citrus", "3.0.0"),
+				namedVersion("citrus", "2.1.0"),
+				namedVersion("citrus", "2.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+
+		assert.eq(lock.packages["citrus@3.0.0"].name, "citrus")
+		assert.eq(lock.packages["citrus@2.1.0"], nil)
+		assert.eq(lock.packages["lemon@1.0.0"].dependencies.citrus, "citrus@3.0.0")
+	end)
+
+	suite:case("versionPinWorksForDirectDep", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "1.2.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.5.0"),
+				namedVersion("citrus", "1.2.0"),
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+
+		assert.eq(lock.dependencies.citrus, "citrus@1.2.0")
+	end)
+
+	suite:case("sourceOverridePathBypassesRegistry", function(assert)
+		local overrideDir = path.join(workingDirectory, "citrus-fork")
+		fs.createDirectory(overrideDir)
+		writeConfig(overrideDir, "citrus", "")
+
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lemon = {
+				sourceKind = "registry",
+				source = "lemon",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "path",
+				source = "./citrus-fork",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			lemon = {
+				namedVersion("lemon", "1.0.0", { citrus = req("citrus", "^2.0.0") }),
+			},
+			citrus = {
+				namedVersion("citrus", "2.1.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+
+		assert.eq(lock.packages["citrus"].sourceKind, "path")
+		assert.eq(lock.packages["citrus"].name, "citrus")
+		assert.eq(lock.packages["citrus@2.1.0"], nil)
+		assert.eq(lock.packages["lemon@1.0.0"].dependencies.citrus, "citrus")
+	end)
+
+	suite:case("lockfileIncludesOverrideFingerprint", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "2.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "2.0.0"),
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+
+		assert.neq(lock.overrides, nil)
+		assert.eq((lock.overrides :: any).citrus, "2.0.0")
+	end)
+
+	suite:case("lockfileVersionIsFourWithOverrides", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "1.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+		assert.eq(lock.version, 4)
+	end)
+
+	suite:case("lockfileVersionIsThreeWithoutOverrides", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+		assert.eq(lock.version, 3)
+	end)
+
+	suite:case("reResolvesWhenOverrideAdded", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.5.0"),
+				namedVersion("citrus", "1.2.0"),
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock1 = resolution.resolve(path.format(workingDirectory), universe)
+		assert.eq(lock1.dependencies.citrus, "citrus@1.5.0")
+
+		-- Add an override to pin to 1.2.0
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "1.2.0",
+			},]]
+		)
+
+		local lock2 = resolution.resolve(path.format(workingDirectory), universe)
+		assert.eq(lock2.dependencies.citrus, "citrus@1.2.0")
+	end)
+
+	suite:case("reResolvesWhenOverrideRemoved", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "1.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.5.0"),
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock1 = resolution.resolve(path.format(workingDirectory), universe)
+		assert.eq(lock1.dependencies.citrus, "citrus@1.0.0")
+
+		-- Remove the override
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]]
+		)
+
+		local lock2 = resolution.resolve(path.format(workingDirectory), universe)
+		assert.eq(lock2.dependencies.citrus, "citrus@1.5.0")
+	end)
+
+	suite:case("overriddenPackageTransitiveDepsStillResolved", function(assert)
+		writeConfig(
+			workingDirectory,
+			"root",
+			[[
+
+			lemon = {
+				sourceKind = "registry",
+				source = "lemon",
+				version = "^1.0.0",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "3.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			lemon = {
+				namedVersion("lemon", "1.0.0", { citrus = req("citrus", "^2.0.0") }),
+			},
+			citrus = {
+				namedVersion("citrus", "3.0.0", { zest = req("zest", "^1.0.0") }),
+				namedVersion("citrus", "2.0.0"),
+			},
+			zest = {
+				namedVersion("zest", "1.1.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(workingDirectory), universe)
+
+		assert.eq(lock.packages["citrus@3.0.0"].name, "citrus")
+		assert.eq(lock.packages["zest@1.1.0"].name, "zest")
+		assert.eq(lock.packages["citrus@3.0.0"].dependencies.zest, "zest@1.1.0")
+	end)
+
+	suite:case("noOverridesFieldInLockfileWhenEmpty", function(assert)
+		writeConfig(workingDirectory, "root", "")
+
+		local lock = resolution.resolve(path.format(workingDirectory), nil)
+		assert.eq(lock.overrides, nil)
 	end)
 end)


### PR DESCRIPTION
- Add overrides support to loom, allowing projects to force specific versions or sources for any transitive dependency (similar to npm/pnpm overrides)
- Two override modes: version pin (force an exact registry version) and source redirect (replace a registry package with a local path or github source)
- Lockfile version bumps to 4 only when overrides are present; projects without overrides stay on version 3

Overrides are declared at the project root in loom.config.luau:

```
return {
    package = { ... },
    overrides = {
        -- Pin a transitive dependency to an exact version
        citrus = { sourceKind = "registry", source = "citrus", version = "3.0.0" },
        -- Or redirect to a local fork
        citrus = { sourceKind = "path", source = "./citrus-fork" },
    },
}
```

The resolver removes conflicting constraints for overridden packages, builds a modified universe respecting the pins, and stitches source-redirected packages back into the dependency graph after solving. The lockfile records a fingerprint of
active overrides so changes trigger re-resolution.