### PR TITLE
`lute/debug`: inspect threads

### DIFF
--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -64,6 +64,10 @@ export type Target = {
 	pauseProcess: (self: Target) -> boolean,
 	--- Gets a list of all Luau coroutines that are being used by the script.
 	getThreads: (self: Target) -> { Thread },
+	--- Gets the main thread of the script, returning nil if debugger is not launched
+	getMainThread: (self: Target) -> Thread?,
+	--- Gets the current stopped thread of the script, returning nil if debugger is not paused
+	getStoppedThread: (self: Target) -> Thread?,
 }
 
 --- Create a new Target handle on the current VM.

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -31,7 +31,7 @@ export type LaunchConfig = {
 	onBreakpointUninstall: ((bp: Breakpoint) -> ())?,
 	--- called when the debugged script exits. `success` reflects if the script exited without errors.
 	onExit: ((success: boolean) -> ())?,
-	--- called when a pauseProcess() request ainterrupts thread `thread` and then actually stops all threads from execution.
+	--- called when a pauseProcess() interrupts `thread` and then actually stops all threads from execution.
 	onPause: ((thread: Thread) -> ())?,
 }
 

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -25,7 +25,7 @@ export type LaunchConfig = {
 	--- called when a breakpoint `bp` is hit; execution is paused until continueProcess() is called
 	onBreakpointHit: ((thread: Thread, bp: Breakpoint) -> ())?,
 	--- called when there is has been an attempt to install the breakpoint `bp` on the VM, regardless
-	--- of success and failure. check the status of `bp` to see if the attempt has succeeded or failed.	
+	--- of success and failure. check the status of `bp` to see if the attempt has succeeded or failed.
 	onBreakpointInstall: ((bp: Breakpoint) -> ())?,
 	--- called when a breakpoint `bp` is uninstalled from the VM
 	onBreakpointUninstall: ((bp: Breakpoint) -> ())?,

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -14,19 +14,25 @@ export type Breakpoint = {
 	status: BreakpointStatus,
 }
 
+--- A thread of execution, which represents one coroutine running on the runtime
+export type Thread = {
+	id: number,
+	name: string,
+}
+
 --- A set of callbacks that we configure before launching our debugger
 export type LaunchConfig = {
 	--- called when a breakpoint `bp` is hit; execution is paused until continueProcess() is called
-	onBreakpointHit: ((bp: Breakpoint) -> ())?,
+	onBreakpointHit: ((thread: Thread, bp: Breakpoint) -> ())?,
 	--- called when there is has been an attempt to install the breakpoint `bp` on the VM, regardless
-	--- of success and failure. check the status of `bp` to see if the attempt has succeeded or failed.
+	--- of success and failure. check the status of `bp` to see if the attempt has succeeded or failed.	
 	onBreakpointInstall: ((bp: Breakpoint) -> ())?,
 	--- called when a breakpoint `bp` is uninstalled from the VM
 	onBreakpointUninstall: ((bp: Breakpoint) -> ())?,
 	--- called when the debugged script exits. `success` reflects if the script exited without errors.
 	onExit: ((success: boolean) -> ())?,
-	--- called when a script actually pauses execution after a call to pauseProcess().
-	onPause: (() -> ())?,
+	--- called when a pauseProcess() request ainterrupts thread `thread` and then actually stops all threads from execution.
+	onPause: ((thread: Thread) -> ())?,
 }
 
 --- A `Target` represents the target program under the debugger.
@@ -56,6 +62,8 @@ export type Target = {
 	--- Pauses a target script if it is running. Return `true` if the target was successfully paused
 	--- and `false` if it was not.
 	pauseProcess: (self: Target) -> boolean,
+	--- Gets a list of all Luau coroutines that are being used by the script.
+	getThreads: (self: Target) -> { Thread },
 }
 
 --- Create a new Target handle on the current VM.

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -22,7 +22,7 @@ export type Thread = {
 
 --- A set of callbacks that we configure before launching our debugger
 export type LaunchConfig = {
-	--- called when a breakpoint `bp` is hit; execution is paused until continueProcess() is called
+	--- called when a breakpoint `bp` is hit on `thread`; execution is paused until continueProcess() is called
 	onBreakpointHit: ((thread: Thread, bp: Breakpoint) -> ())?,
 	--- called when there is has been an attempt to install the breakpoint `bp` on the VM, regardless
 	--- of success and failure. check the status of `bp` to see if the attempt has succeeded or failed.

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -45,10 +45,10 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 	local ioSession = dapStream.makeDapStreamSession(reader, writer)
 	local target = debugger.newTarget()
 	local launchCallbacks: debugger.LaunchConfig = {
-		onBreakpointHit = function(bp: debugger.Breakpoint)
+		onBreakpointHit = function(thread: debugger.Thread, bp: debugger.Breakpoint)
 			ioSession.writeEvent("stopped", {
 				reason = "breakpoint",
-				threadId = 1,
+				threadId = thread.id,
 				hitBreakpointIds = { bp.id },
 			})
 		end,
@@ -66,10 +66,10 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			ioSession.writeEvent("terminated")
 		end,
 		-- we need to give a thread ID upon pausing for VSCode UI
-		onPause = function()
+		onPause = function(thread: debugger.Thread)
 			ioSession.writeEvent("stopped", {
 				reason = "pause",
-				threadId = 1,
+				threadId = thread.id,
 			})
 		end,
 	}
@@ -141,12 +141,17 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			ioSession.writeResponse(reqSeq, true, command, nil, {
 				sources = dapSources,
 			})
-		-- dummy handler for threads
 		elseif command == "threads" then
+			local threads = target:getThreads()
+			local dapThreads = {}
+			for _, thread in threads do
+				table.insert(dapThreads, {
+					id = thread.id,
+					name = thread.name,
+				})
+			end
 			ioSession.writeResponse(reqSeq, true, command, nil, {
-				threads = {
-					{ id = 1, name = "main thread" },
-				},
+				threads = dapThreads,
 			})
 		-- dummy handler for stackTrace
 		elseif command == "stackTrace" then
@@ -154,7 +159,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			ioSession.writeResponse(reqSeq, true, command, nil, {
 				stackFrames = {
 					{
-						id = 1,
+						id = 0,
 						name = "main",
 						source = { path = launchPath.program },
 						line = 1,

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -50,6 +50,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 				reason = "breakpoint",
 				threadId = thread.id,
 				hitBreakpointIds = { bp.id },
+				allThreadsStopped = true,
 			})
 		end,
 		onBreakpointInstall = function(bp: debugger.Breakpoint)
@@ -70,6 +71,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			ioSession.writeEvent("stopped", {
 				reason = "pause",
 				threadId = thread.id,
+				allThreadsStopped = true,
 			})
 		end,
 	}

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -86,8 +86,9 @@ struct Target
     std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
 
     // For inspection while paused:
-    // About multiple coroutines: we don't currently handle task.spawn() but do handle task.defer().
-    // The difference is that task.spawn() tries to run the coroutine inline with our current execution, resulting
+    // About multiple coroutines: we don't currently handle the original implementation of task.spawn(). Calling
+    // task.spawn() in the debugger calls task.defer() instead.
+    // The difference is that the original task.spawn() tries to run the coroutine inline with our current execution, resulting
     // in issues when trying to pause. Similar methods that also run coroutines inline with our current execution will not work.
     // In contrast, in task.defer(), the coroutine is added to set of running coroutines but execution
     // is deferred. Our pause mechanism will then work correctly.
@@ -110,7 +111,7 @@ private:
     int currentBreakpointId = 0;
     bool paused = true;
     bool launched = false;
-    std::unordered_map<int, Breakpoint> breakpoints; // breakpoint id -> breakpoint object (this is unordered_map to support erase)
+    std::unordered_map<int, Breakpoint> breakpoints;    // breakpoint id -> breakpoint object (this is unordered_map to support erase)
     std::unordered_set<lua_State*> continueRequestedBp; // if the thread's lua_State* is in this set, we skip the next bp it hits
     std::optional<Breakpoint> bpHit;
     LaunchConfig launchConfig;

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -87,7 +87,7 @@ struct Target
 
     // For inspection while paused:
     // About multiple coroutines: we don't currently handle the original implementation of task.spawn(). Calling
-    // task.spawn() in the debugger calls task.defer() instead.
+    // task.spawn() when working in the debugger instead calls task.defer() instead.
     // The difference is that the original task.spawn() tries to run the coroutine inline with our current execution, resulting
     // in issues when trying to pause. Similar methods that also run coroutines inline with our current execution will not work.
     // In contrast, in task.defer(), the coroutine is added to set of running coroutines but execution

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 struct lua_State;
@@ -35,15 +36,25 @@ struct Breakpoint
     explicit Breakpoint(int id, std::string sourcePath, int line, BreakpointStatus status);
 };
 
+// Each Thread represents one coroutine in our Lute runtime.
+struct Thread
+{
+    int id = -1;
+    std::string name;
+    Thread() = default; // for unordered_map
+    Thread(int id, std::string name);
+    bool operator==(const Thread& other) const;
+};
+
 struct LaunchConfig
 {
     // onBreakpointInstall is called whenever an installation attempt is actually made, regardless
     // of whether it resulted in being installed or the bp being invalid.
     std::function<void(const Breakpoint& bp)> onBreakpointInstall;
     std::function<void(const Breakpoint& bp)> onBreakpointUninstall;
-    std::function<void(const Breakpoint& bp)> onBreakpointHit;
+    std::function<void(const Thread& thread, const Breakpoint& bp)> onBreakpointHit;
     std::function<void(bool success)> onExit;
-    std::function<void()> onPause;
+    std::function<void(const Thread& thread)> onPause;
 };
 
 struct Target
@@ -74,6 +85,9 @@ struct Target
     std::optional<Breakpoint> getBreakpointById(int breakpointId) const;
     std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
 
+    // For inspection while paused:
+    std::vector<Thread> getThreads() const;
+
     // For actively running scripts:
     bool launch(std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
     bool continueProcess();
@@ -92,7 +106,7 @@ private:
     bool paused = true;
     bool launched = false;
     std::unordered_map<int, Breakpoint> breakpoints; // breakpoint id -> breakpoint object (this is unordered_map to support erase)
-    bool continueRequestedBp = false;
+    std::unordered_set<lua_State*> continueRequestedBp; // if the thread's lua_State* is in this set, we skip the next bp it hits
     std::optional<Breakpoint> bpHit;
     LaunchConfig launchConfig;
 
@@ -107,6 +121,11 @@ private:
     // for require contexts
     std::unique_ptr<RequireCtx> requireCtx;
 
+    // thread information
+    int threadId = 0;
+    std::unordered_map<lua_State*, Thread> stateToThread; // lua_State* -> thread information about that state
+    std::unordered_map<int, lua_State*> threadIdToState;  // thread id -> lua_State*
+
     // private methods are meant for internal calls, so these don't lock targetMutex
     std::optional<Breakpoint> getBreakpointBySourceLineHelper(std::string source, int line) const;
     std::optional<Breakpoint> getBreakpointByIdHelper(int breakpointId) const;
@@ -117,5 +136,6 @@ private:
 
     void installBpHitCallback();
     void installExitCallback();
+    void installThreadCallback();
 };
 } // namespace debug

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -41,7 +41,6 @@ struct Thread
 {
     int id = -1;
     std::string name;
-    Thread() = default; // for unordered_map
     Thread(int id, std::string name);
     bool operator==(const Thread& other) const;
 };
@@ -92,6 +91,8 @@ struct Target
     // in issues when trying to pause. Similar methods that also run coroutines inline with our current execution will not work.
     // In contrast, in task.defer(), the coroutine is added to set of running coroutines but execution
     // is deferred. Our pause mechanism will then work correctly.
+    std::optional<Thread> getMainThread() const;
+    std::optional<Thread> getStoppedThread() const;
     std::vector<Thread> getThreads() const;
 
     // For actively running scripts:

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -108,7 +108,7 @@ private:
     Runtime& parentRuntime;
     std::unique_ptr<Runtime> childRuntime;
 
-    int currentBreakpointId = 0;
+    int currentBreakpointId = 1;
     bool paused = true;
     bool launched = false;
     std::unordered_map<int, Breakpoint> breakpoints;    // breakpoint id -> breakpoint object (this is unordered_map to support erase)
@@ -128,7 +128,7 @@ private:
     std::unique_ptr<RequireCtx> requireCtx;
 
     // thread information
-    int threadId = 0;
+    int threadId = 1;
     std::unordered_map<lua_State*, Thread> stateToThread; // lua_State* -> thread information about that state
     std::unordered_map<int, lua_State*> threadIdToState;  // thread id -> lua_State*
 

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -86,6 +86,11 @@ struct Target
     std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
 
     // For inspection while paused:
+    // About multiple coroutines: we don't currently handle task.spawn() but do handle task.defer().
+    // The difference is that task.spawn() tries to run the coroutine inline with our current execution, resulting
+    // in issues when trying to pause. Similar methods that also run coroutines inline with our current execution will not work.
+    // In contrast, in task.defer(), the coroutine is added to set of running coroutines but execution
+    // is deferred. Our pause mechanism will then work correctly.
     std::vector<Thread> getThreads() const;
 
     // For actively running scripts:

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -378,7 +378,7 @@ static const std::unordered_map<std::string, lua_CFunction> kTargetMethods = {
     {"continueProcess", debug::target_continueProcess},
     {"pauseProcess", debug::target_pauseProcess},
     {"getLoadedSources", debug::target_getLoadedSources},
-    {"getThreasd", debug::target_getThreads}
+    {"getThreads", debug::target_getThreads}
 };
 
 static void initializeTarget(lua_State* L)

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -221,6 +221,38 @@ static int target_getThreads(lua_State* L)
     return 1;
 }
 
+// target.getMainThread()
+// returns Thread | nil
+static int target_getMainThread(lua_State* L)
+{
+    auto target = getTarget(L, 1);
+    std::optional<Thread> thread = target->getMainThread();
+    checkStack(L, 1);
+    if (!thread)
+    {
+        checkStack(L, 1);
+        lua_pushnil(L);
+        return 1;
+    }
+    return pushThread(L, *thread);
+}
+
+// target.getStoppedThread()
+// returns Thread | nil
+static int target_getStoppedThread(lua_State* L)
+{
+    auto target = getTarget(L, 1);
+    std::optional<Thread> thread = target->getStoppedThread();
+    checkStack(L, 1);
+    if (!thread)
+    {
+        checkStack(L, 1);
+        lua_pushnil(L);
+        return 1;
+    }
+    return pushThread(L, *thread);
+}
+
 static std::shared_ptr<Ref> getOptionalCallback(lua_State* L, int tableIndex, const char* field)
 {
     lua_getfield(L, tableIndex, field);
@@ -378,7 +410,9 @@ static const std::unordered_map<std::string, lua_CFunction> kTargetMethods = {
     {"continueProcess", debug::target_continueProcess},
     {"pauseProcess", debug::target_pauseProcess},
     {"getLoadedSources", debug::target_getLoadedSources},
-    {"getThreads", debug::target_getThreads}
+    {"getThreads", debug::target_getThreads},
+    {"getMainThread", debug::target_getMainThread},
+    {"getStoppedThread", debug::target_getStoppedThread},
 };
 
 static void initializeTarget(lua_State* L)

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -83,6 +83,20 @@ static int pushBreakpoint(lua_State* L, const Breakpoint& bp)
     return 1;
 }
 
+// Helper to push a Thread type, which is
+// id: number
+// name: string
+static int pushThread(lua_State* L, const debug::Thread& thread)
+{
+    checkStack(L, 2);
+    lua_createtable(L, 0, 2);
+    lua_pushinteger(L, thread.id);
+    lua_setfield(L, -2, "id");
+    lua_pushstring(L, thread.name.c_str());
+    lua_setfield(L, -2, "name");
+    return 1;
+}
+
 // target.setBreakpoint(string sourcePath, int line)
 // returns a breakpoint
 static int target_setBreakpoint(lua_State* L)
@@ -191,6 +205,22 @@ static int target_getLoadedSources(lua_State* L)
     return 1;
 }
 
