### PR TITLE
`lute/debug`: adds multisource support  

### DIFF
--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -43,6 +43,8 @@ export type Target = {
 	getBreakpointById: (self: Target, id: number) -> Breakpoint?,
 	--- Get a breakpoint at a `sourcePath` at a given line. Returns `nil` if not found.
 	getBreakpointBySourceLine: (self: Target, sourcePath: string, line: number) -> Breakpoint?,
+	--- Gets all Luau sources that have been loaded onto the debugger.
+	getLoadedSources: (self: Target) -> { string },
 	--- Launch a Luau script at at `sourcePath` with the relevant `args` and callbacks.
 	--- Returns whether the script could be launched.
 	launch: (self: Target, sourcePath: string, args: { string }?, config: LaunchConfig?) -> boolean,

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -9,6 +9,7 @@ export type BreakpointStatus = "pendingInstall" | "pendingUninstall" | "installe
 export type Breakpoint = {
 	id: number,
 	line: number,
+	--- this source path will use forward slashes
 	sourcePath: string,
 	status: BreakpointStatus,
 }
@@ -43,7 +44,7 @@ export type Target = {
 	getBreakpointById: (self: Target, id: number) -> Breakpoint?,
 	--- Get a breakpoint at a `sourcePath` at a given line. Returns `nil` if not found.
 	getBreakpointBySourceLine: (self: Target, sourcePath: string, line: number) -> Breakpoint?,
-	--- Gets all Luau sources that have been loaded onto the debugger.
+	--- Gets all Luau sources that have been loaded onto the debugger, with sources using forward slashes.
 	getLoadedSources: (self: Target) -> { string },
 	--- Launch a Luau script at at `sourcePath` with the relevant `args` and callbacks.
 	--- Returns whether the script could be launched.

--- a/lute/debug/CMakeLists.txt
+++ b/lute/debug/CMakeLists.txt
@@ -12,6 +12,6 @@ target_compile_features(Lute.Debug PUBLIC cxx_std_17)
 target_include_directories(Lute.Debug PUBLIC "include" PRIVATE src)
 target_link_libraries(Lute.Debug
     PUBLIC Lute.Runtime
-    PRIVATE Luau.Compiler Luau.VM Luau.Common
+    PRIVATE Luau.Compiler Luau.VM Luau.Common Lute.Require
 )
 target_compile_options(Lute.Debug PRIVATE ${LUTE_OPTIONS})

--- a/lute/debug/CMakeLists.txt
+++ b/lute/debug/CMakeLists.txt
@@ -12,6 +12,6 @@ target_compile_features(Lute.Debug PUBLIC cxx_std_17)
 target_include_directories(Lute.Debug PUBLIC "include" PRIVATE src)
 target_link_libraries(Lute.Debug
     PUBLIC Lute.Runtime
-    PRIVATE Luau.Compiler Luau.VM Luau.Common Lute.Require
+    PRIVATE Luau.Compiler Luau.VM Luau.Common Luau.CLI.lib Lute.Require
 )
 target_compile_options(Lute.Debug PRIVATE ${LUTE_OPTIONS})

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -70,7 +70,7 @@ struct Target
     std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
 
     // For actively running scripts:
-    bool launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
+    bool launch(std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
     bool continueProcess();
     bool pauseProcess();
 

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -28,6 +28,7 @@ enum class BreakpointStatus
 struct Breakpoint
 {
     int id;
+    // This will use forward slashes instead of backwards.
     std::string sourcePath;
     int line;
     BreakpointStatus status;
@@ -48,7 +49,9 @@ struct Target
     explicit Target(Runtime& parentRuntime);
     ~Target();
 
-    // Get list of sources
+    // Get list of sources, with sources using forward slahes consistently.
+    // Our principle in path format is that we accept any path format as input but will
+    // internally use and then output with paths that use exclusively forward slashes.
     std::vector<std::string> getLoadedSources();
 
     // Setting breakpoints is a two step process. We add them to our Target. If they

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "lute/require.h"
 #include "lute/runtime.h"
 
 #include "Luau/DenseHash.h"
@@ -46,6 +47,9 @@ struct Target
 {
     explicit Target(Runtime& parentRuntime);
     ~Target();
+
+    // Get list of sources
+    std::vector<std::string> getLoadedSources();
 
     // Setting breakpoints is a two step process. We add them to our Target. If they
     // involve a source that has already been loaded by the VM, we attempt to install that
@@ -95,6 +99,9 @@ private:
 
     // our stopped thread that we need to requeue when we continue
     lua_State* stoppedThread = nullptr;
+
+    // for require contexts
+    std::unique_ptr<RequireCtx> requireCtx;
 
     // private methods are meant for internal calls, so these don't lock targetMutex
     std::optional<Breakpoint> getBreakpointBySourceLineHelper(std::string source, int line) const;

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -56,7 +56,6 @@ struct Target
     // breakpoint. Otherwise, it exists as a pending breakpoint until new sources are loaded.
     // We do this because clients may 1) configure breakpoints before launching executables
     // 2) we load sources dynamically with @require that a client may want to debug.
-    // TODO: implement 2
     //
     // Guarantees for when breakpoints are installed:
     // Any breakpoint that is placed when the target process is paused (including before launch) and that

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -181,11 +181,10 @@ static int target_getLoadedSources(lua_State* L)
 {
     Target* target = getTarget(L, 1);
     std::vector<std::string> sources = target->getLoadedSources();
-    checkStack(L, 1);
+    checkStack(L, 2);
     lua_createtable(L, sources.size(), 0);
     for (int i = 0; i < (int)sources.size(); i++)
     {
-        checkStack(L, 1);
         lua_pushstring(L, sources[i].c_str());
         lua_rawseti(L, -2, i + 1);
     }

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -175,6 +175,23 @@ static int target_getBreakpointBySourceLine(lua_State* L)
     return pushBreakpoint(L, *bp);
 }
 
+// target.getLoadedSources()
+// returns a table of strings
+static int target_getLoadedSources(lua_State* L)
+{
+    Target* target = getTarget(L, 1);
+    std::vector<std::string> sources = target->getLoadedSources();
+    checkStack(L, 1);
+    lua_createtable(L, sources.size(), 0);
+    for (int i = 0; i < (int)sources.size(); i++)
+    {
+        checkStack(L, 1);
+        lua_pushstring(L, sources[i].c_str());
+        lua_rawseti(L, -2, i + 1);
+    }
+    return 1;
+}
+
 static std::shared_ptr<Ref> getOptionalCallback(lua_State* L, int tableIndex, const char* field)
 {
     lua_getfield(L, tableIndex, field);
@@ -297,7 +314,7 @@ static int target_pauseProcess(lua_State* L)
     return 1;
 }
 
-// debugger.mewTarget()
+// debugger.newTarget()
 // returns Target
 static int debug_newTarget(lua_State* L)
 {
@@ -319,6 +336,7 @@ static const std::unordered_map<std::string, lua_CFunction> kTargetMethods = {
     {"launch", debug::target_launch},
     {"continueProcess", debug::target_continueProcess},
     {"pauseProcess", debug::target_pauseProcess},
+    {"getLoadedSources", debug::target_getLoadedSources},
 };
 
 static void initializeTarget(lua_State* L)

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -45,12 +45,20 @@ Target::~Target()
     childRuntime.reset();
 }
 
-static std::string getChunkFromSource(std::string sourcePath)
+static std::string normalizeSeparators(std::string sourcePath)
+{
+    for (char& c : sourcePath)
+        if (c == '\\')
+            c = '/';
+    return sourcePath;
+}
+
+static std::string getChunkFromSource(const std::string& sourcePath)
 {
     return '@' + sourcePath;
 }
 
-static std::string getSourceFromChunk(std::string chunkname)
+static std::string getSourceFromChunk(const std::string& chunkname)
 {
     if (chunkname.size() > 0 && chunkname[0] == '@')
         return chunkname.substr(1);
@@ -60,6 +68,7 @@ static std::string getSourceFromChunk(std::string chunkname)
 Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
 {
     std::unique_lock lock(targetMutex);
+    sourcePath = normalizeSeparators(sourcePath);
     std::optional<Breakpoint> preexistingBp = getBreakpointBySourceLineHelper(sourcePath, line);
     if (preexistingBp)
         return *preexistingBp;
@@ -183,6 +192,7 @@ std::optional<Breakpoint> Target::getBreakpointBySourceLineHelper(std::string so
 std::optional<Breakpoint> Target::getBreakpointBySourceLine(std::string source, int line) const
 {
     std::unique_lock lock(targetMutex);
+    source = normalizeSeparators(source);
     return getBreakpointBySourceLineHelper(source, line);
 }
 
@@ -280,12 +290,13 @@ std::vector<std::string> Target::getLoadedSources()
     return sources;
 }
 
-bool Target::launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config)
+bool Target::launch(std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config)
 {
     std::vector<Breakpoint> installedBps;
     std::vector<Breakpoint> uninstalledBps;
     {
         std::lock_guard lock(targetMutex);
+        sourcePath = normalizeSeparators(sourcePath);
         // launch() cannot be called twice from the same target, so we assert in
         // debug mode and return false when we are in release mode.
         LUTE_ASSERT(!launched);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -6,6 +6,7 @@
 
 #include "Luau/Compiler.h"
 #include "Luau/DenseHash.h"
+#include "Luau/FileUtils.h"
 #include "Luau/StringUtils.h"
 
 #include "lua.h"
@@ -45,14 +46,6 @@ Target::~Target()
     childRuntime.reset();
 }
 
-static std::string normalizeSeparators(std::string sourcePath)
-{
-    for (char& c : sourcePath)
-        if (c == '\\')
-            c = '/';
-    return sourcePath;
-}
-
 static std::string getChunkFromSource(const std::string& sourcePath)
 {
     return '@' + sourcePath;
@@ -68,7 +61,7 @@ static std::string getSourceFromChunk(const std::string& chunkname)
 Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
 {
     std::unique_lock lock(targetMutex);
-    sourcePath = normalizeSeparators(sourcePath);
+    sourcePath = normalizePath(sourcePath);
     std::optional<Breakpoint> preexistingBp = getBreakpointBySourceLineHelper(sourcePath, line);
     if (preexistingBp)
         return *preexistingBp;
@@ -192,7 +185,7 @@ std::optional<Breakpoint> Target::getBreakpointBySourceLineHelper(std::string so
 std::optional<Breakpoint> Target::getBreakpointBySourceLine(std::string source, int line) const
 {
     std::unique_lock lock(targetMutex);
-    source = normalizeSeparators(source);
+    source = normalizePath(source);
     return getBreakpointBySourceLineHelper(source, line);
 }
 
@@ -282,11 +275,7 @@ std::vector<std::string> Target::getLoadedSources()
     std::vector<std::string> sources;
     sources.reserve(loadedSources.size());
     for (auto& [path, _] : loadedSources)
-    {
-        // we discard the empty sentinel value for loadedSources
-        if (path != "")
-            sources.emplace_back(path);
-    }
+        sources.emplace_back(path);
     return sources;
 }
 
@@ -296,7 +285,7 @@ bool Target::launch(std::string sourcePath, const std::vector<std::string>& args
     std::vector<Breakpoint> uninstalledBps;
     {
         std::lock_guard lock(targetMutex);
-        sourcePath = normalizeSeparators(sourcePath);
+        sourcePath = normalizePath(sourcePath);
         // launch() cannot be called twice from the same target, so we assert in
         // debug mode and return false when we are in release mode.
         LUTE_ASSERT(!launched);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -268,6 +268,7 @@ std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> Target::modifyPendin
 
 std::vector<std::string> Target::getLoadedSources()
 {
+    std::lock_guard lock(targetMutex);
     std::vector<std::string> sources;
     sources.reserve(loadedSources.size());
     for (auto& [path, _] : loadedSources)

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -271,7 +271,7 @@ std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> Target::modifyPendin
 
 std::vector<std::string> Target::getLoadedSources()
 {
-    std::lock_guard lock(targetMutex);
+    std::scoped_lock lock(targetMutex);
     std::vector<std::string> sources;
     sources.reserve(loadedSources.size());
     for (auto& [path, _] : loadedSources)
@@ -284,7 +284,7 @@ bool Target::launch(std::string sourcePath, const std::vector<std::string>& args
     std::vector<Breakpoint> installedBps;
     std::vector<Breakpoint> uninstalledBps;
     {
-        std::lock_guard lock(targetMutex);
+        std::scoped_lock lock(targetMutex);
         sourcePath = normalizePath(sourcePath);
         // launch() cannot be called twice from the same target, so we assert in
         // debug mode and return false when we are in release mode.
@@ -302,7 +302,7 @@ bool Target::launch(std::string sourcePath, const std::vector<std::string>& args
             std::vector<Breakpoint> installed;
             std::vector<Breakpoint> uninstalled;
             {
-                std::scoped_lock(targetMutex);
+                std::scoped_lock lock(targetMutex);
                 // this strips the potential leading @ from the chunkName for consistency when returning to DAP
                 loadedSources[source] = std::make_shared<Ref>(ML, -1);
                 std::tie(installed, uninstalled) = modifyPendingBreakpoints(ML);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -1,6 +1,8 @@
 #include "lute/debuginternals.h"
 
 #include "lute/common.h"
+#include "lute/require.h"
+#include "lute/requirevfs.h"
 
 #include "Luau/Compiler.h"
 #include "Luau/DenseHash.h"
@@ -11,6 +13,7 @@
 
 #include <cstddef>
 #include <fstream>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -40,6 +43,18 @@ Target::~Target()
     // we need to clear all sources (which are stored as refs in the runtime).
     loadedSources.clear();
     childRuntime.reset();
+}
+
+static std::string getChunkFromSource(std::string sourcePath)
+{
+    return '@' + sourcePath;
+}
+
+static std::string getSourceFromChunk(std::string chunkname)
+{
+    if (chunkname.size() > 0 && chunkname[0] == '@')
+        return chunkname.substr(1);
+    return chunkname;
 }
 
 Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
@@ -251,6 +266,19 @@ std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> Target::modifyPendin
     return {installedBpsCallback, uninstalledBpsCallback};
 }
 
+std::vector<std::string> Target::getLoadedSources()
+{
+    std::vector<std::string> sources;
+    sources.reserve(loadedSources.size());
+    for (auto& [path, _] : loadedSources)
+    {
+        // we discard the empty sentinel value for loadedSources
+        if (path != "")
+            sources.emplace_back(path);
+    }
+    return sources;
+}
+
 bool Target::launch(const std::string& sourcePath, const std::vector<std::string>& args, LaunchConfig config)
 {
     std::vector<Breakpoint> installedBps;
@@ -263,7 +291,29 @@ bool Target::launch(const std::string& sourcePath, const std::vector<std::string
         if (launched)
             return false;
         childRuntime = std::make_unique<Runtime>(parentRuntime.reporter, true);
-        setupState(*childRuntime, nullptr);
+        // Set up require system before launch.
+        requireCtx = std::make_unique<RequireCtx>(std::make_unique<RequireVfs>());
+        requireCtx->compileOptions.optimizationLevel = 1;
+        requireCtx->compileOptions.debugLevel = 2;
+        requireCtx->onLoad = [this](const std::string& chunkName, lua_State* ML)
+        {
+            std::unique_lock lock(targetMutex);
+            // this strips the potential leading @ from the chunkName for consistency when returning to DAP
+            loadedSources[getSourceFromChunk(chunkName)] = std::make_shared<Ref>(ML, -1);
+            auto [installed, uninstalled] = modifyPendingBreakpoints(ML);
+            lock.unlock();
+            for (auto& bp : installed)
+                launchConfig.onBreakpointInstall(bp);
+            for (auto& bp : uninstalled)
+                launchConfig.onBreakpointUninstall(bp);
+        };
+        setupState(
+            *childRuntime,
+            [this](lua_State* L)
+            {
+                luaopen_require(L, requireConfigInit, requireCtx.get());
+            }
+        );
         launchConfig = config;
 
         std::ifstream file(sourcePath);
@@ -279,8 +329,11 @@ bool Target::launch(const std::string& sourcePath, const std::vector<std::string
         std::string bytecode = Luau::compile(source, debugOptions);
         lua_State* thread = lua_newthread(childRuntime->GL);
         luaL_sandboxthread(thread);
-        luau_load(thread, sourcePath.c_str(), bytecode.c_str(), bytecode.size(), 0);
+
+        std::string chunkname = getChunkFromSource(sourcePath);
+        luau_load(thread, chunkname.c_str(), bytecode.c_str(), bytecode.size(), 0);
         loadedSources[sourcePath] = std::make_shared<Ref>(thread, -1);
+
         std::tie(installedBps, uninstalledBps) = modifyPendingBreakpoints(thread);
         for (const std::string& arg : args)
             lua_pushstring(thread, arg.c_str());
@@ -327,8 +380,8 @@ void Target::installBpHitCallback()
             target->parentRuntime.reporter.reportError(Luau::format("breakpoint hit at line %d could not find a runtime source", line));
             return;
         }
-        std::string source = info.source;
-        std::optional<Breakpoint> bp = target->getBreakpointBySourceLineHelper(source, line);
+        std::string chunkname = info.source;
+        std::optional<Breakpoint> bp = target->getBreakpointBySourceLineHelper(getSourceFromChunk(chunkname), line);
         // Only stop execution on installed breakpoints; otherwise, don't stop.
         if (bp && bp->status == BreakpointStatus::Installed)
         {
@@ -351,7 +404,7 @@ void Target::installBpHitCallback()
             // It is normal to hit breakpoints that are pending uninstall but not normal
             // to hit any other type of breakpoint so we error in those cases.
             target->parentRuntime.reporter.reportError(
-                Luau::format("breakpoint hit at line %d in %s could not be found in breakpoint map", line, source.c_str())
+                Luau::format("breakpoint hit at line %d in %s could not be found in breakpoint map", line, chunkname.c_str())
             );
         }
     };

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -53,7 +53,7 @@ static std::string getChunkFromSource(const std::string& sourcePath)
 
 static std::string getSourceFromChunk(const std::string& chunkname)
 {
-    if (chunkname.size() > 0 && chunkname[0] == '@')
+    if (chunkname.rfind('@', 0) == 0)
         return chunkname.substr(1);
     return chunkname;
 }
@@ -293,21 +293,26 @@ bool Target::launch(std::string sourcePath, const std::vector<std::string>& args
             return false;
         childRuntime = std::make_unique<Runtime>(parentRuntime.reporter, true);
         // Set up require system before launch.
-        requireCtx = std::make_unique<RequireCtx>(std::make_unique<RequireVfs>());
-        requireCtx->compileOptions.optimizationLevel = 1;
-        requireCtx->compileOptions.debugLevel = 2;
-        requireCtx->onLoad = [this](const std::string& chunkName, lua_State* ML)
+        Luau::CompileOptions options;
+        options.optimizationLevel = 1;
+        options.debugLevel = 2;
+        std::function<void(lua_State * L, const std::string& chunkName)> onChunkLoad = [this](lua_State* ML, const std::string& chunkName)
         {
-            std::unique_lock lock(targetMutex);
-            // this strips the potential leading @ from the chunkName for consistency when returning to DAP
-            loadedSources[getSourceFromChunk(chunkName)] = std::make_shared<Ref>(ML, -1);
-            auto [installed, uninstalled] = modifyPendingBreakpoints(ML);
-            lock.unlock();
+            std::string source = getSourceFromChunk(chunkName);
+            std::vector<Breakpoint> installed;
+            std::vector<Breakpoint> uninstalled;
+            {
+                std::scoped_lock(targetMutex);
+                // this strips the potential leading @ from the chunkName for consistency when returning to DAP
+                loadedSources[source] = std::make_shared<Ref>(ML, -1);
+                std::tie(installed, uninstalled) = modifyPendingBreakpoints(ML);
+            }
             for (auto& bp : installed)
                 launchConfig.onBreakpointInstall(bp);
             for (auto& bp : uninstalled)
                 launchConfig.onBreakpointUninstall(bp);
         };
+        requireCtx = std::make_unique<RequireCtx>(std::make_unique<RequireVfs>(), options, onChunkLoad);
         setupState(
             *childRuntime,
             [this](lua_State* L)
@@ -332,7 +337,12 @@ bool Target::launch(std::string sourcePath, const std::vector<std::string>& args
         luaL_sandboxthread(thread);
 
         std::string chunkname = getChunkFromSource(sourcePath);
-        luau_load(thread, chunkname.c_str(), bytecode.c_str(), bytecode.size(), 0);
+        // TODO: surface compilation errors to the user when debugging.
+        if (luau_load(thread, chunkname.c_str(), bytecode.c_str(), bytecode.size(), 0) != 0)
+        {
+            childRuntime.reset();
+            return false;
+        }
         loadedSources[sourcePath] = std::make_shared<Ref>(thread, -1);
 
         std::tie(installedBps, uninstalledBps) = modifyPendingBreakpoints(thread);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -293,9 +293,9 @@ bool Target::launch(std::string sourcePath, const std::vector<std::string>& args
             return false;
         childRuntime = std::make_unique<Runtime>(parentRuntime.reporter, true);
         // Set up require system before launch.
-        Luau::CompileOptions options;
-        options.optimizationLevel = 1;
-        options.debugLevel = 2;
+        Luau::CompileOptions debugOptions;
+        debugOptions.optimizationLevel = 1;
+        debugOptions.debugLevel = 2;
         std::function<void(lua_State * L, const std::string& chunkName)> onChunkLoad = [this](lua_State* ML, const std::string& chunkName)
         {
             std::string source = getSourceFromChunk(chunkName);
@@ -312,7 +312,7 @@ bool Target::launch(std::string sourcePath, const std::vector<std::string>& args
             for (auto& bp : uninstalled)
                 launchConfig.onBreakpointUninstall(bp);
         };
-        requireCtx = std::make_unique<RequireCtx>(std::make_unique<RequireVfs>(), options, onChunkLoad);
+        requireCtx = std::make_unique<RequireCtx>(std::make_unique<RequireVfs>(), debugOptions, onChunkLoad);
         setupState(
             *childRuntime,
             [this](lua_State* L)
@@ -329,9 +329,6 @@ bool Target::launch(std::string sourcePath, const std::vector<std::string>& args
             return false;
         }
         std::string source((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-        Luau::CompileOptions debugOptions = {};
-        debugOptions.optimizationLevel = 1;
-        debugOptions.debugLevel = 2;
         std::string bytecode = Luau::compile(source, debugOptions);
         lua_State* thread = lua_newthread(childRuntime->GL);
         luaL_sandboxthread(thread);

--- a/lute/require/CMakeLists.txt
+++ b/lute/require/CMakeLists.txt
@@ -30,5 +30,5 @@ target_sources(Lute.Require PRIVATE
 
 target_compile_features(Lute.Require PUBLIC cxx_std_17)
 target_include_directories(Lute.Require PUBLIC include)
-target_link_libraries(Lute.Require PUBLIC Luau.Require PRIVATE Luau.CLI.lib Luau.Compiler Luau.CodeGen Lute.Common Lute.Std Lute.CLI.Commands Lute.Batteries Lute.Std Lute.Lute Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Syntax Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Runtime Lute.Debug)
+target_link_libraries(Lute.Require PUBLIC Luau.Require Luau.Compiler PRIVATE Luau.CLI.lib Luau.CodeGen Lute.Common Lute.Std Lute.CLI.Commands Lute.Batteries Lute.Std Lute.Lute Lute.Crypto Lute.Fs Lute.IO Lute.Luau Lute.Net Lute.Syntax Lute.Task Lute.VM Lute.Process Lute.System Lute.Time Lute.Runtime Lute.Debug)
 target_compile_options(Lute.Require PRIVATE ${LUTE_OPTIONS})

--- a/lute/require/include/lute/require.h
+++ b/lute/require/include/lute/require.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "lute/modulepath.h"
+#include "lute/options.h"
 
+#include "Luau/Compiler.h"
 #include "Luau/Require.h"
 
 #include <memory>
@@ -42,4 +44,7 @@ struct RequireCtx
     RequireCtx(std::unique_ptr<IRequireVfs> vfs);
 
     std::unique_ptr<IRequireVfs> vfs;
+
+    Luau::CompileOptions compileOptions = copts();
+    std::function<void(const std::string& chunkName, lua_State* L)> onLoad;
 };

--- a/lute/require/include/lute/require.h
+++ b/lute/require/include/lute/require.h
@@ -41,10 +41,13 @@ public:
 
 struct RequireCtx
 {
-    RequireCtx(std::unique_ptr<IRequireVfs> vfs);
+    RequireCtx(
+        std::unique_ptr<IRequireVfs> vfs,
+        Luau::CompileOptions compileOptions = copts(),
+        std::function<void(lua_State* L, const std::string& chunkName)> onChunkLoad = nullptr
+    );
 
     std::unique_ptr<IRequireVfs> vfs;
-
-    Luau::CompileOptions compileOptions = copts();
-    std::function<void(const std::string& chunkName, lua_State* L)> onLoad;
+    Luau::CompileOptions compileOptions;
+    std::function<void(lua_State* L, const std::string& chunkName)> onChunkLoad;
 };

--- a/lute/require/include/lute/require.h
+++ b/lute/require/include/lute/require.h
@@ -41,10 +41,11 @@ public:
 
 struct RequireCtx
 {
+    RequireCtx(std::unique_ptr<IRequireVfs> vfs);
     RequireCtx(
         std::unique_ptr<IRequireVfs> vfs,
-        Luau::CompileOptions compileOptions = copts(),
-        std::function<void(lua_State* L, const std::string& chunkName)> onChunkLoad = nullptr
+        Luau::CompileOptions compileOptions,
+        std::function<void(lua_State* L, const std::string& chunkName)> onChunkLoad
     );
 
     std::unique_ptr<IRequireVfs> vfs;

--- a/lute/require/src/require.cpp
+++ b/lute/require/src/require.cpp
@@ -176,14 +176,15 @@ static int load(lua_State* L, void* ctx, const char* path, const char* chunkname
         luaL_error(L, "could not read file '%s'", loadname);
 
     // now we can compile & run module on the new thread
-    std::string bytecode = reqCtx->vfs->isPrecompiled() ? *contents : Luau::compile(*contents, copts());
+    std::string bytecode = reqCtx->vfs->isPrecompiled() ? *contents : Luau::compile(*contents, reqCtx->compileOptions);
     bool errored = true;
     if (luau_load(ML, chunkname, bytecode.data(), bytecode.size(), 0) == 0)
     {
         Luau::CodeGen::CompilationOptions nativeOptions;
         nativeOptions.flags = Luau::CodeGen::CodeGen_OnlyNativeModules;
         Luau::CodeGen::compile(ML, -1, nativeOptions);
-
+        if (reqCtx->onLoad)
+            reqCtx->onLoad(chunkname, ML);
         int status = lua_resume(ML, L, 0);
 
         if (status == 0)

--- a/lute/require/src/require.cpp
+++ b/lute/require/src/require.cpp
@@ -180,9 +180,13 @@ static int load(lua_State* L, void* ctx, const char* path, const char* chunkname
     bool errored = true;
     if (luau_load(ML, chunkname, bytecode.data(), bytecode.size(), 0) == 0)
     {
-        Luau::CodeGen::CompilationOptions nativeOptions;
-        nativeOptions.flags = Luau::CodeGen::CodeGen_OnlyNativeModules;
-        Luau::CodeGen::compile(ML, -1, nativeOptions);
+        // if debug level == 2, we should not do native compilation even if that's flagged as allowed
+        if (reqCtx->compileOptions.debugLevel < 2)
+        {
+            Luau::CodeGen::CompilationOptions nativeOptions;
+            nativeOptions.flags = Luau::CodeGen::CodeGen_OnlyNativeModules;
+            Luau::CodeGen::compile(ML, -1, nativeOptions);
+        }
         if (reqCtx->onLoad)
             reqCtx->onLoad(chunkname, ML);
         int status = lua_resume(ML, L, 0);

--- a/lute/require/src/require.cpp
+++ b/lute/require/src/require.cpp
@@ -245,6 +245,12 @@ void requireConfigInit(luarequire_Configuration* config)
     config->load = load;
 }
 
+RequireCtx::RequireCtx(std::unique_ptr<IRequireVfs> vfs)
+    : vfs(std::move(vfs))
+    , compileOptions(copts())
+{
+}
+
 RequireCtx::RequireCtx(
     std::unique_ptr<IRequireVfs> vfs,
     Luau::CompileOptions compileOptions,

--- a/lute/require/src/require.cpp
+++ b/lute/require/src/require.cpp
@@ -187,8 +187,8 @@ static int load(lua_State* L, void* ctx, const char* path, const char* chunkname
             nativeOptions.flags = Luau::CodeGen::CodeGen_OnlyNativeModules;
             Luau::CodeGen::compile(ML, -1, nativeOptions);
         }
-        if (reqCtx->onLoad)
-            reqCtx->onLoad(chunkname, ML);
+        if (reqCtx->onChunkLoad)
+            reqCtx->onChunkLoad(ML, chunkname);
         int status = lua_resume(ML, L, 0);
 
         if (status == 0)
@@ -245,7 +245,13 @@ void requireConfigInit(luarequire_Configuration* config)
     config->load = load;
 }
 
-RequireCtx::RequireCtx(std::unique_ptr<IRequireVfs> vfs)
+RequireCtx::RequireCtx(
+    std::unique_ptr<IRequireVfs> vfs,
+    Luau::CompileOptions compileOptions,
+    std::function<void(lua_State* L, const std::string& chunkName)> onChunkLoad
+)
     : vfs(std::move(vfs))
+    , compileOptions(std::move(compileOptions))
+    , onChunkLoad(std::move(onChunkLoad))
 {
 }

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -169,4 +169,44 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 			true
 		)
 	end)
+	-- this test case focuses on multiple sources
+	suite:case("multisource", function(check)
+		local target = debug.newTarget()
+		check.eq(typeof(target), "Target")
+		local mainPath = path.format(path.join(proc.cwd(), "tests/src/debug/require_main.luau"))
+		local triangPath = path.format(path.join(proc.cwd(), "tests/src/debug/require_triang.luau"))
+		local bp1 = target:setBreakpoint(mainPath, 5)
+		local _bp2 = target:setBreakpoint(triangPath, 5)
+		local bpHit1 = 0
+		local bpHit2 = 0
+		local onFinished = false
+		local targetLaunched = target:launch(mainPath, {}, {
+			onBreakpointHit = function(bp)
+				if bp.id == bp1.id then
+					bpHit1 += 1
+				else
+					bpHit2 += 1
+				end
+				local continued = target:continueProcess()
+				check.that(continued)
+			end,
+			onExit = function(status)
+				if status then
+					onFinished = true
+				end
+			end,
+		})
+		check.that(targetLaunched)
+		check.eq(
+			waitUntil(function()
+				return onFinished
+			end),
+			true
+		)
+		check.eq(bpHit1, 5)
+		check.eq(bpHit2, 15)
+		local source = target:getLoadedSources()
+		check.that(table.find(source, mainPath))
+		check.that(table.find(source, triangPath))
+	end)
 end)

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -6,7 +6,7 @@ local path = require("@std/path")
 local proc = require("@std/process")
 
 local function normalizePath(p: string): string
-	return p:gsub("\\", "/")
+	return (p:gsub("\\", "/"))
 end
 
 -- a helper function that basically polls a boolean, since Luau does

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -5,6 +5,10 @@ local debug = require("@lute/debugger")
 local path = require("@std/path")
 local proc = require("@std/process")
 
+local function normalizePath(p: string): string
+	return p:gsub("\\", "/")
+end
+
 -- a helper function that basically polls a boolean, since Luau does
 -- not allow the promises/futures we use in the C++ tests
 local function waitUntil(condition: () -> boolean, timeout: number?, pollInterval: number?): boolean
@@ -27,7 +31,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local bp = target:setBreakpoint(fixturePath, 6)
 		check.eq(bp.id, 0)
 		check.eq(bp.line, 6)
-		check.eq(bp.sourcePath, fixturePath)
+		check.eq(bp.sourcePath, normalizePath(fixturePath))
 		check.eq(bp.status, "pendingInstall")
 		local numHits, onFinished, numBreakpointsInstalled = 0, false, 0
 		local targetLaunched = target:launch(fixturePath, {}, {
@@ -66,17 +70,17 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local bpGet = assert(target:getBreakpointById(bp1.id))
 		check.eq(bpGet.id, bp1.id)
 		check.eq(bpGet.line, 6)
-		check.eq(bpGet.sourcePath, fixturePath)
+		check.eq(bpGet.sourcePath, normalizePath(fixturePath))
 		check.eq(bpGet.status, "pendingInstall")
 		bpGet = assert(target:getBreakpointById(bp2.id))
 		check.eq(bpGet.id, bp2.id)
 		check.eq(bpGet.line, 7)
-		check.eq(bpGet.sourcePath, fixturePath)
+		check.eq(bpGet.sourcePath, normalizePath(fixturePath))
 		check.eq(bpGet.status, "pendingInstall")
 		bpGet = assert(target:getBreakpointById(bp3.id))
 		check.eq(bpGet.id, bp3.id)
 		check.eq(bpGet.line, 4)
-		check.eq(bpGet.sourcePath, fixturePath)
+		check.eq(bpGet.sourcePath, normalizePath(fixturePath))
 		check.eq(bpGet.status, "pendingInstall")
 		local bps = target:getBreakpoints()
 		check.eq(#bps, 3)
@@ -91,7 +95,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				if bp.id == bp2.id then
 					check.eq(bp.id, bp2.id)
 					check.eq(bp.line, 7)
-					check.eq(bp.sourcePath, fixturePath)
+					check.eq(bp.sourcePath, normalizePath(fixturePath))
 					check.eq(bp.status, "installed")
 					numHitsBp2 += 1
 					check.eq(#target:getBreakpointsByStatus("installed"), 2)
@@ -124,7 +128,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		bpGet = assert(target:getBreakpointById(bp3.id))
 		check.eq(bpGet.id, bp3.id)
 		check.eq(bpGet.line, 4)
-		check.eq(bpGet.sourcePath, fixturePath)
+		check.eq(bpGet.sourcePath, normalizePath(fixturePath))
 		check.eq(bpGet.status, "installed")
 
 		check.eq(
@@ -206,7 +210,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		check.eq(bpHit1, 5)
 		check.eq(bpHit2, 15)
 		local source = target:getLoadedSources()
-		check.that(table.find(source, mainPath))
-		check.that(table.find(source, triangPath))
+		check.that(table.find(source, normalizePath(mainPath)))
+		check.that(table.find(source, normalizePath(triangPath)))
 	end)
 end)

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -292,4 +292,38 @@ TEST_SUITE("Debug")
         CHECK(continuedProcess);
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }
+
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_multiSource")
+    {
+        std::string mainPath = getDebugFixturePath("require_main.luau");
+        std::string triangPath = getDebugFixturePath("require_triang.luau");
+
+        int bpHit1 = 0, bpHit2 = 0, bpInstalled = 0;
+        Target target(*runtime);
+        Breakpoint bp1 = target.setBreakpoint(mainPath, 5);
+        Breakpoint bp2 = target.setBreakpoint(triangPath, 5);
+        config.onBreakpointInstall = [&](const Breakpoint& bp)
+        {
+            bpInstalled++;
+        };
+        config.onBreakpointHit = [&](const Breakpoint& bp)
+        {
+            if (bp.id == bp1.id)
+                bpHit1++;
+            else if (bp.id == bp2.id)
+                bpHit2++;
+            target.continueProcess();
+        };
+        bool launched = target.launch(mainPath, {}, config);
+        CHECK(launched);
+        // check we are done
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        CHECK(bpHit1 == 5);
+        CHECK(bpHit2 == 15);
+        CHECK(bpInstalled == 2);
+        std::vector<std::string> sources = target.getLoadedSources();
+        CHECK(sources.size() == 2);
+        CHECK(std::find(sources.begin(), sources.end(), mainPath) != sources.end());
+        CHECK(std::find(sources.begin(), sources.end(), triangPath) != sources.end());
+    }
 }

--- a/tests/src/debug/require_main.luau
+++ b/tests/src/debug/require_main.luau
@@ -1,0 +1,6 @@
+local func = require("./require_triang")
+
+local sum = 0
+for i = 1, 5 do
+    sum += func.triangular(3)
+end

--- a/tests/src/debug/require_main.luau
+++ b/tests/src/debug/require_main.luau
@@ -1,6 +1,6 @@
 local func = require("./require_triang")
 
-local sum = 0
-for i = 1, 5 do
-    sum += func.triangular(3)
+local _sum = 0
+for _ = 1, 5 do
+	_sum += func.triangular(3)
 end

--- a/tests/src/debug/require_triang.luau
+++ b/tests/src/debug/require_triang.luau
@@ -1,0 +1,9 @@
+local M = {}
+function M.triangular(x: number)
+	local result = 0
+	for i = 1, x do
+		result += i
+	end
+	return result
+end
+return M


### PR DESCRIPTION
Add support for multiple sources in the debugger
* Intercept calls to loading new modules by modifying the `RequireCtx`
* also add `getLoadedSources` to debugger Target + bindings