### PR TITLE
Refine and standardize `@batteries/cli` usage and help

### DIFF
--- a/batteries/cli.luau
+++ b/batteries/cli.luau
@@ -182,7 +182,7 @@ function cli.forwarded(self: Parser): { string }?
 end
 
 function cli.usage(self: Parser, name: string): string
-	local parts = { name }
+	local parts = { `Usage: {name}` }
 
 	for _, arg in self.positional do
 		if not arg.options.hidden then
@@ -213,24 +213,29 @@ function cli.usage(self: Parser, name: string): string
 	return table.concat(parts, " ")
 end
 
+local function label(argument: ArgData): string
+	if argument.kind == "positional" or argument.kind == "variadic" then
+		local name = if argument.kind == "variadic" then `{argument.name}...` else argument.name
+		return if argument.options.required then `<{name}>` else `[{name}]`
+	end
+
+	local aliasStr = table.concat(argument.options.aliases or {}, ", ")
+	return `--{argument.name}{if #aliasStr > 0 then ` (-{aliasStr})` else ""}`
+end
+
 function cli.help(self: Parser, formatter: ((s: string) -> string)?): ()
 	local fmt = formatter or function(s)
 		return s
 	end
 
-	print(fmt("Usage:"))
+	print(fmt("Options:"))
 	for _, argument in self.arguments do
 		if argument.options.hidden then
 			continue
 		end
 
-		local aliasStr = table.concat(argument.options.aliases or {}, ", ")
 		local reqStr = if argument.options.required then "(required) " else ""
-		print(
-			fmt(
-				`  --{argument.name}{if #aliasStr > 0 then ` (-{aliasStr})` else ""} - {reqStr}{argument.options.help or ""}`
-			)
-		)
+		print(fmt(`  {label(argument)} - {reqStr}{argument.options.help or ""}`))
 	end
 end
 

--- a/batteries/cli.luau
+++ b/batteries/cli.luau
@@ -223,20 +223,22 @@ local function label(argument: ArgData): string
 	return `--{argument.name}{if #aliasStr > 0 then ` (-{aliasStr})` else ""}`
 end
 
-function cli.help(self: Parser, formatter: ((s: string) -> string)?): ()
+function cli.help(self: Parser, formatter: ((s: string) -> string)?): string
 	local fmt = formatter or function(s)
 		return s
 	end
 
-	print(fmt("Options:"))
+	local lines = { fmt("Options:") }
 	for _, argument in self.arguments do
 		if argument.options.hidden then
 			continue
 		end
 
 		local reqStr = if argument.options.required then "(required) " else ""
-		print(fmt(`  {label(argument)} - {reqStr}{argument.options.help or ""}`))
+		table.insert(lines, fmt(`  {label(argument)} - {reqStr}{argument.options.help or ""}`))
 	end
+
+	return table.concat(lines, "\n")
 end
 
 return table.freeze(cli)

--- a/docs/cli/lint/index.md
+++ b/docs/cli/lint/index.md
@@ -10,7 +10,7 @@ You can find the full suite of `lute lint`'s default rules documented as sub-pag
 ## Usage
 
 ```bash
-lute lint [OPTIONS] [...PATHS]
+lute lint [options] [paths...]
 ```
 
 ## Options

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -5,7 +5,7 @@ Generate type definition files for the language server.
 ## Usage
 
 ```bash
-lute setup
+lute setup [options]
 ```
 
 ## Options

