### PR TITLE
Add `values` to `tableext`

### DIFF
--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -62,6 +62,15 @@ function tableext.keys<K, V>(tbl: { [K]: V }): { K }
 	return keys
 end
 
+--- Returns an array of all values in `tbl`. Order is not guaranteed.
+function tableext.values<K, V>(tbl: { [K]: V }): { V }
+	local values = {}
+	for _, v in tbl do
+		table.insert(values, v)
+	end
+	return values
+end
+
 type DeepCloneOptions = { preserveMetatables: boolean?, cloneKeys: boolean?, preserveFrozen: boolean? }
 
 function resolveValue<T>(potentialTbl: T, seen: { [T]: T }, opts: DeepCloneOptions): T

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -75,6 +75,14 @@ test.suite("TableExt", function(suite)
 		end
 	end)
 
+	suite:case("values", function(assert)
+		local a = { a = 1, b = 2, c = 3 }
+		local values = tableext.values(a)
+		for _, value in a do
+			assert.neq(table.find(values, value), nil)
+		end
+	end)
+
 	suite:case("reverse", function(assert)
 		-- in-place
 		local a = { 1, 2, 3 }

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -81,6 +81,7 @@ test.suite("TableExt", function(suite)
 		for _, value in a do
 			assert.neq(table.find(values, value), nil)
 		end
+		assert.eq(#values, 3)
 	end)
 
 	suite:case("reverse", function(assert)


### PR DESCRIPTION
Returns an array of values from a dictionary `tbl` with the keys discarded. It would be useful for functions like `toSet`, `extend` of `TableExt`