### PR TITLE
`lute/debug`: add prototype DAP adapter for breakpoints

### DIFF
--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -18,7 +18,8 @@ export type Breakpoint = {
 export type LaunchConfig = {
 	--- called when a breakpoint `bp` is hit; execution is paused until continueProcess() is called
 	onBreakpointHit: ((bp: Breakpoint) -> ())?,
-	--- called when breakpoint `bp` is successfully installed in the VM
+	--- called when there is has been an attempt to install the breakpoint `bp` on the VM, regardless
+	--- of success and failure. check the status of `bp` to see if the attempt has succeeded or failed.
 	onBreakpointInstall: ((bp: Breakpoint) -> ())?,
 	--- called when a breakpoint `bp` is uninstalled from the VM
 	onBreakpointUninstall: ((bp: Breakpoint) -> ())?,

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -24,7 +24,7 @@ end
 local function clearAndSetBreakpoints(
 	target: debugger.Target,
 	sourcePath: string,
-	newBreakpoints: { dapTypes.SourceBreakpoint }?
+	requestedBreakpoints: { dapTypes.SourceBreakpoint }?
 ): { dapTypes.Breakpoint }
 	local currentBps = target:getBreakpoints()
 	for _, bp in currentBps do
@@ -32,13 +32,13 @@ local function clearAndSetBreakpoints(
 			target:removeBreakpoint(bp.id)
 		end
 	end
-	local requestedBps = {}
-	if newBreakpoints then
-		for _, setBp in newBreakpoints do
-			table.insert(requestedBps, debugToDapBreakpoint(target:setBreakpoint(sourcePath, setBp.line)))
+	local resultBps = {}
+	if requestedBreakpoints then
+		for _, setBp in requestedBreakpoints do
+			table.insert(resultBps, debugToDapBreakpoint(target:setBreakpoint(sourcePath, setBp.line)))
 		end
 	end
-	return requestedBps
+	return resultBps
 end
 
 local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -84,6 +84,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			local capabilities = {
 				supportsConfigurationDoneRequest = true,
 				supportsTerminateRequest = true,
+				supportsLoadedSourcesRequest = true,
 			}
 			ioSession.writeResponse(reqSeq, true, command, nil, capabilities)
 			ioSession.writeEvent("initialized")
@@ -128,6 +129,18 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 					ioSession.writeResponse(reqSeq, launched, command)
 				end
 			end
+		elseif command == "loadedSources" then
+			local sources = target:getLoadedSources()
+			local dapSources = {}
+			for _, source in sources do
+				table.insert(dapSources, {
+					path = source,
+					name = source:match("[^/\\]+$"),
+				})
+			end
+			ioSession.writeResponse(reqSeq, true, command, nil, {
+				sources = dapSources,
+			})
 		-- dummy handler for threads
 		elseif command == "threads" then
 			ioSession.writeResponse(reqSeq, true, command, nil, {

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -1,21 +1,158 @@
 local dapStream = require("./dapStream")
+local dapTypes = require("./dapTypes")
+local debugger = require("@lute/debugger")
+local json = require("@std/json")
+
+local function debugToDapBreakpoint(breakpoint: debugger.Breakpoint): dapTypes.Breakpoint
+	local dapBreakpoint: dapTypes.Breakpoint = {
+		id = breakpoint.id,
+		verified = breakpoint.status == "installed",
+		source = {
+			path = breakpoint.sourcePath,
+		},
+		line = breakpoint.line,
+	}
+	if breakpoint.status == "pendingInstall" then
+		dapBreakpoint.reason = "pending"
+	end
+	if breakpoint.status == "invalid" then
+		dapBreakpoint.reason = "failed"
+	end
+	return dapBreakpoint
+end
+
+local function clearAndSetBreakpoints(
+	target: debugger.Target,
+	sourcePath: string,
+	newBreakpoints: { dapTypes.SourceBreakpoint }?
+): { dapTypes.Breakpoint }
+	local currentBps = target:getBreakpoints()
+	for _, bp in currentBps do
+		if bp.sourcePath == sourcePath then
+			target:removeBreakpoint(bp.id)
+		end
+	end
+	local requestedBps = {}
+	if newBreakpoints then
+		for _, setBp in newBreakpoints do
+			table.insert(requestedBps, debugToDapBreakpoint(target:setBreakpoint(sourcePath, setBp.line)))
+		end
+	end
+	return requestedBps
+end
 
 local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 	local ioSession = dapStream.makeDapStreamSession(reader, writer)
+	local target = debugger.newTarget()
+	local launchCallbacks: debugger.LaunchConfig = {
+		onBreakpointHit = function(bp: debugger.Breakpoint)
+			ioSession.writeEvent("stopped", {
+				reason = "breakpoint",
+				threadId = 1,
+				hitBreakpointIds = { bp.id },
+			})
+		end,
+		onBreakpointInstall = function(bp: debugger.Breakpoint)
+			ioSession.writeEvent("breakpoint", {
+				reason = "changed",
+				breakpoint = debugToDapBreakpoint(bp),
+			})
+		end,
+		onExit = function(success: boolean)
+			local exitCode = if success then 0 else 1
+			ioSession.writeEvent("exited", {
+				exitCode = exitCode,
+			})
+			ioSession.writeEvent("terminated")
+		end,
+		-- we need to give a thread ID upon pausing for VSCode UI
+		onPause = function()
+			ioSession.writeEvent("stopped", {
+				reason = "pause",
+				threadId = 1,
+			})
+		end,
+	}
+	local configurationDone = false
+	local launchConfig: dapTypes.LaunchArgs? = nil
+	local launchSeq = -1
 	while true do
 		local request = ioSession.readDap()
 		local command = request.command :: string
 		local reqSeq = request.seq :: number
 		if command == "initialize" then
-			ioSession.writeResponse(reqSeq, true, command)
+			local capabilities = {
+				supportsConfigurationDoneRequest = true,
+				supportsTerminateRequest = true,
+			}
+			ioSession.writeResponse(reqSeq, true, command, nil, capabilities)
 			ioSession.writeEvent("initialized")
 		elseif command == "configurationDone" then
+			configurationDone = true
+			-- clients can send either configurationDone before or after launch.
+			-- in the second case, we delay sending a response to the launch request until after
+			-- configuration is done.
 			ioSession.writeResponse(reqSeq, true, command)
+			if launchConfig then
+				target:launch(launchConfig.program, launchConfig.args, launchCallbacks)
+				ioSession.writeResponse(launchSeq, true, "launch")
+			end
+		elseif command == "setBreakpoints" then
+			local args = request.arguments :: json.Object
+			local source = args.source :: dapTypes.Source
+			local path = source.path :: string
+			local newBreakpoints = args.breakpoints :: { dapTypes.SourceBreakpoint }?
+			local requestedBreakpoints = clearAndSetBreakpoints(target, path, newBreakpoints)
+
+			ioSession.writeResponse(reqSeq, true, command, nil, {
+				breakpoints = requestedBreakpoints,
+			})
+		elseif command == "continue" then
+			target:continueProcess()
+			ioSession.writeResponse(reqSeq, true, command)
+		elseif command == "pause" then
+			target:pauseProcess()
+			ioSession.writeResponse(reqSeq, true, command)
+		elseif command == "launch" then
+			local args = request.arguments :: dapTypes.LaunchArgs?
+			if args and args.program then
+				launchConfig = {
+					program = args.program,
+					args = args.args,
+				}
+				launchSeq = reqSeq
+				-- configuration is already done, respond to launch
+				if configurationDone then
+					target:launch(launchConfig.program, launchConfig.args, launchCallbacks)
+					ioSession.writeResponse(reqSeq, true, command)
+				end
+			end
+		-- dummy handler for threads
+		elseif command == "threads" then
+			ioSession.writeResponse(reqSeq, true, command, nil, {
+				threads = {
+					{ id = 1, name = "main thread" },
+				},
+			})
+		-- dummy handler for stackTrace
+		elseif command == "stackTrace" then
+			local launchPath = assert(launchConfig, "not launched")
+			ioSession.writeResponse(reqSeq, true, command, nil, {
+				stackFrames = {
+					{
+						id = 1,
+						name = "main",
+						source = { path = launchPath.program },
+						line = 1,
+						column = 0,
+					},
+				},
+				totalFrames = 1,
+			})
 		elseif command == "terminate" or command == "disconnect" then
 			ioSession.writeResponse(reqSeq, true, command)
+			ioSession.writeEvent("terminated")
 			break
-		elseif command == "launch" then
-			ioSession.writeResponse(reqSeq, true, command)
 		else
 			ioSession.writeResponse(reqSeq, false, command, `unsupported command: {command}`)
 		end

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -94,8 +94,8 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			-- configuration is done.
 			ioSession.writeResponse(reqSeq, true, command)
 			if launchConfig then
-				target:launch(launchConfig.program, launchConfig.args, launchCallbacks)
-				ioSession.writeResponse(launchSeq, true, "launch")
+				local launched = target:launch(launchConfig.program, launchConfig.args, launchCallbacks)
+				ioSession.writeResponse(launchSeq, launched, "launch")
 			end
 		elseif command == "setBreakpoints" then
 			local args = request.arguments :: json.Object
@@ -108,11 +108,11 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 				breakpoints = requestedBreakpoints,
 			})
 		elseif command == "continue" then
-			target:continueProcess()
-			ioSession.writeResponse(reqSeq, true, command)
+			local continued = target:continueProcess()
+			ioSession.writeResponse(reqSeq, continued, command)
 		elseif command == "pause" then
-			target:pauseProcess()
-			ioSession.writeResponse(reqSeq, true, command)
+			local paused = target:pauseProcess()
+			ioSession.writeResponse(reqSeq, paused, command)
 		elseif command == "launch" then
 			local args = request.arguments :: dapTypes.LaunchArgs?
 			if args and args.program then
@@ -123,8 +123,9 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 				launchSeq = reqSeq
 				-- configuration is already done, respond to launch
 				if configurationDone then
-					target:launch(launchConfig.program, launchConfig.args, launchCallbacks)
-					ioSession.writeResponse(reqSeq, true, command)
+					-- TODO: better error handling when launching. report the error back to the user.
+					local launched = target:launch(launchConfig.program, launchConfig.args, launchCallbacks)
+					ioSession.writeResponse(reqSeq, launched, command)
 				end
 			end
 		-- dummy handler for threads

--- a/lute/cli/commands/debug/dapTypes.luau
+++ b/lute/cli/commands/debug/dapTypes.luau
@@ -1,0 +1,36 @@
+-- while these types may have additional fields, we only record
+-- the ones the DAP server currently uses.
+
+export type Capabilitiy = {
+	supportConfigurationDoneRequest: boolean?,
+	supportTerminateRequest: boolean?,
+}
+
+export type Source = {
+	path: string?,
+	name: string?,
+}
+
+export type SourceBreakpoint = {
+	line: number,
+}
+
+export type SetBreakpointsArgs = {
+	source: Source,
+	breakpoints: { SourceBreakpoint }?,
+}
+
+export type Breakpoint = {
+	id: number?,
+	verified: boolean,
+	source: Source?,
+	reason: ("pending" | "failed")?,
+	line: number?,
+}
+
+export type LaunchArgs = {
+	program: string,
+	args: { string }?,
+}
+
+return {}

--- a/lute/cli/commands/debug/dapTypes.luau
+++ b/lute/cli/commands/debug/dapTypes.luau
@@ -1,14 +1,15 @@
--- while these types may have additional fields, we only record
--- the ones the DAP server currently uses.
+-- these types reflect our requirements for our implementation of DAP, not
+-- necessarily the actual DAP specification. For example, sources in DAP could have
+-- path be optional, but we enforce that it is required.
 
-export type Capabilitiy = {
-	supportConfigurationDoneRequest: boolean?,
-	supportTerminateRequest: boolean?,
+export type Capability = {
+	supportConfigurationDoneRequest: boolean,
+	supportTerminateRequest: boolean,
 }
 
 export type Source = {
-	path: string?,
-	name: string?,
+	path: string,
+	name: string?
 }
 
 export type SourceBreakpoint = {
@@ -17,15 +18,15 @@ export type SourceBreakpoint = {
 
 export type SetBreakpointsArgs = {
 	source: Source,
-	breakpoints: { SourceBreakpoint }?,
+	breakpoints: { SourceBreakpoint },
 }
 
 export type Breakpoint = {
-	id: number?,
+	id: number,
 	verified: boolean,
-	source: Source?,
+	source: Source,
 	reason: ("pending" | "failed")?,
-	line: number?,
+	line: number,
 }
 
 export type LaunchArgs = {

--- a/lute/cli/commands/debug/dapTypes.luau
+++ b/lute/cli/commands/debug/dapTypes.luau
@@ -9,7 +9,7 @@ export type Capability = {
 
 export type Source = {
 	path: string,
-	name: string?
+	name: string?,
 }
 
 export type SourceBreakpoint = {

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -37,6 +37,8 @@ struct Breakpoint
 
 struct LaunchConfig
 {
+    // onBreakpointInstall is called whenever an installation attempt is actually made, regardless
+    // of whether it resulted in being installed or the bp being invalid.
     std::function<void(const Breakpoint& bp)> onBreakpointInstall;
     std::function<void(const Breakpoint& bp)> onBreakpointUninstall;
     std::function<void(const Breakpoint& bp)> onBreakpointHit;

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -72,10 +72,10 @@ Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
     // they are scheduled for pending installs.
     if (childRuntime && paused)
     {
-        bool installed = installBreakpoint(childRuntime->GL, it->second);
+        installBreakpoint(childRuntime->GL, it->second);
         Breakpoint bpCopy = it->second;
         lock.unlock();
-        if (installed && launchConfig.onBreakpointInstall)
+        if (bpCopy.status != BreakpointStatus::PendingInstall && launchConfig.onBreakpointInstall)
             launchConfig.onBreakpointInstall(bpCopy);
         return bpCopy;
     }
@@ -251,7 +251,8 @@ std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> Target::modifyPendin
     {
         if (bp.status == BreakpointStatus::PendingInstall)
         {
-            if (installBreakpoint(L, bp) && launchConfig.onBreakpointInstall)
+            installBreakpoint(L, bp);
+            if (bp.status != BreakpointStatus::PendingInstall && launchConfig.onBreakpointInstall)
                 installedBpsCallback.emplace_back(bp);
         }
         if (bp.status == BreakpointStatus::PendingUninstall)

--- a/tests/cli/debug.test.luau
+++ b/tests/cli/debug.test.luau
@@ -123,9 +123,9 @@ test.suite("LuteDebug", function(suite)
 		dapStream.dapLoop(reader, write)
 		checkEquivalence(getWritten())
 	end)
-	-- tests specifically for DAP set breakpoints format
-	suite:case("luteDebugBreakpoints", function(assert)
-		local fixturePath = path.format(path.join(process.cwd(), "tests/src/debug/simple.luau"))
+	-- tests DAP setBreakpoints and loadedSources
+	suite:case("luteDebugBreakpointsSources", function(assert)
+		local fixturePath = path.format(path.join(process.cwd(), "tests/src/debug/loop.luau"))
 		local inMsg1 = makeMessage({
 			seq = 1,
 			type = "request",
@@ -136,49 +136,68 @@ test.suite("LuteDebug", function(suite)
 			seq = 2,
 			type = "request",
 			command = "setBreakpoints",
-			arguments = { source = { path = fixturePath }, breakpoints = { { line = 2 } } },
+			arguments = { source = { path = fixturePath }, breakpoints = { { line = 4 } } },
 		})
-		local inMsg3 = makeMessage({ seq = 3, type = "request", command = "terminate" })
-		local input = inMsg1 .. inMsg2 .. inMsg3
+		local inMsg3 = makeMessage({ seq = 3, type = "request", command = "configurationDone" })
+		local inMsg4 =
+			makeMessage({ seq = 4, type = "request", command = "launch", arguments = { program = fixturePath } })
+		local inMsg5 = makeMessage({ seq = 5, type = "request", command = "loadedSources" })
+		local inMsg6 = makeMessage({ seq = 6, type = "request", command = "terminate" })
+		local input = inMsg1 .. inMsg2 .. inMsg3 .. inMsg4 .. inMsg5 .. inMsg6
 
 		local write, getWritten, _ = makeWriter()
 		dapStream.dapLoop(makeChunkReader(input, #input), write)
 		local written = getWritten()
 
 		local msg1, rest1 = parseJsonMessage(written)
-		assert.eq(msg1.type, "response")
 		assert.eq(msg1.command, "initialize")
 		assert.eq(msg1.success, true)
 
 		local msg2, rest2 = parseJsonMessage(rest1)
-		assert.eq(msg2.type, "event")
 		assert.eq(msg2.event, "initialized")
 
 		local msg3, rest3 = parseJsonMessage(rest2)
-		assert.eq(msg3.type, "response")
 		assert.eq(msg3.command, "setBreakpoints")
 		assert.eq(msg3.success, true)
-		local body = msg3.body :: json.Object
-		local bps = json.asArray(body.breakpoints) :: json.Array
+		local bpBody = msg3.body :: json.Object
+		local bps = json.asArray(bpBody.breakpoints) :: json.Array
 		assert.that(bps ~= nil)
 		assert.eq(#bps, 1)
 		local bp = json.asObject(bps[1]) :: json.Object
 		assert.that(bp ~= nil)
 		assert.eq(bp.verified, false)
-		assert.eq(bp.line, 2)
+		assert.eq(bp.line, 4)
 		assert.eq(bp.reason, "pending")
 
 		local msg4, rest4 = parseJsonMessage(rest3)
-		assert.eq(msg4.type, "response")
-		assert.eq(msg4.command, "terminate")
+		assert.eq(msg4.command, "configurationDone")
 		assert.eq(msg4.success, true)
 
-		local msg5, _ = parseJsonMessage(rest4)
-		assert.eq(msg5.type, "event")
-		assert.eq(msg5.event, "terminated")
+		local msg5, rest5 = parseJsonMessage(rest4)
+		assert.eq(msg5.command, "launch")
+		assert.eq(msg5.success, true)
+
+		local msg6, rest6 = parseJsonMessage(rest5)
+		assert.eq(msg6.command, "loadedSources")
+		assert.eq(msg6.success, true)
+		local srcBody = msg6.body :: json.Object
+		local sources = json.asArray(srcBody.sources) :: json.Array
+		assert.that(sources ~= nil)
+		assert.eq(#sources, 1)
+		local source = json.asObject(sources[1]) :: json.Object
+		assert.that(source ~= nil)
+		assert.eq(source.path, fixturePath)
+		assert.eq(source.name, "loop.luau")
+
+		local msg7, rest7 = parseJsonMessage(rest6)
+		assert.eq(msg7.command, "terminate")
+		assert.eq(msg7.success, true)
+
+		local msg8, _ = parseJsonMessage(rest7)
+		assert.eq(msg8.event, "terminated")
 	end)
 	-- tests specifically for DAP unknown format
-	suite:case("unknown", function(assert)
+	suite:case("luteDebugUnknown", function(assert)
 		local inMsg1 = makeMessage({
 			seq = 1,
 			type = "request",
@@ -199,10 +218,12 @@ test.suite("LuteDebug", function(suite)
 		assert.eq(msg1.command, "bad")
 		assert.eq(msg1.message, "unsupported command: bad")
 		assert.eq(msg1.success, false)
+
 		local msg2, rest2 = parseJsonMessage(rest1)
 		assert.eq(msg2.type, "response")
 		assert.eq(msg2.command, "disconnect")
 		assert.eq(msg2.success, true)
+
 		local msg3, _ = parseJsonMessage(rest2)
 		assert.eq(msg3.type, "event")
 		assert.eq(msg3.event, "terminated")

--- a/tests/cli/debug.test.luau
+++ b/tests/cli/debug.test.luau
@@ -43,9 +43,8 @@ test.suite("LuteDebug", function(suite)
 	suite:case("luteDebugDAPStream", function(assert)
 		local input = 'Content-Length: 100\r\n\r\n{"seq":1,"type":"request","command":"initialize","arguments":{"clientID":"test","adapterID":"lute"}}'
 			.. 'Content-Length: 56\r\n\r\n{"seq":2,"type":"request","command":"configurationDone"}'
-			.. 'Content-Length: 45\r\n\r\n{"seq":3,"type":"request","command":"launch"}'
+			.. 'Content-Length: 82\r\n\r\n{"seq":3,"type":"request","command":"launch","arguments":{"program":"/test.luau"}}'
 			.. 'Content-Length: 48\r\n\r\n{"seq":4,"type":"request","command":"terminate"}'
-
 		local function checkEquivalence(written: string)
 			local msg1, rest1 = parseJsonMessage(written)
 			assert.eq(msg1.type, "response")

--- a/tests/cli/debug.test.luau
+++ b/tests/cli/debug.test.luau
@@ -85,12 +85,16 @@ test.suite("LuteDebug", function(suite)
 			assert.eq(msg4.request_seq, 3)
 			assert.eq(msg4.seq, 4)
 
-			local msg5, _ = parseJsonMessage(rest4)
+			local msg5, rest5 = parseJsonMessage(rest4)
 			assert.eq(msg5.type, "response")
 			assert.eq(msg5.command, "terminate")
 			assert.eq(msg5.success, true)
 			assert.eq(msg5.request_seq, 4)
 			assert.eq(msg5.seq, 5)
+
+			local msg6, _ = parseJsonMessage(rest5)
+			assert.eq(msg6.type, "event")
+			assert.eq(msg6.event, "terminated")
 		end
 
 		-- check for multiple different block sizes of the reader
@@ -172,6 +176,36 @@ test.suite("LuteDebug", function(suite)
 		local msg5, _ = parseJsonMessage(rest4)
 		assert.eq(msg5.type, "event")
 		assert.eq(msg5.event, "terminated")
+	end)
+	-- tests specifically for DAP unknown format
+	suite:case("unknown", function(assert)
+		local inMsg1 = makeMessage({
+			seq = 1,
+			type = "request",
+			command = "bad",
+		})
+		local inMsg2 = makeMessage({
+			seq = 2,
+			type = "request",
+			command = "disconnect",
+		})
+		local input = inMsg1 .. inMsg2
+		local write, getWritten, _ = makeWriter()
+		dapStream.dapLoop(makeChunkReader(input, #input), write)
+		local written = getWritten()
+
+		local msg1, rest1 = parseJsonMessage(written)
+		assert.eq(msg1.type, "response")
+		assert.eq(msg1.command, "bad")
+		assert.eq(msg1.message, "unsupported command: bad")
+		assert.eq(msg1.success, false)
+		local msg2, rest2 = parseJsonMessage(rest1)
+		assert.eq(msg2.type, "response")
+		assert.eq(msg2.command, "disconnect")
+		assert.eq(msg2.success, true)
+		local msg3, _ = parseJsonMessage(rest2)
+		assert.eq(msg3.type, "event")
+		assert.eq(msg3.event, "terminated")
 	end)
 	suite:case("luteDebugHelpMessage", function(assert)
 		local result = process.run({ lutePath, "debug", "-h" })

--- a/tests/cli/debug.test.luau
+++ b/tests/cli/debug.test.luau
@@ -7,6 +7,10 @@ local process = require("@std/process")
 local lutePath = path.format(process.execPath())
 local USAGE = "Usage: lute debug serve"
 
+local function normalizePath(p: string): string
+	return (p:gsub("\\", "/"))
+end
+
 local function makeMessage(obj: { [string]: any }): string
 	local body = json.serialize(obj)
 	return `Content-Length: {#body}\r\n\r\n{body}`
@@ -186,7 +190,7 @@ test.suite("LuteDebug", function(suite)
 		assert.eq(#sources, 1)
 		local source = json.asObject(sources[1]) :: json.Object
 		assert.that(source ~= nil)
-		assert.eq(source.path, fixturePath)
+		assert.eq(source.path, normalizePath(fixturePath))
 		assert.eq(source.name, "loop.luau")
 
 		local msg7, rest7 = parseJsonMessage(rest6)

--- a/tests/cli/debug.test.luau
+++ b/tests/cli/debug.test.luau
@@ -7,6 +7,11 @@ local process = require("@std/process")
 local lutePath = path.format(process.execPath())
 local USAGE = "Usage: lute debug serve"
 
+local function makeMessage(obj: { [string]: any }): string
+	local body = json.serialize(obj)
+	return `Content-Length: {#body}\r\n\r\n{body}`
+end
+
 local function makeChunkReader(readMessage: string, blockSize: number)
 	local pos = 1
 	return function()
@@ -40,11 +45,19 @@ local function parseJsonMessage(msg: string): (json.Object, string)
 end
 
 test.suite("LuteDebug", function(suite)
+	-- tests specifically for DAP Stream I/O
 	suite:case("luteDebugDAPStream", function(assert)
-		local input = 'Content-Length: 100\r\n\r\n{"seq":1,"type":"request","command":"initialize","arguments":{"clientID":"test","adapterID":"lute"}}'
-			.. 'Content-Length: 56\r\n\r\n{"seq":2,"type":"request","command":"configurationDone"}'
-			.. 'Content-Length: 82\r\n\r\n{"seq":3,"type":"request","command":"launch","arguments":{"program":"/test.luau"}}'
-			.. 'Content-Length: 48\r\n\r\n{"seq":4,"type":"request","command":"terminate"}'
+		local inMsg1 = makeMessage({
+			seq = 1,
+			type = "request",
+			command = "initialize",
+			arguments = { clientID = "test", adapterID = "lute" },
+		})
+		local inMsg2 = makeMessage({ seq = 2, type = "request", command = "configurationDone" })
+		local inMsg3 =
+			makeMessage({ seq = 3, type = "request", command = "launch", arguments = { program = "/test.luau" } })
+		local inMsg4 = makeMessage({ seq = 4, type = "request", command = "terminate" })
+		local input = inMsg1 .. inMsg2 .. inMsg3 .. inMsg4
 		local function checkEquivalence(written: string)
 			local msg1, rest1 = parseJsonMessage(written)
 			assert.eq(msg1.type, "response")
@@ -68,7 +81,7 @@ test.suite("LuteDebug", function(suite)
 			local msg4, rest4 = parseJsonMessage(rest3)
 			assert.eq(msg4.type, "response")
 			assert.eq(msg4.command, "launch")
-			assert.eq(msg4.success, true)
+			assert.eq(msg4.success, false)
 			assert.eq(msg4.request_seq, 3)
 			assert.eq(msg4.seq, 4)
 
@@ -105,6 +118,60 @@ test.suite("LuteDebug", function(suite)
 		clear()
 		dapStream.dapLoop(reader, write)
 		checkEquivalence(getWritten())
+	end)
+	-- tests specifically for DAP set breakpoints format
+	suite:case("luteDebugBreakpoints", function(assert)
+		local fixturePath = path.format(path.join(process.cwd(), "tests/src/debug/simple.luau"))
+		local inMsg1 = makeMessage({
+			seq = 1,
+			type = "request",
+			command = "initialize",
+			arguments = { clientID = "test", adapterID = "lute" },
+		})
+		local inMsg2 = makeMessage({
+			seq = 2,
+			type = "request",
+			command = "setBreakpoints",
+			arguments = { source = { path = fixturePath }, breakpoints = { { line = 2 } } },
+		})
+		local inMsg3 = makeMessage({ seq = 3, type = "request", command = "terminate" })
+		local input = inMsg1 .. inMsg2 .. inMsg3
+
+		local write, getWritten, _ = makeWriter()
+		dapStream.dapLoop(makeChunkReader(input, #input), write)
+		local written = getWritten()
+
+		local msg1, rest1 = parseJsonMessage(written)
+		assert.eq(msg1.type, "response")
+		assert.eq(msg1.command, "initialize")
+		assert.eq(msg1.success, true)
+
+		local msg2, rest2 = parseJsonMessage(rest1)
+		assert.eq(msg2.type, "event")
+		assert.eq(msg2.event, "initialized")
+
+		local msg3, rest3 = parseJsonMessage(rest2)
+		assert.eq(msg3.type, "response")
+		assert.eq(msg3.command, "setBreakpoints")
+		assert.eq(msg3.success, true)
+		local body = msg3.body :: json.Object
+		local bps = json.asArray(body.breakpoints) :: json.Array
+		assert.that(bps ~= nil)
+		assert.eq(#bps, 1)
+		local bp = json.asObject(bps[1]) :: json.Object
+		assert.that(bp ~= nil)
+		assert.eq(bp.verified, false)
+		assert.eq(bp.line, 2)
+		assert.eq(bp.reason, "pending")
+
+		local msg4, rest4 = parseJsonMessage(rest3)
+		assert.eq(msg4.type, "response")
+		assert.eq(msg4.command, "terminate")
+		assert.eq(msg4.success, true)
+
+		local msg5, _ = parseJsonMessage(rest4)
+		assert.eq(msg5.type, "event")
+		assert.eq(msg5.event, "terminated")
 	end)
 	suite:case("luteDebugHelpMessage", function(assert)
 		local result = process.run({ lutePath, "debug", "-h" })


### PR DESCRIPTION
A basic implementation of a DAP adapter that can handle breakpoints, continuing, and pausing
* Also changes `onBreakpointInstall` to signal when installation fails as well

<img width="1203" height="960" alt="Screenshot 2026-07-24 at 3 22 39 PM" src="https://github.com/user-attachments/assets/4db8b3e1-b760-4a2b-b3e8-434e465ff537" />
(Note: line highlighting is provided by stack frames, which is why it's stuck at line 1 above. really the important thing to look at is the breakpoints bar in the bottom left, where we can see that we've hit a bp)