### PR TITLE
`lute self`: Support updating to latest nightly builds

### DIFF
--- a/docs/cli/self.md
+++ b/docs/cli/self.md
@@ -24,13 +24,19 @@ Update the installed host executable to the latest stable release:
 lute self update
 ```
 
+Update to the latest nightly build:
+
+```bash
+lute self update --nightly
+```
+
 Install a specific release with `--version`. Both `1.0.1` and `v1.0.1` are accepted:
 
 ```bash
 lute self update --version 1.0.1
 ```
 
-Specify the desired nightly version explicitly if desired:
+Specify a particular nightly version explicitly if desired:
 
 ```bash
 lute self update --version 1.0.1-nightly.20260710

--- a/lute/cli/commands/self/init.luau
+++ b/lute/cli/commands/self/init.luau
@@ -11,7 +11,7 @@ Manage the host lute installation in ~/.lute.
 COMMANDS:
   install      Install the running lute into ~/.lute/bin and update PATH
   uninstall    Remove the host lute binary and PATH entry
-  update       Update the host lute to the latest release
+  update       Update the host lute to the latest stable or nightly release
   help         Show this help message
 
 Use --help with any command for more information.

--- a/lute/cli/commands/self/release.luau
+++ b/lute/cli/commands/self/release.luau
@@ -15,6 +15,28 @@ local function normalizeTag(tag: string): string
 	return `v{string.lower(stripped)}`
 end
 
