### PR TITLE
Handle tables with __iter metamethod in `deepClone`

### DIFF
--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -84,7 +84,7 @@ function deepClone<T>(tbl: T, seen: { [T]: T }, opts: DeepCloneOptions): T
 
 	seen[tbl] = clone
 
-	for k, v in pairs(tbl :: any) do
+	for k, v in pairs(tbl) do
 		local resolvedKey = if opts.cloneKeys and typeof(k) == "table" then resolveValue(k, seen, opts) else k
 
 		clone[resolvedKey] = if typeof(v) == "table" then resolveValue(v, seen, opts) else v

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -84,7 +84,7 @@ function deepClone<T>(tbl: T, seen: { [T]: T }, opts: DeepCloneOptions): T
 
 	seen[tbl] = clone
 
-	for k, v in next, tbl :: any do
+	for k, v in pairs(tbl :: any) do
 		local resolvedKey = if opts.cloneKeys and typeof(k) == "table" then resolveValue(k, seen, opts) else k
 
 		clone[resolvedKey] = if typeof(v) == "table" then resolveValue(v, seen, opts) else v

--- a/lute/std/libs/tableext.luau
+++ b/lute/std/libs/tableext.luau
@@ -84,7 +84,7 @@ function deepClone<T>(tbl: T, seen: { [T]: T }, opts: DeepCloneOptions): T
 
 	seen[tbl] = clone
 
-	for k, v in tbl :: any do
+	for k, v in next, tbl :: any do
 		local resolvedKey = if opts.cloneKeys and typeof(k) == "table" then resolveValue(k, seen, opts) else k
 
 		clone[resolvedKey] = if typeof(v) == "table" then resolveValue(v, seen, opts) else v

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -353,7 +353,7 @@ test.suite("TableExt", function(suite)
 		assert.that(not table.isfrozen(nestedFrozenClone))
 		assert.that(table.isfrozen(nestedFrozenClone.key))
 
-		-- Preservation of tables with overwritten iter method
+		-- Correctly clones tables with iter metamethod
 		local overwrittenIter = setmetatable({ a = 1, b = { 2, 3 } }, {
 			__iter = function(self)
 				local index = 0

--- a/tests/std/tableext.test.luau
+++ b/tests/std/tableext.test.luau
@@ -352,5 +352,22 @@ test.suite("TableExt", function(suite)
 		assert.eq(nestedFrozenClone, nestedFrozen)
 		assert.that(not table.isfrozen(nestedFrozenClone))
 		assert.that(table.isfrozen(nestedFrozenClone.key))
+
+		-- Preservation of tables with overwritten iter method
+		local overwrittenIter = setmetatable({ a = 1, b = { 2, 3 } }, {
+			__iter = function(self)
+				local index = 0
+				return function()
+					index += 1
+					return self.b[index]
+				end
+			end,
+		})
+
+		local copiedIter = tableext.deepClone(overwrittenIter)
+		assert.that(copiedIter.a)
+		assert.that(copiedIter.b)
+		assert.eq(copiedIter.a, overwrittenIter.a)
+		assert.eq(copiedIter.b, overwrittenIter.b)
 	end)
 end)


### PR DESCRIPTION
`tableext.deepClone` failed to correctly clone tables with `__iter` metamethods that didn't perform conventional key, value iteration. I discovered this while cloning the CST returned by lute's `parser` APIs, and found that `CstPunctuated` nodes were missing the `separators` field due to their `__iter` method.

This PR updates `deepClone`'s iteration over a table to use `pairs`, such that all key, value pairs of cloned tables are handled.