### PR TITLE
Improve `lute pkg` help text

### DIFF
--- a/lute/cli/commands/pkg/init.luau
+++ b/lute/cli/commands/pkg/init.luau
@@ -14,6 +14,7 @@ Loom package manager for Luau projects.
 COMMANDS:
   install                                   Install dependencies from loom.config.luau
   auth --token <token> [--domain <domain>]  Save authentication credentials
+  run <script.luau> [args...]               Run a Luau script from loom.lock.
 
 Use --help with any command for more information.
 ]])

--- a/lute/cli/commands/pkg/loom-core/src/commands/authenticate.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/authenticate.luau
@@ -8,9 +8,9 @@ local function authenticate(...: string)
 
 	local valid, err = pcall(cli.parse, args, { ... })
 	if not valid then
-	    print(err)
-	    args:help()
-	    error()
+		print(err)
+		args:help()
+		error(err)
 	end
 
 	local token = args:get("token")

--- a/lute/cli/commands/pkg/loom-core/src/commands/authenticate.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/authenticate.luau
@@ -5,13 +5,15 @@ local function authenticate(...: string)
 	local args = cli.parser()
 	args:add("token", "option", { help = "Authentication token", required = true })
 	args:add("domain", "option", { help = "Domain to authenticate with", default = "github.com" })
-	args:parse({ ... })
 
-	local token = args:get("token")
-	if not token then
-		error("Usage: `lute pkg auth --token <token> [--domain <domain>]`")
+	local valid, err = pcall(cli.parse, args, { ... })
+	if not valid then
+	    print(err)
+	    args:help()
+	    error()
 	end
 
+	local token = args:get("token")
 	local domain = args:get("domain") or "github.com"
 	authenticationStore.saveAuthenticationToken(domain, token)
 end

--- a/lute/cli/commands/pkg/loom-core/src/commands/authenticate.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/authenticate.luau
@@ -13,7 +13,7 @@ local function authenticate(...: string)
 		error(err)
 	end
 
-	local token = args:get("token")
+	local token = args:get("token") :: string -- non-nil because required = true
 	local domain = args:get("domain") or "github.com"
 	authenticationStore.saveAuthenticationToken(domain, token)
 end

--- a/lute/cli/commands/pkg/loom-core/src/commands/install.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/install.luau
@@ -43,9 +43,9 @@ local function install(...: string)
 
 	local valid, err = pcall(cli.parse, args, { ... })
 	if not valid then
-	    print(err)
-	    args:help()
-	    error()
+		print(err)
+		args:help()
+		error(err)
 	end
 
 	local excludeDev = args:get("exclude-dev") ~= nil

--- a/lute/cli/commands/pkg/loom-core/src/commands/install.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/install.luau
@@ -40,7 +40,13 @@ local function install(...: string)
 	local args = cli.parser()
 	args:add("exclude-dev", "flag", { help = "Skip dev dependencies" })
 	args:add("locked", "flag", { help = "Error if lockfile doesn't match manifest (CI mode)" })
-	args:parse({ ... })
+
+	local valid, err = pcall(cli.parse, args, { ... })
+	if not valid then
+	    print(err)
+	    args:help()
+	    error()
+	end
 
 	local excludeDev = args:get("exclude-dev") ~= nil
 	local locked = args:get("locked") ~= nil

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -44,8 +44,7 @@ Commands:
 	run (default)   Run a Luau script.
 	check           Type check Luau files.
 	compile         Compile a Luau script into a standalone executable.
-	debug           Debug a Luau script.
-	pkg             Loom package manager for Luau projects (install/auth/run).
+    debug           Debug a Luau script.
 	setup           Generate type definition files for the language server.
 	transform       Run a specified code transformation on specified Luau files.
 	lint            Run linting rules on specified Luau files.
@@ -66,13 +65,6 @@ Compile Options:
 Debug Options:
 	lute debug serve
 		Serves a DAP server for Luau for use with a development environment.
-
-Pkg Options:
-	lute pkg <install|auth|run>
-		Loom package manager for Luau projects.
-			install                 Install dependencies from loom.config.luau
-			auth                    Save authentication credentials
-			run <script.luau>       Run a Luau script from loom.lock.
 
 Setup Options:
 	lute setup

--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -44,7 +44,8 @@ Commands:
 	run (default)   Run a Luau script.
 	check           Type check Luau files.
 	compile         Compile a Luau script into a standalone executable.
-    debug           Debug a Luau script.
+	debug           Debug a Luau script.
+	pkg             Loom package manager for Luau projects (install/auth/run).
 	setup           Generate type definition files for the language server.
 	transform       Run a specified code transformation on specified Luau files.
 	lint            Run linting rules on specified Luau files.
@@ -65,6 +66,13 @@ Compile Options:
 Debug Options:
 	lute debug serve
 		Serves a DAP server for Luau for use with a development environment.
+
+Pkg Options:
+	lute pkg <install|auth|run>
+		Loom package manager for Luau projects.
+			install                 Install dependencies from loom.config.luau
+			auth                    Save authentication credentials
+			run <script.luau>       Run a Luau script from loom.lock.
 
 Setup Options:
 	lute setup


### PR DESCRIPTION
- Related #1272 
- Adds `lute pkg run` to `lute pkg --help`
- <details><summary>Improved `lute pkg install --help`: </summary>
  
  Before:
  ```
  @batteries/cli.luau:103: Unknown argument: help
  stacktrace:
  [C] function assert
  @batteries/cli.luau:103 function parse
  @cli/pkg/loom-core/src/commands/install.luau:43 function install
  @cli/pkg/init.luau:33 function main
  @cli/pkg/init.luau:43
  ```
  After:
  ```
  @batteries/cli.luau:103: Unknown argument: help
  Usage:
    --exclude-dev - Skip dev dependencies
    --locked - Error if lockfile doesn't match manifest (CI mode)
  
  stacktrace:
  [C] function error
  @cli/pkg/loom-core/src/commands/install.luau:48 function install
  @cli/pkg/init.luau:34 function main
  @cli/pkg/init.luau:44
  ```

</details>

- <details><summary>Improved `lute pkg auth --help`: </summary>
  
  Before:
  ```
  @batteries/cli.luau:103: Unknown argument: help
  stacktrace:
  [C] function assert
  @batteries/cli.luau:103 function parse
  @cli/pkg/loom-core/src/commands/authenticate.luau:8 function authenticate
  @cli/pkg/init.luau:35 function main
  @cli/pkg/init.luau:43
  ```
  After:
  ```
  @batteries/cli.luau:103: Unknown argument: help
  Usage:
    --token - (required) Authentication token
    --domain - Domain to authenticate with
  
  stacktrace:
  [C] function error
  @cli/pkg/loom-core/src/commands/authenticate.luau:13 function authenticate
  @cli/pkg/init.luau:36 function main
  @cli/pkg/init.luau:44
  ```

</details>