+// target.getThreads()
+// returns a table of Threads
+static int target_getThreads(lua_State* L)
+{
+    auto target = getTarget(L, 1);
+    const std::vector<debug::Thread>& threads = target->getThreads();
+    checkStack(L, 1);
+    lua_createtable(L, threads.size(), 0);
+    for (int i = 0; i < (int)threads.size(); i++)
+    {
+        pushThread(L, threads.at(i));
+        lua_rawseti(L, -2, i + 1);
+    }
+    return 1;
+}
+
 static std::shared_ptr<Ref> getOptionalCallback(lua_State* L, int tableIndex, const char* field)
 {
     lua_getfield(L, tableIndex, field);
@@ -218,11 +248,11 @@ static std::function<void(const Breakpoint&)> makeBreakpointCallback(std::shared
 
 // target.launch(string sourcePath, vector<string> args, LaunchConfig callbacks) where
 // LaunchConfig = {
-//     onBreakpointHit(Breakpoint bp) -> ()
+//     onBreakpointHit(Thread thread, Breakpoint bp) -> ()
 //     onBreakpointInstall(Breakpoint bp) -> ()
 //     onBreakpointUninstall(Breakpoint bp) -> ()
 //     onExit(bool success) -> ()
-//     onPause() -> ()
+//     onPause(Thread thread) -> ()
 // }
 // returns boolean
 static int target_launch(lua_State* L)
@@ -251,7 +281,18 @@ static int target_launch(lua_State* L)
     {
         // all of these schedule the handler to run on the parent runtime queue.
         if (auto ref = getOptionalCallback(L, 4, "onBreakpointHit"))
-            config.onBreakpointHit = makeBreakpointCallback(ref, runtime);
+            config.onBreakpointHit = [ref, runtime](const Thread& thread, const Breakpoint& bp)
+            {
+                runtime->scheduleLuauCallback(
+                    ref,
+                    [thread, bp](lua_State* L)
+                    {
+                        pushThread(L, thread);
+                        pushBreakpoint(L, bp);
+                        return 2;
+                    }
+                );
+            };
         if (auto ref = getOptionalCallback(L, 4, "onBreakpointInstall"))
             config.onBreakpointInstall = makeBreakpointCallback(ref, runtime);
         if (auto ref = getOptionalCallback(L, 4, "onBreakpointUninstall"))
@@ -273,13 +314,14 @@ static int target_launch(lua_State* L)
         }
         if (auto ref = getOptionalCallback(L, 4, "onPause"))
         {
-            config.onPause = [ref, runtime]()
+            config.onPause = [ref, runtime](const Thread& thread)
             {
                 runtime->scheduleLuauCallback(
                     ref,
-                    [](lua_State* L)
+                    [thread](lua_State* L)
                     {
-                        return 0;
+                        pushThread(L, thread);
+                        return 1;
                     }
                 );
             };
@@ -336,6 +378,7 @@ static const std::unordered_map<std::string, lua_CFunction> kTargetMethods = {
     {"continueProcess", debug::target_continueProcess},
     {"pauseProcess", debug::target_pauseProcess},
     {"getLoadedSources", debug::target_getLoadedSources},
+    {"getThreasd", debug::target_getThreads}
 };
 
 static void initializeTarget(lua_State* L)

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -376,7 +376,7 @@ bool Target::launch(std::string sourcePath, const std::vector<std::string>& args
         // thread initialization
         scriptThread = thread;
         threadIdToState.insert_or_assign(threadId, thread);
-        stateToThread.insert_or_assign(thread, Thread(threadId, "Coroutine " + std::to_string(threadId)));
+        stateToThread.insert_or_assign(thread, Thread(threadId, "Main Coroutine"));
         threadId++;
 
         lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
@@ -501,13 +501,21 @@ void Target::installThreadCallback()
     };
 }
 
-
 std::optional<Thread> Target::getMainThread() const
 {
     std::unique_lock lock(targetMutex);
     if (!launched)
         return std::nullopt;
     return stateToThread.at(scriptThread);
+}
+
+
+std::optional<Thread> Target::getStoppedThread() const
+{
+    std::unique_lock lock(targetMutex);
+    if (!launched || !paused)
+        return std::nullopt;
+    return stateToThread.at(stoppedThread);
 }
 
 std::vector<Thread> Target::getThreads() const

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -405,8 +405,9 @@ void Target::installBpHitCallback()
     cb->debugbreak = [](lua_State* L, lua_Debug* ar)
     {
         auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
-        // We land on the same instruction after a continue() after hitting a bp so we basically don't do anything
         std::unique_lock lock(target->targetMutex);
+        // We land on the same instruction after a continue() after hitting a bp so if we have
+        // already have continue() on this thread, we basically don't do anything
         if (auto it = target->continueRequestedBp.find(L); it != target->continueRequestedBp.end())
         {
             target->continueRequestedBp.erase(it);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -375,8 +375,8 @@ bool Target::launch(std::string sourcePath, const std::vector<std::string>& args
 
         // thread initialization
         scriptThread = thread;
-        threadIdToState[threadId] = thread;
-        stateToThread[thread] = Thread(threadId, "Coroutine " + std::to_string(threadId));
+        threadIdToState.insert_or_assign(threadId, thread);
+        stateToThread.insert_or_assign(thread, Thread(threadId, "Coroutine " + std::to_string(threadId)));
         threadId++;
 
         lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
@@ -432,7 +432,7 @@ void Target::installBpHitCallback()
             target->stoppedThread = L;
             lua_break(L);
             auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
-            debug::Thread thread = target->stateToThread[L];
+            debug::Thread thread = target->stateToThread.at(L);
             lock.unlock();
             if (target->launchConfig.onBreakpointHit)
                 target->launchConfig.onBreakpointHit(thread, bp.value());
@@ -477,15 +477,12 @@ void Target::installThreadCallback()
         // this means a thread is being garbage collected
         if (LP == nullptr)
         {
+
             if (auto it = target->stateToThread.find(L); it != target->stateToThread.end())
             {
                 int id = it->second.id;
                 target->stateToThread.erase(it);
-                if (auto it2 = target->threadIdToState.find(id); it2 != target->threadIdToState.end())
-                {
-                    target->threadIdToState.erase(it2);
-                }
-                else
+                if (target->threadIdToState.erase(id) == 0)
                 {
                     target->parentRuntime.reporter.reportError(Luau::format("userthread callback fired for unregistered thread id %d", id));
                 }
@@ -497,11 +494,20 @@ void Target::installThreadCallback()
         }
         else
         {
-            target->threadIdToState[target->threadId] = L;
-            target->stateToThread[L] = Thread(target->threadId, "Coroutine " + std::to_string(target->threadId));
+            target->threadIdToState.insert_or_assign(target->threadId, L);
+            target->stateToThread.insert_or_assign(L, Thread(target->threadId, "Coroutine " + std::to_string(target->threadId)));
             target->threadId++;
         }
     };
+}
+
+
+std::optional<Thread> Target::getMainThread() const
+{
+    std::unique_lock lock(targetMutex);
+    if (!launched)
+        return std::nullopt;
+    return stateToThread.at(scriptThread);
 }
 
 std::vector<Thread> Target::getThreads() const
@@ -568,7 +574,7 @@ bool Target::pauseProcess()
         target->paused = true;
         target->childRuntime->stopDebug();
         target->stoppedThread = L;
-        debug::Thread thread = target->stateToThread[L];
+        debug::Thread thread = target->stateToThread.at(L);
         // We transition into a paused state. Let's modify all pending breakpoints.
         auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
         lua_break(L);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -536,7 +536,6 @@ bool Target::continueProcess()
             if (currentBp && currentBp->status == BreakpointStatus::Installed)
                 continueRequestedBp.insert(stoppedThread);
             bpHit = std::nullopt;
-            stoppedBpLine = -1;
         }
         childRuntime->runningThreads.push_back({true, getRefForThread(stoppedThread), 0});
         // This schedule() wakes up the runtime in runContinuously() to re-run runToCompletion() in case that has exited. This is a no-op if

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -40,7 +40,7 @@ Thread::Thread(int id, std::string name)
 
 bool Thread::operator==(const Thread& other) const
 {
-    return id == other.id;
+    return id == other.id && name == other.name;
 }
 
 Target::Target(Runtime& parentRuntime)

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -32,6 +32,17 @@ Breakpoint::Breakpoint(int id, std::string sourcePath, int line, BreakpointStatu
 {
 }
 
+Thread::Thread(int id, std::string name)
+    : id(id)
+    , name(name)
+{
+}
+
+bool Thread::operator==(const Thread& other) const
+{
+    return id == other.id;
+}
+
 Target::Target(Runtime& parentRuntime)
     : parentRuntime(parentRuntime)
     , loadedSources("")
@@ -362,11 +373,18 @@ bool Target::launch(std::string sourcePath, const std::vector<std::string>& args
         childRuntime->runningThreads.push_back({true, getRefForThread(thread), static_cast<int>(args.size())});
         lua_pop(childRuntime->GL, 1);
 
+        // thread initialization
         scriptThread = thread;
+        threadIdToState[threadId] = thread;
+        stateToThread[thread] = Thread(threadId, "Coroutine " + std::to_string(threadId));
+        threadId++;
+
         lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
         cb->userdata = this;
         installBpHitCallback();
         installExitCallback();
+        installThreadCallback();
+
         // All VM setup happens synchronously before runContinuously starts the background thread.
         // The no-op schedule wakes the event loop so it picks up the queued thread.
         paused = false;
@@ -389,9 +407,9 @@ void Target::installBpHitCallback()
         auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
         // We land on the same instruction after a continue() after hitting a bp so we basically don't do anything
         std::unique_lock lock(target->targetMutex);
-        if (target->continueRequestedBp)
+        if (auto it = target->continueRequestedBp.find(L); it != target->continueRequestedBp.end())
         {
-            target->continueRequestedBp = false;
+            target->continueRequestedBp.erase(it);
             return;
         }
         lua_Debug info = {};
@@ -413,9 +431,10 @@ void Target::installBpHitCallback()
             target->stoppedThread = L;
             lua_break(L);
             auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
+            debug::Thread thread = target->stateToThread[L];
             lock.unlock();
             if (target->launchConfig.onBreakpointHit)
-                target->launchConfig.onBreakpointHit(bp.value());
+                target->launchConfig.onBreakpointHit(thread, bp.value());
             for (auto& bp : installed)
                 target->launchConfig.onBreakpointInstall(bp);
             for (auto& bp : uninstalled)
@@ -446,33 +465,84 @@ void Target::installExitCallback()
     childRuntime->addThreadCompletionHandler(scriptThread, std::move(completion));
 }
 
+void Target::installThreadCallback()
+{
+    lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
+    cb->userthread = [](lua_State* LP, lua_State* L)
+    {
+        auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
+        std::unique_lock lock(target->targetMutex);
+
+        // this means a thread is being garbage collected
+        if (LP == nullptr)
+        {
+            if (auto it = target->stateToThread.find(L); it != target->stateToThread.end())
+            {
+                int id = it->second.id;
+                target->stateToThread.erase(it);
+                if (auto it2 = target->threadIdToState.find(id); it2 != target->threadIdToState.end())
+                {
+                    target->threadIdToState.erase(it2);
+                }
+                else
+                {
+                    target->parentRuntime.reporter.reportError(Luau::format("userthread callback fired for unregistered thread id %d", id));
+                }
+            }
+            else
+            {
+                target->parentRuntime.reporter.reportError(Luau::format("userthread callback fired for unregistered lua_State* %p", (void*)L));
+            }
+        }
+        else
+        {
+            target->threadIdToState[target->threadId] = L;
+            target->stateToThread[L] = Thread(target->threadId, "Coroutine " + std::to_string(target->threadId));
+            target->threadId++;
+        }
+    };
+}
+
+std::vector<Thread> Target::getThreads() const
+{
+    std::unique_lock lock(targetMutex);
+    std::vector<Thread> result;
+    for (auto& [L, thread] : stateToThread)
+    {
+        if (lua_costatus(childRuntime->GL, L) != LUA_COFIN && lua_costatus(childRuntime->GL, L) != LUA_COERR)
+            result.emplace_back(thread);
+    }
+    return result;
+}
+
 bool Target::continueProcess()
 {
 
     std::unique_lock lock(targetMutex);
     if (!launched || !paused)
         return false;
+    // this clears the interrupts that triggers when the process is paused from client request
+    // in case it has not actually been triggered.
+    lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
+    cb->interrupt = nullptr;
     if (stoppedThread)
     {
+        // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
+        if (bpHit)
+        {
+            // we need to check if our breakpoint is still currently installed after
+            // onBreakpointHit() callback
+            std::optional<Breakpoint> currentBp = getBreakpointByIdHelper(bpHit->id);
+            if (currentBp && currentBp->status == BreakpointStatus::Installed)
+                continueRequestedBp.insert(stoppedThread);
+            bpHit = std::nullopt;
+            stoppedBpLine = -1;
+        }
         childRuntime->runningThreads.push_back({true, getRefForThread(stoppedThread), 0});
         // This schedule() wakes up the runtime in runContinuously() to re-run runToCompletion() in case that has exited. This is a no-op if
         // runToCompletion() has not exited.
         childRuntime->schedule([]() {});
         stoppedThread = nullptr;
-    }
-    // this clears the interrupts that triggers when the process is paused from client request
-    // in case it has not actually been triggered.
-    lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
-    cb->interrupt = nullptr;
-    // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
-    if (bpHit)
-    {
-        // we need to check if our breakpoint is still currently installed after
-        // onBreakpointHit() callback
-        std::optional<Breakpoint> currentBp = getBreakpointByIdHelper(bpHit->id);
-        if (currentBp && currentBp->status == BreakpointStatus::Installed)
-            continueRequestedBp = true;
-        bpHit = std::nullopt;
     }
     paused = false;
     childRuntime->continueDebug();
@@ -498,6 +568,7 @@ bool Target::pauseProcess()
         target->paused = true;
         target->childRuntime->stopDebug();
         target->stoppedThread = L;
+        debug::Thread thread = target->stateToThread[L];
         // We transition into a paused state. Let's modify all pending breakpoints.
         auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
         lua_break(L);
@@ -506,7 +577,7 @@ bool Target::pauseProcess()
         lock.unlock();
         // Since pausing actually only happens when the interrupt callback runs we have a callback
         if (target->launchConfig.onPause)
-            target->launchConfig.onPause();
+            target->launchConfig.onPause(thread);
         for (auto& bp : installed)
             target->launchConfig.onBreakpointInstall(bp);
         for (auto& bp : uninstalled)

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -138,6 +138,7 @@ struct Runtime
     std::function<void*(lua_State*)> requireContextFactory;
 
     // for debug mode only:
+    const bool debugMode;
     void stopDebug();
     void continueDebug();
 
@@ -158,7 +159,6 @@ private:
     uv_loop_t eventLoop;
 
     // for debug mode only:
-    const bool debugMode;
     std::mutex debugMutex;
     std::atomic<bool> debugStopped = false;
     std::condition_variable debugStoppedCv;

--- a/lute/task/src/task.cpp
+++ b/lute/task/src/task.cpp
@@ -185,6 +185,11 @@ private:
 int lua_spawn(lua_State* L)
 {
     LuaThread newThread{L, "task.spawn"};
+    // In debug mode, if we run new thread inline, our pausing mechanism
+    // does not work, so we switch to deferring.
+    Runtime* runtime = getRuntime(L);
+    if (runtime && runtime->debugMode)
+        return newThread.defer();
     return newThread.resume();
 }
 

--- a/tests/cli/debug.test.luau
+++ b/tests/cli/debug.test.luau
@@ -203,8 +203,8 @@ test.suite("LuteDebug", function(suite)
 		assert.eq(#threads, 1)
 		local thread = json.asObject(threads[1]) :: json.Object
 		assert.that(thread ~= nil)
-		assert.eq(thread.id, 0)
-		assert.eq(thread.name, "Coroutine 0")
+		assert.eq(thread.id, 1)
+		assert.eq(thread.name, "Coroutine 1")
 
 		local msg8, rest8 = parseJsonMessage(rest7)
 		assert.eq(msg8.command, "terminate")

--- a/tests/cli/debug.test.luau
+++ b/tests/cli/debug.test.luau
@@ -204,7 +204,7 @@ test.suite("LuteDebug", function(suite)
 		local thread = json.asObject(threads[1]) :: json.Object
 		assert.that(thread ~= nil)
 		assert.eq(thread.id, 1)
-		assert.eq(thread.name, "Coroutine 1")
+		assert.eq(thread.name, "Main Coroutine")
 
 		local msg8, rest8 = parseJsonMessage(rest7)
 		assert.eq(msg8.command, "terminate")

--- a/tests/cli/debug.test.luau
+++ b/tests/cli/debug.test.luau
@@ -127,8 +127,8 @@ test.suite("LuteDebug", function(suite)
 		dapStream.dapLoop(reader, write)
 		checkEquivalence(getWritten())
 	end)
-	-- tests DAP setBreakpoints and loadedSources
-	suite:case("luteDebugBreakpointsSources", function(assert)
+	-- tests DAP can launch code, then tests setBreakpoints, threads, loadedSources
+	suite:case("luteDebugLaunch", function(assert)
 		local fixturePath = path.format(path.join(process.cwd(), "tests/src/debug/loop.luau"))
 		local inMsg1 = makeMessage({
 			seq = 1,
@@ -146,8 +146,9 @@ test.suite("LuteDebug", function(suite)
 		local inMsg4 =
 			makeMessage({ seq = 4, type = "request", command = "launch", arguments = { program = fixturePath } })
 		local inMsg5 = makeMessage({ seq = 5, type = "request", command = "loadedSources" })
-		local inMsg6 = makeMessage({ seq = 6, type = "request", command = "terminate" })
-		local input = inMsg1 .. inMsg2 .. inMsg3 .. inMsg4 .. inMsg5 .. inMsg6
+		local inMsg6 = makeMessage({ seq = 5, type = "request", command = "threads" })
+		local inMsg7 = makeMessage({ seq = 6, type = "request", command = "terminate" })
+		local input = inMsg1 .. inMsg2 .. inMsg3 .. inMsg4 .. inMsg5 .. inMsg6 .. inMsg7
 
 		local write, getWritten, _ = makeWriter()
 		dapStream.dapLoop(makeChunkReader(input, #input), write)
@@ -194,11 +195,23 @@ test.suite("LuteDebug", function(suite)
 		assert.eq(source.name, "loop.luau")
 
 		local msg7, rest7 = parseJsonMessage(rest6)
-		assert.eq(msg7.command, "terminate")
+		assert.eq(msg7.command, "threads")
 		assert.eq(msg7.success, true)
+		local threadBody = msg7.body :: json.Object
+		local threads = json.asArray(threadBody.threads) :: json.Array
+		assert.that(threads ~= nil)
+		assert.eq(#threads, 1)
+		local thread = json.asObject(threads[1]) :: json.Object
+		assert.that(thread ~= nil)
+		assert.eq(thread.id, 0)
+		assert.eq(thread.name, "Coroutine 0")
 
-		local msg8, _ = parseJsonMessage(rest7)
-		assert.eq(msg8.event, "terminated")
+		local msg8, rest8 = parseJsonMessage(rest7)
+		assert.eq(msg8.command, "terminate")
+		assert.eq(msg8.success, true)
+
+		local msg9, _ = parseJsonMessage(rest8)
+		assert.eq(msg9.event, "terminated")
 	end)
 	-- tests specifically for DAP unknown format
 	suite:case("luteDebugUnknown", function(assert)

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -35,7 +35,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		check.eq(bp.status, "pendingInstall")
 		local numHits, onFinished, numBreakpointsInstalled = 0, false, 0
 		local targetLaunched = target:launch(fixturePath, {}, {
-			onBreakpointHit = function(_bp)
+			onBreakpointHit = function(_thread, _bp)
 				numHits += 1
 				local continued = target:continueProcess()
 				check.that(continued)
@@ -91,7 +91,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		check.eq(bpGet, nil)
 		local numHitsBp2, numHitsBp3, onFinished, numBreakpointsUninstalled = 0, 0, false, 0
 		local targetLaunched = target:launch(fixturePath, {}, {
-			onBreakpointHit = function(bp)
+			onBreakpointHit = function(_thread, bp)
 				if bp.id == bp2.id then
 					check.eq(bp.id, bp2.id)
 					check.eq(bp.line, 7)
@@ -185,7 +185,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local bpHit2 = 0
 		local onFinished = false
 		local targetLaunched = target:launch(mainPath, {}, {
-			onBreakpointHit = function(bp)
+			onBreakpointHit = function(_thread, bp)
 				if bp.id == bp1.id then
 					bpHit1 += 1
 				else
@@ -212,5 +212,49 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local source = target:getLoadedSources()
 		check.that(table.find(source, normalizePath(mainPath)))
 		check.that(table.find(source, normalizePath(triangPath)))
+	end)
+	-- this test case focuses on multiple threads
+	suite:case("multithread", function(check)
+		local target = debug.newTarget()
+		check.eq(typeof(target), "Target")
+		local mainPath = path.format(path.join(proc.cwd(), "tests/src/debug/spawn.luau"))
+		local bp1 = target:setBreakpoint(mainPath, 7)
+		local _bp2 = target:setBreakpoint(mainPath, 14)
+		local bpHit1 = 0
+		local bpHit2 = 0
+		local onFinished = false
+		local maxThreads = 0
+		local targetLaunched = target:launch(mainPath, {}, {
+			onBreakpointHit = function(thread, bp)
+				if bp.id == bp1.id then
+					check.eq(thread.id, 1)
+					check.eq(thread.name, "Coroutine 1")
+					bpHit1 += 1
+				else
+					check.eq(thread.id, 2)
+					check.eq(thread.name, "Coroutine 2")
+					bpHit2 += 1
+				end
+				local threads = target:getThreads()
+				maxThreads = math.max(maxThreads, #threads)
+				local continued = target:continueProcess()
+				check.that(continued)
+			end,
+			onExit = function(status)
+				if status then
+					onFinished = true
+				end
+			end,
+		})
+		check.that(targetLaunched)
+		check.eq(
+			waitUntil(function()
+				return onFinished
+			end),
+			true
+		)
+		check.eq(bpHit1, 5)
+		check.eq(bpHit2, 5)
+		check.eq(maxThreads, 3)
 	end)
 end)

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -227,10 +227,14 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local targetLaunched = target:launch(mainPath, {}, {
 			onBreakpointHit = function(thread, bp)
 				if bp.id == bp1.id then
+					local stoppedThread = assert(target:getStoppedThread())
+					check.eq(stoppedThread.id, 2)
 					check.eq(thread.id, 2)
 					check.eq(thread.name, "Coroutine 2")
 					bpHit1 += 1
 				else
+					local stoppedThread = assert(target:getStoppedThread())
+					check.eq(stoppedThread.id, 3)
 					check.eq(thread.id, 3)
 					check.eq(thread.name, "Coroutine 3")
 					bpHit2 += 1
@@ -247,6 +251,9 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 			end,
 		})
 		check.that(targetLaunched)
+		local stoppedThread = assert(target:getMainThread())
+		check.eq(stoppedThread.id, 1)
+		check.eq(stoppedThread.name, "Main Coroutine")
 		check.eq(
 			waitUntil(function()
 				return onFinished

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -29,7 +29,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		check.eq(typeof(target), "Target")
 		local fixturePath = path.format(path.join(proc.cwd(), "tests/src/debug/loop.luau"))
 		local bp = target:setBreakpoint(fixturePath, 6)
-		check.eq(bp.id, 0)
+		check.eq(bp.id, 1)
 		check.eq(bp.line, 6)
 		check.eq(bp.sourcePath, normalizePath(fixturePath))
 		check.eq(bp.status, "pendingInstall")
@@ -227,12 +227,12 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local targetLaunched = target:launch(mainPath, {}, {
 			onBreakpointHit = function(thread, bp)
 				if bp.id == bp1.id then
-					check.eq(thread.id, 1)
-					check.eq(thread.name, "Coroutine 1")
-					bpHit1 += 1
-				else
 					check.eq(thread.id, 2)
 					check.eq(thread.name, "Coroutine 2")
+					bpHit1 += 1
+				else
+					check.eq(thread.id, 3)
+					check.eq(thread.name, "Coroutine 3")
 					bpHit2 += 1
 				end
 				local threads = target:getThreads()

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -217,7 +217,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 	suite:case("multithread", function(check)
 		local target = debug.newTarget()
 		check.eq(typeof(target), "Target")
-		local mainPath = path.format(path.join(proc.cwd(), "tests/src/debug/spawn.luau"))
+		local mainPath = path.format(path.join(proc.cwd(), "tests/src/debug/task.luau"))
 		local bp1 = target:setBreakpoint(mainPath, 7)
 		local _bp2 = target:setBreakpoint(mainPath, 14)
 		local bpHit1 = 0

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -42,11 +42,11 @@ TEST_SUITE("Debug")
         Breakpoint bp3 = target.setBreakpoint(fixturePath, 3);
 
         // check breakpoints before launch
-        CHECK(bp.id == 0);
+        CHECK(bp.id == 1);
         checkBreakpointId(target, bp.id, BreakpointStatus::PendingInstall, fixturePath, 2);
-        CHECK(bp2.id == 1);
+        CHECK(bp2.id == 2);
         checkBreakpointId(target, bp2.id, BreakpointStatus::PendingInstall, fixturePath, 100);
-        CHECK(bp3.id == 2);
+        CHECK(bp3.id == 3);
         checkBreakpointId(target, bp3.id, BreakpointStatus::PendingInstall, fixturePath, 3);
 
         // check cannot find not-set breakpoint
@@ -59,7 +59,7 @@ TEST_SUITE("Debug")
 
         std::function<void(const Breakpoint& bp)> onBreakpointInstall = [&](const Breakpoint& bp)
         {
-            if (bp.id == 3)
+            if (bp.id == 4)
                 bp4InstalledPromise.set_value();
         };
 
@@ -103,7 +103,7 @@ TEST_SUITE("Debug")
 
         // check that setting breakpoints at same breakpoint returns same id
         Breakpoint bp5 = target.setBreakpoint(fixturePath, 2);
-        CHECK(bp5.id == 0);
+        CHECK(bp5.id == 1);
         checkBreakpointId(target, bp5.id, BreakpointStatus::Installed, fixturePath, 2);
 
         // wait until script is finished to call destructors
@@ -358,15 +358,15 @@ TEST_SUITE("Debug")
         {
             if (bp.id == bp1.id)
             {
-                CHECK(thread.id == 1);
+                CHECK(thread.id == 2);
                 hitsBp1++;
                 const std::vector<Thread>& threads = target.getThreads();
                 maxThreadsSeen = std::max(maxThreadsSeen, (int)threads.size());
                 if (threads.size() == 3)
                 {
-                    Thread t0(0, "Coroutine 0");
-                    Thread t1(1, "Coroutine 1");
-                    Thread t2(2, "Coroutine 2");
+                    Thread t0(1, "Coroutine 1");
+                    Thread t1(2, "Coroutine 2");
+                    Thread t2(3, "Coroutine 3");
                     CHECK(std::find(threads.begin(), threads.end(), t0) != threads.end());
                     CHECK(std::find(threads.begin(), threads.end(), t1) != threads.end());
                     CHECK(std::find(threads.begin(), threads.end(), t2) != threads.end());
@@ -374,16 +374,16 @@ TEST_SUITE("Debug")
             }
             else if (bp.id == bp2.id)
             {
-                CHECK(thread.id == 2);
+                CHECK(thread.id == 3);
                 hitsBp2++;
             }
             else
             {
                 // after joining all threads, we only have one left over (the main coroutine)
                 const std::vector<Thread>& threads = target.getThreads();
-                CHECK(thread.id == 0);
+                CHECK(thread.id == 1);
                 CHECK(threads.size() == 1);
-                CHECK(threads.at(0) == Thread(0, "Coroutine 0"));
+                CHECK(threads.at(0) == Thread(1, "Coroutine 1"));
             }
             target.continueProcess();
             // we shouldn't get threads when things are crunning

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -63,7 +63,7 @@ TEST_SUITE("Debug")
                 bp4InstalledPromise.set_value();
         };
 
-        std::function<void(const Breakpoint& bp)> onBreakpointHit = [&](const Breakpoint& bp)
+        std::function<void(const Thread&, const Breakpoint& bp)> onBreakpointHit = [&](const Thread&, const Breakpoint& bp)
         {
             // we wait until bp4 is added; otherwise we can get an error
             // where the program terminates before bp4 is added
@@ -141,7 +141,7 @@ TEST_SUITE("Debug")
 
         // trigger breakpoint removals when our breakpoint is hit (thus, the execution is currently paused
         // and we can see changes to it being pending uninstall)
-        std::function<void(const Breakpoint& bp)> onBreakpointHit = [&](const Breakpoint& bp)
+        std::function<void(const Thread&, const Breakpoint& bp)> onBreakpointHit = [&](const Thread&, const Breakpoint& bp)
         {
             checkBreakpointId(target, bp.id, BreakpointStatus::Installed, fixturePath, bp.line);
 
@@ -188,7 +188,7 @@ TEST_SUITE("Debug")
         Breakpoint bp3 = target.setBreakpoint(fixturePath, 7);
         int hitBp1 = 0, hitBp2 = 0, hitBp3 = 0;
 
-        std::function<void(const Breakpoint& bp)> onBreakpointHit = [&](const Breakpoint& hitBp)
+        std::function<void(const Thread&, const Breakpoint& bp)> onBreakpointHit = [&](const Thread&, const Breakpoint& hitBp)
         {
             if (hitBp.id == bp1.id)
                 hitBp1++;
@@ -225,7 +225,7 @@ TEST_SUITE("Debug")
         std::promise<void> hitPromise2;
         std::future<void> hitFuture2 = hitPromise2.get_future();
 
-        config.onBreakpointHit = [&](const Breakpoint& bp)
+        config.onBreakpointHit = [&](const Thread&, const Breakpoint& bp)
         {
             if (bp.id == bp1.id)
                 hitPromise1.set_value();
@@ -268,7 +268,7 @@ TEST_SUITE("Debug")
         // This tests whether we pause after continuing. This is pretty
         // strange but is unfortunately, the best way of guaranteeing that a pause request
         // goes through without timing conerns.
-        config.onBreakpointHit = [&](const Breakpoint& bp)
+        config.onBreakpointHit = [&](const Thread&, const Breakpoint& bp)
         {
             bool continuedProcess = target.continueProcess();
             CHECK(continuedProcess);
@@ -276,7 +276,7 @@ TEST_SUITE("Debug")
             CHECK(pausedProcess);
             hitPromise.set_value();
         };
-        config.onPause = [&]()
+        config.onPause = [&](const Thread&)
         {
             numPause++;
         };
@@ -324,7 +324,7 @@ TEST_SUITE("Debug")
         {
             bpInstalled++;
         };
-        config.onBreakpointHit = [&](const Breakpoint& bp)
+        config.onBreakpointHit = [&](const Thread&, const Breakpoint& bp)
         {
             if (bp.id == bp1.id)
                 bpHit1++;

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -359,12 +359,15 @@ TEST_SUITE("Debug")
             if (bp.id == bp1.id)
             {
                 CHECK(thread.id == 2);
+                auto stoppedThread = target.getStoppedThread();
+                REQUIRE(stoppedThread.has_value());
+                CHECK(stoppedThread->id == 2);
                 hitsBp1++;
                 const std::vector<Thread>& threads = target.getThreads();
                 maxThreadsSeen = std::max(maxThreadsSeen, (int)threads.size());
                 if (threads.size() == 3)
                 {
-                    Thread t0(1, "Coroutine 1");
+                    Thread t0(1, "Main Coroutine");
                     Thread t1(2, "Coroutine 2");
                     Thread t2(3, "Coroutine 3");
                     CHECK(std::find(threads.begin(), threads.end(), t0) != threads.end());
@@ -375,20 +378,30 @@ TEST_SUITE("Debug")
             else if (bp.id == bp2.id)
             {
                 CHECK(thread.id == 3);
+                auto stoppedThread = target.getStoppedThread();
+                REQUIRE(stoppedThread.has_value());
+                CHECK(stoppedThread->id == 3);
                 hitsBp2++;
             }
             else
             {
                 // after joining all threads, we only have one left over (the main coroutine)
+                auto stoppedThread = target.getStoppedThread();
+                REQUIRE(stoppedThread.has_value());
+                CHECK(stoppedThread->id == 1);
                 const std::vector<Thread>& threads = target.getThreads();
                 CHECK(thread.id == 1);
                 CHECK(threads.size() == 1);
-                CHECK(threads.at(0) == Thread(1, "Coroutine 1"));
+                CHECK(threads.at(0) == Thread(1, "Main Coroutine"));
             }
             target.continueProcess();
             // we shouldn't get threads when things are crunning
         };
         target.launch(fixturePath, {}, config);
+        auto mainThread = target.getMainThread();
+        REQUIRE(mainThread.has_value());
+        CHECK(mainThread->id == 1);
+        CHECK(mainThread->name == "Main Coroutine");
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         // over the course of execution, the maximum number of threads encountered should be 3
         CHECK(maxThreadsSeen == 3);

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -346,7 +346,7 @@ TEST_SUITE("Debug")
     }
     TEST_CASE_FIXTURE(DebugFixture, "Debug_threadTracking")
     {
-        std::string fixturePath = getDebugFixturePath("spawn.luau");
+        std::string fixturePath = getDebugFixturePath("task.luau");
         Target target(*runtime);
         Breakpoint bp1 = target.setBreakpoint(fixturePath, 7);
         Breakpoint bp2 = target.setBreakpoint(fixturePath, 14);

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -256,6 +256,7 @@ TEST_SUITE("Debug")
         CHECK(continuedProcess);
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }
+
     TEST_CASE_FIXTURE(DebugFixture, "Debug_pauseProcess")
     {
         std::string fixturePath = getDebugFixturePath("loop.luau");
@@ -292,6 +293,7 @@ TEST_SUITE("Debug")
         CHECK(continuedProcess);
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }
+
     TEST_CASE_FIXTURE(DebugFixture, "Debug_destroyInfiniteLoop")
     {
         // This tests that we don't stall on the Runtime destruction even when we are running
@@ -311,6 +313,7 @@ TEST_SUITE("Debug")
         );
         REQUIRE(destroyFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }
+
     TEST_CASE_FIXTURE(DebugFixture, "Debug_multiSource")
     {
         std::string mainPath = getDebugFixturePath("require_main.luau");
@@ -344,6 +347,7 @@ TEST_SUITE("Debug")
         CHECK(std::find(sources.begin(), sources.end(), mainPath) != sources.end());
         CHECK(std::find(sources.begin(), sources.end(), triangPath) != sources.end());
     }
+
     TEST_CASE_FIXTURE(DebugFixture, "Debug_threadTracking")
     {
         std::string fixturePath = getDebugFixturePath("task.luau");

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -364,9 +364,9 @@ TEST_SUITE("Debug")
                 maxThreadsSeen = std::max(maxThreadsSeen, (int)threads.size());
                 if (threads.size() == 3)
                 {
-                    Thread t0(0, "Thread 0");
-                    Thread t1(1, "Thread 1");
-                    Thread t2(0, "Thread 2");
+                    Thread t0(0, "Coroutine 0");
+                    Thread t1(1, "Coroutine 1");
+                    Thread t2(2, "Coroutine 2");
                     CHECK(std::find(threads.begin(), threads.end(), t0) != threads.end());
                     CHECK(std::find(threads.begin(), threads.end(), t1) != threads.end());
                     CHECK(std::find(threads.begin(), threads.end(), t2) != threads.end());
@@ -383,7 +383,7 @@ TEST_SUITE("Debug")
                 const std::vector<Thread>& threads = target.getThreads();
                 CHECK(thread.id == 0);
                 CHECK(threads.size() == 1);
-                CHECK(threads.at(0) == Thread(0, "Thread 0"));
+                CHECK(threads.at(0) == Thread(0, "Coroutine 0"));
             }
             target.continueProcess();
             // we shouldn't get threads when things are crunning

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -367,12 +367,12 @@ TEST_SUITE("Debug")
                 maxThreadsSeen = std::max(maxThreadsSeen, (int)threads.size());
                 if (threads.size() == 3)
                 {
-                    Thread t0(1, "Main Coroutine");
-                    Thread t1(2, "Coroutine 2");
-                    Thread t2(3, "Coroutine 3");
-                    CHECK(std::find(threads.begin(), threads.end(), t0) != threads.end());
+                    Thread t1(1, "Main Coroutine");
+                    Thread t2(2, "Coroutine 2");
+                    Thread t3(3, "Coroutine 3");
                     CHECK(std::find(threads.begin(), threads.end(), t1) != threads.end());
                     CHECK(std::find(threads.begin(), threads.end(), t2) != threads.end());
+                    CHECK(std::find(threads.begin(), threads.end(), t3) != threads.end());
                 }
             }
             else if (bp.id == bp2.id)

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -344,4 +344,55 @@ TEST_SUITE("Debug")
         CHECK(std::find(sources.begin(), sources.end(), mainPath) != sources.end());
         CHECK(std::find(sources.begin(), sources.end(), triangPath) != sources.end());
     }
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_threadTracking")
+    {
+        std::string fixturePath = getDebugFixturePath("spawn.luau");
+        Target target(*runtime);
+        Breakpoint bp1 = target.setBreakpoint(fixturePath, 7);
+        Breakpoint bp2 = target.setBreakpoint(fixturePath, 14);
+        Breakpoint bp3 = target.setBreakpoint(fixturePath, 22);
+
+        int maxThreadsSeen = 0;
+        int hitsBp1 = 0, hitsBp2 = 0;
+        config.onBreakpointHit = [&](const Thread& thread, const Breakpoint& bp)
+        {
+            if (bp.id == bp1.id)
+            {
+                CHECK(thread.id == 1);
+                hitsBp1++;
+                const std::vector<Thread>& threads = target.getThreads();
+                maxThreadsSeen = std::max(maxThreadsSeen, (int)threads.size());
+                if (threads.size() == 3)
+                {
+                    Thread t0(0, "Thread 0");
+                    Thread t1(1, "Thread 1");
+                    Thread t2(0, "Thread 2");
+                    CHECK(std::find(threads.begin(), threads.end(), t0) != threads.end());
+                    CHECK(std::find(threads.begin(), threads.end(), t1) != threads.end());
+                    CHECK(std::find(threads.begin(), threads.end(), t2) != threads.end());
+                }
+            }
+            else if (bp.id == bp2.id)
+            {
+                CHECK(thread.id == 2);
+                hitsBp2++;
+            }
+            else
+            {
+                // after joining all threads, we only have one left over (the main coroutine)
+                const std::vector<Thread>& threads = target.getThreads();
+                CHECK(thread.id == 0);
+                CHECK(threads.size() == 1);
+                CHECK(threads.at(0) == Thread(0, "Thread 0"));
+            }
+            target.continueProcess();
+            // we shouldn't get threads when things are crunning
+        };
+        target.launch(fixturePath, {}, config);
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        // over the course of execution, the maximum number of threads encountered should be 3
+        CHECK(maxThreadsSeen == 3);
+        CHECK(hitsBp1 == 5);
+        CHECK(hitsBp2 == 5);
+    }
 }

--- a/tests/src/debug/spawn.luau
+++ b/tests/src/debug/spawn.luau
@@ -1,0 +1,22 @@
+local task = require("@lute/task")
+local total_sum = 0
+
+task.spawn(function()
+	for i = 1, 5 do
+		task.wait(0)
+		total_sum += 1
+	end
+end)
+
+task.spawn(function()
+	for i = 1, 5 do
+		task.wait(0)
+		total_sum += 1
+	end
+end)
+
+while total_sum ~= 10 do
+	task.wait(0.01)
+end
+-- just for checking after we joined both threads
+total_sum += 1

--- a/tests/src/debug/task.luau
+++ b/tests/src/debug/task.luau
@@ -2,14 +2,14 @@ local task = require("@lute/task")
 local total_sum = 0
 
 task.defer(function()
-	for i = 1, 5 do
+	for _i = 1, 5 do
 		task.wait(0)
 		total_sum += 1
 	end
 end)
 
 task.defer(function()
-	for i = 1, 5 do
+	for _i = 1, 5 do
 		task.wait(0)
 		total_sum += 1
 	end

--- a/tests/src/debug/task.luau
+++ b/tests/src/debug/task.luau
@@ -1,14 +1,14 @@
 local task = require("@lute/task")
 local total_sum = 0
 
-task.spawn(function()
+task.defer(function()
 	for i = 1, 5 do
 		task.wait(0)
 		total_sum += 1
 	end
 end)
 
-task.spawn(function()
+task.defer(function()
 	for i = 1, 5 do
 		task.wait(0)
 		total_sum += 1


### PR DESCRIPTION
Adds thread/coroutine inspection for multiple co-routines (part 1/3 of PRs dealing with inspecting into state)
* Creates data structures to keep track of threads getting created and destroyed while working with bps
* Make sure `onPause` and `onBreakpointHit` take in threadId, keeping in align with DAP protocol
* Add `getStoppedThread`, `getThreads` and `getMainThread` for inspection
* (maybe?) replace `task.spawn()` behavior with `task.defer()` in debug mode to allow for correct pausing
* switch everything to use 1-indexing to match Luau

btw: i use threads and coroutines interchangeably even though they are semantically different since we have `Thread` objects tracking coroutines

<img width="1503" height="927" alt="Screenshot 2026-07-31 at 11 36 06 AM" src="https://github.com/user-attachments/assets/0be8b04b-79aa-4217-8028-5de6386fc54c" />