### PR TITLE
`lute/runtime`: fix scheduling issue with blocking on uv event loop

### DIFF
--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -602,7 +602,7 @@ static std::function<void(const Breakpoint&)> makeBreakpointCallback(std::shared
 {
     return [ref, runtime](const Breakpoint& bp)
     {
-        runtime->scheduleLuauCallback(
+        runtime->scheduleDebugLuauCallback(
             ref,
             [bp](lua_State* L)
             {
@@ -652,7 +652,7 @@ static int target_launch(lua_State* L)
         if (auto ref = getOptionalCallback(L, 4, "onBreakpointHit"))
             config.onBreakpointHit = [ref, runtime](const Thread& thread, const Breakpoint& bp)
             {
-                runtime->scheduleLuauCallback(
+                runtime->scheduleDebugLuauCallback(
                     ref,
                     [thread, bp](lua_State* L)
                     {
@@ -670,7 +670,7 @@ static int target_launch(lua_State* L)
         {
             config.onExit = [ref, runtime](bool success)
             {
-                runtime->scheduleLuauCallback(
+                runtime->scheduleDebugLuauCallback(
                     ref,
                     [success](lua_State* L)
                     {
@@ -685,7 +685,7 @@ static int target_launch(lua_State* L)
         {
             config.onPause = [ref, runtime](const Thread& thread)
             {
-                runtime->scheduleLuauCallback(
+                runtime->scheduleDebugLuauCallback(
                     ref,
                     [thread](lua_State* L)
                     {
@@ -699,7 +699,7 @@ static int target_launch(lua_State* L)
         {
             config.onPrint = [ref, runtime](std::string message, std::string source, int line)
             {
-                runtime->scheduleLuauCallback(
+                runtime->scheduleDebugLuauCallback(
                     ref,
                     [message, source, line](lua_State* L)
                     {
@@ -716,7 +716,7 @@ static int target_launch(lua_State* L)
         {
             config.onStepStop = [ref, runtime](const Thread& thread, const StepInfo& stepInfo)
             {
-                runtime->scheduleLuauCallback(
+                runtime->scheduleDebugLuauCallback(
                     ref,
                     [thread, stepInfo](lua_State* L)
                     {

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -96,6 +96,7 @@ Target::~Target()
                 return;
             lua_break(L);
         };
+        parentRuntime.numLaunchedDebuggees--;
     }
     childRuntime.reset();
 }
@@ -445,6 +446,7 @@ std::optional<std::string> Target::launch(std::string sourcePath, const std::vec
         // The no-op schedule wakes the event loop so it picks up the queued thread.
         paused = false;
         launched = true;
+        parentRuntime.numLaunchedDebuggees++;
         childRuntime->schedule([]() {});
         childRuntime->runContinuously();
     }

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -154,6 +154,7 @@ private:
     std::condition_variable runLoopCv;
     uv_thread_t runLoopThread = {};
     bool runLoopThreadStarted = false;
+    uv_async_t wakeup;
 
     std::atomic<int> activeTokens;
     uv_loop_t eventLoop;

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -139,6 +139,7 @@ struct Runtime
 
     // for debug mode only:
     const bool debugMode;
+    std::atomic<int> numLaunchedDebuggees = 0;
     void stopDebug();
     void continueDebug();
     // Same as scheduleLuauCallback but we since we don't call this within a libuv completion callback

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -141,6 +141,9 @@ struct Runtime
     const bool debugMode;
     void stopDebug();
     void continueDebug();
+    // Same as scheduleLuauCallback but we since we don't call this within a libuv completion callback
+    // we need to wake up the libuv event loop.
+    void scheduleDebugLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher);
 
 private:
     bool runThreadCompletionHandler(lua_State* L, int status);

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -154,10 +154,10 @@ private:
     std::condition_variable runLoopCv;
     uv_thread_t runLoopThread = {};
     bool runLoopThreadStarted = false;
-    uv_async_t wakeup;
 
     std::atomic<int> activeTokens;
     uv_loop_t eventLoop;
+    uv_async_t wakeupEventLoop;
 
     // for debug mode only:
     std::mutex debugMutex;

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -32,9 +32,18 @@ Runtime::Runtime(LuteReporter& reporter, bool debugMode)
 
     if (uv_loop_init(&eventLoop) < 0)
     {
-        LUTE_ASSERT("Couldn't initialize runtime event loop");
+        reporter.reportError("Couldn't initialize runtime event loop");
+        LUTE_ASSERT(false);
     }
-    uv_async_init(&eventLoop, &wakeup, [](uv_async_t*) {});
+
+    // We need a way to communicate from other uv threads to the main event loop.
+    if (uv_async_init(&eventLoop, &wakeup, [](uv_async_t*) {}) < 0)
+    {
+        reporter.reportError("Couldn't initialize uv_async handle to wake up main event");
+        LUTE_ASSERT(false);
+    }
+    // This unreferences wakeup so that it does not count towards hasWork() through uv_loop_alive
+    uv_unref((uv_handle_t*)&wakeup);
 }
 
 Runtime::~Runtime()
@@ -53,10 +62,15 @@ Runtime::~Runtime()
         runLoopThreadStarted = false;
     }
     uv_close((uv_handle_t*)&wakeup, nullptr);
+    //  We need to run the event loop to process the uv_close since it is asynchronous
     uv_run(&eventLoop, UV_RUN_ONCE);
-    // At this point, Runtime::hasWork will have returned false (i.e uv_loop_alive is false)
-    // This means there are no outstanding handles, or file descriptors or work, to do, and we can exit
-    uv_loop_close(&eventLoop);
+    //  At this point, Runtime::hasWork will have returned false (i.e uv_loop_alive is false)
+    //  This means there are no outstanding handles, or file descriptors or work, to do, and we can exit
+    if (uv_loop_close(&eventLoop) < 0)
+    {
+        reporter.reportError("uv main loop failed to destruct due to active handles");
+        LUTE_ASSERT(false);
+    }
 }
 
 bool Runtime::hasWork()
@@ -276,6 +290,8 @@ void Runtime::schedule(std::function<void()> f)
     continuations.push_back(std::move(f));
 
     runLoopCv.notify_one();
+    // We may be blocked on uv_run(getEventLoop(), UV_RUN_ONCE) in runOnce().
+    // This signals the uv_loop and unblocks it to run the continuation.
     uv_async_send(&wakeup);
 }
 

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -35,7 +35,6 @@ Runtime::Runtime(LuteReporter& reporter, bool debugMode)
         reporter.reportError("Couldn't initialize runtime event loop");
         LUTE_ASSERT(false);
     }
-
     // We need a way to communicate from other uv threads to the main event loop.
     if (uv_async_init(&eventLoop, &wakeupEventLoop, [](uv_async_t*) {}) < 0)
     {
@@ -357,7 +356,6 @@ void Runtime::scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::functi
 
 void Runtime::scheduleDebugLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher)
 {
-    LUTE_ASSERT(debugMode);
     scheduleLuauCallback(callbackRef, argPusher);
     // We may be blocked on uv_run(getEventLoop(), UV_RUN_ONCE) in runOnce().
     // This signals the uv_loop and unblocks it to run the continuation.

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -34,6 +34,7 @@ Runtime::Runtime(LuteReporter& reporter, bool debugMode)
     {
         LUTE_ASSERT("Couldn't initialize runtime event loop");
     }
+    uv_async_init(&eventLoop, &wakeup, [](uv_async_t*) {});
 }
 
 Runtime::~Runtime()
@@ -51,6 +52,8 @@ Runtime::~Runtime()
         uv_thread_join(&runLoopThread);
         runLoopThreadStarted = false;
     }
+    uv_close((uv_handle_t*)&wakeup, nullptr);
+    uv_run(&eventLoop, UV_RUN_ONCE);
     // At this point, Runtime::hasWork will have returned false (i.e uv_loop_alive is false)
     // This means there are no outstanding handles, or file descriptors or work, to do, and we can exit
     uv_loop_close(&eventLoop);
@@ -336,6 +339,7 @@ void Runtime::scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::functi
     );
 
     runLoopCv.notify_one();
+    uv_async_send(&wakeup);
 }
 
 void Runtime::runInWorkQueue(std::function<void()> f)

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -32,14 +32,12 @@ Runtime::Runtime(LuteReporter& reporter, bool debugMode)
 
     if (uv_loop_init(&eventLoop) < 0)
     {
-        reporter.reportError("Couldn't initialize runtime event loop");
-        LUTE_ASSERT(false);
+        LUTE_ASSERT(!"Couldn't initialize runtime event loop");
     }
-    // We need a way to communicate from other uv threads to the main event loop.
+    // We need a way to communicate from other uv threads to the main event loop for scheduleDebugLuauCallback.
     if (uv_async_init(&eventLoop, &wakeupEventLoop, [](uv_async_t*) {}) < 0)
     {
-        reporter.reportError("Couldn't initialize uv_async handle to wake up main event");
-        LUTE_ASSERT(false);
+        LUTE_ASSERT(!"Couldn't initialize uv_async handle to wake up main event");
     }
     // This unreferences wakeupEventLoop so that it does not count towards hasWork() through uv_loop_alive
     uv_unref((uv_handle_t*)&wakeupEventLoop);
@@ -67,8 +65,7 @@ Runtime::~Runtime()
     //  This means there are no outstanding handles, or file descriptors or work, to do, and we can exit
     if (uv_loop_close(&eventLoop) < 0)
     {
-        reporter.reportError("uv main loop failed to destruct due to active handles");
-        LUTE_ASSERT(false);
+        LUTE_ASSERT(!"uv main loop failed to destruct due to active handles");
     }
 }
 
@@ -243,7 +240,7 @@ void Runtime::runContinuously()
                            ) == 0;
 
     if (!runLoopThreadStarted)
-        LUTE_ASSERT("Failed to create runtime runloop thread");
+        LUTE_ASSERT(!"Failed to create runtime runloop thread");
 }
 
 bool Runtime::hasContinuations()

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -290,9 +290,6 @@ void Runtime::schedule(std::function<void()> f)
     continuations.push_back(std::move(f));
 
     runLoopCv.notify_one();
-    // We may be blocked on uv_run(getEventLoop(), UV_RUN_ONCE) in runOnce().
-    // This signals the uv_loop and unblocks it to run the continuation.
-    uv_async_send(&wakeupEventLoop);
 }
 
 void Runtime::scheduleLuauError(std::shared_ptr<Ref> ref, std::string error)
@@ -312,7 +309,6 @@ void Runtime::scheduleLuauError(std::shared_ptr<Ref> ref, std::string error)
     );
 
     runLoopCv.notify_one();
-    uv_async_send(&wakeupEventLoop);
 }
 
 void Runtime::scheduleLuauResume(std::shared_ptr<Ref> ref, std::function<int(lua_State*)> cont)
@@ -336,7 +332,6 @@ void Runtime::scheduleLuauResume(std::shared_ptr<Ref> ref, std::function<int(lua
     );
 
     runLoopCv.notify_one();
-    uv_async_send(&wakeupEventLoop);
 }
 
 void Runtime::scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher)
@@ -358,6 +353,14 @@ void Runtime::scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::functi
     );
 
     runLoopCv.notify_one();
+}
+
+void Runtime::scheduleDebugLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher)
+{
+    LUTE_ASSERT(debugMode);
+    scheduleLuauCallback(callbackRef, argPusher);
+    // We may be blocked on uv_run(getEventLoop(), UV_RUN_ONCE) in runOnce().
+    // This signals the uv_loop and unblocks it to run the continuation.
     uv_async_send(&wakeupEventLoop);
 }
 

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -276,6 +276,7 @@ void Runtime::schedule(std::function<void()> f)
     continuations.push_back(std::move(f));
 
     runLoopCv.notify_one();
+    uv_async_send(&wakeup);
 }
 
 void Runtime::scheduleLuauError(std::shared_ptr<Ref> ref, std::string error)
@@ -295,6 +296,7 @@ void Runtime::scheduleLuauError(std::shared_ptr<Ref> ref, std::string error)
     );
 
     runLoopCv.notify_one();
+    uv_async_send(&wakeup);
 }
 
 void Runtime::scheduleLuauResume(std::shared_ptr<Ref> ref, std::function<int(lua_State*)> cont)
@@ -318,6 +320,7 @@ void Runtime::scheduleLuauResume(std::shared_ptr<Ref> ref, std::function<int(lua
     );
 
     runLoopCv.notify_one();
+    uv_async_send(&wakeup);
 }
 
 void Runtime::scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher)

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -37,13 +37,13 @@ Runtime::Runtime(LuteReporter& reporter, bool debugMode)
     }
 
     // We need a way to communicate from other uv threads to the main event loop.
-    if (uv_async_init(&eventLoop, &wakeup, [](uv_async_t*) {}) < 0)
+    if (uv_async_init(&eventLoop, &wakeupEventLoop, [](uv_async_t*) {}) < 0)
     {
         reporter.reportError("Couldn't initialize uv_async handle to wake up main event");
         LUTE_ASSERT(false);
     }
-    // This unreferences wakeup so that it does not count towards hasWork() through uv_loop_alive
-    uv_unref((uv_handle_t*)&wakeup);
+    // This unreferences wakeupEventLoop so that it does not count towards hasWork() through uv_loop_alive
+    uv_unref((uv_handle_t*)&wakeupEventLoop);
 }
 
 Runtime::~Runtime()
@@ -61,7 +61,7 @@ Runtime::~Runtime()
         uv_thread_join(&runLoopThread);
         runLoopThreadStarted = false;
     }
-    uv_close((uv_handle_t*)&wakeup, nullptr);
+    uv_close((uv_handle_t*)&wakeupEventLoop, nullptr);
     //  We need to run the event loop to process the uv_close since it is asynchronous
     uv_run(&eventLoop, UV_RUN_ONCE);
     //  At this point, Runtime::hasWork will have returned false (i.e uv_loop_alive is false)
@@ -292,7 +292,7 @@ void Runtime::schedule(std::function<void()> f)
     runLoopCv.notify_one();
     // We may be blocked on uv_run(getEventLoop(), UV_RUN_ONCE) in runOnce().
     // This signals the uv_loop and unblocks it to run the continuation.
-    uv_async_send(&wakeup);
+    uv_async_send(&wakeupEventLoop);
 }
 
 void Runtime::scheduleLuauError(std::shared_ptr<Ref> ref, std::string error)
