### PR TITLE
`lute/debug`: connect pausing to Runtime

### DIFF
--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -285,6 +285,8 @@ bool Target::launch(const std::string& sourcePath, const std::vector<std::string
         lua_pop(childRuntime->GL, 1);
 
         scriptThread = thread;
+        lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
+        cb->userdata = this;
         installBpHitCallback();
         installExitCallback();
         // All VM setup happens synchronously before runContinuously starts the background thread.
@@ -304,7 +306,6 @@ bool Target::launch(const std::string& sourcePath, const std::vector<std::string
 void Target::installBpHitCallback()
 {
     lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
-    cb->userdata = this;
     cb->debugbreak = [](lua_State* L, lua_Debug* ar)
     {
         auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
@@ -406,7 +407,6 @@ bool Target::pauseProcess()
     if (!launched || paused)
         return false;
     lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
-    cb->userdata = this;
     // the interrupt callback calls at any safepoint, which
     // is the soonest we can pause execution safely.
     // safepoints are loop back edges or function calls/returns.

--- a/lute/debug/src/debugger.cpp
+++ b/lute/debug/src/debugger.cpp
@@ -259,7 +259,7 @@ bool Target::launch(const std::string& sourcePath, const std::vector<std::string
         std::lock_guard lock(targetMutex);
         // launch() cannot be called twice from the same target.
         LUTE_ASSERT(!launched);
-        childRuntime = std::make_unique<Runtime>(parentRuntime.reporter);
+        childRuntime = std::make_unique<Runtime>(parentRuntime.reporter, true);
         setupState(*childRuntime, nullptr);
         launchConfig = config;
 
@@ -308,7 +308,6 @@ void Target::installBpHitCallback()
     cb->debugbreak = [](lua_State* L, lua_Debug* ar)
     {
         auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
-        // TODO: this pause/resume mechanism assumes single co-routine runtime
         // We land on the same instruction after a continue() after hitting a bp so we basically don't do anything
         std::unique_lock lock(target->targetMutex);
         if (target->continueRequestedBp)
@@ -330,8 +329,9 @@ void Target::installBpHitCallback()
         if (bp && bp->status == BreakpointStatus::Installed)
         {
             target->bpHit = *bp;
-            target->resumeToken = getResumeToken(L);
             target->paused = true;
+            target->childRuntime->stopDebug();
+            target->stoppedThread = L;
             lua_break(L);
             auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
             lock.unlock();
@@ -353,7 +353,9 @@ void Target::installBpHitCallback()
     };
 }
 
-// TODO: this exit handler assumes single coroutine runtime
+// When the main script's coroutine exits, we can say that our debugging of the debuggee has terminated.
+// Theoretically, the debuggee can still be alive on the Runtime but should be cleaned up after
+// the Target itself is destroyed.
 void Target::installExitCallback()
 {
     ThreadCompletionHandler completion;
@@ -369,8 +371,20 @@ bool Target::continueProcess()
 {
 
     std::unique_lock lock(targetMutex);
-    if (!paused || !resumeToken)
+    if (!launched || !paused)
         return false;
+    if (stoppedThread)
+    {
+        childRuntime->runningThreads.push_back({true, getRefForThread(stoppedThread), 0});
+        // This schedule() wakes up the runtime in runContinuously() to re-run runToCompletion() in case that has exited. This is a no-op if
+        // runToCompletion() has not exited.
+        childRuntime->schedule([]() {});
+        stoppedThread = nullptr;
+    }
+    // this clears the interrupts that triggers when the process is paused from client request
+    // in case it has not actually been triggered.
+    lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
+    cb->interrupt = nullptr;
     // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
     if (bpHit)
     {
@@ -381,14 +395,45 @@ bool Target::continueProcess()
             continueRequestedBp = true;
         bpHit = std::nullopt;
     }
-    resumeToken->complete(
-        [](lua_State* L)
-        {
-            return 0;
-        }
-    );
-    resumeToken = nullptr;
     paused = false;
+    childRuntime->continueDebug();
+    return true;
+}
+
+bool Target::pauseProcess()
+{
+    std::unique_lock lock(targetMutex);
+    if (!launched || paused)
+        return false;
+    lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
+    cb->userdata = this;
+    // the interrupt callback calls at any safepoint, which
+    // is the soonest we can pause execution safely.
+    // safepoints are loop back edges or function calls/returns.
+    cb->interrupt = [](lua_State* L, int gc)
+    {
+        // gc runs when it is not -1
+        if (gc != -1)
+            return;
+        auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
+        std::unique_lock lock(target->targetMutex);
+        target->paused = true;
+        target->childRuntime->stopDebug();
+        target->stoppedThread = L;
+        // We transition into a paused state. Let's modify all pending breakpoints.
+        auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
+        lua_break(L);
+        // Clear out the interrupt callback after we are done.
+        lua_callbacks(L)->interrupt = nullptr;
+        lock.unlock();
+        // Since pausing actually only happens when the interrupt callback runs we have a callback
+        if (target->launchConfig.onPause)
+            target->launchConfig.onPause();
+        for (auto& bp : installed)
+            target->launchConfig.onBreakpointInstall(bp);
+        for (auto& bp : uninstalled)
+            target->launchConfig.onBreakpointUninstall(bp);
+    };
     return true;
 }
 } // namespace debug

--- a/lute/debug/src/debugger.h
+++ b/lute/debug/src/debugger.h
@@ -39,6 +39,7 @@ struct LaunchConfig
     std::function<void(const Breakpoint& bp)> onBreakpointUninstall;
     std::function<void(const Breakpoint& bp)> onBreakpointHit;
     std::function<void(bool success)> onExit;
+    std::function<void()> onPause;
 };
 
 struct Target
@@ -68,6 +69,7 @@ struct Target
     // For actively running scripts:
     bool launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
     bool continueProcess();
+    bool pauseProcess();
 
 private:
     // targetMutex protects the entire Target, since Target can be accessed from the main thread
@@ -84,13 +86,15 @@ private:
     std::unordered_map<int, Breakpoint> breakpoints; // breakpoint id -> breakpoint object (this is unordered_map to support erase)
     bool continueRequestedBp = false;
     std::optional<Breakpoint> bpHit;
-    ResumeToken resumeToken;
     LaunchConfig launchConfig;
 
     Luau::DenseHashMap<std::string, std::shared_ptr<Ref>> loadedSources; // source path -> reference to chunk
 
     // thread for our launched script
     lua_State* scriptThread = nullptr;
+
+    // our stopped thread that we need to requeue when we continue
+    lua_State* stoppedThread = nullptr;
 
     // private methods are meant for internal calls, so these don't lock targetMutex
     std::optional<Breakpoint> getBreakpointBySourceLineHelper(std::string source, int line) const;

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -57,7 +57,7 @@ using RuntimeStep = Luau::Variant<StepSuccess, StepErr, StepEmpty>;
 
 struct Runtime
 {
-    Runtime(LuteReporter& reporter);
+    Runtime(LuteReporter& reporter, bool debugMode = false);
     ~Runtime();
 
     bool runToCompletion();
@@ -137,6 +137,10 @@ struct Runtime
     // Runtimes. Set during parent Runtime's setup.
     std::function<void*(lua_State*)> requireContextFactory;
 
+    // for debug mode only:
+    void stopDebug();
+    void continueDebug();
+
 private:
     bool runThreadCompletionHandler(lua_State* L, int status);
     void clearThreadCompletionHandler(lua_State* L);
@@ -152,6 +156,12 @@ private:
 
     std::atomic<int> activeTokens;
     uv_loop_t eventLoop;
+
+    // for debug mode only:
+    const bool debugMode;
+    std::mutex debugMutex;
+    std::atomic<bool> debugStopped = false;
+    std::condition_variable debugStoppedCv;
 };
 
 Runtime* getRuntime(lua_State* L);

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -20,10 +20,11 @@ static void lua_close_checked(lua_State* L)
         lua_close(L);
 }
 
-Runtime::Runtime(LuteReporter& reporter)
+Runtime::Runtime(LuteReporter& reporter, bool debugMode)
     : reporter(reporter)
     , globalState(nullptr, lua_close_checked)
     , dataCopy(nullptr, lua_close_checked)
+    , debugMode(debugMode)
 {
 
     stop.store(false);
@@ -66,6 +67,14 @@ bool Runtime::hasWork()
 
 RuntimeStep Runtime::runOnce()
 {
+    if (debugMode)
+    {
+        // when paused while debugging, nothing should happen (not even I/O)
+        std::unique_lock<std::mutex> lock(debugMutex);
+        while (debugStopped)
+            debugStoppedCv.wait(lock);
+    }
+
     uv_run_mode mode = (hasContinuations() || hasThreads()) ? UV_RUN_NOWAIT : UV_RUN_ONCE;
     uv_run(getEventLoop(), mode);
 
@@ -361,6 +370,26 @@ void Runtime::releasePendingToken()
 {
     [[maybe_unused]] int before = activeTokens.fetch_sub(1);
     assert(before > 0);
+}
+
+void Runtime::continueDebug()
+{
+    LUTE_ASSERT(debugMode);
+    std::unique_lock<std::mutex> lock(debugMutex);
+    debugStopped = false;
+    debugStoppedCv.notify_one();
+}
+
+// stopDebug() actually allows for some C bookkeeping when we are unwinding the stack
+// when it is called within a callback such as debugbreak or debugInterrupt, which you could imagine might
+// lead to a race condition. The important thing is that this bookkeeping does not touch the Luau state that we can inspect
+// making this a nonissue.
+// We never schedule any Luau code to run afterwards, which means this is fine.
+void Runtime::stopDebug()
+{
+    LUTE_ASSERT(debugMode);
+    std::unique_lock<std::mutex> lock(debugMutex);
+    debugStopped = true;
 }
 
 uv_loop_t* Runtime::getEventLoop()

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -67,14 +67,6 @@ bool Runtime::hasWork()
 
 RuntimeStep Runtime::runOnce()
 {
-    if (debugMode)
-    {
-        // when paused while debugging, nothing should happen (not even I/O)
-        std::unique_lock<std::mutex> lock(debugMutex);
-        while (debugStopped)
-            debugStoppedCv.wait(lock);
-    }
-
     uv_run_mode mode = (hasContinuations() || hasThreads()) ? UV_RUN_NOWAIT : UV_RUN_ONCE;
     uv_run(getEventLoop(), mode);
 
@@ -161,6 +153,14 @@ bool Runtime::runToCompletion()
 {
     while (hasWork())
     {
+        if (debugMode)
+        {
+            // when paused while debugging, nothing should happen
+            std::unique_lock<std::mutex> lock(debugMutex);
+            while (debugStopped)
+                debugStoppedCv.wait(lock);
+        }
+
         auto step = runOnce();
 
         if (auto err = Luau::get_if<StepErr>(&step))

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -188,7 +188,7 @@ TEST_SUITE("Debug")
         CHECK(hitBp3 == 1);
     }
 
-    TEST_CASE_FIXTURE(DebugFixture, "Debug_pausesOnBreakpoint")
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_stopOnBreakpoint")
     {
         std::string fixturePath = getDebugFixturePath("simple.luau");
         Target target(*runtime);
@@ -228,6 +228,42 @@ TEST_SUITE("Debug")
 
         // continue execution
         continuedProcess = target.continueProcess();
+        CHECK(continuedProcess);
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+    }
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_pauseProcess")
+    {
+        std::string fixturePath = getDebugFixturePath("loop.luau");
+        Target target(*runtime);
+        target.setBreakpoint(fixturePath, 1);
+
+        int numPause = 0;
+        std::promise<void> hitPromise;
+        std::future<void> hitFuture = hitPromise.get_future();
+        // This tests whether we pause after continuing. This is pretty
+        // strange but is unfortunately, the best way of guaranteeing that a pause request
+        // goes through without timing conerns.
+        config.onBreakpointHit = [&](const Breakpoint& bp)
+        {
+            bool continuedProcess = target.continueProcess();
+            CHECK(continuedProcess);
+            bool pausedProcess = target.pauseProcess();
+            CHECK(pausedProcess);
+            hitPromise.set_value();
+        };
+        config.onPause = [&]()
+        {
+            numPause++;
+        };
+        bool launched = target.launch(fixturePath, {}, config);
+        CHECK(launched);
+        // we hit the breakpoint and should be paused now.
+        REQUIRE(hitFuture.wait_for(std::chrono::seconds(2)) == std::future_status::ready);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(0)) == std::future_status::timeout);
+        CHECK(numPause == 1);
+
+        bool continuedProcess = target.continueProcess();
         CHECK(continuedProcess);
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }


### PR DESCRIPTION
Previously, we used `resumeTokens` to do pausing in the debugger. This is unsustainable for multi-coroutine applications. Instead, we introduce a`debugMode` to `Runtime` that enables pausing all coroutines at once. We also add a `pauseProcess` method in the debugger itself that can be called outside of breakpoints.

The pausing pathway is now:
1. Trigger the presently queued running coroutine to break out of execution. The easiest way to do this is to set a callback in the VM and then call `lua_break`
2. Use the runtime's `stopDebug()` to actually stop queuing of further coroutines.