### PR TITLE
Add a minimal DAP adapter

### DIFF
--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -1,91 +1,100 @@
 local io = require("@std/io")
 local json = require("@std/json")
 
-local readBuf = ""
-local writeSeqNum = 1
+-- we want generic Reader/Writer functions to easily test + support
+-- different transport mechanisms
+type Reader = (string?) -> string
+type Writer = (string) -> ()
 
-local function readDap(): json.Object
-	while not readBuf:find("\r\n\r\n") do
-		readBuf ..= io.input()
+local function dapLoop(reader: Reader, writer: Writer)
+	local readBuf = ""
+	local seqNum = 1
+
+	local function readDap(): json.Object
+		while not readBuf:find("\r\n\r\n") do
+			readBuf ..= reader()
+		end
+
+		-- the header for a DAP request will always be of the form
+		-- "Content-Length: 119\r\n\r\n"
+		local headerEnd = readBuf:find("\r\n\r\n")
+		assert(headerEnd, "missing \r\n\r\n when reading")
+		local header = readBuf:sub(1, headerEnd - 1)
+		local contentLength = tonumber(header:match("Content%-Length: (%d+)"))
+		assert(contentLength, "missing Content-Length in protocol read")
+		readBuf = readBuf:sub(headerEnd + 4)
+
+		while #readBuf < contentLength do
+			readBuf ..= reader()
+		end
+
+		local body = readBuf:sub(1, contentLength)
+		local deserialized = json.deserialize(body)
+		deserialized = assert(json.asObject(deserialized), "incoming protocol read could not be deserialized")
+
+		readBuf = readBuf:sub(contentLength + 1)
+		return deserialized
 	end
 
-	-- the header for a DAP request will always be of the form
-	-- "Content-Length: 119\r\n\r\n"
-	local headerEnd = readBuf:find("\r\n\r\n")
-	assert(headerEnd, "missing \r\n\r\n when reading")
-	local header = readBuf:sub(1, headerEnd - 1)
-	local contentLength = tonumber(header:match("Content%-Length: (%d+)"))
-	assert(contentLength, "missing Content-Length in protocol read")
-	readBuf = readBuf:sub(headerEnd + 4)
+	local function writeResponse(
+		requestSeq: number,
+		success: boolean,
+		command: string,
+		message: string?,
+		body: json.Object?
+	)
+		local response: json.Object = {
+			seq = seqNum,
+			type = "response",
+			request_seq = requestSeq,
+			success = success,
+			command = command,
+		}
+		if message then
+			response.message = message
+		end
+		if body then
+			response.body = body
+		end
+		seqNum += 1
 
