### PR TITLE
Add `lute pkg` to the top-level help text

### DIFF
--- a/lute/cli/src/climain.cpp
+++ b/lute/cli/src/climain.cpp
@@ -44,7 +44,8 @@ Commands:
 	run (default)   Run a Luau script.
 	check           Type check Luau files.
 	compile         Compile a Luau script into a standalone executable.
-    debug           Debug a Luau script.
+	debug           Debug a Luau script.
+	pkg             Loom package manager for Luau projects (install/auth/run).
 	setup           Generate type definition files for the language server.
 	transform       Run a specified code transformation on specified Luau files.
 	lint            Run linting rules on specified Luau files.
@@ -65,6 +66,13 @@ Compile Options:
 Debug Options:
 	lute debug serve
 		Serves a DAP server for Luau for use with a development environment.
+
+Pkg Options:
+	lute pkg <install|auth|run>
+		Loom package manager for Luau projects.
+			install                 Install dependencies from loom.config.luau
+			auth                    Save authentication credentials
+			run <script.luau>       Run a Luau script from loom.lock.
 
 Setup Options:
 	lute setup


### PR DESCRIPTION
- Follows #1273 
- Closes #1272
- Adds `lute pkg` to `lute --help`

This maybe should not be merged until `lute pkg` is more stable. See https://github.com/luau-lang/lute/pull/1273#issuecomment-5182508159