### PR TITLE
Make `self` command casing consistent

### DIFF
--- a/docs/cli/self.md
+++ b/docs/cli/self.md
@@ -2,7 +2,7 @@
 order: 8
 ---
 
-# Self
+# self
 
 Manage a Lute installation stored in `~/.lute`.
 


### PR DESCRIPTION
After https://github.com/luau-lang/lute/pull/1205 was merged, I noticed the documentation has the wrong casing for `Self` instead of `self` (see https://lute.luau.org/cli/self.html)