### PR TITLE
`lute/debug`: add stack traces

### DIFF
--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -99,7 +99,7 @@ export type Target = {
 	--- Returns `true` if target was paused before stepping and `false` otherwise.
 	stepOut: (self: Target, threadId: number) -> boolean,
 	--- Gets our current stopped location, consisting of (sourcePath: string, line: number)
-	--- Returns nil if we are not stopped.
+	--- Returns (nil, nil) if we are not stopped.
 	getStoppedLocation: (self: Target) -> (string?, number?),
 	--- Gets a list of all Luau coroutines that are being used by the script.
 	getThreads: (self: Target) -> { Thread },

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -20,6 +20,16 @@ export type Thread = {
 	name: string,
 }
 
+--- A stack frame of the execution. New stack frames are recreated every time execution is paused, and
+--- ids are reused.
+export type StackFrame = {
+	id: number,
+	name: string,
+	sourcePath: string,
+	line: number,
+	column: number,
+}
+
 --- A set of callbacks that we configure before launching our debugger
 export type LaunchConfig = {
 	--- called when a breakpoint `bp` is hit on `thread`; execution is paused until continueProcess() is called
@@ -70,6 +80,13 @@ export type Target = {
 	getMainThread: (self: Target) -> Thread?,
 	--- Gets the current stopped thread of the script, returning nil if debugger is not paused
 	getStoppedThread: (self: Target) -> Thread?,
+	--- Gets a stack frame on a coroutine with `threadId` at level `level` (where 0 is the shallowest). Return `nil`
+	--- if script is running or no such stack frame exists at that level.
+	getStackFrame: (self: Target, threadId: number, level: number) -> StackFrame?,
+	--- Gets a stack trace on a coroutine with `threadId` starting from level `startLevel` and going for at maximum
+	--- `numFrames` frames. If `startLevel` is not specified, we start at level 0. If `numFrames` is not specified,
+	--- we return until the deepest frame.
+	getStackTrace: (self: Target, threadId: number, startLevel: number?, numFrames: number?) -> { StackFrame }?,
 }
 
 --- Create a new Target handle on the current VM.

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -98,9 +98,9 @@ export type Target = {
 	--- Steps out of the current function call in thread id `threadId`.
 	--- Returns `true` if target was paused before stepping and `false` otherwise.
 	stepOut: (self: Target, threadId: number) -> boolean,
-	--- Gets our current line of execution when we are stopped.
-	--- Returns -1 if we are not stopped.
-	getLine: (self: Target) -> number,
+	--- Gets our current stopped location, consisting of (sourcePath: string, line: number)
+	--- Returns nil if we are not stopped.
+	getStoppedLocation: (self: Target) -> (string?, number?),
 	--- Gets a list of all Luau coroutines that are being used by the script.
 	getThreads: (self: Target) -> { Thread },
 	--- Gets the main thread of the script, returning nil if debugger is not launched

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -80,6 +80,9 @@ export type Target = {
 	getMainThread: (self: Target) -> Thread?,
 	--- Gets the current stopped thread of the script, returning nil if debugger is not paused
 	getStoppedThread: (self: Target) -> Thread?,
+	--- Gets the depth of the call stack within thread with `threadId`. If not paused or not launched or if
+	--- such a thread does not exist, return `-1`.
+	getStackDepth: (self: Target, threadId: number) -> number,
 	--- Gets a stack frame on a coroutine with `threadId` at level `level` (where 0 is the shallowest). Return `nil`
 	--- if script is running or no such stack frame exists at that level.
 	getStackFrame: (self: Target, threadId: number, level: number) -> StackFrame?,

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -100,6 +100,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 				supportsConfigurationDoneRequest = true,
 				supportsTerminateRequest = true,
 				supportsLoadedSourcesRequest = true,
+				supportsDelayedStackTraceLoading = true,
 			}
 			ioSession.writeResponse(reqSeq, true, command, nil, capabilities)
 			ioSession.writeEvent("initialized")
@@ -172,20 +173,32 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			ioSession.writeResponse(reqSeq, true, command, nil, {
 				threads = dapThreads,
 			})
-		-- dummy handler for stackTrace
 		elseif command == "stackTrace" then
-			local launchPath = assert(launchConfig, "not launched")
-			ioSession.writeResponse(reqSeq, true, command, nil, {
-				stackFrames = {
-					{
-						id = 0,
-						name = "main",
-						source = createSource(launchPath.program),
-						line = 1,
-						column = 0,
+			local args = request.arguments :: json.Object
+			local threadId = args.threadId :: number
+			local startFrame = args.startFrame :: number?
+			local levels = args.levels :: number?
+			local stackTrace = target:getStackTrace(threadId, startFrame, levels)
+			if not stackTrace then
+				ioSession.writeResponse(reqSeq, false, command, "notStopped")
+				continue
+			end
+			assert(stackTrace)
+			local dapStackTrace = {}
+			for _, frame in stackTrace do
+				table.insert(dapStackTrace, {
+					id = frame.id,
+					name = frame.name,
+					source = {
+						path = frame.sourcePath,
 					},
-				},
-				totalFrames = 1,
+					line = frame.line,
+					column = frame.column,
+				})
+			end
+			ioSession.writeResponse(reqSeq, true, command, nil, {
+				stackFrames = dapStackTrace,
+				totalFrames = target:getStackDepth(threadId),
 			})
 		elseif command == "terminate" or command == "disconnect" then
 			ioSession.writeResponse(reqSeq, true, command)

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -189,9 +189,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 				table.insert(dapStackTrace, {
 					id = frame.id,
 					name = frame.name,
-					source = {
-						path = frame.sourcePath,
-					},
+					source = createSource(frame.sourcePath),
 					line = frame.line,
 					column = frame.column,
 				})

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -3,7 +3,10 @@ local dapTypes = require("./dapTypes")
 local debugger = require("@lute/debugger")
 local json = require("@std/json")
 
-local function createSource(sourcePath: string): dapTypes.Source
+local function createSource(sourcePath: string): dapTypes.Source?
+	if sourcePath == "" or sourcePath == "=[C]" then
+		return nil
+	end
 	return {
 		path = sourcePath,
 		name = sourcePath:match("[^/\\]+$"),
@@ -14,7 +17,7 @@ local function debugToDapBreakpoint(breakpoint: debugger.Breakpoint): dapTypes.B
 	local dapBreakpoint: dapTypes.Breakpoint = {
 		id = breakpoint.id,
 		verified = breakpoint.status == "installed",
-		source = createSource(breakpoint.sourcePath),
+		source = assert(createSource(breakpoint.sourcePath)),
 		line = breakpoint.line,
 	}
 	if breakpoint.status == "pendingInstall" then
@@ -83,7 +86,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			ioSession.writeEvent("output", {
 				category = "stdout",
 				output = message,
-				source = createSource(source),
+				source = assert(createSource(source)),
 				line = line,
 			})
 		end,
@@ -163,7 +166,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			local sources = target:getLoadedSources()
 			local dapSources = {}
 			for _, source in sources do
-				table.insert(dapSources, createSource(source))
+				table.insert(dapSources, assert(createSource(source)))
 			end
 			ioSession.writeResponse(reqSeq, true, command, nil, {
 				sources = dapSources,

--- a/lute/cli/commands/debug/dapTypes.luau
+++ b/lute/cli/commands/debug/dapTypes.luau
@@ -5,6 +5,8 @@
 export type Capability = {
 	supportConfigurationDoneRequest: boolean,
 	supportTerminateRequest: boolean,
+	supportsLoadedSourcesRequest: boolean,
+	supportsDelayedStackTraceLoading: boolean,
 }
 
 export type Source = {

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -117,11 +117,11 @@ struct Target
     // in issues when trying to pause. Similar methods that also run coroutines inline with our current execution will not work.
     // In contrast, in task.defer(), the coroutine is added to set of running coroutines but execution
     // is deferred. Our pause mechanism will then work correctly.
-    int getLine() const;
+    std::optional<std::pair<std::string, int>> getStoppedLocation() const;
     int getStackDepth(int threadId);
     std::optional<Thread> getMainThread() const; // can be used when not paused
     std::optional<Thread> getStoppedThread() const;
-    std::vector<Thread> getThreads() const;
+    std::vector<Thread> getThreads() const; // can be used when not paused
     std::optional<StackFrame> getStackFrame(int threadId, int level);
     std::optional<std::vector<StackFrame>> getStackTrace(int threadId, int startLevel = 0, int maximumLevel = 0);
 
@@ -163,6 +163,7 @@ private:
     // Due to the way Lua debugger callbacks works, we need to set the line in the callback. otherwise, outside of the callback, lua_getinfo
     // will return the previous line.
     int stoppedLine = -1;
+    std::string stoppedLocation = "";
 
     // for require contexts
     std::unique_ptr<RequireCtx> requireCtx;
@@ -193,7 +194,7 @@ private:
     bool uninstallBreakpoint(lua_State* L, Breakpoint& bp);
     std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> modifyPendingBreakpoints(lua_State* L);
 
-    void computeStoppedLine(lua_State* L);
+    void computeStoppedLocation(lua_State* L);
 
     void installBpHitCallback();
     void installExitCallback();

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -138,6 +138,9 @@ private:
     // our stopped thread that we need to requeue when we continue
     lua_State* stoppedThread = nullptr;
     std::shared_ptr<Ref> stoppedThreadRef;
+    // Due to the way Lua debugger callbacks works, we need to set the line in the callback. otherwise, outside of the callback, lua_getinfo
+    // will return the previous line.
+    int stoppedLine = -1;
 
     // for require contexts
     std::unique_ptr<RequireCtx> requireCtx;

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -45,6 +45,15 @@ struct Thread
     bool operator==(const Thread& other) const;
 };
 
+struct StackFrame
+{
+    int id = -1;
+    std::string name;
+    std::string sourcePath;
+    int line = 0;
+    int column = 0;
+};
+
 struct LaunchConfig
 {
     // onBreakpointInstall is called whenever an installation attempt is actually made, regardless
@@ -95,6 +104,8 @@ struct Target
     std::optional<Thread> getMainThread() const;
     std::optional<Thread> getStoppedThread() const;
     std::vector<Thread> getThreads() const;
+    std::optional<StackFrame> getStackFrame(int threadId, int level);
+    std::optional<std::vector<StackFrame>> getStackTrace(int threadId, int startLevel = 0, int maximumLevel = 0);
 
     // For actively running scripts:
     std::optional<std::string> launch(std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
@@ -136,9 +147,18 @@ private:
     std::unordered_map<lua_State*, Thread> stateToThread; // lua_State* -> thread information about that state
     std::unordered_map<int, lua_State*> threadIdToState;  // thread id -> lua_State*
 
+    // stack frame information
+    // note: stack frames are copies between these two data structures, not pointers. That's ok because the debugger
+    // should never modify the stack frames themselves.
+    // stack frame ID information is reset upon every continue(). The base id resets to 1 as well.
+    int stackframeId = 1;
+    std::unordered_map<int, std::unordered_map<int, StackFrame>> stateToStackFrame; // thread id -> level -> stackFrame
+    std::unordered_map<int, std::pair<int, int>> idToStackFrameInfo;                // stack frame id -> stack frame's (thread id, level)
+
     // private methods are meant for internal calls, so these don't lock targetMutex
     std::optional<Breakpoint> getBreakpointBySourceLineHelper(std::string source, int line) const;
     std::optional<Breakpoint> getBreakpointByIdHelper(int breakpointId) const;
+    std::optional<StackFrame> getStackFrameHelper(int threadId, int level);
 
     bool installBreakpoint(lua_State* L, Breakpoint& bp);
     bool uninstallBreakpoint(lua_State* L, Breakpoint& bp);

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -104,6 +104,7 @@ struct Target
     std::optional<Thread> getMainThread() const;
     std::optional<Thread> getStoppedThread() const;
     std::vector<Thread> getThreads() const;
+    int getStackDepth(int threadId);
     std::optional<StackFrame> getStackFrame(int threadId, int level);
     std::optional<std::vector<StackFrame>> getStackTrace(int threadId, int startLevel = 0, int maximumLevel = 0);
 

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -97,6 +97,29 @@ static int pushThread(lua_State* L, const debug::Thread& thread)
     return 1;
 }
 
+// Helper to push a StackFrame type, which is
+// id: number
+// name: string
+// sourcePath: string
+// line: number
+// column: number
+static int pushStackFrame(lua_State* L, const debug::StackFrame& frame)
+{
+    checkStack(L, 2);
+    lua_createtable(L, 0, 5);
+    lua_pushinteger(L, frame.id);
+    lua_setfield(L, -2, "id");
+    lua_pushstring(L, frame.name.c_str());
+    lua_setfield(L, -2, "name");
+    lua_pushstring(L, frame.sourcePath.c_str());
+    lua_setfield(L, -2, "sourcePath");
+    lua_pushinteger(L, frame.line);
+    lua_setfield(L, -2, "line");
+    lua_pushinteger(L, frame.column);
+    lua_setfield(L, -2, "column");
+    return 1;
+}
+
 // target.setBreakpoint(string sourcePath, int line)
 // returns a breakpoint
 static int target_setBreakpoint(lua_State* L)
@@ -251,6 +274,48 @@ static int target_getStoppedThread(lua_State* L)
         return 1;
     }
     return pushThread(L, *thread);
+}
+
+// target.getStackFrame(int threadId, int level)
+// return StackFrame | nil
+static int target_getStackFrame(lua_State* L)
+{
+    auto target = getTarget(L, 1);
+    int threadId = luaL_checkinteger(L, 2);
+    int level = luaL_checkinteger(L, 2);
+    std::optional<debug::StackFrame> stackframe = target->getStackFrame(threadId, level);
+    if (!stackframe)
+    {
+        checkStack(L, 1);
+        lua_pushnil(L);
+        return 1;
+    }
+    return pushStackFrame(L, *stackframe);
+}
+
+// target.getStackTrace(int threadId, int startLevel = 0, int numFrames = 0)
+// return {StackFrame} | nil
+static int target_getStackTrace(lua_State* L)
+{
+    auto target = getTarget(L, 1);
+    int threadId = luaL_checkinteger(L, 2);
+    int startLevel = (int)luaL_optinteger(L, 3, 0);
+    int numFrames = (int)luaL_optinteger(L, 4, 0);
+    std::optional<std::vector<debug::StackFrame>> stackframes = target->getStackTrace(threadId, startLevel, numFrames);
+    if (!stackframes)
+    {
+        checkStack(L, 1);
+        lua_pushnil(L);
+        return 1;
+    }
+    checkStack(L, 1);
+    lua_createtable(L, stackframes->size(), 0);
+    for (int i = 0; i < (int)stackframes->size(); i++)
+    {
+        pushStackFrame(L, stackframes->at(i));
+        lua_rawseti(L, -2, i + 1);
+    }
+    return 1;
 }
 
 static std::shared_ptr<Ref> getOptionalCallback(lua_State* L, int tableIndex, const char* field)
@@ -434,6 +499,8 @@ static const std::unordered_map<std::string, lua_CFunction> kTargetMethods = {
     {"getThreads", debug::target_getThreads},
     {"getMainThread", debug::target_getMainThread},
     {"getStoppedThread", debug::target_getStoppedThread},
+    {"getStackFrame", debug::target_getStackFrame},
+    {"getStackTrace", debug::target_getStackTrace}
 };
 
 static void initializeTarget(lua_State* L)

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -276,13 +276,25 @@ static int target_getStoppedThread(lua_State* L)
     return pushThread(L, *thread);
 }
 
+// target.getStackDepth(int threadId)
+// return an integer
+static int target_getStackDepth(lua_State* L)
+{
+    auto target = getTarget(L, 1);
+    int threadId = luaL_checkinteger(L, 2);
+    int depth = target->getStackDepth(threadId);
+    checkStack(L, 1);
+    lua_pushinteger(L, depth);
+    return 1;
+}
+
 // target.getStackFrame(int threadId, int level)
 // return StackFrame | nil
 static int target_getStackFrame(lua_State* L)
 {
     auto target = getTarget(L, 1);
     int threadId = luaL_checkinteger(L, 2);
-    int level = luaL_checkinteger(L, 2);
+    int level = luaL_checkinteger(L, 3);
     std::optional<debug::StackFrame> stackframe = target->getStackFrame(threadId, level);
     if (!stackframe)
     {
@@ -499,8 +511,9 @@ static const std::unordered_map<std::string, lua_CFunction> kTargetMethods = {
     {"getThreads", debug::target_getThreads},
     {"getMainThread", debug::target_getMainThread},
     {"getStoppedThread", debug::target_getStoppedThread},
+    {"getStackDepth", debug::target_getStackDepth},
     {"getStackFrame", debug::target_getStackFrame},
-    {"getStackTrace", debug::target_getStackTrace}
+    {"getStackTrace", debug::target_getStackTrace},
 };
 
 static void initializeTarget(lua_State* L)

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -116,7 +116,7 @@ static int pushBreakpoint(lua_State* L, const Breakpoint& bp)
 // Helper to push a Thread type, which is
 // id: number
 // name: string
-static int pushThread(lua_State* L, const debug::Thread& thread)
+static int pushThread(lua_State* L, const Thread& thread)
 {
     checkStack(L, 2);
     lua_createtable(L, 0, 2);
@@ -133,7 +133,7 @@ static int pushThread(lua_State* L, const debug::Thread& thread)
 // sourcePath: string
 // line: number
 // column: number
-static int pushStackFrame(lua_State* L, const debug::StackFrame& frame)
+static int pushStackFrame(lua_State* L, const StackFrame& frame)
 {
     checkStack(L, 2);
     lua_createtable(L, 0, 5);
@@ -349,7 +349,7 @@ static int target_getStoppedLocation(lua_State* L)
 static int target_getThreads(lua_State* L)
 {
     auto target = getTarget(L, 1);
-    const std::vector<debug::Thread>& threads = target->getThreads();
+    const std::vector<Thread>& threads = target->getThreads();
     checkStack(L, 1);
     lua_createtable(L, threads.size(), 0);
     for (int i = 0; i < (int)threads.size(); i++)
@@ -411,7 +411,7 @@ static int target_getStackFrame(lua_State* L)
     auto target = getTarget(L, 1);
     int threadId = luaL_checkinteger(L, 2);
     int level = luaL_checkinteger(L, 3);
-    std::optional<debug::StackFrame> stackframe = target->getStackFrame(threadId, level);
+    std::optional<StackFrame> stackframe = target->getStackFrame(threadId, level);
     if (!stackframe)
     {
         checkStack(L, 1);
@@ -429,7 +429,7 @@ static int target_getStackTrace(lua_State* L)
     int threadId = luaL_checkinteger(L, 2);
     int startLevel = (int)luaL_optinteger(L, 3, 0);
     int numFrames = (int)luaL_optinteger(L, 4, 0);
-    std::optional<std::vector<debug::StackFrame>> stackframes = target->getStackTrace(threadId, startLevel, numFrames);
+    std::optional<std::vector<StackFrame>> stackframes = target->getStackTrace(threadId, startLevel, numFrames);
     if (!stackframes)
     {
         checkStack(L, 1);

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -325,15 +325,23 @@ static int target_stepOver(lua_State* L)
     return 1;
 }
 
-// target.getLine()
-// returns a integer
-static int target_getLine(lua_State* L)
+// target.getStoppedLocation()
+// returns a (string, integer) | (nil, nil)
+static int target_getStoppedLocation(lua_State* L)
 {
     Target* target = getTarget(L, 1);
-    int line = target->getLine();
-    checkStack(L, 1);
-    lua_pushinteger(L, line);
-    return 1;
+    std::optional<std::pair<std::string, int>> stoppedLocation = target->getStoppedLocation();
+    if (!stoppedLocation)
+    {
+        checkStack(L, 2);
+        lua_pushnil(L);
+        lua_pushnil(L);
+        return 2;
+    }
+    checkStack(L, 2);
+    lua_pushstring(L, stoppedLocation->first.c_str());
+    lua_pushinteger(L, stoppedLocation->second);
+    return 2;
 }
 
 // target.getThreads()
@@ -636,7 +644,7 @@ static const std::unordered_map<std::string, lua_CFunction> kTargetMethods = {
     {"stepIn", debug::target_stepIn},
     {"stepOut", debug::target_stepOut},
     {"stepOver", debug::target_stepOver},
-    {"getLine", debug::target_getLine},
+    {"getStoppedLocation", debug::target_getStoppedLocation},
     {"getThreads", debug::target_getThreads},
     {"getMainThread", debug::target_getMainThread},
     {"getStoppedThread", debug::target_getStoppedThread},

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -422,8 +422,9 @@ void Target::installBpHitCallback()
             return;
         }
         lua_Debug info = {};
-        lua_getinfo(L, 0, "sl", &info);
-        int line = info.currentline;
+        lua_getinfo(L, 0, "s", &info);
+        int line = ar->currentline;
+        target->stoppedLine = line;
         if (!info.source)
         {
             target->parentRuntime.reporter.reportError(Luau::format("breakpoint hit at line %d could not find a runtime source", line));
@@ -655,7 +656,6 @@ std::optional<std::vector<StackFrame>> Target::getStackTrace(int threadId, int s
 
 bool Target::continueProcess()
 {
-
     std::unique_lock lock(targetMutex);
     if (!launched || !paused)
         return false;
@@ -710,6 +710,9 @@ bool Target::pauseProcess()
         debug::Thread thread = target->stateToThread.at(L);
         // We transition into a paused state. Let's modify all pending breakpoints.
         auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
+        lua_Debug info = {};
+        lua_getinfo(L, 0, "l", &info);
+        target->stoppedLine = info.currentline;
         lua_break(L);
         // Clear out the interrupt callback after we are done.
         lua_callbacks(L)->interrupt = nullptr;

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -568,6 +568,91 @@ std::vector<Thread> Target::getThreads() const
     return result;
 }
 
+std::optional<StackFrame> Target::getStackFrameHelper(int threadId, int level)
+{
+    if (!paused)
+        return std::nullopt;
+    if (threadIdToState.find(threadId) == threadIdToState.end())
+    {
+        return std::nullopt;
+    }
+    std::unordered_map<int, StackFrame>& levelMap = stateToStackFrame[threadId];
+    auto it = levelMap.find(level);
+    if (it == levelMap.end())
+    {
+        StackFrame frame;
+        frame.id = stackframeId;
+        stackframeId++;
+        lua_Debug ar = {};
+        if (!lua_getinfo(threadIdToState[threadId], level, "sln", &ar))
+            return std::nullopt;
+
+        frame.name = ar.name ? ar.name : "(anonymous)";
+        if (ar.source)
+        {
+            frame.sourcePath = getSourceFromChunk(ar.source);
+            // edge case: when we hit a breakpoint, the pc is sent backward one
+            // so that we can hit it again, so lua_getinfo() fails.
+            if (level == 0 && stoppedLine != -1)
+                frame.line = stoppedLine;
+            else
+                frame.line = ar.currentline;
+        }
+        else
+        {
+            frame.sourcePath = "";
+            frame.line = 0;
+        }
+        frame.column = 0;
+        levelMap[level] = frame;
+        idToStackFrameInfo[frame.id] = std::make_pair(threadId, level);
+        return frame;
+    }
+    return it->second;
+}
+
+std::optional<StackFrame> Target::getStackFrame(int threadId, int level)
+{
+    std::unique_lock lock(targetMutex);
+    return getStackFrameHelper(threadId, level);
+}
+
+std::optional<std::vector<StackFrame>> Target::getStackTrace(int threadId, int startLevel, int numFrames)
+{
+    std::unique_lock lock(targetMutex);
+    if (!paused)
+        return std::nullopt;
+    if (threadIdToState.find(threadId) == threadIdToState.end())
+    {
+        return std::nullopt;
+    }
+    int stackDepth = lua_stackdepth(threadIdToState[threadId]);
+    if (startLevel >= stackDepth)
+    {
+        return std::nullopt;
+    }
+    int maximumLevel;
+    if (numFrames == 0)
+    {
+        maximumLevel = stackDepth;
+    }
+    else
+    {
+        maximumLevel = std::min(startLevel + numFrames, stackDepth);
+    }
+    std::vector<StackFrame> stackTrace;
+    for (int i = startLevel; i < maximumLevel; i++)
+    {
+        std::optional<StackFrame> frame = getStackFrameHelper(threadId, i);
+        if (!frame)
+        {
+            return std::nullopt;
+        }
+        stackTrace.emplace_back(*frame);
+    }
+    return stackTrace;
+}
+
 bool Target::continueProcess()
 {
 

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -633,7 +633,7 @@ std::optional<std::vector<StackFrame>> Target::getStackTrace(int threadId, int s
         return std::nullopt;
     int stackDepth = lua_stackdepth(threadIdToState[threadId]);
     if (startLevel >= stackDepth)
-        return std::nullopt;
+        return std::vector<StackFrame>{};
     int maximumLevel;
     if (numFrames == 0)
         maximumLevel = stackDepth;

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -307,19 +307,24 @@ std::vector<std::string> Target::getLoadedSources()
     return sources;
 }
 
-int Target::getLine() const
+std::optional<std::pair<std::string, int>> Target::getStoppedLocation() const
 {
     std::unique_lock lock(targetMutex);
     if (!launched || !paused)
-        return -1;
-    return stoppedLine;
+        return std::nullopt;
+    return std::make_pair(stoppedLocation, stoppedLine);
 }
 
-void Target::computeStoppedLine(lua_State* L)
+void Target::computeStoppedLocation(lua_State* L)
 {
     lua_Debug info = {};
-    lua_getinfo(L, 0, "l", &info);
+    if (!lua_getinfo(L, 0, "sl", &info))
+        return;
     stoppedLine = info.currentline;
+    if (info.source)
+        stoppedLocation = getSourceFromChunk(info.source);
+    else
+        stoppedLocation = "";
 }
 
 std::optional<std::string> Target::launch(std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config)
@@ -452,7 +457,7 @@ void Target::installBpHitCallback()
             target->bpHit = *bp;
             target->paused = true;
             target->childRuntime->stopDebug();
-            target->stoppedLine = line;
+            target->computeStoppedLocation(L);
             target->stoppedThread = L;
             target->stoppedThreadRef = getRefForThread(L);
             // Clear out stepping when this happens.
@@ -703,6 +708,7 @@ void Target::continueProcessHelper()
         stoppedThread = nullptr;
         stoppedThreadRef = nullptr;
         stoppedLine = -1;
+        stoppedLocation = "";
     }
     paused = false;
     childRuntime->continueDebug();
@@ -740,7 +746,7 @@ bool Target::pauseProcess()
         debug::Thread thread = target->stateToThread.at(L);
         // We transition into a paused state. Let's modify all pending breakpoints.
         auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
-        target->computeStoppedLine(L);
+        target->computeStoppedLocation(L);
         lua_break(L);
         // Clear out the interrupt and debugstep callback after we are done.
         lua_callbacks(L)->interrupt = nullptr;
@@ -756,7 +762,6 @@ bool Target::pauseProcess()
     };
     return true;
 }
-
 
 bool Target::step(int threadId, StepType type)
 {
@@ -813,7 +818,7 @@ bool Target::step(int threadId, StepType type)
             target->childRuntime->stopDebug();
             target->stoppedThread = L;
             target->stoppedThreadRef = getRefForThread(L);
-            target->stoppedLine = ar->currentline;
+            target->computeStoppedLocation(L);
             target->stepInfo = std::nullopt;
             auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
             lua_break(L);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -424,7 +424,6 @@ void Target::installBpHitCallback()
         lua_Debug info = {};
         lua_getinfo(L, 0, "s", &info);
         int line = ar->currentline;
-        target->stoppedLine = line;
         if (!info.source)
         {
             target->parentRuntime.reporter.reportError(Luau::format("breakpoint hit at line %d could not find a runtime source", line));
@@ -438,6 +437,7 @@ void Target::installBpHitCallback()
             target->bpHit = *bp;
             target->paused = true;
             target->childRuntime->stopDebug();
+            target->stoppedLine = line;
             target->stoppedThread = L;
             target->stoppedThreadRef = getRefForThread(L);
             lua_break(L);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -569,14 +569,20 @@ std::vector<Thread> Target::getThreads() const
     return result;
 }
 
+
+int Target::getStackDepth(int threadId)
+{
+    if (!launched || !paused || threadIdToState.find(threadId) == threadIdToState.end())
+        return -1;
+    return lua_stackdepth(threadIdToState.at(threadId));
+}
+
 std::optional<StackFrame> Target::getStackFrameHelper(int threadId, int level)
 {
     if (!paused)
         return std::nullopt;
     if (threadIdToState.find(threadId) == threadIdToState.end())
-    {
         return std::nullopt;
-    }
     std::unordered_map<int, StackFrame>& levelMap = stateToStackFrame[threadId];
     auto it = levelMap.find(level);
     if (it == levelMap.end())
@@ -624,31 +630,21 @@ std::optional<std::vector<StackFrame>> Target::getStackTrace(int threadId, int s
     if (!paused)
         return std::nullopt;
     if (threadIdToState.find(threadId) == threadIdToState.end())
-    {
         return std::nullopt;
-    }
     int stackDepth = lua_stackdepth(threadIdToState[threadId]);
     if (startLevel >= stackDepth)
-    {
         return std::nullopt;
-    }
     int maximumLevel;
     if (numFrames == 0)
-    {
         maximumLevel = stackDepth;
-    }
     else
-    {
         maximumLevel = std::min(startLevel + numFrames, stackDepth);
-    }
     std::vector<StackFrame> stackTrace;
     for (int i = startLevel; i < maximumLevel; i++)
     {
         std::optional<StackFrame> frame = getStackFrameHelper(threadId, i);
         if (!frame)
-        {
             return std::nullopt;
-        }
         stackTrace.emplace_back(*frame);
     }
     return stackTrace;

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -591,10 +591,16 @@ std::optional<StackFrame> Target::getStackFrameHelper(int threadId, int level)
         frame.id = stackframeId;
         stackframeId++;
         lua_Debug ar = {};
-        if (!lua_getinfo(threadIdToState[threadId], level, "sln", &ar))
+        lua_State* threadLua = threadIdToState.at(threadId);
+        if (!lua_getinfo(threadLua, level, "sln", &ar))
             return std::nullopt;
-
-        frame.name = ar.name ? ar.name : "(anonymous)";
+        if (!ar.name)
+            if (threadLua == scriptThread && level == lua_stackdepth(threadLua) - 1)
+                frame.name = "(entry)";
+            else
+                frame.name = "(anonymous)";
+        else
+            frame.name = ar.name;
         if (ar.source)
         {
             frame.sourcePath = getSourceFromChunk(ar.source);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -663,6 +663,12 @@ bool Target::continueProcess()
     // in case it has not actually been triggered.
     lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
     cb->interrupt = nullptr;
+
+    // we clear the stack frame information
+    stackframeId = 1;
+    stateToStackFrame.clear();
+    idToStackFrameInfo.clear();
+
     if (stoppedThread)
     {
         // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
@@ -681,6 +687,7 @@ bool Target::continueProcess()
         childRuntime->schedule([]() {});
         stoppedThread = nullptr;
         stoppedThreadRef = nullptr;
+        stoppedLine = -1;
     }
     paused = false;
     childRuntime->continueDebug();

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -331,7 +331,11 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		)
 		local threads = target:getThreads()
 		local threadId = threads[1].id
-		check.eq(target:getLine(), 9)
+		local source, line = target:getStoppedLocation()
+		assert(line)
+		assert(source)
+		check.eq(source, normalizePath(mainPath))
+		check.eq(line, 9)
 		target:step(threadId, "stepIn")
 		check.eq(
 			waitUntil(function()
@@ -339,7 +343,11 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 			end),
 			true
 		)
-		check.eq(target:getLine(), 10)
+		source, line = target:getStoppedLocation()
+		assert(line)
+		assert(source)
+		check.eq(source, normalizePath(mainPath))
+		check.eq(line, 10)
 		target:stepIn(threadId)
 		check.eq(
 			waitUntil(function()
@@ -347,7 +355,11 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 			end),
 			true
 		)
-		check.eq(target:getLine(), 2)
+		source, line = target:getStoppedLocation()
+		assert(line)
+		assert(source)
+		check.eq(source, normalizePath(mainPath))
+		check.eq(line, 2)
 		target:stepOut(threadId)
 		check.eq(
 			waitUntil(function()
@@ -355,7 +367,11 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 			end),
 			true
 		)
-		check.eq(target:getLine(), 11)
+		source, line = target:getStoppedLocation()
+		assert(line)
+		assert(source)
+		check.eq(source, normalizePath(mainPath))
+		check.eq(line, 11)
 		target:stepOver(threadId)
 		check.eq(
 			waitUntil(function()
@@ -363,7 +379,11 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 			end),
 			true
 		)
-		check.eq(target:getLine(), 12)
+		source, line = target:getStoppedLocation()
+		assert(line)
+		assert(source)
+		check.eq(source, normalizePath(mainPath))
+		check.eq(line, 12)
 		target:continueProcess()
 		check.eq(
 			waitUntil(function()

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -315,6 +315,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				local stacktrace = target:getStackTrace(threads[1].id)
 				assert(stacktrace)
 				check.eq(#stacktrace, hits + 1)
+				check.eq(target:getStackDepth(threads[1].id), hits + 1)
 				for i, frame in stacktrace do
 					check.eq(frame.id, i)
 					check.eq(frame.column, 0)
@@ -327,6 +328,12 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 						check.eq(frame.line, 5)
 					end
 				end
+				-- this a small check that getStackFrame() works
+				local specificFrame = target:getStackFrame(threads[1].id, 0)
+				assert(specificFrame)
+				check.eq(specificFrame.id, 1)
+				check.eq(specificFrame.column, 0)
+				check.eq(specificFrame.sourcePath, mainPath)
 				local continued = target:continueProcess()
 				check.that(continued)
 			end,

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -299,4 +299,49 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		check.eq(prints[2].msg, "custom_value\n")
 		check.eq(prints[2].line, 7)
 	end)
+	-- this test case focuses on inspecting stack trace
+	suite:case("inspectStackTrace", function(check)
+		local target = debug.newTarget()
+		check.eq(typeof(target), "Target")
+		local mainPath = path.format(path.join(proc.cwd(), "tests/src/debug/pow.luau"))
+		target:setBreakpoint(mainPath, 5)
+		local hits = 0
+		local onFinished = false
+		local targetLaunched = target:launch(mainPath, {}, {
+			onBreakpointHit = function(thread, bp)
+				hits += 1
+				local threads = target:getThreads()
+				check.eq(#threads, 1)
+				local stacktrace = target:getStackTrace(threads[1].id)
+				assert(stacktrace)
+				check.eq(#stacktrace, hits + 1)
+				for i, frame in stacktrace do
+					check.eq(frame.id, i)
+					check.eq(frame.column, 0)
+					check.eq(frame.sourcePath, mainPath)
+					if i == #stacktrace then
+						check.eq(frame.name, "(anonymous)")
+						check.eq(frame.line, 8)
+					else
+						check.eq(frame.name, "pow")
+						check.eq(frame.line, 5)
+					end
+				end
+				local continued = target:continueProcess()
+				check.that(continued)
+			end,
+			onExit = function(status)
+				if status then
+					onFinished = true
+				end
+			end,
+		})
+		check.that(targetLaunched)
+		check.eq(
+			waitUntil(function()
+				return onFinished
+			end),
+			true
+		)
+	end)
 end)

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -307,7 +307,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		target:setBreakpoint(mainPath, 5)
 		local hits = 0
 		local onFinished = false
-		local targetLaunched = target:launch(mainPath, {}, {
+		local launchError = target:launch(mainPath, {}, {
 			onBreakpointHit = function(thread, bp)
 				hits += 1
 				local threads = target:getThreads()
@@ -321,7 +321,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 					check.eq(frame.column, 0)
 					check.eq(frame.sourcePath, mainPath)
 					if i == #stacktrace then
-						check.eq(frame.name, "(anonymous)")
+						check.eq(frame.name, "(entry)")
 						check.eq(frame.line, 8)
 					else
 						check.eq(frame.name, "pow")
@@ -343,7 +343,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				end
 			end,
 		})
-		check.that(targetLaunched)
+		check.eq(launchError, nil)
 		check.eq(
 			waitUntil(function()
 				return onFinished

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -319,7 +319,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				for i, frame in stacktrace do
 					check.eq(frame.id, i)
 					check.eq(frame.column, 0)
-					check.eq(frame.sourcePath, mainPath)
+					check.eq(frame.sourcePath, normalizePath(mainPath))
 					if i == #stacktrace then
 						check.eq(frame.name, "(entry)")
 						check.eq(frame.line, 8)
@@ -333,7 +333,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				assert(specificFrame)
 				check.eq(specificFrame.id, 1)
 				check.eq(specificFrame.column, 0)
-				check.eq(specificFrame.sourcePath, mainPath)
+				check.eq(specificFrame.sourcePath, normalizePath(mainPath))
 				local continued = target:continueProcess()
 				check.that(continued)
 			end,

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -308,7 +308,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local hits = 0
 		local onFinished = false
 		local launchError = target:launch(mainPath, {}, {
-			onBreakpointHit = function(thread, bp)
+			onBreakpointHit = function(_thread, _bp)
 				hits += 1
 				local threads = target:getThreads()
 				check.eq(#threads, 1)

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -445,4 +445,78 @@ TEST_SUITE("Debug")
         CHECK(hitsBp1 == 5);
         CHECK(hitsBp2 == 5);
     }
+
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_stackFrame")
+    {
+        std::string fixturePath = getDebugFixturePath("recursion.luau");
+        Target target(*runtime);
+        Breakpoint bpA = target.setBreakpoint(fixturePath, 4);
+        Breakpoint bpB = target.setBreakpoint(fixturePath, 8);
+        Breakpoint mainBp = target.setBreakpoint(fixturePath, 14);
+        int hits = 0;
+        config.onBreakpointHit = [&](const Thread&, const Breakpoint& bp)
+        {
+            const std::vector<Thread>& threads = target.getThreads();
+            CHECK(threads.size() == 1);
+            int threadId = threads.at(0).id;
+            std::optional<std::vector<StackFrame>> stacktrace = target.getStackTrace(threadId);
+            REQUIRE(stacktrace.has_value());
+            // our stack trace should from the most deep stack frame go main -> a -> b -> a -> b ....
+            // the stack trace returns this in reverse since it starts from the shallowest stack frame.
+            hits++;
+            bool hitA = false;
+            int expectedTraceSize = hits;
+            if (bp.id == bpA.id)
+            {
+                hitA = true;
+            }
+            CHECK(stacktrace->size() == expectedTraceSize);
+
+            for (int i = 0; i < expectedTraceSize; i++)
+            {
+                int line;
+                int column = 0;
+                std::string name;
+                std::string sourcePath = fixturePath;
+                if (i == expectedTraceSize - 1)
+                {
+                    line = 14;
+                    name = "(anonymous)";
+                }
+                else if ((hitA && i % 2 == 0) || (!hitA && i % 2 == 1))
+                {
+                    line = 4;
+                    name = "a";
+                }
+                else
+                {
+                    // the function name field is not set during the equality operation
+                    // so B stays anonymous
+                    name = "(anonymous)";
+                    if (!hitA && i == 0)
+                    {
+                        line = 8;
+                    }
+                    else
+                    {
+                        line = 11;
+                    }
+                }
+                StackFrame frame = stacktrace->at(i);
+                CHECK(frame.id == i + 1);
+                CHECK(frame.column == column);
+                CHECK(frame.line == line);
+                CHECK(frame.name == name);
+                CHECK(frame.sourcePath == sourcePath);
+            }
+            bool continued = target.continueProcess();
+            CHECK(continued);
+            stacktrace = target.getStackTrace(threadId);
+            // we shouldn't get stack trace when things are paused
+            REQUIRE(!stacktrace.has_value());
+        };
+        target.launch(fixturePath, {}, config);
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        CHECK(hits == 9);
+    }
 }

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -471,7 +471,7 @@ TEST_SUITE("Debug")
                 hitA = true;
             }
             CHECK(stacktrace->size() == expectedTraceSize);
-
+            CHECK(target.getStackDepth(threadId) == expectedTraceSize);
             for (int i = 0; i < expectedTraceSize; i++)
             {
                 int line;

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -481,7 +481,7 @@ TEST_SUITE("Debug")
                 if (i == expectedTraceSize - 1)
                 {
                     line = 14;
-                    name = "(anonymous)";
+                    name = "(entry)";
                 }
                 else if ((hitA && i % 2 == 0) || (!hitA && i % 2 == 1))
                 {

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <future>
+#include <optional>
 #include <thread>
 
 #include "debugfixture.h"
@@ -252,10 +253,11 @@ TEST_SUITE("Debug")
         // check that we actually stopped at the breakpoint by having not hit the exit
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(0)) == std::future_status::timeout);
-        CHECK(target.getLine() == 2);
+        REQUIRE(target.getStoppedLocation().has_value());
+        CHECK(target.getStoppedLocation() == std::make_pair(fixturePath, 2));
         // continue execution
         continuedProcess = target.continueProcess();
-        CHECK(target.getLine() == -1);
+        REQUIRE(!target.getStoppedLocation().has_value());
         CHECK(continuedProcess);
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     }
@@ -292,7 +294,8 @@ TEST_SUITE("Debug")
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(0)) == std::future_status::timeout);
         CHECK(numPause == 1);
         // The pause should stop right after we finish the last line of the inner for loop.
-        CHECK(target.getLine() == 5);
+        REQUIRE(target.getStoppedLocation().has_value());
+        CHECK(target.getStoppedLocation()->second == 5);
         bool continuedProcess = target.continueProcess();
         CHECK(continuedProcess);
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
@@ -383,7 +386,6 @@ TEST_SUITE("Debug")
         CHECK(prints[1] == std::make_pair(std::string("custom_value\n"), 7));
     }
 
-
     TEST_CASE_FIXTURE(DebugFixture, "Debug_step")
     {
         std::string mainPath = getDebugFixturePath("step.luau");
@@ -413,39 +415,45 @@ TEST_SUITE("Debug")
         // check we have hit bp
         REQUIRE(hitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         // step in acts like step over when there's no function calls
-        CHECK(target.getLine() == 9);
+        REQUIRE(target.getStoppedLocation().has_value());
+        CHECK(target.getStoppedLocation()->second == 9);
         bool stepped = target.stepIn(threadId);
         CHECK(stepped);
         REQUIRE(stepFuture.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
-        CHECK(target.getLine() == 10);
+        REQUIRE(target.getStoppedLocation().has_value());
+        CHECK(target.getStoppedLocation()->second == 10);
         stepPromise = std::promise<void>{};
         stepFuture = stepPromise.get_future();
         // step into function f
         stepped = target.stepIn(threadId);
         CHECK(stepped);
         REQUIRE(stepFuture.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
-        CHECK(target.getLine() == 2);
+        REQUIRE(target.getStoppedLocation().has_value());
+        CHECK(target.getStoppedLocation()->second == 2);
         stepPromise = std::promise<void>{};
         stepFuture = stepPromise.get_future();
         // this steps out of function to the next line in the caller
         stepped = target.stepOut(threadId);
         CHECK(stepped);
         REQUIRE(stepFuture.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
-        CHECK(target.getLine() == 11);
+        REQUIRE(target.getStoppedLocation().has_value());
+        CHECK(target.getStoppedLocation()->second == 11);
         stepPromise = std::promise<void>{};
         stepFuture = stepPromise.get_future();
         // this steps over a function
         stepped = target.stepOver(threadId);
         CHECK(stepped);
         REQUIRE(stepFuture.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
-        CHECK(target.getLine() == 12);
+        REQUIRE(target.getStoppedLocation().has_value());
+        CHECK(target.getStoppedLocation()->second == 12);
         stepPromise = std::promise<void>{};
         stepFuture = stepPromise.get_future();
         // this steps to the virtual last line
         stepped = target.stepOver(threadId);
         CHECK(stepped);
         REQUIRE(stepFuture.wait_for(std::chrono::seconds(1)) == std::future_status::ready);
-        CHECK(target.getLine() == 13);
+        REQUIRE(target.getStoppedLocation().has_value());
+        CHECK(target.getStoppedLocation()->second == 13);
         target.stepOver(threadId);
 
         // check we are done

--- a/tests/src/debug/pow.luau
+++ b/tests/src/debug/pow.luau
@@ -1,0 +1,8 @@
+local function pow(n: int)
+	if n == 0 then
+		return 1
+	end
+	return 2 * pow(n - 1)
+end
+
+pow(5)

--- a/tests/src/debug/recursion.luau
+++ b/tests/src/debug/recursion.luau
@@ -1,0 +1,14 @@
+local b: (n: number) -> number
+
+local function a(n: number): number
+    return n + b(n);
+end
+
+b = function(n: number): number
+    if n == 0 then
+        return 0
+    end
+    return n +  a(n-1)
+end
+
+a(3)

--- a/tests/src/debug/recursion.luau
+++ b/tests/src/debug/recursion.luau
@@ -1,14 +1,14 @@
 local b: (n: number) -> number
 
 local function a(n: number): number
-    return n + b(n);
+	return n + b(n)
 end
 
 b = function(n: number): number
-    if n == 0 then
-        return 0
-    end
-    return n +  a(n-1)
+	if n == 0 then
+		return 0
+	end
+	return n + a(n - 1)
 end
 
 a(3)


### PR DESCRIPTION
Adds stack frames/stack traces (part 2/3 of PRs dealing with inspecting into state)
* Adds `getStackDepth`, `getStackFrame`, and `getStackTrace` to debugger
* Modify `getLine` to `getStoppedLocation` to include source path
* Allows for delayed stack loading in DAP
* In DAP by supporting stack frames we allow for line highlighting

https://github.com/user-attachments/assets/ea426af3-2952-4141-803f-0797ce2f2f37

