### PR TITLE
fix: requiring a bare directory without init file should not cause ambiguity

### DIFF
--- a/lute/require/src/modulepath.cpp
+++ b/lute/require/src/modulepath.cpp
@@ -132,17 +132,17 @@ ResolvedRealPath ModulePath::getRealPath() const
             }
         }
 
-        if (hasInit)
-        {
-            if (resolvedType)
-                return {NavigationStatus::Ambiguous};
+        // Path is a directory with an init file but there is also a sibling file with the same name (e.g. foo.luau and foo/init.luau), so this is ambiguous.
+        if (hasInit && resolvedType)
+            return {NavigationStatus::Ambiguous};
 
-            resolvedType = ResolvedRealPath::PathType::File;
-        }
-        else if (!resolvedType)
-        {
+        // Path is a directory with no init file and no sibling file, so we know this is a directory.
+        if (!resolvedType)
             resolvedType = ResolvedRealPath::PathType::Directory;
-        }
+
+        // Path is a directory with an init file and no sibling file, so we know this is a file (the init file).
+        if (hasInit)
+            resolvedType = ResolvedRealPath::PathType::File;
     }
 
     if (!resolvedType)

--- a/lute/require/src/modulepath.cpp
+++ b/lute/require/src/modulepath.cpp
@@ -119,7 +119,6 @@ ResolvedRealPath ModulePath::getRealPath() const
     if (isADirectory(partialRealPath))
     {
         bool hasInit = false;
-        std::string_view initSuffix;
 
         for (std::string_view potentialSuffix : kInitSuffixes)
         {
@@ -129,7 +128,7 @@ ResolvedRealPath ModulePath::getRealPath() const
                     return {NavigationStatus::Ambiguous};
 
                 hasInit = true;
-                initSuffix = potentialSuffix;
+                suffix = potentialSuffix;
             }
         }
 
@@ -139,7 +138,6 @@ ResolvedRealPath ModulePath::getRealPath() const
                 return {NavigationStatus::Ambiguous};
 
             resolvedType = ResolvedRealPath::PathType::File;
-            suffix = initSuffix;
         }
         else if (!resolvedType)
         {

--- a/lute/require/src/modulepath.cpp
+++ b/lute/require/src/modulepath.cpp
@@ -118,23 +118,33 @@ ResolvedRealPath ModulePath::getRealPath() const
 
     if (isADirectory(partialRealPath))
     {
-        if (resolvedType)
-            return {NavigationStatus::Ambiguous};
+        bool hasInit = false;
+        std::string_view initSuffix;
 
         for (std::string_view potentialSuffix : kInitSuffixes)
         {
             if (isAFile(partialRealPath + std::string(potentialSuffix)))
             {
-                if (resolvedType)
+                if (hasInit)
                     return {NavigationStatus::Ambiguous};
 
-                resolvedType = ResolvedRealPath::PathType::File;
-                suffix = potentialSuffix;
+                hasInit = true;
+                initSuffix = potentialSuffix;
             }
         }
 
-        if (!resolvedType)
+        if (hasInit)
+        {
+            if (resolvedType)
+                return {NavigationStatus::Ambiguous};
+
+            resolvedType = ResolvedRealPath::PathType::File;
+            suffix = initSuffix;
+        }
+        else if (!resolvedType)
+        {
             resolvedType = ResolvedRealPath::PathType::Directory;
+        }
     }
 
     if (!resolvedType)

--- a/tests/cli/run.test.luau
+++ b/tests/cli/run.test.luau
@@ -18,14 +18,29 @@ test.suite("LuteRun", function(suite)
 	end)
 
 	suite:case("sameNamedFileAndDirectory", function(assert)
-		-- Setup
+		-- A bare directory (no init file) should not prevent the sibling file from resolving.
 		fs.createDirectory(rundir)
 		fs.createDirectory(pathlib.join(rundir, "hello"))
 
 		local helloFilePath = pathlib.join(rundir, "hello.luau")
 		fs.writeStringToFile(helloFilePath, "print('Hello world')")
 
-		-- Execute
+		local result = process.run({ lutePath, pathlib.format(helloFilePath) })
+
+		assert.eq(result.exitcode, 0)
+		assert.strContains(result.stdout, "Hello world")
+	end)
+
+	suite:case("sameNamedFileAndDirectoryWithInit", function(assert)
+		-- A directory with an init file is ambiguous with a sibling file.
+		fs.createDirectory(rundir)
+		local helloDir = pathlib.join(rundir, "hello")
+		fs.createDirectory(helloDir)
+		fs.writeStringToFile(pathlib.join(helloDir, "init.luau"), "print('Init')")
+
+		local helloFilePath = pathlib.join(rundir, "hello.luau")
+		fs.writeStringToFile(helloFilePath, "print('Hello world')")
+
 		local result = process.run({ lutePath, pathlib.format(helloFilePath) })
 
 		assert.eq(result.exitcode, 1)

--- a/tests/src/modulepath.test.cpp
+++ b/tests/src/modulepath.test.cpp
@@ -49,3 +49,37 @@ TEST_CASE("module_path")
         }
     }
 }