+local function isNightlyTag(tag: string): boolean
+	return string.find(normalizeTag(tag), "-nightly.", 1, true) ~= nil
+end
+
+type ReleaseInfo = {
+	read tag_name: string?,
+	read draft: boolean?,
+}
+
+local function selectLatestNightlyTag(releases: { ReleaseInfo }): string?
+	for _, release in releases do
+		if release.draft == true then
+			continue
+		end
+		local tag = release.tag_name
+		if tag ~= nil and isNightlyTag(tag) then
+			return normalizeTag(tag)
+		end
+	end
+	return nil
+end
+
 local function headers(): { [string]: string }
 	local h = {
 		["User-Agent"] = "lute-self",
@@ -38,6 +60,25 @@ local function queryLatestTag(repo: string): string
 		error("Latest GitHub release did not include a tag")
 	end
 	return normalizeTag(data.tag_name)
+end
+
+local function queryLatestNightlyTag(repo: string): string
+	for page = 1, 2 do
+		local url = `https://api.github.com/repos/{repo}/releases?per_page=100&page={page}`
+		local res = net.request(url, { method = "GET", headers = headers() })
+		if not res.ok then
+			error(`Failed to query nightly releases: HTTP {res.status}\n{string.sub(res.body, 1, 200)}`)
+		end
+		local data = json.deserialize(res.body) :: { ReleaseInfo }
+		if #data == 0 then
+			break
+		end
+		local tag = selectLatestNightlyTag(data)
+		if tag ~= nil then
+			return tag
+		end
+	end
+	error("No nightly GitHub release found")
 end
 
 local function osSlug(): string
@@ -94,7 +135,10 @@ local function downloadBinary(repo: string, tag: string, executableName: string)
 end
 
 return table.freeze({
+	isNightlyTag = isNightlyTag,
 	normalizeTag = normalizeTag,
+	selectLatestNightlyTag = selectLatestNightlyTag,
 	queryLatestTag = queryLatestTag,
+	queryLatestNightlyTag = queryLatestNightlyTag,
 	downloadBinary = downloadBinary,
 })

--- a/lute/cli/commands/self/update.luau
+++ b/lute/cli/commands/self/update.luau
@@ -65,13 +65,10 @@ return function(...: string)
 		error("Automatic updates are not supported for nightly releases. Use --nightly or --version.")
 	end
 
-	local tag =
-	    if requested ~= nil then
-		    release.normalizeTag(requested)
-	    elseif nightly then
-		    release.queryLatestNightlyTag(REPO)
-	    else
-		    release.queryLatestTag(REPO)
+	local tag = if requested ~= nil
+		then release.normalizeTag(requested)
+		elseif nightly then release.queryLatestNightlyTag(REPO)
+		else release.queryLatestTag(REPO)
 
 	if current == tag then
 		print(`lute is up to date ({tag})`)

--- a/lute/cli/commands/self/update.luau
+++ b/lute/cli/commands/self/update.luau
@@ -14,13 +14,15 @@ local HELP_STRING = [[
 Update the host lute binary to the latest release.
 
 OPTIONS:
+  --nightly           Install the latest nightly build
   --version <version> Install a specific release (e.g. 1.0.1)
-  -h, --help         Show this help message
+  -h, --help          Show this help message
 ]]
 
 return function(...: string)
 	local args = cli.parser()
 	args:add("help", "flag", { help = "Show this help message", aliases = { "h" } })
+	args:add("nightly", "flag", { help = "Install the latest nightly build" })
 	args:add("version", "option", { help = "Install a specific release tag instead of the latest" })
 	args:parse({ ... })
 
@@ -45,6 +47,11 @@ return function(...: string)
 	end
 
 	local requested = args:get("version")
+	local nightly = args:has("nightly")
+
+	if requested ~= nil and nightly then
+		error("--nightly and --version are mutually exclusive")
+	end
 
 	local current: string? = nil
 	local ok, result = pcall(process.run, { destination, "--version" }, nil)
@@ -54,11 +61,19 @@ return function(...: string)
 		print(`warning: could not read version from {destination}; proceeding with update`)
 	end
 
-	if requested == nil and current ~= nil and string.find(current, "-nightly.", 1, true) ~= nil then
-		error("Automatic updates are not supported for nightly releases. Use --version to select a nightly release.")
+	if requested == nil and not nightly and current ~= nil and release.isNightlyTag(current) then
+		error("Automatic updates are not supported for nightly releases. Use --nightly or --version.")
 	end
 
-	local tag = if requested ~= nil then release.normalizeTag(requested) else release.queryLatestTag(REPO)
+	local tag: string
+	if requested ~= nil then
+		tag = release.normalizeTag(requested)
+	elseif nightly then
+		tag = release.queryLatestNightlyTag(REPO)
+	else
+		tag = release.queryLatestTag(REPO)
+	end
+
 	if current == tag then
 		print(`lute is up to date ({tag})`)
 		return

--- a/lute/cli/commands/self/update.luau
+++ b/lute/cli/commands/self/update.luau
@@ -65,14 +65,13 @@ return function(...: string)
 		error("Automatic updates are not supported for nightly releases. Use --nightly or --version.")
 	end
 
-	local tag: string
-	if requested ~= nil then
-		tag = release.normalizeTag(requested)
-	elseif nightly then
-		tag = release.queryLatestNightlyTag(REPO)
-	else
-		tag = release.queryLatestTag(REPO)
-	end
+	local tag =
+	    if requested ~= nil then
+		    release.normalizeTag(requested)
+	    elseif nightly then
+		    release.queryLatestNightlyTag(REPO)
+	    else
+		    release.queryLatestTag(REPO)
 
 	if current == tag then
 		print(`lute is up to date ({tag})`)

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -84,7 +84,7 @@ Self Options:
 		Manages the host lute installation in ~/.lute.
 			install                 Install the running lute as the host lute into ~/.lute/bin and update PATH.
 			uninstall               Remove the host lute binary and PATH entry.
-			update                  Update the host lute to the latest release.
+			update                  Update the host lute to the latest stable or nightly release.
 
 General Options:
 	-h, --help    Display this usage message.

--- a/tests/cli/self.test.luau
+++ b/tests/cli/self.test.luau
@@ -30,6 +30,10 @@ test.suite("LuteSelf", function(suite)
 			assert.eq(result.exitcode, 0)
 			assert.strContains(result.stdout, `Usage: lute self {command}`)
 		end
+
+		local updateHelp = run("update", "--help")
+		assert.strContains(updateHelp.stdout, "--nightly")
+		assert.strContains(updateHelp.stdout, "--version")
 	end)
 
 	suite:case("rejectsUnknownCommand", function(assert)
@@ -49,6 +53,40 @@ test.suite("LuteSelf", function(suite)
 		assert.eq(release.normalizeTag(" V1.0.1 "), "v1.0.1")
 		assert.eq(release.normalizeTag("1.0.1-nightly.20260710"), "v1.0.1-nightly.20260710")
 		assert.eq(release.normalizeTag("V1.0.1-NIGHTLY.20260710"), "v1.0.1-nightly.20260710")
+	end)
+
+	suite:case("classifiesNightlyTags", function(assert)
+		assert.eq(release.isNightlyTag("v1.0.1"), false)
+		assert.eq(release.isNightlyTag("1.0.1"), false)
+		assert.eq(release.isNightlyTag("v1.0.1-nightly.20260710"), true)
+		assert.eq(release.isNightlyTag("1.0.1-nightly.20260710"), true)
+		assert.eq(release.isNightlyTag("V1.0.1-NIGHTLY.20260710"), true)
+	end)
+
+	suite:case("selectsLatestNightlyTag", function(assert)
+		assert.eq(release.selectLatestNightlyTag({}), nil)
+		assert.eq(
+			release.selectLatestNightlyTag({
+				{ tag_name = "v1.0.1", draft = false },
+				{ tag_name = "v1.0.0", draft = false },
+			}),
+			nil
+		)
+		assert.eq(
+			release.selectLatestNightlyTag({
+				{ tag_name = "v1.0.1-nightly.20260715", draft = true },
+				{ tag_name = "v1.0.1", draft = false },
+				{ tag_name = "v1.0.1-nightly.20260714", draft = false },
+				{ tag_name = "v1.0.1-nightly.20260710", draft = false },
+			}),
+			"v1.0.1-nightly.20260714"
+		)
+		assert.eq(
+			release.selectLatestNightlyTag({
+				{ tag_name = "v1.0.1-nightly.20260715", draft = false },
+			}),
+			"v1.0.1-nightly.20260715"
+		)
 	end)
 
 	suite:case("installsAndUninstallsHostBinary", function(assert)


### PR DESCRIPTION
Pretty straightforward, implements a `--nightly` flag to update to the latest nightly build as opposed to the latest official release which is currently at `1.0.0`: https://api.github.com/repos/luau-lang/lute/releases/latest