### PR TITLE
infra: enable CI for merge groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: ["primary", "release/**"]
   pull_request:
     branches: ["primary"]
+  merge_group:
+    branches: ["primary"]
 
 # CI on the "primary" branch opts out of concurrency grouping by using the run's
 # unique run_id.
@@ -40,6 +42,14 @@ jobs:
             options: --c-compiler clang --cxx-compiler clang++ --enable-sanitizers
             use-bootstrap: true
             run-on-event: push
+          - os: ubuntu-latest
+            options: --c-compiler gcc --cxx-compiler g++ --enable-sanitizers
+            use-bootstrap: true
+            run-on-event: merge_group
+          - os: ubuntu-latest
+            options: --c-compiler clang --cxx-compiler clang++ --enable-sanitizers
+            use-bootstrap: true
+            run-on-event: merge_group
       fail-fast: false
 
     steps:


### PR DESCRIPTION
We've got some interest in trying out a merge queue for lute, which means that we need to modify our CI to actually _run_ in the event that we have a merge queue going. Otherwise, everything will just fail immediately.