+
+TEST_CASE("module_path_bare_directory_not_ambiguous")
+{
+    for (const std::string& luteProjectRoot : {getLuteProjectRootRelative(), getLuteProjectRootAbsolute()})
+    {
+        std::string modulePathRoot = joinPaths(luteProjectRoot, "tests/src/modulepathroot");
+        std::string file = "module/init.luau";
+
+        std::optional<ModulePath> mp = ModulePath::create(modulePathRoot, file, isFile, isDirectory);
+        REQUIRE(mp);
+
+        SUBCASE("file_with_sibling_bare_directory_resolves")
+        {
+            CHECK(mp->toParent() == NavigationStatus::Success);
+            CHECK(mp->toChild("baredir") == NavigationStatus::Success);
+            CHECK(mp->getRealPath().realPath == joinPaths(modulePathRoot, "baredir.luau"));
+            CHECK(mp->getRealPath().type == ResolvedRealPath::PathType::File);
+        }
+
+        SUBCASE("bare_directory_child_resolves")
+        {
+            CHECK(mp->toParent() == NavigationStatus::Success);
+            CHECK(mp->toChild("baredir") == NavigationStatus::Success);
+            CHECK(mp->toChild("child") == NavigationStatus::Success);
+            CHECK(mp->getRealPath().realPath == joinPaths(modulePathRoot, "baredir/child.luau"));
+        }
+
+        SUBCASE("file_with_sibling_init_directory_is_ambiguous")
+        {
+            CHECK(mp->toParent() == NavigationStatus::Success);
+            CHECK(mp->toChild("ambiguous") == NavigationStatus::Ambiguous);
+        }
+    }
+}

--- a/tests/src/modulepath.test.cpp
+++ b/tests/src/modulepath.test.cpp
@@ -81,5 +81,21 @@ TEST_CASE("module_path_bare_directory_not_ambiguous")
             CHECK(mp->toParent() == NavigationStatus::Success);
             CHECK(mp->toChild("ambiguous") == NavigationStatus::Ambiguous);
         }
+
+        SUBCASE("case_mismatch_file_with_bare_directory_resolves")
+        {
+            CHECK(mp->toParent() == NavigationStatus::Success);
+            CHECK(mp->toChild("foo") == NavigationStatus::Success);
+            CHECK(mp->getRealPath().realPath == joinPaths(modulePathRoot, "foo.luau"));
+            CHECK(mp->getRealPath().type == ResolvedRealPath::PathType::File);
+        }
+
+        SUBCASE("case_mismatch_bare_directory_child_resolves")
+        {
+            CHECK(mp->toParent() == NavigationStatus::Success);
+            CHECK(mp->toChild("Foo") == NavigationStatus::Success);
+            CHECK(mp->toChild("bar") == NavigationStatus::Success);
+            CHECK(mp->getRealPath().realPath == joinPaths(modulePathRoot, "Foo/bar.luau"));
+        }
     }
 }

--- a/tests/src/modulepathroot/Foo/bar.luau
+++ b/tests/src/modulepathroot/Foo/bar.luau
@@ -1,0 +1,1 @@
+return { "bar" }

--- a/tests/src/modulepathroot/ambiguous.luau
+++ b/tests/src/modulepathroot/ambiguous.luau
@@ -1,0 +1,1 @@
+return { "ambiguous_file" }

--- a/tests/src/modulepathroot/ambiguous/init.luau
+++ b/tests/src/modulepathroot/ambiguous/init.luau
@@ -1,0 +1,1 @@
+return { "ambiguous_init" }