@@ -312,7 +312,7 @@ void Runtime::scheduleLuauError(std::shared_ptr<Ref> ref, std::string error)
     );
 
     runLoopCv.notify_one();
-    uv_async_send(&wakeup);
+    uv_async_send(&wakeupEventLoop);
 }
 
 void Runtime::scheduleLuauResume(std::shared_ptr<Ref> ref, std::function<int(lua_State*)> cont)
@@ -336,7 +336,7 @@ void Runtime::scheduleLuauResume(std::shared_ptr<Ref> ref, std::function<int(lua
     );
 
     runLoopCv.notify_one();
-    uv_async_send(&wakeup);
+    uv_async_send(&wakeupEventLoop);
 }
 
 void Runtime::scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher)
@@ -358,7 +358,7 @@ void Runtime::scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::functi
     );
 
     runLoopCv.notify_one();
-    uv_async_send(&wakeup);
+    uv_async_send(&wakeupEventLoop);
 }
 
 void Runtime::runInWorkQueue(std::function<void()> f)

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -353,6 +353,7 @@ void Runtime::scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::functi
 
 void Runtime::scheduleDebugLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher)
 {
+    LUTE_ASSERT(numLaunchedDebuggees > 0);
     scheduleLuauCallback(callbackRef, argPusher);
     // We may be blocked on uv_run(getEventLoop(), UV_RUN_ONCE) in runOnce().
     // This signals the uv_loop and unblocks it to run the continuation.

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -354,7 +354,7 @@ void Runtime::scheduleLuauCallback(std::shared_ptr<Ref> callbackRef, std::functi
 void Runtime::scheduleDebugLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher)
 {
     LUTE_ASSERT(numLaunchedDebuggees > 0);
-    scheduleLuauCallback(callbackRef, argPusher);
+    scheduleLuauCallback(callbackRef, std::move(argPusher));
     // We may be blocked on uv_run(getEventLoop(), UV_RUN_ONCE) in runOnce().
     // This signals the uv_loop and unblocks it to run the continuation.
     uv_async_send(&wakeupEventLoop);


### PR DESCRIPTION
Fixes scheduled continuations and callbacks blocking on `uv_run(getEventLoop(), UV_RUN_ONCE)` in `runOnce`.  
* When testing the DAP adapter, I was seeing behavior where callbacks such as `onExit` would not fire until after receiving I/O from the VSCode debugging client. 
* This uses `uv_async` to attempt to fix that.
* Empirically it fixes the DAP problem above.