--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -5,7 +5,7 @@ Run tests discovered in .test.luau and .spec.luau files (defaults to looking for
 ## Usage
 
 ```bash
-lute test [OPTIONS] [PATHS...]
+lute test [options] [paths...]
 ```
 
 ## Options

--- a/docs/cli/transform.md
+++ b/docs/cli/transform.md
@@ -6,7 +6,7 @@ Individual code transformers can specify custom migration options, which are par
 ## Usage
 
 ```bash
-lute transform <transformer script> [options...] <files...>
+lute transform [migration-path] [options] [files...] [-- [--option value...]]
 ```
 
 ## Options

--- a/lute/cli/commands/debug/init.luau
+++ b/lute/cli/commands/debug/init.luau
@@ -2,18 +2,14 @@ local io = require("@std/io")
 local cli = require("@batteries/cli")
 local dap = require("@self/dap")
 
-local USAGE = "Usage: lute debug serve"
-
-local function printHelp()
-	print(USAGE)
+local function printHelp(args: cli.Parser)
+	print(args:usage("lute debug"))
+	print("\nStarts the Lute debugger as a DAP server.\n")
+	print(args:help())
 	print([[
-Starts the Lute debugger as a DAP server.
 
 SUBCOMMANDS:
   serve                   Start a DAP debug adapter server over stdio
-
-OPTIONS:
-  -h, --help              Show this help message
 
 EXAMPLES:
   lute debug serve
@@ -23,19 +19,19 @@ end
 local function main(...: string)
 	local args = cli.parser()
 	args:add("help", "flag", { help = "Show help message", aliases = { "h" } })
-	args:add("subcommand", "positional", { help = "serve", required = false })
+	args:add("subcommand", "positional", { help = "Subcommand to run (serve)", required = false })
 
 	args:parse({ ... })
 
 	if args:has("help") then
-		printHelp()
+		printHelp(args)
 		return
 	end
 
 	if args:get("subcommand") == "serve" then
 		dap.dapLoop(io.input, io.write)
 	else
-		printHelp()
+		printHelp(args)
 	end
 end
 

--- a/lute/cli/commands/doc/init.luau
+++ b/lute/cli/commands/doc/init.luau
@@ -5,7 +5,6 @@ local path = require("@std/path")
 local process = require("@std/process")
 local stringext = require("@std/stringext")
 
-local USAGE = "Usage: lute doc [OPTIONS] [...MODULE_PATHS]"
 local DEFAULT_OUTPUT_DIR = path.resolve(process.cwd(), "docs")
 
 local STDLIB_MODULE_ALIASES = {
@@ -47,14 +46,11 @@ type Mapping = {
 	[string]: { alias: string, destination: string },
 }
 
-local function printHelp()
-	print(USAGE)
+local function printHelp(args: cli.Parser)
+	print(args:usage("lute doc"))
+	print("\nGenerate Markdown documentation for Luau module(s).\n")
+	print(args:help())
 	print([[
-Generate Markdown documentation for Luau module(s).
-
-OPTIONS:
-  -h, --help              Show this help message
-  -o, --output=DIR        Output directory for generated docs (default: ./docs in current working directory)
 
 MODULE_PATHS:
   Path(s) to Luau module(s) to generate documentation for. Only files with .luau or .lua extensions will be processed.
@@ -661,11 +657,12 @@ local function main(...: string)
 		"option",
 		{ help = "Output directory for generated docs", default = tostring(DEFAULT_OUTPUT_DIR), aliases = { "o" } }
 	)
+	args:add("module-paths", "variadic", { help = "Luau module(s) to generate documentation for" })
 
 	args:parse({ ... })
 
 	if args:has("help") then
-		printHelp()
+		printHelp(args)
 		return
 	end
 
@@ -683,10 +680,14 @@ local function main(...: string)
 		return
 	end
 
-	local modulePaths = args:forwarded()
+	-- Paths land in variadics, but anything after `--` still arrives as forwarded args.
+	local modulePaths = table.clone(args:variadics())
+	local fwdArgs = args:forwarded() or {}
+	table.move(fwdArgs, 1, #fwdArgs, #modulePaths + 1, modulePaths)
+
 	assert(
-		modulePaths ~= nil and #modulePaths > 0,
-		"Error: No module paths specified.\n\n" .. USAGE .. "\n\nUse --help for more information."
+		#modulePaths > 0,
+		`Error: No module paths specified.\n\n{args:usage("lute doc")}\n\nUse --help for more information.`
 	)
 
 	print("Generating documentation...")

--- a/lute/cli/commands/doc/init.luau
+++ b/lute/cli/commands/doc/init.luau
@@ -48,7 +48,7 @@ type Mapping = {
 
 local function printHelp(args: cli.Parser)
 	print(args:usage("lute doc"))
-	print("\nGenerate Markdown documentation for Luau module(s).\n")
+	print("\nGenerate Markdown documentation for Luau modules.\n")
 	print(args:help())
 	print([[
 

--- a/lute/cli/commands/doc/init.luau
+++ b/lute/cli/commands/doc/init.luau
@@ -53,7 +53,7 @@ local function printHelp(args: cli.Parser)
 	print([[
 
 MODULE_PATHS:
-  Path(s) to Luau module(s) to generate documentation for. Only files with .luau or .lua extensions will be processed.
+  Paths to Luau modules to generate documentation for. Only files with .luau or .lua extensions will be processed.
   Paths can be absolute or relative to the current working directory.
 
 EXAMPLES:
@@ -657,7 +657,7 @@ local function main(...: string)
 		"option",
 		{ help = "Output directory for generated docs", default = tostring(DEFAULT_OUTPUT_DIR), aliases = { "o" } }
 	)
-	args:add("module-paths", "variadic", { help = "Luau module(s) to generate documentation for" })
+	args:add("module-paths", "variadic", { help = "Luau modules to generate documentation for" })
 
 	args:parse({ ... })
 

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -19,7 +19,7 @@ local SEQUENTIAL = false
 local function printHelp(args: cli.Parser)
 	print(args:usage("lute lint"))
 	print("\nLint the specified Luau file using the specified lint rule(s) or using the default rules.\n")
-	args:help()
+	print(args:help())
 	print([[
 
 PATHS:

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -73,7 +73,7 @@ local function main(...: string)
 	args:add("json", "flag", { help = "Output lint violations in JSON format", aliases = { "j" } })
 	args:add("no-default-lints", "flag", { help = "Disables the default lint rules" })
 	args:add("output", "option", { help = "Write diagnostics output to file", aliases = { "o" } })
-	args:add("rules", "option", { help = "Linting rule(s) to apply", aliases = { "r" } })
+	args:add("rules", "option", { help = "Linting rules to apply", aliases = { "r" } })
 	args:add(
 		"string-input",
 		"option",

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -18,12 +18,12 @@ local SEQUENTIAL = false
 
 local function printHelp(args: cli.Parser)
 	print(args:usage("lute lint"))
-	print("\nLint the specified Luau file using the specified lint rule(s) or using the default rules.\n")
+	print("\nLint the specified Luau file using the specified lint rules or using the default rules.\n")
 	print(args:help())
 	print([[
 
 PATHS:
-  Path(s) to the Luau file(s) or folders containing Luau files to be linted. Only files with .luau or .lua extensions will be linted.
+  Paths to the Luau files or folders containing Luau files to be linted. Only files with .luau or .lua extensions will be linted.
 
 EXAMPLES:
   lute lint -r examples/lints/almost_swapped.luau bad_swap.luau

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -13,32 +13,14 @@ local process = require("@std/process")
 local tableext = require("@std/tableext")
 local types = require("@lint")
 
-local USAGE = "Usage: lute lint [OPTIONS] [...PATHS]"
 local VERBOSE = false
 local SEQUENTIAL = false
 
-local function printHelp()
-	print(USAGE)
-	-- Ordering of options: help + verbose fist, then options with aliases in alphabetical order, then options without aliases in alphabetical order
+local function printHelp(args: cli.Parser)
+	print(args:usage("lute lint"))
+	print("\nLint the specified Luau file using the specified lint rule(s) or using the default rules.\n")
+	args:help()
 	print([[
-Lint the specified Luau file using the specified lint rule(s) or using the default rules.
-
-OPTIONS:
-  -h, --help              Show this help message
-  -v, --verbose		  	  Enable verbose output
-  -c, --config [PATH]	  Path to configuration file. By default, lute lint will look for a
-  						  the .config.luau file in the calling directory.
-  -j, --json              Output lint violations in JSON format matching the LSP diagnostic spec.
-  -o, --output [PATH]	  Write lint violation or JSON output to the specified file instead of stdout.
-  -r, --rules [RULE]      Path to a single lint rule or a folder containing lint rules. If a folder
-  						  is provided, any subfolders containing init.luau files will be treated as
-						  modules exporting lint rules, while all other .luau files will be treated
-						  as individual lint rules. If unspecified, the default lint rules are used.
-  -s, --string-input	  Lint the provided string input instead of reading from files.
-  --auto-fix			  Automatically apply fixes for lint violations that provide a suggested fix.
-						  Assumes that suggested fixes do not overlap.
-  --no-default-lints	  Disables the default lint rules.
-  --sequential			  Lint files sequentially. Files are linted in parallel by default.
 
 PATHS:
   Path(s) to the Luau file(s) or folders containing Luau files to be linted. Only files with .luau or .lua extensions will be linted.
@@ -99,20 +81,25 @@ local function main(...: string)
 	)
 	args:add("verbose", "flag", { help = "Enable verbose output", aliases = { "v" } })
 	args:add("sequential", "flag", { help = "Lint files sequentially (parallel by default)" })
+	args:add("paths", "variadic", { help = "Files or folders to lint (defaults to the current directory)" })
 
 	args:parse({ ... })
 
 	if args:has("help") then
-		printHelp()
+		printHelp(args)
 		return
 	end
 
 	VERBOSE = args:has("verbose")
 	SEQUENTIAL = args:has("sequential")
 
-	local inputFiles = args:forwarded()
+	-- Paths land in variadics, but anything after `--` still arrives as forwarded args.
+	local inputFiles = table.clone(args:variadics())
+	local fwdArgs = args:forwarded() or {}
+	table.move(fwdArgs, 1, #fwdArgs, #inputFiles + 1, inputFiles)
+
 	local stringInput = args:get("string-input")
-	if (inputFiles == nil or #inputFiles == 0) and not stringInput then
+	if #inputFiles == 0 and not stringInput then
 		inputFiles = { pathLib.format(process.cwd()) }
 	end
 

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -96,7 +96,7 @@ local function main(...: string)
 	-- Paths land in variadics, but anything after `--` still arrives as forwarded args.
 	local inputFiles = table.clone(args:variadics())
 	local fwdArgs = args:forwarded() or {}
-	table.move(fwdArgs, 1, #fwdArgs, #inputFiles + 1, inputFiles)
+	tableext.extend(inputFiles, fwdArgs)
 
 	local stringInput = args:get("string-input")
 	if #inputFiles == 0 and not stringInput then

--- a/lute/cli/commands/lint/init.luau
+++ b/lute/cli/commands/lint/init.luau
@@ -63,24 +63,36 @@ end
 local function main(...: string)
 	local args = cli.parser()
 
-	args:add(
-		"auto-fix",
-		"flag",
-		{ help = "Automatically apply fixes for lint violations that provide a suggested fix" }
-	)
-	args:add("config", "option", { help = "Path to configuration file", aliases = { "c" } })
+	args:add("auto-fix", "flag", {
+		help = "Automatically apply fixes for lint violations that provide a suggested fix. Assumes that suggested fixes do not overlap.",
+	})
+	args:add("config", "option", {
+		help = "Path to configuration file. By default, lute lint will look for the .config.luau file in the calling directory.",
+		aliases = { "c" },
+	})
 	args:add("help", "flag", { help = "Show help message", aliases = { "h" } })
-	args:add("json", "flag", { help = "Output lint violations in JSON format", aliases = { "j" } })
+	args:add(
+		"json",
+		"flag",
+		{ help = "Output lint violations in JSON format matching the LSP diagnostic spec", aliases = { "j" } }
+	)
 	args:add("no-default-lints", "flag", { help = "Disables the default lint rules" })
-	args:add("output", "option", { help = "Write diagnostics output to file", aliases = { "o" } })
-	args:add("rules", "option", { help = "Linting rules to apply", aliases = { "r" } })
+	args:add(
+		"output",
+		"option",
+		{ help = "Write lint violation or JSON output to the specified file instead of stdout", aliases = { "o" } }
+	)
+	args:add("rules", "option", {
+		help = "Path to a single lint rule or a folder containing lint rules. If a folder is provided, any subfolders containing init.luau files will be treated as modules exporting lint rules, while all other .luau files will be treated as individual lint rules. If unspecified, the default lint rules are used",
+		aliases = { "r" },
+	})
 	args:add(
 		"string-input",
 		"option",
 		{ help = "Lint the provided string input instead of reading from files", aliases = { "s" } }
 	)
 	args:add("verbose", "flag", { help = "Enable verbose output", aliases = { "v" } })
-	args:add("sequential", "flag", { help = "Lint files sequentially (parallel by default)" })
+	args:add("sequential", "flag", { help = "Lint files sequentially. Files are linted in parallel by default." })
 	args:add("paths", "variadic", { help = "Files or folders to lint (defaults to the current directory)" })
 
 	args:parse({ ... })

--- a/lute/cli/commands/new/init.luau
+++ b/lute/cli/commands/new/init.luau
@@ -4,18 +4,11 @@ local path = require("@std/path")
 local process = require("@std/process")
 local typedefs = require("./lib/typedefs")
 
-local USAGE = "Usage: lute new <project-name>"
-
-local function printHelp()
-	print(USAGE)
+local function printHelp(args: cli.Parser)
+	print(args:usage("lute new"))
+	print("\nCreate a new Lute project with a standard directory layout.\n")
+	print(args:help())
 	print([[
-Create a new Lute project with a standard directory layout.
-
-ARGUMENTS:
-  <project-name>    Name of the project to create
-
-OPTIONS:
-  -h, --help        Show this help message
 
 EXAMPLES:
   lute new myproject
@@ -25,17 +18,17 @@ end
 local function main(...: string)
 	local args = cli.parser()
 	args:add("help", "flag", { help = "Show this help message", aliases = { "h" } })
-	args:add("name", "positional", { help = "Name of the project to create" })
+	args:add("project-name", "positional", { help = "Name of the project to create" })
 	args:parse({ ... })
 
 	if args:has("help") then
-		printHelp()
+		printHelp(args)
 		return
 	end
 
-	local projectName = args:get("name")
+	local projectName = args:get("project-name")
 	if projectName == nil or projectName == "" then
-		print("Error: Missing required argument <project-name>.\n\n" .. USAGE .. "\nUse --help for more information.")
+		print(`Error: Missing required argument <project-name>.\n\n{args:usage("lute new")}\nUse --help for more information.`)
 		process.exit(1)
 	end
 

--- a/lute/cli/commands/new/init.luau
+++ b/lute/cli/commands/new/init.luau
@@ -28,7 +28,9 @@ local function main(...: string)
 
 	local projectName = args:get("project-name")
 	if projectName == nil or projectName == "" then
-		print(`Error: Missing required argument <project-name>.\n\n{args:usage("lute new")}\nUse --help for more information.`)
+		print(
+			`Error: Missing required argument <project-name>.\n\n{args:usage("lute new")}\nUse --help for more information.`
+		)
 		process.exit(1)
 	end
 

--- a/lute/cli/commands/pkg/loom-core/src/commands/authenticate.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/authenticate.luau
@@ -9,7 +9,7 @@ local function authenticate(...: string)
 	local valid, err = pcall(cli.parse, args, { ... })
 	if not valid then
 		print(err)
-		args:help()
+		print(args:help())
 		error(err)
 	end
 

--- a/lute/cli/commands/pkg/loom-core/src/commands/install.luau
+++ b/lute/cli/commands/pkg/loom-core/src/commands/install.luau
@@ -44,7 +44,7 @@ local function install(...: string)
 	local valid, err = pcall(cli.parse, args, { ... })
 	if not valid then
 		print(err)
-		args:help()
+		print(args:help())
 		error(err)
 	end
 

--- a/lute/cli/commands/setup/init.luau
+++ b/lute/cli/commands/setup/init.luau
@@ -16,14 +16,9 @@ args:add("with-luaurc", "flag", { help = "Also write a .luaurc file in the curre
 args:parse({ ... })
 
 if args:has("help") then
-	print("Usage: lute setup [options]")
-	print([[
-Install Lute type definitions to ~/.lute/typedefs/{version}.
-
-OPTIONS:
-  --with-luaurc     Also write a .luaurc file in the current directory
-  -h, --help        Show this help message
-]])
+	print(args:usage("lute setup"))
+	print("\nInstall Lute type definitions to ~/.lute/typedefs/{version}.\n")
+	print(args:help())
 	return
 end
 

--- a/lute/cli/commands/test/init.luau
+++ b/lute/cli/commands/test/init.luau
@@ -10,6 +10,7 @@ local testtypes = require("@std/test/types")
 local reporter = require("@self/reporter")
 local test = require("@std/test")
 local snaprunner = require("@self/snap/runner")
+local tableext = require("@std/tableext")
 local updater = require("@self/snap/updater")
 
 local function loadtests(testfiles: { path.Path })
@@ -146,29 +147,34 @@ local function main(...: string)
 	args:add("case", "option", { help = "Run only test cases matching the specified name", aliases = { "c" } })
 	args:add("interactive", "flag", { help = "Interactively accept/reject snapshot changes", aliases = { "i" } })
 	args:add("update", "flag", { help = "Auto-accept all snapshot changes", aliases = { "u" } })
+	args:add("paths", "variadic", { help = "Directories or files to search for tests (default: ./)" })
 
 	args:parse({ ... })
 
 	if args:has("help") then
+		print(args:usage("lute test"))
+		print()
 		print(args:help())
 		return
 	end
 
-	local forwarded = args:forwarded()
+	local paths = table.clone(args:variadics())
+	tableext.extend(paths, args:forwarded())
+
 	-- Check if this is a snapshot subcommand
-	if forwarded and #forwarded > 0 and forwarded[1] == "snapshots" then
-		if #forwarded == 1 then
+	if paths[1] == "snapshots" then
+		if #paths == 1 then
 			runsnapshots({ "./tests" }, args:has("update"), args:has("interactive"))
 		else
 			local searchpaths = {}
-			for idx = 2, #forwarded do
-				table.insert(searchpaths, forwarded[idx])
+			for idx = 2, #paths do
+				table.insert(searchpaths, paths[idx])
 			end
 			runsnapshots(searchpaths, args:has("update"), args:has("interactive"))
 		end
 	end
 
-	local searchpath = if forwarded and #forwarded > 0 then forwarded else { "./" }
+	local searchpath = if #paths > 0 then paths else { "./" }
 	local testfiles = finder.findtestfiles(searchpath)
 
 	if args:has("list") then

--- a/lute/cli/commands/transform/init.luau
+++ b/lute/cli/commands/transform/init.luau
@@ -172,22 +172,20 @@ local function applyMigration(
 	end
 end
 
-local USAGE = "Usage: lute transform [options] <migration-path> [files...] [-- [--option value...]]"
+local function usageText(args: cli.Parser): string
+	return `{args:usage("lute transform")} [-- [--option value...]]`
+end
 
-local function printHelp()
-	print(USAGE)
+local function printHelp(args: cli.Parser)
+	print(usageText(args))
+	print("\nApply the specified code transformation to the given files.\n")
+	print(args:help())
 	print([[
-Apply the specified code transformation to the given files.
-
-OPTIONS:
-  -h, --help              Show this help message
-  --dry-run               Preview changes without writing files
-  -o, --output [FILE]     Write output to a single file instead of in-place (only works if a single input file is specified)
 
 lute transform also supports forwarding options to the code transformation script by placing them after a '--' separator. For example:
 
   lute transform my-migration.luau files/ -- --option value
-	]])
+]])
 end
 
 local function main(...: string)
@@ -209,13 +207,13 @@ local function main(...: string)
 	args:parse({ ... })
 
 	if args:has("help") then
-		printHelp()
+		printHelp(args)
 		return
 	end
 
 	local migrationPath = args:get("migration-path")
 	if not migrationPath then
-		print(`Error: No code transformation script specified.\n\n{USAGE}\nUse --help for more information.`)
+		print(`Error: No code transformation script specified.\n\n{usageText(args)}\nUse --help for more information.`)
 		process.exit(1)
 		error("Unreachable") -- LUAUFIX: Remove once we can refine migrationPath is string outside this block
 	end

--- a/lute/cli/commands/transform/init.luau
+++ b/lute/cli/commands/transform/init.luau
@@ -197,7 +197,7 @@ local function main(...: string)
 		"flag",
 		{ help = "Interactive mode, where you can preview and confirm changes", aliases = { "i" } }
 	)
-	args:add("output", "option", { help = "Write output to this file (single input only)", aliases = { "o" } })
+	args:add("output", "option", { help = "Write output to a single file instead of in-place (only works if a single input file is specified)", aliases = { "o" } })
 	args:add("migration-path", "positional", { help = "Path to the migration script to run" })
 	args:add(
 		"files",

--- a/lute/cli/commands/transform/init.luau
+++ b/lute/cli/commands/transform/init.luau
@@ -197,7 +197,10 @@ local function main(...: string)
 		"flag",
 		{ help = "Interactive mode, where you can preview and confirm changes", aliases = { "i" } }
 	)
-	args:add("output", "option", { help = "Write output to a single file instead of in-place (only works if a single input file is specified)", aliases = { "o" } })
+	args:add("output", "option", {
+		help = "Write output to a single file instead of in-place (only works if a single input file is specified)",
+		aliases = { "o" },
+	})
 	args:add("migration-path", "positional", { help = "Path to the migration script to run" })
 	args:add(
 		"files",

--- a/tests/batteries/cli/snapshots/help_no_alias_when_absent.snap
+++ b/tests/batteries/cli/snapshots/help_no_alias_when_absent.snap
@@ -1,2 +1,2 @@
-Usage:
+Options:
   --verbose - Enable verbose output

--- a/tests/batteries/cli/snapshots/help_no_alias_when_absent.snap.luau
+++ b/tests/batteries/cli/snapshots/help_no_alias_when_absent.snap.luau
@@ -2,4 +2,4 @@ local cli = require("@batteries/cli")
 
 local p = cli.parser()
 p:add("verbose", "flag", { help = "Enable verbose output" })
-p:help()
+print(p:help())

--- a/tests/batteries/cli/snapshots/help_shows_alias.snap
+++ b/tests/batteries/cli/snapshots/help_shows_alias.snap
@@ -1,2 +1,2 @@
-Usage:
+Options:
   --verbose (-v) - Enable verbose output

--- a/tests/batteries/cli/snapshots/help_shows_alias.snap.luau
+++ b/tests/batteries/cli/snapshots/help_shows_alias.snap.luau
@@ -2,4 +2,4 @@ local cli = require("@batteries/cli")
 
 local p = cli.parser()
 p:add("verbose", "flag", { aliases = { "v" }, help = "Enable verbose output" })
-p:help()
+print(p:help())

--- a/tests/batteries/cli/snapshots/help_shows_multiple_aliases.snap
+++ b/tests/batteries/cli/snapshots/help_shows_multiple_aliases.snap
@@ -1,2 +1,2 @@
-Usage:
+Options:
   --verbose (-v, V) - Enable verbose output

--- a/tests/batteries/cli/snapshots/help_shows_multiple_aliases.snap.luau
+++ b/tests/batteries/cli/snapshots/help_shows_multiple_aliases.snap.luau
@@ -2,4 +2,4 @@ local cli = require("@batteries/cli")
 
 local p = cli.parser()
 p:add("verbose", "flag", { aliases = { "v", "V" }, help = "Enable verbose output" })
-p:help()
+print(p:help())

--- a/tests/cli/debug.test.luau
+++ b/tests/cli/debug.test.luau
@@ -5,7 +5,7 @@ local path = require("@std/path")
 local process = require("@std/process")
 
 local lutePath = path.format(process.execPath())
-local USAGE = "Usage: lute debug serve"
+local USAGE = "Usage: lute debug [subcommand] [options]"
 
 local function normalizePath(p: string): string
 	return (p:gsub("\\", "/"))

--- a/tests/cli/doc.test.luau
+++ b/tests/cli/doc.test.luau
@@ -8,7 +8,7 @@ local tmpDir = system.tmpdir()
 local tmpOutputDir = path.join(tmpDir, "lute-doc-output")
 local lutePath = path.format(process.execPath())
 
-local USAGE = "Usage: lute doc [OPTIONS]"
+local USAGE = "Usage: lute doc [options] [module-paths...]"
 
 -- Will add specific module test case (see examples/docs) once --module option is added
 test.suite("LuteDoc", function(suite)

--- a/tests/cli/lint.test.luau
+++ b/tests/cli/lint.test.luau
@@ -38,7 +38,7 @@ local LINT_RULE_MESSAGES = {
 	reassigned_parameter = "warning[reassigned_parameter]: Did you mean to reassign to a function parameter?",
 }
 
-local USAGE = "Usage: lute lint [OPTIONS] [...PATHS]"
+local USAGE = "Usage: lute lint [options] [paths...]"
 
 local LUAURC_CONTENT = [[
 {

--- a/tests/cli/new.test.luau
+++ b/tests/cli/new.test.luau
@@ -63,7 +63,7 @@ test.suite("LuteNew", function(suite)
 		local result = process.run({ lutePath, "new" }, { cwd = pathlib.format(workdir) })
 
 		assert.eq(result.exitcode, 1)
-		assert.strContains(result.stdout, "Missing required argument <project-name>")
+		assert.strContains(result.stderr, "Error: Missing required argument <project-name>.")
 	end)
 
 	suite:case("failsWhenDirectoryAlreadyExists", function(assert)
@@ -79,7 +79,7 @@ test.suite("LuteNew", function(suite)
 		local result = process.run({ lutePath, "new", "--help" }, { cwd = pathlib.format(workdir) })
 
 		assert.eq(result.exitcode, 0)
-		assert.strContains(result.stdout, "Usage: lute new <project-name>")
+		assert.strContains(result.stdout, "Usage: lute new [project-name] [options]")
 	end)
 
 	suite:case("typechecksOutOfTheBox", function(assert)

--- a/tests/cli/new.test.luau
+++ b/tests/cli/new.test.luau
@@ -63,7 +63,7 @@ test.suite("LuteNew", function(suite)
 		local result = process.run({ lutePath, "new" }, { cwd = pathlib.format(workdir) })
 
 		assert.eq(result.exitcode, 1)
-		assert.strContains(result.stderr, "Error: Missing required argument <project-name>.")
+		assert.strContains(result.stdout, "Error: Missing required argument <project-name>.")
 	end)
 
 	suite:case("failsWhenDirectoryAlreadyExists", function(assert)

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -19,8 +19,9 @@ test.suite("LuteTestCommand", function(suite)
 		-- Run lute test with -h flag
 		local result = process.run({ lutePath, "test", "-h" })
 
-		-- Check that it exits successfully and prints help
+		-- Check that it exits successfully and prints both the usage line and the options
 		assert.eq(result.exitcode, 0)
+		assert.strContains(result.stdout, "Usage: lute test [options] [paths...]")
 		assert.strContains(result.stdout, "Options:")
 	end)
 

--- a/tests/cli/test.test.luau
+++ b/tests/cli/test.test.luau
@@ -21,7 +21,7 @@ test.suite("LuteTestCommand", function(suite)
 
 		-- Check that it exits successfully and prints help
 		assert.eq(result.exitcode, 0)
-		assert.strContains(result.stdout, "Usage:")
+		assert.strContains(result.stdout, "Options:")
 	end)
 
 	suite:case("luteTestRunsTestsInDiscoveryFolder", function(assert)

--- a/tests/cli/transform.test.luau
+++ b/tests/cli/transform.test.luau
@@ -24,7 +24,7 @@ local transformeePath = path.format(path.join(tmpDir, "transformee.luau"))
 local outputPath = path.format(path.join(tmpDir, "transformee_output.luau"))
 local luaurcFile = path.format(path.join(tmpDir, ".luaurc"))
 
-local USAGE = "Usage: lute transform [options] <migration-path> [files...] [-- [--option value...]]"
+local USAGE = "Usage: lute transform [migration-path] [options] [files...] [-- [--option value...]]"
 
 test.suite("LuteTransform", function(suite)
 	suite:beforeEach(function()
@@ -65,7 +65,7 @@ test.suite("LuteTransform", function(suite)
 
 		assert.eq(result.exitcode, 1)
 		assert.strContains(
-			testutil.normalizeLineEndings(result.stdout),
+			testutil.normalizeLineEndings(result.stderr),
 			`Error: No code transformation script specified.\n\n{USAGE}\nUse --help for more information.`
 		)
 	end)

--- a/tests/cli/transform.test.luau
+++ b/tests/cli/transform.test.luau
@@ -65,7 +65,7 @@ test.suite("LuteTransform", function(suite)
 
 		assert.eq(result.exitcode, 1)
 		assert.strContains(
-			testutil.normalizeLineEndings(result.stderr),
+			testutil.normalizeLineEndings(result.stdout),
 			`Error: No code transformation script specified.\n\n{USAGE}\nUse --help for more information.`
 		)
 	end)

--- a/tools/luthier.luau
+++ b/tools/luthier.luau
@@ -574,15 +574,15 @@ end
 
 local function printHelp()
 	print("luthier — a build tool for lute")
-	args:help(function(str)
+	print(args:help(function(str)
 		return richterm.combine(richterm.bold, richterm.yellow)(str)
-	end)
+	end))
 end
 
 local function usageError(message: string, details: string?, usage: string?)
 	local lowercased = string.lower(string.sub(message, 1, 1)) .. string.sub(message, 2)
 	print(richterm.combine(richterm.bold, richterm.red)(`Error: {lowercased}`))
-	print(richterm.combine(richterm.bold, richterm.yellow)(`Usage: {usage or args:usage("luthier <subcommand>")}`))
+	print(richterm.combine(richterm.bold, richterm.yellow)(usage or args:usage("luthier <subcommand>")))
 	if details then
 		print(richterm.combine(richterm.bold, richterm.yellow)(details))
 	end


### PR DESCRIPTION
- `cli.usage` now prepends the "Usage:" label
- `cli.help` now returns the constructed string (instead of printing it)
- `cli.help` now formats positional and variadic arguments
- The existing lute subcommands have been migrate to a consistent pattern for rendering usage/help fields