--- a/tests/src/modulepathroot/baredir.luau
+++ b/tests/src/modulepathroot/baredir.luau
@@ -1,0 +1,1 @@
+return { "baredir" }

--- a/tests/src/modulepathroot/baredir/child.luau
+++ b/tests/src/modulepathroot/baredir/child.luau
@@ -1,0 +1,1 @@
+return { "child" }

--- a/tests/src/modulepathroot/foo.luau
+++ b/tests/src/modulepathroot/foo.luau
@@ -1,0 +1,1 @@
+return { "foo" }

--- a/tests/std/luau.test.luau
+++ b/tests/std/luau.test.luau
@@ -160,6 +160,63 @@ test.suite("LuauTypeofModuleSuite", function(suite)
 		local expected = path.format(testPath):gsub("\\", "/")
 		assert.eq(resolvedPath, expected)
 	end)
+
+	suite:case("resolveModuleBareDirectoryNotAmbiguous", function(assert)
+		-- Reproduces the structure from issue #1279:
+		-- project/
+		-- ├── root.luau
+		-- ├── foo.luau
+		-- └── Foo/
+		--     └── bar.luau
+		local projectDir = path.join(tmpDir, "resolvemodule_baredir")
+		if fs.exists(projectDir) then
+			fs.removeDirectory(projectDir, { recursive = true })
+		end
+		fs.createDirectory(projectDir)
+
+		local rootPath = path.join(projectDir, "root.luau")
+		fs.writeStringToFile(rootPath, 'return require("./foo")')
+
+		local fooPath = path.join(projectDir, "foo.luau")
+		fs.writeStringToFile(fooPath, 'return "foo"')
+
+		local fooDirPath = path.join(projectDir, "Foo")
+		fs.createDirectory(fooDirPath)
+		fs.writeStringToFile(path.join(fooDirPath, "bar.luau"), 'return "bar"')
+
+		-- ./foo should resolve to foo.luau (bare Foo/ directory is not a module)
+		local resolvedFoo = luau.resolveModule("./foo", rootPath)
+		local expectedFoo = path.format(fooPath):gsub("\\", "/")
+		assert.eq(resolvedFoo, expectedFoo)
+
+		-- ./Foo/bar should resolve to Foo/bar.luau
+		local resolvedBar = luau.resolveModule("./Foo/bar", rootPath)
+		local expectedBar = path.format(path.join(fooDirPath, "bar.luau")):gsub("\\", "/")
+		assert.eq(resolvedBar, expectedBar)
+	end)
+
+	suite:case("resolveModuleDirectoryWithInitIsAmbiguous", function(assert)
+		-- When a directory has an init file, it is ambiguous with a sibling file.
+		local projectDir = path.join(tmpDir, "resolvemodule_ambiguous")
+		if fs.exists(projectDir) then
+			fs.removeDirectory(projectDir, { recursive = true })
+		end
+		fs.createDirectory(projectDir)
+
+		local rootPath = path.join(projectDir, "root.luau")
+		fs.writeStringToFile(rootPath, 'return require("./foo")')
+
+		fs.writeStringToFile(path.join(projectDir, "foo.luau"), 'return "foo_file"')
+
+		local fooDirPath = path.join(projectDir, "foo")
+		fs.createDirectory(fooDirPath)
+		fs.writeStringToFile(path.join(fooDirPath, "init.luau"), 'return "foo_init"')
+
+		-- ./foo should be ambiguous (both foo.luau and foo/init.luau exist)
+		local ok, err = pcall(luau.resolveModule, "./foo", rootPath)
+		assert.eq(ok, false)
+		assert.strContains(tostring(err), "ambiguous")
+	end)
 end)
 
 test.suite("LuauRequiresSuite", function(suite)


### PR DESCRIPTION
fixes https://github.com/luau-lang/lute/issues/1279

When a file like `foo.luau` has a sibling directory named `foo/`, we previously reported an ambiguity error unconditionally. But if the directory had no `init.luau` or `init.lua` file, we shouldn't be reporting an ambiguity error because we know that we aren't requiring the `foo/` directory directly. 

This fix defers the ambiguity check until after we scan the directory for init files, so now if we `require(foo)` with:
* `foo.luau` + `foo/` with no init = require resolves to `foo.luau` (and we can still require any files inside the directory)
* `foo.luau` + `foo/` with `init.luau` results in an ambiguous error