### PR TITLE
`lute/debug`: exception breakpoints

### DIFF
--- a/.styluaignore
+++ b/.styluaignore
@@ -3,3 +3,4 @@
 **/*unformatted*.luau
 tests/src/debug/compile_error.luau
 tests/src/debug/xpcall.luau
+tests/src/debug/exception.luau

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -34,6 +34,14 @@ export type Breakpoint = {
 	status: BreakpointStatus,
 }
 
+--- Info about exception breakpoints and which ids they are using
+export type ExceptionBreakpointInfo = {
+	uncaughtExceptions: boolean,
+	uncaughtId: number,
+	caughtExceptions: boolean,
+	caughtId: number,
+}
+
 --- The type of step we are taking
 export type StepType = "stepIn" | "stepOut" | "stepOver"
 
@@ -122,6 +130,9 @@ export type LaunchConfig = {
 	onStepStop: ((thread: Thread, info: StepInfo) -> ())?,
 	--- called when we hit a log point `bp` and we are asked to log `message`
 	onLogpointHit: ((message: string, bp: Breakpoint) -> ())?,
+	--- called when hitting an exception on `thread`. `bpId` reflects the id of the bp hit. These ids
+	--- match what is returned by setExceptionBreakpoint. `message` is the message thrown by the exception.
+	onException: ((thread: Thread, bpId: number, message: string) -> ())?,
 }
 
 --- A `Target` represents the target program under the debugger.
@@ -141,6 +152,9 @@ export type Target = {
 	getBreakpointById: (self: Target, id: number) -> Breakpoint?,
 	--- Get a breakpoint at a `sourcePath` at a given line. Returns `nil` if not found.
 	getBreakpointBySourceLine: (self: Target, sourcePath: string, line: number) -> Breakpoint?,
+	--- Sets/removes whether we hit exception breakpoints for caught or uncaught exceptions based on the
+	--- booleans `caught` and `uncaught`. Returns a sumamry of the current exception bp state.
+	setExceptionBreakpoint: (self: Target, caught: boolean, uncaught: boolean) -> ExceptionBreakpointInfo,
 	--- Gets all Luau sources that have been loaded onto the debugger, with sources using forward slashes.
 	getLoadedSources: (self: Target) -> { string },
 	--- Launch a Luau script at at `sourcePath` with the relevant `args` and callbacks defined in `config`.

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -152,9 +152,9 @@ export type Target = {
 	getBreakpointById: (self: Target, id: number) -> Breakpoint?,
 	--- Get a breakpoint at a `sourcePath` at a given line. Returns `nil` if not found.
 	getBreakpointBySourceLine: (self: Target, sourcePath: string, line: number) -> Breakpoint?,
-	--- Sets/removes whether we hit exception breakpoints for caught or uncaught exceptions based on the
-	--- booleans `caught` and `uncaught`. Returns a sumamry of the current exception bp state.
-	setExceptionBreakpoint: (self: Target, caught: boolean, uncaught: boolean) -> ExceptionBreakpointInfo,
+	--- Sets/removes whether we hit exception breakpoints for uncaught or caught exceptions based on the
+	--- booleans `uncaught` and `caught`. Returns a sumamry of the current exception bp state.
+	setExceptionBreakpoint: (self: Target, uncaught: boolean, caught: boolean) -> ExceptionBreakpointInfo,
 	--- Gets all Luau sources that have been loaded onto the debugger, with sources using forward slashes.
 	getLoadedSources: (self: Target) -> { string },
 	--- Launch a Luau script at at `sourcePath` with the relevant `args` and callbacks defined in `config`.

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -57,7 +57,18 @@ local function clearAndSetBreakpoints(
 end
 
 local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
-	local ioSession = dapStream.makeDapStreamSession(reader, writer)
+	local fs = require("@std/fs")
+	local logFile = fs.open("/tmp/lute-dap.log", "w")
+	local function log(msg: string)
+		fs.write(logFile, msg .. "\n")
+	end
+	local function loggingWriter(message: string)
+		local headerEnd = message:find("\r\n\r\n")
+		local body = if headerEnd then message:sub(headerEnd + 4) else message
+		log(`[send] {body}`)
+		writer(message)
+	end
+	local ioSession = dapStream.makeDapStreamSession(reader, loggingWriter)
 	local target = debugger.newTarget()
 	local launchCallbacks: debugger.LaunchConfig = {
 		onBreakpointHit = function(thread: debugger.Thread, bp: debugger.Breakpoint)
@@ -113,6 +124,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			})
 		end,
 		onException = function(thread: debugger.Thread, bpId: number, message: string)
+			log(`[exception] thread={thread.id} bpId={bpId} message={message}`)
 			ioSession.writeEvent("stopped", {
 				reason = "exception",
 				threadId = thread.id,
@@ -129,6 +141,8 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 		local request = ioSession.readDap()
 		local command = request.command :: string
 		local reqSeq = request.seq :: number
+		local argsJson = if request.arguments ~= nil then json.serialize(request.arguments :: json.Value) else "nil"
+		log(`[recv] {command} seq={reqSeq} args={argsJson}`)
 		if command == "initialize" then
 			local capabilities = {
 				supportsConfigurationDoneRequest = true,
@@ -194,7 +208,11 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 					caught = true
 				end
 			end
+			log(`[setExceptionBreakpoints] filters={table.concat(filters, ",")} caught={caught} uncaught={uncaught}`)
 			local exceptionInfo = target:setExceptionBreakpoint(caught, uncaught)
+			log(
+				`[setExceptionBreakpoints] result caughtId={exceptionInfo.caughtId} caughtExceptions={exceptionInfo.caughtExceptions} uncaughtId={exceptionInfo.uncaughtId} uncaughtExceptions={exceptionInfo.uncaughtExceptions}`
+			)
 			local requestedBreakpoints: { dapTypes.Breakpoint } = {}
 			for _, filter in filters do
 				if filter == "uncaught" then
@@ -215,6 +233,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			})
 		elseif command == "continue" then
 			local continued = target:continueProcess()
+			log(`[continue] continued={continued}`)
 			ioSession.writeResponse(reqSeq, continued, command)
 		elseif command == "pause" then
 			local paused = target:pauseProcess()

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -57,18 +57,7 @@ local function clearAndSetBreakpoints(
 end
 
 local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
-	local fs = require("@std/fs")
-	local logFile = fs.open("/tmp/lute-dap.log", "w")
-	local function log(msg: string)
-		fs.write(logFile, msg .. "\n")
-	end
-	local function loggingWriter(message: string)
-		local headerEnd = message:find("\r\n\r\n")
-		local body = if headerEnd then message:sub(headerEnd + 4) else message
-		log(`[send] {body}`)
-		writer(message)
-	end
-	local ioSession = dapStream.makeDapStreamSession(reader, loggingWriter)
+	local ioSession = dapStream.makeDapStreamSession(reader, writer)
 	local target = debugger.newTarget()
 	local launchCallbacks: debugger.LaunchConfig = {
 		onBreakpointHit = function(thread: debugger.Thread, bp: debugger.Breakpoint)
@@ -124,7 +113,6 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			})
 		end,
 		onException = function(thread: debugger.Thread, bpId: number, message: string)
-			log(`[exception] thread={thread.id} bpId={bpId} message={message}`)
 			ioSession.writeEvent("stopped", {
 				reason = "exception",
 				threadId = thread.id,
@@ -141,8 +129,6 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 		local request = ioSession.readDap()
 		local command = request.command :: string
 		local reqSeq = request.seq :: number
-		local argsJson = if request.arguments ~= nil then json.serialize(request.arguments :: json.Value) else "nil"
-		log(`[recv] {command} seq={reqSeq} args={argsJson}`)
 		if command == "initialize" then
 			local capabilities = {
 				supportsConfigurationDoneRequest = true,
@@ -208,11 +194,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 					caught = true
 				end
 			end
-			log(`[setExceptionBreakpoints] filters={table.concat(filters, ",")} caught={caught} uncaught={uncaught}`)
 			local exceptionInfo = target:setExceptionBreakpoint(caught, uncaught)
-			log(
-				`[setExceptionBreakpoints] result caughtId={exceptionInfo.caughtId} caughtExceptions={exceptionInfo.caughtExceptions} uncaughtId={exceptionInfo.uncaughtId} uncaughtExceptions={exceptionInfo.uncaughtExceptions}`
-			)
 			local requestedBreakpoints: { dapTypes.Breakpoint } = {}
 			for _, filter in filters do
 				if filter == "uncaught" then
@@ -233,7 +215,6 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			})
 		elseif command == "continue" then
 			local continued = target:continueProcess()
-			log(`[continue] continued={continued}`)
 			ioSession.writeResponse(reqSeq, continued, command)
 		elseif command == "pause" then
 			local paused = target:pauseProcess()

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -203,7 +203,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 						verified = true,
 					})
 				end
-				if filter == "uncaught" then
+				if filter == "caught" then
 					table.insert(requestedBreakpoints, {
 						id = exceptionInfo.caughtId,
 						verified = true,

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -112,6 +112,15 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 				line = breakpoint.line,
 			})
 		end,
+		onException = function(thread: debugger.Thread, bpId: number, message: string)
+			ioSession.writeEvent("stopped", {
+				reason = "exception",
+				threadId = thread.id,
+				allThreadsStopped = true,
+				text = message,
+				hitBreakpointIds = { bpId },
+			})
+		end,
 	}
 	local configurationDone = false
 	local launchConfig: dapTypes.LaunchArgs? = nil
@@ -131,6 +140,20 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 				supportsConditionalBreakpoints = true,
 				supportsHitConditionalBreakpoints = true,
 				supportsLogPoints = true,
+				exceptionBreakpointFilters = {
+					{
+						filter = "uncaught",
+						label = "Uncaught Exceptions",
+						description = "Stop debugger at all points where an uncaught exception is thrown",
+						default = true,
+					},
+					{
+						filter = "caught",
+						label = "Caught Exceptions",
+						description = "Stop debugger at all points where a caught exception is thrown in a pcall()",
+						default = false,
+					},
+				},
 			}
 			ioSession.writeResponse(reqSeq, true, command, nil, capabilities)
 			ioSession.writeEvent("initialized")
@@ -155,6 +178,38 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 			local newBreakpoints = args.breakpoints :: { dapTypes.SourceBreakpoint }?
 			local requestedBreakpoints = clearAndSetBreakpoints(target, path, newBreakpoints)
 
+			ioSession.writeResponse(reqSeq, true, command, nil, {
+				breakpoints = requestedBreakpoints,
+			})
+		elseif command == "setExceptionBreakpoints" then
+			local args = request.arguments :: json.Object
+			local filters = args.filters :: { string }
+			local uncaught = false
+			local caught = false
+			for _, filter in filters do
+				if filter == "uncaught" then
+					uncaught = true
+				end
+				if filter == "caught" then
+					caught = true
+				end
+			end
+			local exceptionInfo = target:setExceptionBreakpoint(caught, uncaught)
+			local requestedBreakpoints: { dapTypes.Breakpoint } = {}
+			for _, filter in filters do
+				if filter == "uncaught" then
+					table.insert(requestedBreakpoints, {
+						id = exceptionInfo.uncaughtId,
+						verified = true,
+					})
+				end
+				if filter == "uncaught" then
+					table.insert(requestedBreakpoints, {
+						id = exceptionInfo.caughtId,
+						verified = true,
+					})
+				end
+			end
 			ioSession.writeResponse(reqSeq, true, command, nil, {
 				breakpoints = requestedBreakpoints,
 			})

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -150,7 +150,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 					{
 						filter = "caught",
 						label = "Caught Exceptions",
-						description = "Stop debugger at all points where a caught exception is thrown in a pcall()",
+						description = "Stop debugger at all points where a caught exception is thrown in a pcall()/xpcall()",
 						default = false,
 					},
 				},

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -194,7 +194,7 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 					caught = true
 				end
 			end
-			local exceptionInfo = target:setExceptionBreakpoint(caught, uncaught)
+			local exceptionInfo = target:setExceptionBreakpoint(uncaught, caught)
 			local requestedBreakpoints: { dapTypes.Breakpoint } = {}
 			for _, filter in filters do
 				if filter == "uncaught" then

--- a/lute/cli/commands/debug/dapTypes.luau
+++ b/lute/cli/commands/debug/dapTypes.luau
@@ -2,6 +2,13 @@
 -- necessarily the actual DAP specification. For example, sources in DAP could have
 -- path be optional, but we enforce that it is required.
 
+export type exceptionBreakpointFilter = {
+	filter: string,
+	label: string,
+	description: string,
+	default: boolean,
+}
+
 export type Capability = {
 	supportConfigurationDoneRequest: boolean,
 	supportTerminateRequest: boolean,
@@ -12,6 +19,7 @@ export type Capability = {
 	supportsConditionalBreakpoints: boolean,
 	supportsHitConditionalBreakpoints: boolean,
 	supportsLogPoints: boolean,
+	exceptionBreakpointFilters: { exceptionBreakpointFilter },
 }
 
 export type Source = {
@@ -34,9 +42,9 @@ export type SetBreakpointsArgs = {
 export type Breakpoint = {
 	id: number,
 	verified: boolean,
-	source: Source,
+	source: Source?,
 	reason: ("pending" | "failed")?,
-	line: number,
+	line: number?,
 }
 
 export type LaunchArgs = {

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -174,7 +174,7 @@ struct Target
     std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
 
     // Exception breakpoints are mostly separate from normal breakpoints. They have negative
-    // breakpoint IDs for DAP purposes. 
+    // breakpoint IDs for DAP purposes.
     ExceptionBreakpointInfo setExceptionBreakpoint(bool caught, bool uncaught);
 
     // For inspection:
@@ -288,7 +288,14 @@ private:
 
     void computeStoppedLocation(lua_State* L);
     void unsetStoppedLocation();    
-    void stoppedSetState(lua_State* L);
+    // Controls how stoppedSetState decides between the yielding and non-yielding stop pathways.
+    enum class StopYieldMode
+    {
+        Auto,
+        ForceNoYield,
+        Neither,
+    };
+    void stoppedSetState(lua_State* L, StopYieldMode yieldMode = StopYieldMode::Auto);
     void stoppedDispatchCallback(std::function<void()> debugStopCallback);
 
     Variable makeVariable(lua_State* L, const std::string& name);

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -110,7 +110,7 @@ struct Variable
     std::string value;
     std::string type;
     int variableReference = 0;
-    bool isTrue();
+    bool isTruthy();
 };
 
 using EvaluateResult = std::variant<Variable, std::string>;

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -175,7 +175,7 @@ struct Target
 
     // Exception breakpoints are mostly separate from normal breakpoints. They have negative
     // breakpoint IDs for DAP purposes.
-    ExceptionBreakpointInfo setExceptionBreakpoint(bool caught, bool uncaught);
+    ExceptionBreakpointInfo setExceptionBreakpoint(bool uncaught, bool caught);
 
     // For inspection:
     // About multiple coroutines: we don't currently handle the original implementation of task.spawn(). Calling

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -48,6 +48,14 @@ struct Breakpoint
     Breakpoint(int id, std::string sourcePath, int line, BreakpointConfig config, BreakpointStatus status);
 };
 
+struct ExceptionBreakpointInfo
+{
+    bool uncaughtExceptions = false;
+    const int uncaughtId = -1;
+    bool caughtExceptions = false;
+    const int caughtId = -2;
+};
+
 // Each Thread represents one coroutine in our Lute runtime.
 struct Thread
 {
@@ -134,6 +142,7 @@ struct LaunchConfig
     std::function<void(const Thread& thread)> onPause;
     std::function<void(const std::string& message, const std::string& source, int line)> onPrint;
     std::function<void(const Thread& thread, const StepInfo& stepInfo)> onStepStop;
+    std::function<void(const Thread& thread, bool caught, const std::string& errorMessage)> onException;
 };
 
 struct Target
@@ -163,6 +172,10 @@ struct Target
     std::vector<Breakpoint> getBreakpointsByStatus(BreakpointStatus status) const;
     std::optional<Breakpoint> getBreakpointById(int breakpointId) const;
     std::optional<Breakpoint> getBreakpointBySourceLine(std::string source, int line) const;
+
+    // Exception breakpoints are mostly separate from normal breakpoints. They have negative
+    // breakpoint IDs for DAP purposes. 
+    ExceptionBreakpointInfo setExceptionBreakpoint(bool caught, bool uncaught);
 
     // For inspection:
     // About multiple coroutines: we don't currently handle the original implementation of task.spawn(). Calling
@@ -209,6 +222,8 @@ private:
     std::unordered_map<int, Breakpoint> breakpoints;    // breakpoint id -> breakpoint object (this is unordered_map to support erase)
     std::unordered_set<lua_State*> continueRequestedBp; // if the thread's lua_State* is in this set, we skip the next bp it hits
     std::optional<Breakpoint> bpHit;
+    ExceptionBreakpointInfo exceptionBpInfo;
+    bool stoppedUncaughtException = false;
     LaunchConfig launchConfig;
 
     Luau::DenseHashMap<std::string, std::shared_ptr<Ref>> loadedSources; // source path -> reference to chunk
@@ -288,6 +303,7 @@ private:
     void installBpHitCallback();
     void installExitCallback();
     void installThreadCallback();
+    void installExceptionCallback();
 
     static int replacePrint(lua_State* L);
 };

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -142,7 +142,7 @@ struct LaunchConfig
     std::function<void(const Thread& thread)> onPause;
     std::function<void(const std::string& message, const std::string& source, int line)> onPrint;
     std::function<void(const Thread& thread, const StepInfo& stepInfo)> onStepStop;
-    std::function<void(const Thread& thread, bool caught, const std::string& errorMessage)> onException;
+    std::function<void(const Thread& thread, int bpId, const std::string& errorMessage)> onException;
 };
 
 struct Target

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -48,12 +48,15 @@ struct Breakpoint
     Breakpoint(int id, std::string sourcePath, int line, BreakpointConfig config, BreakpointStatus status);
 };
 
+// Exception breakpoints act as filters, so only if uncaughtExceptions or caughtExceptions
+// is true do we surface these exceptions.
 struct ExceptionBreakpointInfo
 {
-    bool uncaughtExceptions = false;
+    bool uncaughtExceptions;
     const int uncaughtId = -1;
-    bool caughtExceptions = false;
+    bool caughtExceptions;
     const int caughtId = -2;
+    ExceptionBreakpointInfo(bool uncaughtExceptions, bool caughtExceptions);
 };
 
 // Each Thread represents one coroutine in our Lute runtime.

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -254,6 +254,26 @@ static int pushStepInfo(lua_State* L, const StepInfo& stepInfo)
     return 1;
 }
 
+// Helper to push an ExceptionBreakpointInfo type, which is
+// uncaughtExceptions: boolean,
+// uncaughtId: number,
+// caughtExceptions: boolean,
+// caughtId: number
+static int pushExceptionBreakpointInfo(lua_State* L, const ExceptionBreakpointInfo& info)
+{
+    checkStack(L, 2);
+    lua_createtable(L, 0, 4);
+    lua_pushboolean(L, info.uncaughtExceptions);
+    lua_setfield(L, -2, "uncaughtExceptions");
+    lua_pushinteger(L, info.uncaughtId);
+    lua_setfield(L, -2, "uncaughtId");
+    lua_pushboolean(L, info.caughtExceptions);
+    lua_setfield(L, -2, "caughtExceptions");
+    lua_pushinteger(L, info.caughtId);
+    lua_setfield(L, -2, "caughtId");
+    return 1;
+}
+
 // target.setBreakpoint(string sourcePath, int line, BreakpointConfig config)
 // BreakpointConfig = {condition: string, hitCondition: string, logMessage: string}
 // returns a breakpoint
@@ -362,6 +382,17 @@ static int target_getBreakpointBySourceLine(lua_State* L)
         return 1;
     }
     return pushBreakpoint(L, *bp);
+}
+
+// target.setExceptionBreakpoint(bool caught, bool uncaught)
+// returns a ExceptionBpInfo
+static int target_setExceptionBreakpoint(lua_State* L)
+{
+    Target* target = getTarget(L, 1);
+    bool caught = luaL_checkboolean(L, 2);
+    bool uncaught = luaL_checkboolean(L, 3);
+    ExceptionBreakpointInfo info = target->setExceptionBreakpoint(caught, uncaught);
+    return pushExceptionBreakpointInfo(L, info);
 }
 
 // target.getLoadedSources()
@@ -676,6 +707,7 @@ static std::function<void(const Breakpoint&)> makeBreakpointCallback(std::shared
 //     onPrint(string message, string source, int line) -> ()
 //     onStepStop(Thread thread, StepInfo stepInfo) -> ()
 //     onLogpointHit(string message, Breakpoint bp) -> ()
+//     onException(Thread thread, int bpId, string errorMessage) -> ()
 // }
 // returns string | nil
 static int target_launch(lua_State* L)
@@ -797,6 +829,22 @@ static int target_launch(lua_State* L)
                 );
             };
         }
+        if (auto ref = getOptionalCallback(L, 4, "onException"))
+        {
+            config.onException = [ref, runtime](const Thread& thread, int bpId, const std::string& errorMessage)
+            {
+                runtime->scheduleLuauCallback(
+                    ref,
+                    [thread, bpId, errorMessage](lua_State* L)
+                    {
+                        pushThread(L, thread);
+                        lua_pushinteger(L, bpId);
+                        lua_pushstring(L, errorMessage.c_str());
+                        return 3;
+                    }
+                );
+            };
+        }
     }
     std::optional<std::string> error = target->launch(source, args, config);
     checkStack(L, 1);
@@ -867,6 +915,7 @@ static const std::unordered_map<std::string, lua_CFunction> kTargetMethods = {
     {"getVariables", debug::target_getVariables},
     {"getVariablesByScopeType", debug::target_getVariablesByScopeType},
     {"evaluateExpression", debug::target_evaluateExpression},
+    {"setExceptionBreakpoint", debug::target_setExceptionBreakpoint}
 };
 
 static void initializeTarget(lua_State* L)

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -384,14 +384,14 @@ static int target_getBreakpointBySourceLine(lua_State* L)
     return pushBreakpoint(L, *bp);
 }
 
-// target.setExceptionBreakpoint(bool caught, bool uncaught)
+// target.setExceptionBreakpoint(bool uncaught, bool caught)
 // returns a ExceptionBpInfo
 static int target_setExceptionBreakpoint(lua_State* L)
 {
     Target* target = getTarget(L, 1);
-    bool caught = luaL_checkboolean(L, 2);
-    bool uncaught = luaL_checkboolean(L, 3);
-    ExceptionBreakpointInfo info = target->setExceptionBreakpoint(caught, uncaught);
+    bool uncaught = luaL_checkboolean(L, 2);
+    bool caught = luaL_checkboolean(L, 3);
+    ExceptionBreakpointInfo info = target->setExceptionBreakpoint(uncaught, caught);
     return pushExceptionBreakpointInfo(L, info);
 }
 

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -833,7 +833,7 @@ static int target_launch(lua_State* L)
         {
             config.onException = [ref, runtime](const Thread& thread, int bpId, const std::string& errorMessage)
             {
-                runtime->scheduleLuauCallback(
+                runtime->scheduleDebugLuauCallback(
                     ref,
                     [thread, bpId, errorMessage](lua_State* L)
                     {

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -845,7 +845,7 @@ std::vector<Thread> Target::getThreads() const
     std::vector<Thread> result;
     for (auto& [L, thread] : stateToThread)
     {
-        if (lua_costatus(childRuntime->GL, L) != LUA_COFIN && lua_costatus(childRuntime->GL, L) != LUA_COERR)
+        if (L == stoppedThread || (lua_costatus(childRuntime->GL, L) != LUA_COFIN && lua_costatus(childRuntime->GL, L) != LUA_COERR))
             result.emplace_back(thread);
     }
     return result;

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -84,8 +84,15 @@ bool Variable::isTruthy()
     return value != "false" && value != "nil";
 }
 
+ExceptionBreakpointInfo::ExceptionBreakpointInfo(bool uncaughtExceptions, bool caughtExceptions)
+    : uncaughtExceptions(uncaughtExceptions)
+    , caughtExceptions(caughtExceptions)
+{
+}
+
 Target::Target(Runtime& parentRuntime)
     : parentRuntime(parentRuntime)
+    , exceptionBpInfo(false, false)
     , loadedSources("")
 {
 }

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -772,12 +772,7 @@ void Target::installExceptionCallback()
         std::unique_lock lock(target->targetMutex);
         if (!target->exceptionBpInfo.uncaughtExceptions)
             return false;
-        target->paused = true;
-        target->childRuntime->stopDebug();
-        target->stoppedThread = L;
-        target->stoppedThreadRef = getRefForThread(L);
-        target->computeStoppedLocation(L);
-        target->stepInfo = std::nullopt;
+        target->stoppedHelper(L);
         target->stoppedUncaughtException = true;
         Thread thread = target->stateToThread.at(L);
         const char* s = luaL_tolstring(L, -1, nullptr);
@@ -800,12 +795,7 @@ void Target::installExceptionCallback()
         std::unique_lock lock(target->targetMutex);
         if (!target->exceptionBpInfo.caughtExceptions)
             return;
-        target->paused = true;
-        target->childRuntime->stopDebug();
-        target->stoppedThread = L;
-        target->stoppedThreadRef = getRefForThread(L);
-        target->computeStoppedLocation(L);
-        target->stepInfo = std::nullopt;
+        target->stoppedHelper(L);
         Thread thread = target->stateToThread.at(L);
         const char* s = luaL_tolstring(L, -1, nullptr);
         std::string errorMessage = s ? s : "unknown error";

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -338,10 +338,10 @@ std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> Target::modifyPendin
     return {installedBpsCallback, uninstalledBpsCallback};
 }
 
-ExceptionBreakpointInfo Target::setExceptionBreakpoint(bool caught, bool uncaught)
+ExceptionBreakpointInfo Target::setExceptionBreakpoint(bool uncaught, bool caught)
 {
-    exceptionBpInfo.caughtExceptions = caught;
     exceptionBpInfo.uncaughtExceptions = uncaught;
+    exceptionBpInfo.caughtExceptions = caught;
     return exceptionBpInfo;
 }
 

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -769,12 +769,16 @@ void Target::installThreadCallback()
 
 void Target::installExceptionCallback()
 {
+    // uncaught errors are (unlike any other debug callbacks) handled by the runtime
+    // when it detects that we've encountered a runtime error.
     childRuntime->onUncaughtError = [](lua_State* L)
     {
         auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
         std::unique_lock lock(target->targetMutex);
         if (!target->exceptionBpInfo.uncaughtExceptions)
             return false;
+        // we don't need to perform any stopping here because are coroutine is already unwound and finished.
+        // the only thing we want to do is to stop running of turue coroutines with stopDebug().
         target->stoppedSetState(L, StopYieldMode::Neither);
         target->stoppedUncaughtException = true;
         Thread thread = target->stateToThread.at(L);
@@ -797,12 +801,15 @@ void Target::installExceptionCallback()
         return true;
     };
     lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
+    // for caught exceptions:
     cb->debugprotectederror = [](lua_State* L)
     {
         auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
         std::unique_lock lock(target->targetMutex);
         if (!target->exceptionBpInfo.caughtExceptions)
             return;
+        // We force into the no yield state. Otherwise, if we yield the thread,
+        // we drop any potential error handlers that could be assosciated with an xpcall.
         target->stoppedSetState(L, StopYieldMode::ForceNoYield);
         Thread thread = target->stateToThread.at(L);
         const char* s = luaL_tolstring(L, -1, nullptr);
@@ -1455,6 +1462,7 @@ void Target::continueProcessHelper()
         }
         else
         {
+            // run the thread completion handler on the current thread.
             childRuntime->runUncaughtExceptionCompletion(stoppedThread);
             stoppedUncaughtException = false;
         }

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -585,7 +585,7 @@ bool Target::evaluateBpHitCondition(lua_State* L, const Breakpoint& bp)
         return false;
     }
     Variable var = std::get<Variable>(result);
-    return var.isTrue();
+    return var.isTruthy();
 }
 
 std::string Target::evaluateLogMessage(lua_State* L, const Breakpoint& bp)

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -790,7 +790,7 @@ void Target::installExceptionCallback()
         for (auto& bp : uninstalled)
             target->launchConfig.onBreakpointUninstall(bp);
         if (target->launchConfig.onException)
-            target->launchConfig.onException(thread, false, errorMessage);
+            target->launchConfig.onException(thread, target->exceptionBpInfo.uncaughtId, errorMessage);
         return true;
     };
     lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
@@ -818,7 +818,7 @@ void Target::installExceptionCallback()
         for (auto& bp : uninstalled)
             target->launchConfig.onBreakpointUninstall(bp);
         if (target->launchConfig.onException)
-            target->launchConfig.onException(thread, true, errorMessage);
+            target->launchConfig.onException(thread, target->exceptionBpInfo.caughtId, errorMessage);
     };
 }
 

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -79,7 +79,7 @@ VariableScope VariableScope::makeTable(int variableReference, int luaref)
     return VariableScope{variableReference, VariableScopeType::Table, "Table", -1, -1, luaref};
 }
 
-bool Variable::isTrue()
+bool Variable::isTruthy()
 {
     return value != "false" && value != "nil";
 }
@@ -564,7 +564,7 @@ bool Target::evaluateBpCondition(lua_State* L, const Breakpoint& bp)
         return false;
     }
     Variable var = std::get<Variable>(result);
-    return var.isTrue();
+    return var.isTruthy();
 }
 
 bool Target::evaluateBpHitCondition(lua_State* L, const Breakpoint& bp)

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -383,7 +383,7 @@ void Target::unsetStoppedLocation()
     stoppedLocation = "";
 }
 
-void Target::stoppedSetState(lua_State* L)
+void Target::stoppedSetState(lua_State* L, StopYieldMode yieldMode)
 {
     paused = true;
     childRuntime->stopDebug();
@@ -399,7 +399,10 @@ void Target::stoppedSetState(lua_State* L)
     // Otherwise, in a nonyieldable state, we simply set stoppedNoYield to be true. This
     // will later force us to wait on a condition variable, preventing execution from continuing in our
     // current coroutine.
-    if (lua_isyieldable(L))
+    if (yieldMode == StopYieldMode::Neither)
+        return;
+
+    if (lua_isyieldable(L) && yieldMode != StopYieldMode::ForceNoYield)
         lua_break(L);
     else
         stoppedNoYield = true;
@@ -772,7 +775,7 @@ void Target::installExceptionCallback()
         std::unique_lock lock(target->targetMutex);
         if (!target->exceptionBpInfo.uncaughtExceptions)
             return false;
-        target->stoppedHelper(L);
+        target->stoppedSetState(L, StopYieldMode::Neither);
         target->stoppedUncaughtException = true;
         Thread thread = target->stateToThread.at(L);
         const char* s = luaL_tolstring(L, -1, nullptr);
@@ -780,12 +783,17 @@ void Target::installExceptionCallback()
         lua_pop(L, 1);
         auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
         lock.unlock();
-        for (auto& bp : installed)
-            target->launchConfig.onBreakpointInstall(bp);
-        for (auto& bp : uninstalled)
-            target->launchConfig.onBreakpointUninstall(bp);
-        if (target->launchConfig.onException)
-            target->launchConfig.onException(thread, target->exceptionBpInfo.uncaughtId, errorMessage);
+        target->stoppedDispatchCallback(
+            [target, thread, installed = std::move(installed), uninstalled = std::move(uninstalled), errorMessage]()
+            {
+                if (target->launchConfig.onException)
+                    target->launchConfig.onException(thread, target->exceptionBpInfo.uncaughtId, errorMessage);
+                for (auto& bp : installed)
+                    target->launchConfig.onBreakpointInstall(bp);
+                for (auto& bp : uninstalled)
+                    target->launchConfig.onBreakpointUninstall(bp);
+            }
+        );
         return true;
     };
     lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
@@ -795,20 +803,24 @@ void Target::installExceptionCallback()
         std::unique_lock lock(target->targetMutex);
         if (!target->exceptionBpInfo.caughtExceptions)
             return;
-        target->stoppedHelper(L);
+        target->stoppedSetState(L, StopYieldMode::ForceNoYield);
         Thread thread = target->stateToThread.at(L);
         const char* s = luaL_tolstring(L, -1, nullptr);
         std::string errorMessage = s ? s : "unknown error";
         lua_pop(L, 1);
         auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
-        lua_break(L);
         lock.unlock();
-        for (auto& bp : installed)
-            target->launchConfig.onBreakpointInstall(bp);
-        for (auto& bp : uninstalled)
-            target->launchConfig.onBreakpointUninstall(bp);
-        if (target->launchConfig.onException)
-            target->launchConfig.onException(thread, target->exceptionBpInfo.caughtId, errorMessage);
+        target->stoppedDispatchCallback(
+            [target, thread, installed = std::move(installed), uninstalled = std::move(uninstalled), errorMessage]()
+            {
+                if (target->launchConfig.onException)
+                    target->launchConfig.onException(thread, target->exceptionBpInfo.caughtId, errorMessage);
+                for (auto& bp : installed)
+                    target->launchConfig.onBreakpointInstall(bp);
+                for (auto& bp : uninstalled)
+                    target->launchConfig.onBreakpointUninstall(bp);
+            }
+        );
     };
 }
 
@@ -1419,20 +1431,27 @@ void Target::continueProcessHelper()
     {
         if (!stoppedUncaughtException)
         {
-            // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
-            if (bpHit)
+            if (!stoppedNoYield)
             {
-                // we need to check if our breakpoint is still currently installed after
-                // onBreakpointHit() callback
-                std::optional<Breakpoint> currentBp = getBreakpointByIdHelper(bpHit->id);
-                if (currentBp && !stoppedNoYield && currentBp->status == BreakpointStatus::Installed)
-                    continueRequestedBp.insert(stoppedThread);
-                bpHit = std::nullopt;
+                // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
+                if (bpHit)
+                {
+                    // we need to check if our breakpoint is still currently installed after
+                    // onBreakpointHit() callback
+                    std::optional<Breakpoint> currentBp = getBreakpointByIdHelper(bpHit->id);
+                    if (currentBp && currentBp->status == BreakpointStatus::Installed)
+                        continueRequestedBp.insert(stoppedThread);
+                }
+                childRuntime->runningThreads.emplace_front(true, stoppedThreadRef, 0);
+                // This schedule() wakes up the runtime in runContinuously() to re-run runToCompletion() in case that has exited. This is a no-op if
+                // runToCompletion() has not exited.
+                childRuntime->schedule([]() {});
             }
-            childRuntime->runningThreads.emplace_front(true, stoppedThreadRef, 0);
-            // This schedule() wakes up the runtime in runContinuously() to re-run runToCompletion() in case that has exited. This is a no-op if
-            // runToCompletion() has not exited.
-            childRuntime->schedule([]() {});
+            else
+            {
+                stoppedNoYield = false;
+            }
+            bpHit = std::nullopt;
         }
         else
         {

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -338,6 +338,13 @@ std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> Target::modifyPendin
     return {installedBpsCallback, uninstalledBpsCallback};
 }
 
+ExceptionBreakpointInfo Target::setExceptionBreakpoint(bool caught, bool uncaught)
+{
+    exceptionBpInfo.caughtExceptions = caught;
+    exceptionBpInfo.uncaughtExceptions = uncaught;
+    return exceptionBpInfo;
+}
+
 std::vector<std::string> Target::getLoadedSources()
 {
     std::unique_lock lock(targetMutex);
@@ -502,6 +509,7 @@ std::optional<std::string> Target::launch(std::string sourcePath, const std::vec
         installBpHitCallback();
         installExitCallback();
         installThreadCallback();
+        installExceptionCallback();
 
         // All VM setup happens synchronously before runContinuously starts the background thread.
         // The no-op schedule wakes the event loop so it picks up the queued thread.
@@ -753,6 +761,64 @@ void Target::installThreadCallback()
             target->stateToThread.insert_or_assign(L, Thread{target->threadId, "Coroutine " + std::to_string(target->threadId)});
             target->threadId++;
         }
+    };
+}
+
+void Target::installExceptionCallback()
+{
+    childRuntime->onUncaughtError = [](lua_State* L)
+    {
+        auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
+        std::unique_lock lock(target->targetMutex);
+        if (!target->exceptionBpInfo.uncaughtExceptions)
+            return false;
+        target->paused = true;
+        target->childRuntime->stopDebug();
+        target->stoppedThread = L;
+        target->stoppedThreadRef = getRefForThread(L);
+        target->computeStoppedLocation(L);
+        target->stepInfo = std::nullopt;
+        target->stoppedUncaughtException = true;
+        Thread thread = target->stateToThread.at(L);
+        const char* s = luaL_tolstring(L, -1, nullptr);
+        std::string errorMessage = s ? s : "unknown error";
+        lua_pop(L, 1);
+        auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
+        lock.unlock();
+        for (auto& bp : installed)
+            target->launchConfig.onBreakpointInstall(bp);
+        for (auto& bp : uninstalled)
+            target->launchConfig.onBreakpointUninstall(bp);
+        if (target->launchConfig.onException)
+            target->launchConfig.onException(thread, false, errorMessage);
+        return true;
+    };
+    lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
+    cb->debugprotectederror = [](lua_State* L)
+    {
+        auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
+        std::unique_lock lock(target->targetMutex);
+        if (!target->exceptionBpInfo.caughtExceptions)
+            return;
+        target->paused = true;
+        target->childRuntime->stopDebug();
+        target->stoppedThread = L;
+        target->stoppedThreadRef = getRefForThread(L);
+        target->computeStoppedLocation(L);
+        target->stepInfo = std::nullopt;
+        Thread thread = target->stateToThread.at(L);
+        const char* s = luaL_tolstring(L, -1, nullptr);
+        std::string errorMessage = s ? s : "unknown error";
+        lua_pop(L, 1);
+        auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
+        lua_break(L);
+        lock.unlock();
+        for (auto& bp : installed)
+            target->launchConfig.onBreakpointInstall(bp);
+        for (auto& bp : uninstalled)
+            target->launchConfig.onBreakpointUninstall(bp);
+        if (target->launchConfig.onException)
+            target->launchConfig.onException(thread, true, errorMessage);
     };
 }
 
@@ -1361,18 +1427,18 @@ void Target::continueProcessHelper()
 
     if (stoppedThread)
     {
-        // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
-        if (bpHit)
+        if (!stoppedUncaughtException)
         {
-            // we need to check if our breakpoint is still currently installed after
-            // onBreakpointHit() callback
-            std::optional<Breakpoint> currentBp = getBreakpointByIdHelper(bpHit->id);
-            if (currentBp && !stoppedNoYield && currentBp->status == BreakpointStatus::Installed)
-                continueRequestedBp.insert(stoppedThread);
-            bpHit = std::nullopt;
-        }
-        if (!stoppedNoYield)
-        {
+            // we are continuing on a breakpoint and so might need to flag continueRequestedBp.
+            if (bpHit)
+            {
+                // we need to check if our breakpoint is still currently installed after
+                // onBreakpointHit() callback
+                std::optional<Breakpoint> currentBp = getBreakpointByIdHelper(bpHit->id);
+                if (currentBp && !stoppedNoYield && currentBp->status == BreakpointStatus::Installed)
+                    continueRequestedBp.insert(stoppedThread);
+                bpHit = std::nullopt;
+            }
             childRuntime->runningThreads.emplace_front(true, stoppedThreadRef, 0);
             // This schedule() wakes up the runtime in runContinuously() to re-run runToCompletion() in case that has exited. This is a no-op if
             // runToCompletion() has not exited.
@@ -1380,7 +1446,8 @@ void Target::continueProcessHelper()
         }
         else
         {
-            stoppedNoYield = false;
+            childRuntime->runUncaughtExceptionCompletion(stoppedThread);
+            stoppedUncaughtException = false;
         }
         stoppedThread = nullptr;
         stoppedThreadRef = nullptr;

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -142,14 +142,14 @@ struct Runtime
     // for debug mode only:
     const bool debugMode;
     std::atomic<int> numLaunchedDebuggees = 0;
-    // Same as scheduleLuauCallback but we since we don't call this within a libuv completion callback
-    // we need to wake up the libuv event loop.
-    void scheduleDebugLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher);
     std::function<void()> pendingDebugStopNotification;
     void stopDebug();
     void continueDebug();
     void waitForDebugContinue();
-
+    // Same as scheduleLuauCallback but we since we don't call this within a libuv completion callback
+    // we need to wake up the libuv event loop.
+    void scheduleDebugLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher);
+    // uncaught exceptions are handled by the runtime when we finish a thread that has an erroring state.
     std::function<bool(lua_State* L)> onUncaughtError;
     bool runUncaughtExceptionCompletion(lua_State* L);
 

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -142,13 +142,16 @@ struct Runtime
     // for debug mode only:
     const bool debugMode;
     std::atomic<int> numLaunchedDebuggees = 0;
+    // Same as scheduleLuauCallback but we since we don't call this within a libuv completion callback
+    // we need to wake up the libuv event loop.
+    void scheduleDebugLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher);
     std::function<void()> pendingDebugStopNotification;
     void stopDebug();
     void continueDebug();
     void waitForDebugContinue();
-    // Same as scheduleLuauCallback but we since we don't call this within a libuv completion callback
-    // we need to wake up the libuv event loop.
-    void scheduleDebugLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher);
+
+    std::function<bool(lua_State* L)> onUncaughtError;
+    bool runUncaughtExceptionCompletion(lua_State* L);
 
 private:
     bool runThreadCompletionHandler(lua_State* L, int status);

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -149,6 +149,8 @@ RuntimeStep Runtime::runOnce()
 
     // if we're in debugmode and encounter an exception, return step sucess here to pause execution.
     // We then call the thread completion callback with LUA_ERRRUN on target.continueProcess()
+    // We can never return StepErr here, so in the debug mode, the entirety of
+    // error reporting is the responsibility of the debugger onUncaughtException callback.
     if (debugMode && status == LUA_ERRRUN && onUncaughtError && onUncaughtError(L))
     {
         return StepSuccess{L};
@@ -422,7 +424,7 @@ void Runtime::continueDebug()
 
 // stopDebug() actually allows for some C bookkeeping when we are unwinding the stack
 // when it is called within a callback such as debugbreak or debugInterrupt.
-// We thus schedule any Luau callbacks to run after we are guaranteed to be stopped 
+// We thus schedule any Luau callbacks to run after we are guaranteed to be stopped
 // in runToCompletion().
 void Runtime::stopDebug()
 {

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -147,6 +147,13 @@ RuntimeStep Runtime::runOnce()
     else
         status = lua_resume(L, nullptr, next.argumentCount);
 
+    // if we're in debugmode return step sucess here to pause execution
+    // and call the thread completion callback on target.continueProcess()
+    if (debugMode && status == LUA_ERRRUN && onUncaughtError && onUncaughtError(L))
+    {
+        return StepSuccess{L};
+    }
+
     if (status == LUA_YIELD || status == LUA_BREAK)
     {
         return StepSuccess{L};
@@ -430,6 +437,12 @@ void Runtime::waitForDebugContinue()
     std::unique_lock<std::mutex> lock(debugMutex);
     while (debugStopped)
         debugStoppedCv.wait(lock);
+}
+
+bool Runtime::runUncaughtExceptionCompletion(lua_State* L)
+{
+    LUTE_ASSERT(debugMode);
+    return runThreadCompletionHandler(L, LUA_COERR);
 }
 
 uv_loop_t* Runtime::getEventLoop()

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -147,8 +147,8 @@ RuntimeStep Runtime::runOnce()
     else
         status = lua_resume(L, nullptr, next.argumentCount);
 
-    // if we're in debugmode return step sucess here to pause execution
-    // and call the thread completion callback on target.continueProcess()
+    // if we're in debugmode and encounter an exception, return step sucess here to pause execution.
+    // We then call the thread completion callback with LUA_ERRRUN on target.continueProcess()
     if (debugMode && status == LUA_ERRRUN && onUncaughtError && onUncaughtError(L))
     {
         return StepSuccess{L};
@@ -442,7 +442,7 @@ void Runtime::waitForDebugContinue()
 bool Runtime::runUncaughtExceptionCompletion(lua_State* L)
 {
     LUTE_ASSERT(debugMode);
-    return runThreadCompletionHandler(L, LUA_COERR);
+    return runThreadCompletionHandler(L, LUA_ERRRUN);
 }
 
 uv_loop_t* Runtime::getEventLoop()

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -825,4 +825,37 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 			check.eq(logs[i], `wow {10 * (i - 1)}\n`)
 		end
 	end)
+	-- this test case focuses on exception breakpoints (both caught and uncaught)
+	suite:case("exception", function(check)
+		local target = debug.newTarget()
+		check.eq(typeof(target), "Target")
+		local mainPath = path.format(path.join(proc.cwd(), "tests/src/debug/exception.luau"))
+		local exceptionInfo = target:setExceptionBreakpoint(true, true)
+		local hits = 0
+		local onFinished = false
+		local targetLaunched = target:launch(mainPath, {}, {
+			onException = function(thread, id, message)
+				hits += 1
+				check.eq(thread.id, 1)
+				if id == exceptionInfo.caughtId then
+					check.eq(message, `{mainPath}:3: attempt to index nil with 'foo'`)
+				else
+					check.eq(message, `{mainPath}:7: attempt to index nil with 'foo'`)
+				end
+				target:continueProcess()
+			end,
+			onExit = function(status)
+				check.eq(status, false)
+				onFinished = true
+			end,
+		})
+		check.eq(targetLaunched, nil)
+		check.eq(
+			waitUntil(function()
+				return onFinished
+			end),
+			true
+		)
+		check.eq(hits, 2)
+	end)
 end)

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -838,9 +838,9 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				hits += 1
 				check.eq(thread.id, 1)
 				if id == exceptionInfo.caughtId then
-					check.eq(message, `{mainPath}:3: attempt to index nil with 'foo'`)
+					check.eq(message, `{normalizePath(mainPath)}:3: attempt to index nil with 'foo'`)
 				else
-					check.eq(message, `{mainPath}:7: attempt to index nil with 'foo'`)
+					check.eq(message, `{normalizePath(mainPath)}:7: attempt to index nil with 'foo'`)
 				end
 				target:continueProcess()
 			end,

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -1,4 +1,5 @@
 #include "lute/debuginternals.h"
+
 #include "Luau/StringUtils.h"
 
 #include <chrono>
@@ -1057,5 +1058,48 @@ TEST_SUITE("Debug")
         // check we are done
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         CHECK(hits == 2);
+    }
+
+    // This test is specifically designed to make sure the error handler still runs after finishing with a caught exception.
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_exception_xpcall")
+    {
+        std::string mainPath = getDebugFixturePath("xpcall.luau");
+        Target target(*runtime);
+        ExceptionBreakpointInfo info = target.setExceptionBreakpoint(true, true);
+        target.setBreakpoint(mainPath, 7);
+        int hits = 0;
+        config.onException = [&](const Thread& thread, int bpId, const std::string& message)
+        {
+            if (bpId == info.caughtId)
+            {
+                hits++;
+                CHECK(message == Luau::format("%s:2: attempt to call a nil value", mainPath.c_str()));
+                CHECK(thread.id == 1);
+                target.continueProcess();
+            }
+        };
+        config.onBreakpointHit = [&](const Thread& thread, const Breakpoint&)
+        {
+            const std::vector<Thread>& threads = target.getThreads();
+            REQUIRE(threads.size() == 1);
+            std::optional<std::vector<StackFrame>> stackframe = target.getStackTrace(threads.at(0).id);
+            REQUIRE(stackframe.has_value());
+            EvaluateResult result = target.evaluateExpression("returned", stackframe->at(0).id);
+            REQUIRE(std::holds_alternative<Variable>(result));
+            Variable var = std::get<Variable>(result);
+            CHECK(var.value == "false");
+            CHECK(var.type == "boolean");
+            result = target.evaluateExpression("_data", stackframe->at(0).id);
+            REQUIRE(std::holds_alternative<Variable>(result));
+            var = std::get<Variable>(result);
+            CHECK(var.value == "\"error found\"");
+            CHECK(var.type == "string");
+            target.continueProcess();
+        };
+        std::optional<std::string> error = target.launch(mainPath, {}, config);
+        CHECK(!error);
+        // check we are done
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        CHECK(hits == 1);
     }
 }

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -1027,4 +1027,34 @@ TEST_SUITE("Debug")
             CHECK(logs[i] == expected);
         }
     };
+
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_exception")
+    {
+        std::string mainPath = getDebugFixturePath("exception.luau");
+        Target target(*runtime);
+        target.setExceptionBreakpoint(true, true);
+        int hits = 0;
+        config.onException = [&](const Thread& thread, bool caught, const std::string& message)
+        {
+            if (caught)
+            {
+                hits++;
+                CHECK(message == Luau::format("%s:3: attempt to index nil with \'foo\'", mainPath.c_str()));
+                CHECK(thread.id == 1);
+                target.continueProcess();
+            }
+            else
+            {
+                hits++;
+                CHECK(message == Luau::format("%s:7: attempt to index nil with \'foo\'", mainPath.c_str()));
+                CHECK(thread.id == 1);
+                target.continueProcess();
+            }
+        };
+        std::optional<std::string> error = target.launch(mainPath, {}, config);
+        CHECK(!error);
+        // check we are done
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        CHECK(hits == 2);
+    }
 }

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -1,3 +1,4 @@
+#include "lute/debuginternals.h"
 #include "Luau/StringUtils.h"
 
 #include <chrono>
@@ -1032,11 +1033,11 @@ TEST_SUITE("Debug")
     {
         std::string mainPath = getDebugFixturePath("exception.luau");
         Target target(*runtime);
-        target.setExceptionBreakpoint(true, true);
+        ExceptionBreakpointInfo info = target.setExceptionBreakpoint(true, true);
         int hits = 0;
-        config.onException = [&](const Thread& thread, bool caught, const std::string& message)
+        config.onException = [&](const Thread& thread, int bpId, const std::string& message)
         {
-            if (caught)
+            if (bpId == info.caughtId)
             {
                 hits++;
                 CHECK(message == Luau::format("%s:3: attempt to index nil with \'foo\'", mainPath.c_str()));

--- a/tests/src/debug/exception.luau
+++ b/tests/src/debug/exception.luau
@@ -1,0 +1,7 @@
+local ok, err = pcall(function()
+	local y = nil
+	return y.foo
+end)
+
+local z = nil
+print(z.foo)

--- a/tests/src/debug/exception.luau
+++ b/tests/src/debug/exception.luau
@@ -1,4 +1,4 @@
-local ok, err = pcall(function()
+local _ok, _err = pcall(function()
 	local y = nil
 	return y.foo
 end)


### PR DESCRIPTION
Enables exception breakpoints for the debugger
* "Uncaught exceptions" will catch runtime errors and pause the runtime, allowing for inspection.
* "Caught exceptions" will catch caught exceptions 


https://github.com/user-attachments/assets/e61e701b-b454-4caf-a385-e81223014298