-	while #readBuf < contentLength do
-		readBuf ..= io.input()
+		local encoded = json.serialize(response)
+		writer(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
 	end
 
-	local body = readBuf:sub(1, contentLength)
-	local deserialized = json.deserialize(body)
-	deserialized = assert(json.asObject(deserialized), "incoming protocol read could not be deserialized")
+	local function writeEvent(event: string, body: json.Object?)
+		local msg: json.Object = {
+			seq = seqNum,
+			type = "event",
+			event = event,
+		}
+		if body then
+			msg.body = body
+		end
+		seqNum += 1
 
-	readBuf = readBuf:sub(contentLength + 1)
-	return deserialized
+		local encoded = json.serialize(msg)
+		writer(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
+	end
+
+	while true do
+		local request = readDap()
+		local command = request.command :: string
+		local seq = request.seq :: number
+		if command == "initialize" then
+			writeResponse(seq, true, command)
+			writeEvent("initialized")
+		elseif command == "configurationDone" then
+			writeResponse(seq, true, command)
+		elseif command == "terminate" or command == "disconnect" then
+			writeResponse(seq, true, command)
+			break
+		else
+			writeResponse(seq, false, command, `unsupported command: {command}`)
+		end
+	end
 end
 
-local function writeResponse(
-	requestSeq: number,
-	success: boolean,
-	command: string,
-	message: string?,
-	body: json.Object?
-)
-	local response: json.Object = {
-		seq = writeSeqNum,
-		type = "response",
-		request_seq = requestSeq,
-		success = success,
-		command = command,
-	}
-	if message then
-		response.message = message
-	end
-	if body then
-		response.body = body
-	end
-	writeSeqNum += 1
-
-	local encoded = json.serialize(response)
-	io.write(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
-end
-
-local function writeEvent(event: string, body: json.Object?)
-	local msg: json.Object = {
-		seq = writeSeqNum,
-		type = "event",
-		event = event,
-	}
-	if body then
-		msg.body = body
-	end
-	writeSeqNum += 1
-
-	local encoded = json.serialize(msg)
-	io.write(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
-end
-
-local function dapLoop()
-    while true do
-        local request = readDap()
-        local command = request.command :: string
-        local seq = request.seq :: number
-        if command == "initialize" then
-            writeResponse(seq, true, command)
-            writeEvent("initialized")
-        elseif command == "configurationDone" then
-            writeResponse(seq, true, command)
-        elseif command == "terminate" or command == "disconnect" then 
-            writeResponse(seq, true, command)
-            break
-        else
-            writeResponse(seq, false, command, `unsupported command: {command}`)
-        end
-    end
-end
+return {
+	dapLoop = dapLoop,
+}

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -79,7 +79,7 @@ local function dapLoop()
         if command == "initialize" then
             writeResponse(seq, true, command)
             writeEvent("initialized")
-        if command == "configurationDone" then
+        elseif command == "configurationDone" then
             writeResponse(seq, true, command)
         elseif command == "terminate" or command == "disconnect" then 
             writeResponse(seq, true, command)

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -1,97 +1,23 @@
-local json = require("@std/json")
+local dapStream = require("./dapStream")
 
--- we want generic Reader/Writer functions to easily test + support
--- different transport mechanisms
-type Reader = (string?) -> string
-type Writer = (string) -> ()
-
-local function dapLoop(reader: Reader, writer: Writer)
-	local readBuf = ""
-	local seqNum = 1
-
-	local function readDap(): json.Object
-		while not readBuf:find("\r\n\r\n") do
-			readBuf ..= reader()
-		end
-
-		-- the header for a DAP request will always be of the form
-		-- "Content-Length: 119\r\n\r\n"
-		local headerEnd = readBuf:find("\r\n\r\n")
-		assert(headerEnd, "missing \r\n\r\n when reading")
-		local header = readBuf:sub(1, headerEnd - 1)
-		local contentLength = tonumber(header:match("Content%-Length: (%d+)"))
-		assert(contentLength, "missing Content-Length in protocol read")
-		readBuf = readBuf:sub(headerEnd + 4)
-
-		while #readBuf < contentLength do
-			readBuf ..= reader()
-		end
-
-		local body = readBuf:sub(1, contentLength)
-		local deserialized = json.deserialize(body)
-		deserialized = assert(json.asObject(deserialized), "incoming protocol read could not be deserialized")
-
-		readBuf = readBuf:sub(contentLength + 1)
-		return deserialized
-	end
-
-	local function writeResponse(
-		requestSeq: number,
-		success: boolean,
-		command: string,
-		message: string?,
-		body: json.Object?
-	)
-		local response: json.Object = {
-			seq = seqNum,
-			type = "response",
-			request_seq = requestSeq,
-			success = success,
-			command = command,
-		}
-		if message then
-			response.message = message
-		end
-		if body then
-			response.body = body
-		end
-		seqNum += 1
-
-		local encoded = json.serialize(response)
-		writer(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
-	end
-
-	local function writeEvent(event: string, body: json.Object?)
-		local msg: json.Object = {
-			seq = seqNum,
-			type = "event",
-			event = event,
-		}
-		if body then
-			msg.body = body
-		end
-		seqNum += 1
-
-		local encoded = json.serialize(msg)
-		writer(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
-	end
-
+local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
+	local ioSession = dapStream.makeDapStreamSession(reader, writer)
 	while true do
-		local request = readDap()
+		local request = ioSession.readDap()
 		local command = request.command :: string
-		local seq = request.seq :: number
+		local reqSeq = request.seq :: number
 		if command == "initialize" then
-			writeResponse(seq, true, command)
-			writeEvent("initialized")
+			ioSession.writeResponse(reqSeq, true, command)
+			ioSession.writeEvent("initialized")
 		elseif command == "configurationDone" then
-			writeResponse(seq, true, command)
+			ioSession.writeResponse(reqSeq, true, command)
 		elseif command == "terminate" or command == "disconnect" then
-			writeResponse(seq, true, command)
+			ioSession.writeResponse(reqSeq, true, command)
 			break
 		elseif command == "launch" then
-			writeResponse(seq, true, command)
+			ioSession.writeResponse(reqSeq, true, command)
 		else
-			writeResponse(seq, false, command, `unsupported command: {command}`)
+			ioSession.writeResponse(reqSeq, false, command, `unsupported command: {command}`)
 		end
 	end
 end

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -89,6 +89,8 @@ local function dapLoop(reader: Reader, writer: Writer)
 		elseif command == "terminate" or command == "disconnect" then
 			writeResponse(seq, true, command)
 			break
+		elseif command == "launch" then
+			writeResponse(seq, true, command)
 		else
 			writeResponse(seq, false, command, `unsupported command: {command}`)
 		end

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -1,4 +1,3 @@
-local io = require("@std/io")
 local json = require("@std/json")
 
 -- we want generic Reader/Writer functions to easily test + support

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -1,0 +1,91 @@
+local io = require("@std/io")
+local json = require("@std/json")
+
+local readBuf = ""
+local writeSeqNum = 1
+
+local function readDap(): json.Object
+	while not readBuf:find("\r\n\r\n") do
+		readBuf ..= io.input()
+	end
+
+	-- the header for a DAP request will always be of the form
+	-- "Content-Length: 119\r\n\r\n"
+	local headerEnd = readBuf:find("\r\n\r\n")
+	assert(headerEnd, "missing \r\n\r\n when reading")
+	local header = readBuf:sub(1, headerEnd - 1)
+	local contentLength = tonumber(header:match("Content%-Length: (%d+)"))
+	assert(contentLength, "missing Content-Length in protocol read")
+	readBuf = readBuf:sub(headerEnd + 4)
+
+	while #readBuf < contentLength do
+		readBuf ..= io.input()
+	end
+
+	local body = readBuf:sub(1, contentLength)
+	local deserialized = json.deserialize(body)
+	deserialized = assert(json.asObject(deserialized), "incoming protocol read could not be deserialized")
+
+	readBuf = readBuf:sub(contentLength + 1)
+	return deserialized
+end
+
+local function writeResponse(
+	requestSeq: number,
+	success: boolean,
+	command: string,
+	message: string?,
+	body: json.Object?
+)
+	local response: json.Object = {
+		seq = writeSeqNum,
+		type = "response",
+		request_seq = requestSeq,
+		success = success,
+		command = command,
+	}
+	if message then
+		response.message = message
+	end
+	if body then
+		response.body = body
+	end
+	writeSeqNum += 1
+
+	local encoded = json.serialize(response)
+	io.write(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
+end
+
+local function writeEvent(event: string, body: json.Object?)
+	local msg: json.Object = {
+		seq = writeSeqNum,
+		type = "event",
+		event = event,
+	}
+	if body then
+		msg.body = body
+	end
+	writeSeqNum += 1
+
+	local encoded = json.serialize(msg)
+	io.write(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
+end
+
+local function dapLoop()
+    while true do
+        local request = readDap()
+        local command = request.command :: string
+        local seq = request.seq :: number
+        if command == "initialize" then
+            writeResponse(seq, true, command)
+            writeEvent("initialized")
+        if command == "configurationDone" then
+            writeResponse(seq, true, command)
+        elseif command == "terminate" or command == "disconnect" then 
+            writeResponse(seq, true, command)
+            break
+        else
+            writeResponse(seq, false, command, `unsupported command: {command}`)
+        end
+    end
+end

--- a/lute/cli/commands/debug/dapStream.luau
+++ b/lute/cli/commands/debug/dapStream.luau
@@ -1,0 +1,88 @@
+local json = require("@std/json")
+
+-- we want generic Reader/Writer functions to easily test + support
+-- different transport mechanisms
+export type Reader = (string?) -> string
+export type Writer = (string) -> ()
+
+local function makeDapStreamSession(reader: Reader, writer: Writer)
+	local readBuf = ""
+	local seqNum = 1
+
+	-- because we are getting chunks of input, we want to pass in the readBuf of the
+	-- previous successful call into the next call
+	local function readDap(): json.Object
+		while not readBuf:find("\r\n\r\n") do
+			readBuf ..= reader()
+		end
+
+		-- the header for a DAP request will always be of the form
+		-- "Content-Length: 119\r\n\r\n"
+		local headerEnd = readBuf:find("\r\n\r\n")
+		assert(headerEnd, "missing \r\n\r\n when reading")
+		local header = readBuf:sub(1, headerEnd - 1)
+		local contentLength = tonumber(header:match("Content%-Length: (%d+)"))
+		assert(contentLength, "missing Content-Length in protocol read")
+		readBuf = readBuf:sub(headerEnd + 4)
+
+		while #readBuf < contentLength do
+			readBuf ..= reader()
+		end
+
+		local body = readBuf:sub(1, contentLength)
+		local deserialized = json.deserialize(body)
+		deserialized = assert(json.asObject(deserialized), "incoming protocol read could not be deserialized")
+
+		readBuf = readBuf:sub(contentLength + 1)
+		return deserialized
+	end
+
+	local function writeResponse(
+		requestSeq: number,
+		success: boolean,
+		command: string,
+		message: string?,
+		body: json.Object?
+	)
+		local response: json.Object = {
+			seq = seqNum,
+			type = "response",
+			request_seq = requestSeq,
+			success = success,
+			command = command,
+		}
+		if message then
+			response.message = message
+		end
+		if body then
+			response.body = body
+		end
+		local encoded = json.serialize(response)
+		writer(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
+		seqNum = seqNum + 1
+	end
+
+	local function writeEvent(event: string, body: json.Object?)
+		local msg: json.Object = {
+			seq = seqNum,
+			type = "event",
+			event = event,
+		}
+		if body then
+			msg.body = body
+		end
+		local encoded = json.serialize(msg)
+		writer(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
+		seqNum = seqNum + 1
+	end
+
+	return {
+		readDap = readDap,
+		writeResponse = writeResponse,
+		writeEvent = writeEvent,
+	}
+end
+
+return {
+	makeDapStreamSession = makeDapStreamSession,
+}

--- a/lute/cli/commands/debug/dapStream.luau
+++ b/lute/cli/commands/debug/dapStream.luau
@@ -51,12 +51,8 @@ local function makeDapStreamSession(reader: Reader, writer: Writer)
 			success = success,
 			command = command,
 		}
-		if message then
-			response.message = message
-		end
-		if body then
-			response.body = body
-		end
+		response.message = message or nil
+		response.body = body or nil
 		local encoded = json.serialize(response)
 		writer(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
 		seqNum = seqNum + 1
@@ -68,9 +64,7 @@ local function makeDapStreamSession(reader: Reader, writer: Writer)
 			type = "event",
 			event = event,
 		}
-		if body then
-			msg.body = body
-		end
+		msg.body = body or nil
 		local encoded = json.serialize(msg)
 		writer(`Content-Length: {#encoded}\r\n\r\n{encoded}`)
 		seqNum = seqNum + 1

--- a/lute/cli/commands/debug/init.luau
+++ b/lute/cli/commands/debug/init.luau
@@ -1,0 +1,42 @@
+local io = require("@std/io")
+local cli = require("@batteries/cli")
+local dap = require("@self/dap")
+
+local USAGE = "Usage: lute debug serve"
+
+local function printHelp()
+	print(USAGE)
+	print([[
+Starts the Lute debugger as a DAP server.
+
+SUBCOMMANDS:
+  serve                   Start a DAP debug adapter server over stdio
+
+OPTIONS:
+  -h, --help              Show this help message
+
+EXAMPLES:
+  lute debug serve
+]])
+end
+
+local function main(...: string)
+	local args = cli.parser()
+	args:add("help", "flag", { help = "Show help message", aliases = { "h" } })
+	args:add("subcommand", "positional", { help = "serve", required = false })
+
+	args:parse({ ... })
+
+	if args:has("help") then
+		printHelp()
+		return
+	end
+
+	if args:get("subcommand") == "serve" then
+		dap.dapLoop(io.input, io.write)
+	else
+		printHelp()
+	end
+end
+
+main(...)

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -62,8 +62,8 @@ Compile Options:
 		Compiles entry point and auto-discovered dependencies into a standalone executable.
 
 Debug Options:
-    lute debug serve
-        Serves a DAP server for Luau for use with a development environment.
+	lute debug serve
+		Serves a DAP server for Luau for use with a development environment.
 
 Setup Options:
 	lute setup

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -44,6 +44,7 @@ Commands:
 	run (default)   Run a Luau script.
 	check           Type check Luau files.
 	compile         Compile a Luau script into a standalone executable.
+    debug           Debug a Luau script.
 	setup           Generate type definition files for the language server.
 	transform       Run a specified code transformation on specified Luau files.
 	lint            Run linting rules on specified Luau files.
@@ -59,6 +60,10 @@ Check Options:
 Compile Options:
 	lute compile <entry.luau> [--output <executable>]
 		Compiles entry point and auto-discovered dependencies into a standalone executable.
+
+Debug Options:
+    lute debug serve
+        Serves a DAP server for Luau for use with a development environment.
 
 Setup Options:
 	lute setup
@@ -278,28 +283,31 @@ static std::vector<std::string> getLuteScripts(const std::string& luteFolderPath
     if (!normalizedPrefix.empty() && normalizedPrefix.back() != '/')
         normalizedPrefix += '/';
 
-    traverseDirectory(luteFolderPath, [&](const std::string& rawFilePath)
-    {
-        std::string filePath = normalizePath(rawFilePath);
-        std::string rel = filePath.substr(normalizedPrefix.size());
-        size_t slashPos = rel.find('/');
-
-        // If there's a slash at the end, we'll check if the rest is init.luau or init.lua, and add it as a command if so.
-        if (slashPos != std::string::npos)
+    traverseDirectory(
+        luteFolderPath,
+        [&](const std::string& rawFilePath)
         {
-            std::string rest = rel.substr(slashPos + 1);
-            if (rest.find('/') == std::string::npos && (rest == "init.luau" || rest == "init.lua"))
-                names.insert(rel.substr(0, slashPos));
+            std::string filePath = normalizePath(rawFilePath);
+            std::string rel = filePath.substr(normalizedPrefix.size());
+            size_t slashPos = rel.find('/');
 
-            return;
+            // If there's a slash at the end, we'll check if the rest is init.luau or init.lua, and add it as a command if so.
+            if (slashPos != std::string::npos)
+            {
+                std::string rest = rel.substr(slashPos + 1);
+                if (rest.find('/') == std::string::npos && (rest == "init.luau" || rest == "init.lua"))
+                    names.insert(rel.substr(0, slashPos));
+
+                return;
+            }
+
+            // Otherwise, we can just look for .luau or .lua files and add them as commands without the extension.
+            if (rel.size() > 5 && rel.substr(rel.size() - 5) == ".luau")
+                names.insert(rel.substr(0, rel.size() - 5));
+            else if (rel.size() > 4 && rel.substr(rel.size() - 4) == ".lua")
+                names.insert(rel.substr(0, rel.size() - 4));
         }
-
-        // Otherwise, we can just look for .luau or .lua files and add them as commands without the extension.
-        if (rel.size() > 5 && rel.substr(rel.size() - 5) == ".luau")
-            names.insert(rel.substr(0, rel.size() - 5));
-        else if (rel.size() > 4 && rel.substr(rel.size() - 4) == ".lua")
-            names.insert(rel.substr(0, rel.size() - 4));
-    });
+    );
 
     return {names.begin(), names.end()};
 }
@@ -689,7 +697,7 @@ int cliMain(int argc, char** argv, LuteReporter& reporter)
     std::optional<std::string> exePath = Process::getExecPath(&err);
     if (!exePath)
     {
-	    reporter.formatError("Unable to find the `lute` executable path: Process::getExecPath failed with error: %s", err.c_str());
+        reporter.formatError("Unable to find the `lute` executable path: Process::getExecPath failed with error: %s", err.c_str());
         return 1;
     }
 

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -283,31 +283,28 @@ static std::vector<std::string> getLuteScripts(const std::string& luteFolderPath
     if (!normalizedPrefix.empty() && normalizedPrefix.back() != '/')
         normalizedPrefix += '/';
 
-    traverseDirectory(
-        luteFolderPath,
-        [&](const std::string& rawFilePath)
+    traverseDirectory(luteFolderPath, [&](const std::string& rawFilePath)
+    {
+        std::string filePath = normalizePath(rawFilePath);
+        std::string rel = filePath.substr(normalizedPrefix.size());
+        size_t slashPos = rel.find('/');
+
+        // If there's a slash at the end, we'll check if the rest is init.luau or init.lua, and add it as a command if so.
+        if (slashPos != std::string::npos)
         {
-            std::string filePath = normalizePath(rawFilePath);
-            std::string rel = filePath.substr(normalizedPrefix.size());
-            size_t slashPos = rel.find('/');
+            std::string rest = rel.substr(slashPos + 1);
+            if (rest.find('/') == std::string::npos && (rest == "init.luau" || rest == "init.lua"))
+                names.insert(rel.substr(0, slashPos));
 
-            // If there's a slash at the end, we'll check if the rest is init.luau or init.lua, and add it as a command if so.
-            if (slashPos != std::string::npos)
-            {
-                std::string rest = rel.substr(slashPos + 1);
-                if (rest.find('/') == std::string::npos && (rest == "init.luau" || rest == "init.lua"))
-                    names.insert(rel.substr(0, slashPos));
-
-                return;
-            }
-
-            // Otherwise, we can just look for .luau or .lua files and add them as commands without the extension.
-            if (rel.size() > 5 && rel.substr(rel.size() - 5) == ".luau")
-                names.insert(rel.substr(0, rel.size() - 5));
-            else if (rel.size() > 4 && rel.substr(rel.size() - 4) == ".lua")
-                names.insert(rel.substr(0, rel.size() - 4));
+            return;
         }
-    );
+
+        // Otherwise, we can just look for .luau or .lua files and add them as commands without the extension.
+        if (rel.size() > 5 && rel.substr(rel.size() - 5) == ".luau")
+            names.insert(rel.substr(0, rel.size() - 5));
+        else if (rel.size() > 4 && rel.substr(rel.size() - 4) == ".lua")
+            names.insert(rel.substr(0, rel.size() - 4));
+    });
 
     return {names.begin(), names.end()};
 }
@@ -697,7 +694,7 @@ int cliMain(int argc, char** argv, LuteReporter& reporter)
     std::optional<std::string> exePath = Process::getExecPath(&err);
     if (!exePath)
     {
-        reporter.formatError("Unable to find the `lute` executable path: Process::getExecPath failed with error: %s", err.c_str());
+	    reporter.formatError("Unable to find the `lute` executable path: Process::getExecPath failed with error: %s", err.c_str());
         return 1;
     }
 

--- a/tests/cli/dap.test.luau
+++ b/tests/cli/dap.test.luau
@@ -76,6 +76,7 @@ test.suite("LuteDap", function(suite)
 			assert.eq(msg5.seq, 5)
 		end
 
+		-- check for multiple different block sizes of the reader
 		local reader = makeChunkReader(input, 16)
 		local write, getWritten, clear = makeWriter()
 		dap.dapLoop(reader, write)
@@ -92,6 +93,11 @@ test.suite("LuteDap", function(suite)
 		checkEquivalence(getWritten())
 
 		reader = makeChunkReader(input, 2)
+		clear()
+		dap.dapLoop(reader, write)
+		checkEquivalence(getWritten())
+
+		reader = makeChunkReader(input, #input)
 		clear()
 		dap.dapLoop(reader, write)
 		checkEquivalence(getWritten())

--- a/tests/cli/dap.test.luau
+++ b/tests/cli/dap.test.luau
@@ -38,7 +38,8 @@ test.suite("LuteDap", function(suite)
 	suite:case("basicInitializationTermination", function(assert)
 		local input = 'Content-Length: 100\r\n\r\n{"seq":1,"type":"request","command":"initialize","arguments":{"clientID":"test","adapterID":"lute"}}'
 			.. 'Content-Length: 56\r\n\r\n{"seq":2,"type":"request","command":"configurationDone"}'
-			.. 'Content-Length: 48\r\n\r\n{"seq":3,"type":"request","command":"terminate"}'
+			.. 'Content-Length: 45\r\n\r\n{"seq":3,"type":"request","command":"launch"}'
+			.. 'Content-Length: 48\r\n\r\n{"seq":4,"type":"request","command":"terminate"}'
 
 		local function checkEquivalence(written: string)
 			local msg1, rest1 = parseJsonMessage(written)
@@ -51,14 +52,28 @@ test.suite("LuteDap", function(suite)
 			local msg2, rest2 = parseJsonMessage(rest1)
 			assert.eq(msg2.type, "event")
 			assert.eq(msg2.event, "initialized")
+			assert.eq(msg2.seq, 2)
 
 			local msg3, rest3 = parseJsonMessage(rest2)
 			assert.eq(msg3.type, "response")
 			assert.eq(msg3.command, "configurationDone")
+			assert.eq(msg3.success, true)
+			assert.eq(msg3.request_seq, 2)
+			assert.eq(msg3.seq, 3)
 
-			local msg4, _ = parseJsonMessage(rest3)
+			local msg4, rest4 = parseJsonMessage(rest3)
 			assert.eq(msg4.type, "response")
-			assert.eq(msg4.command, "terminate")
+			assert.eq(msg4.command, "launch")
+			assert.eq(msg4.success, true)
+			assert.eq(msg4.request_seq, 3)
+			assert.eq(msg4.seq, 4)
+
+			local msg5, _ = parseJsonMessage(rest4)
+			assert.eq(msg5.type, "response")
+			assert.eq(msg5.command, "terminate")
+			assert.eq(msg5.success, true)
+			assert.eq(msg5.request_seq, 4)
+			assert.eq(msg5.seq, 5)
 		end
 
 		local reader = makeChunkReader(input, 16)

--- a/tests/cli/dap.test.luau
+++ b/tests/cli/dap.test.luau
@@ -1,0 +1,84 @@
+local test = require("@std/test")
+local json = require("@std/json")
+local dap = require("../../lute/cli/commands/debug/dap")
+
+local function makeChunkReader(readMessage: string, blockSize: number)
+	local pos = 1
+	return function()
+		local chunk = readMessage:sub(pos, pos + blockSize - 1)
+		pos += blockSize
+		return chunk
+	end
+end
+
+local function makeWriter()
+	local written = ""
+	local function write(message: string)
+		written ..= message
+	end
+	local function getWritten()
+		return written
+	end
+	local function clear()
+		written = ""
+	end
+	return write, getWritten, clear
+end
+
+local function parseJsonMessage(msg: string): (json.Object, string)
+	local headerEnd = assert(msg:find("\r\n\r\n"), "missing \\r\\n\\r\\n") :: number
+	local header = msg:sub(1, headerEnd - 1)
+	local contentLength = assert(tonumber(header:match("Content%-Length: (%d+)")), "missing Content-Length") :: number
+	local body = msg:sub(headerEnd + 4, headerEnd + 3 + contentLength)
+	local remaining = msg:sub(headerEnd + 4 + contentLength)
+	return assert(json.asObject(json.deserialize(body)), "body is not a JSON object"), remaining
+end
+
+test.suite("LuteDap", function(suite)
+	suite:case("basicInitializationTermination", function(assert)
+		local input = 'Content-Length: 100\r\n\r\n{"seq":1,"type":"request","command":"initialize","arguments":{"clientID":"test","adapterID":"lute"}}'
+			.. 'Content-Length: 56\r\n\r\n{"seq":2,"type":"request","command":"configurationDone"}'
+			.. 'Content-Length: 48\r\n\r\n{"seq":3,"type":"request","command":"terminate"}'
+
+		local function checkEquivalence(written: string)
+			local msg1, rest1 = parseJsonMessage(written)
+			assert.eq(msg1.type, "response")
+			assert.eq(msg1.command, "initialize")
+			assert.eq(msg1.success, true)
+			assert.eq(msg1.request_seq, 1)
+			assert.eq(msg1.seq, 1)
+
+			local msg2, rest2 = parseJsonMessage(rest1)
+			assert.eq(msg2.type, "event")
+			assert.eq(msg2.event, "initialized")
+
+			local msg3, rest3 = parseJsonMessage(rest2)
+			assert.eq(msg3.type, "response")
+			assert.eq(msg3.command, "configurationDone")
+
+			local msg4, _ = parseJsonMessage(rest3)
+			assert.eq(msg4.type, "response")
+			assert.eq(msg4.command, "terminate")
+		end
+
+		local reader = makeChunkReader(input, 16)
+		local write, getWritten, clear = makeWriter()
+		dap.dapLoop(reader, write)
+		checkEquivalence(getWritten())
+
+		reader = makeChunkReader(input, 7)
+		clear()
+		dap.dapLoop(reader, write)
+		checkEquivalence(getWritten())
+
+		reader = makeChunkReader(input, 4)
+		clear()
+		dap.dapLoop(reader, write)
+		checkEquivalence(getWritten())
+
+		reader = makeChunkReader(input, 2)
+		clear()
+		dap.dapLoop(reader, write)
+		checkEquivalence(getWritten())
+	end)
+end)

--- a/tests/cli/debug.test.luau
+++ b/tests/cli/debug.test.luau
@@ -1,6 +1,11 @@
 local test = require("@std/test")
 local json = require("@std/json")
 local dapStream = require("../../lute/cli/commands/debug/dap")
+local path = require("@std/path")
+local process = require("@std/process")
+
+local lutePath = path.format(process.execPath())
+local USAGE = "Usage: lute debug serve"
 
 local function makeChunkReader(readMessage: string, blockSize: number)
 	local pos = 1
@@ -34,8 +39,8 @@ local function parseJsonMessage(msg: string): (json.Object, string)
 	return assert(json.asObject(json.deserialize(body)), "body is not a JSON object"), remaining
 end
 
-test.suite("LuteDap", function(suite)
-	suite:case("basicInitializationTermination", function(assert)
+test.suite("LuteDebug", function(suite)
+	suite:case("luteDebugDAPStream", function(assert)
 		local input = 'Content-Length: 100\r\n\r\n{"seq":1,"type":"request","command":"initialize","arguments":{"clientID":"test","adapterID":"lute"}}'
 			.. 'Content-Length: 56\r\n\r\n{"seq":2,"type":"request","command":"configurationDone"}'
 			.. 'Content-Length: 45\r\n\r\n{"seq":3,"type":"request","command":"launch"}'
@@ -101,5 +106,19 @@ test.suite("LuteDap", function(suite)
 		clear()
 		dapStream.dapLoop(reader, write)
 		checkEquivalence(getWritten())
+	end)
+	suite:case("luteDebugHelpMessage", function(assert)
+		local result = process.run({ lutePath, "debug", "-h" })
+
+		assert.eq(result.exitcode, 0)
+		assert.strContains(result.stdout, USAGE)
+
+		result = process.run({ lutePath, "debug", "--h" })
+		assert.eq(result.exitcode, 0)
+		assert.strContains(result.stdout, USAGE)
+
+		result = process.run({ lutePath, "debug", "--help" })
+		assert.eq(result.exitcode, 0)
+		assert.strContains(result.stdout, USAGE)
 	end)
 end)

--- a/tests/cli/debug.test.luau
+++ b/tests/cli/debug.test.luau
@@ -1,6 +1,6 @@
 local test = require("@std/test")
 local json = require("@std/json")
-local dap = require("../../lute/cli/commands/debug/dap")
+local dapStream = require("../../lute/cli/commands/debug/dap")
 
 local function makeChunkReader(readMessage: string, blockSize: number)
 	local pos = 1
@@ -79,27 +79,27 @@ test.suite("LuteDap", function(suite)
 		-- check for multiple different block sizes of the reader
 		local reader = makeChunkReader(input, 16)
 		local write, getWritten, clear = makeWriter()
-		dap.dapLoop(reader, write)
+		dapStream.dapLoop(reader, write)
 		checkEquivalence(getWritten())
 
 		reader = makeChunkReader(input, 7)
 		clear()
-		dap.dapLoop(reader, write)
+		dapStream.dapLoop(reader, write)
 		checkEquivalence(getWritten())
 
 		reader = makeChunkReader(input, 4)
 		clear()
-		dap.dapLoop(reader, write)
+		dapStream.dapLoop(reader, write)
 		checkEquivalence(getWritten())
 
 		reader = makeChunkReader(input, 2)
 		clear()
-		dap.dapLoop(reader, write)
+		dapStream.dapLoop(reader, write)
 		checkEquivalence(getWritten())
 
 		reader = makeChunkReader(input, #input)
 		clear()
-		dap.dapLoop(reader, write)
+		dapStream.dapLoop(reader, write)
 		checkEquivalence(getWritten())
 	end)
 end)


### PR DESCRIPTION
This adds a minimal DAP adapter, which is not currently callable by the `lute` CLI
* we handle I/O and JSON parsing correctly (and add some tests for this)
* add some minimal implementations for the debugger startup/terminate events

If we modify Mandolin, we can connect it to VSCode
<img width="1236" height="817" alt="Screenshot 2026-07-10 at 2 11 11 PM" src="https://github.com/user-attachments/assets/d9d280f3-bc67-4a6d-a21a-b2ad9bb341ef" />

