### PR TITLE
`lute/debug`: fix destructor when in infinite loop

### DIFF
--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -47,6 +47,7 @@ Target::~Target()
     // any infinite/long-running coroutines.
     if (launched)
     {
+        childRuntime->continueDebug();
         lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
         cb->interrupt = [](lua_State* L, int gc)
         {

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -43,6 +43,18 @@ Target::~Target()
     // We want to stop the runtime so nothing runs while we are destroying the target but first
     // we need to clear all sources (which are stored as refs in the runtime).
     loadedSources.clear();
+    // this interrupts execution of runToCompletion() in order to stop
+    // any infinite/long-running coroutines.
+    if (launched)
+    {
+        lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
+        cb->interrupt = [](lua_State* L, int gc)
+        {
+            if (gc != -1)
+                return;
+            lua_break(L);
+        };
+    }
     childRuntime.reset();
 }
 

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -292,7 +292,25 @@ TEST_SUITE("Debug")
         CHECK(continuedProcess);
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_destroyInfiniteLoop")
+    {
+        // This tests that we don't stall on the Runtime destruction even when we are running
+        // an infinite loop.
+        std::string fixturePath = getDebugFixturePath("infiniteloop.luau");
 
+        std::future<void> destroyFuture = std::async(
+            std::launch::async,
+            [&]()
+            {
+                Target target(*runtime);
+                target.launch(fixturePath, {}, config);
+                // This is a timing pause to make sure that we actually start execution of the script.
+                std::this_thread::sleep_for(std::chrono::milliseconds(10));
+                // At this point target and its Runtime should be destroyed.
+            }
+        );
+        REQUIRE(destroyFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+    }
     TEST_CASE_FIXTURE(DebugFixture, "Debug_multiSource")
     {
         std::string mainPath = getDebugFixturePath("require_main.luau");

--- a/tests/src/debug/infiniteloop.luau
+++ b/tests/src/debug/infiniteloop.luau
@@ -1,0 +1,4 @@
+local _step1 = 0
+while true do
+	_step1 = 1 - _step1
+end


### PR DESCRIPTION
Fix `Target` destructor in infinite loop case as part of splitting https://github.com/luau-lang/lute/pull/1233 up.
- If the debugger is running an infinite loop, that coroutine would never break and so the destructor will stall infinitely.
- This PR fixes this by making sure that always coroutines break out of execution in our destructor by setting the `interrupt` callback. This interrupt callback is called on back edges of loops or function calls/returns (which realistically will always occur when the thread is running an infinite loop)