### PR TITLE
Reenable a suppressed flag

### DIFF
--- a/lute/cli/src/luauflags.cpp
+++ b/lute/cli/src/luauflags.cpp
@@ -33,7 +33,6 @@ void setLuauFlags()
 {
     enableAllLuauFlags();
 
-    setLuauFlag("LuauRemovePrimitiveTypeConstraintAndSubtypingUnifier", false);
     // Individual flags can be overridden here as needed, e.g.:
     // setLuauFlag("LuauSomeFlagThatCausedARegression", false);
 }


### PR DESCRIPTION
This broke typechecking somewhere, but should now be fixed after the latest Luau update.