### PR TITLE
`lute/debug`: fix stack frame display for multithreaded code

### DIFF
--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -655,7 +655,7 @@ std::optional<StackFrame> Target::getStackFrameHelper(int threadId, int level)
             frame.sourcePath = getSourceFromChunk(ar.source);
             // edge case: when we hit a breakpoint, the pc is sent backward one
             // so that we can hit it again, so lua_getinfo() fails.
-            if (level == 0 && stoppedLine != -1)
+            if (level == 0 && stoppedLine != -1 && threadLua == stoppedThread)
                 frame.line = stoppedLine;
             else
                 frame.line = ar.currentline;

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -272,7 +272,8 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		check.eq(typeof(target), "Target")
 		local mainPath = path.format(path.join(proc.cwd(), "tests/src/debug/task.luau"))
 		local bp1 = target:setBreakpoint(mainPath, 7)
-		local _bp2 = target:setBreakpoint(mainPath, 14)
+		local bp2 = target:setBreakpoint(mainPath, 14)
+		local _bp3 = target:setBreakpoint(mainPath, 22)
 		local bpHit1 = 0
 		local bpHit2 = 0
 		local onFinished = false
@@ -280,20 +281,70 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local launchError = target:launch(mainPath, {}, {
 			onBreakpointHit = function(thread, bp)
 				if bp.id == bp1.id then
+					check.eq(thread.id, 2)
 					local stoppedThread = assert(target:getStoppedThread())
 					check.eq(stoppedThread.id, 2)
-					check.eq(thread.id, 2)
-					check.eq(thread.name, "Coroutine 2")
 					bpHit1 += 1
-				else
+					local threads = target:getThreads()
+					maxThreads = math.max(maxThreads, #threads)
+					if #threads == 3 then
+						local nameById = {}
+						for _, t in threads do
+							nameById[t.id] = t.name
+						end
+						check.eq(nameById[1], "Main Coroutine")
+						check.eq(nameById[2], "Coroutine 2")
+						check.eq(nameById[3], "Coroutine 3")
+					end
+					local stackTrace = assert(target:getStackTrace(thread.id))
+					local threadStack = stackTrace[#stackTrace]
+					check.eq(threadStack.line, 7)
+					local vars = assert(target:getVariablesByScopeType(threadStack.id, "locals"))
+					checkVariable(check, vars, "_i", tostring(bpHit1), "number", false)
+					for _, otherThread in threads do
+						if otherThread.id == 3 then
+							local otherTrace = assert(target:getStackTrace(otherThread.id))
+							local line = otherTrace[#otherTrace].line
+							check.that(line >= 12 and line <= 15)
+						end
+						if otherThread.id == 1 then
+							local otherTrace = assert(target:getStackTrace(otherThread.id))
+							local line = otherTrace[#otherTrace].line
+							check.that(line >= 18 and line <= 20)
+						end
+					end
+				elseif bp.id == bp2.id then
+					check.eq(thread.id, 3)
 					local stoppedThread = assert(target:getStoppedThread())
 					check.eq(stoppedThread.id, 3)
-					check.eq(thread.id, 3)
-					check.eq(thread.name, "Coroutine 3")
+					local stackTrace = assert(target:getStackTrace(thread.id))
+					local threadStack = stackTrace[#stackTrace]
+					check.eq(threadStack.line, 14)
+					local threads = target:getThreads()
+					for _, otherThread in threads do
+						if otherThread.id == 2 then
+							local otherTrace = assert(target:getStackTrace(otherThread.id))
+							local line = otherTrace[#otherTrace].line
+							check.that(line >= 5 and line <= 8)
+						end
+						if otherThread.id == 1 then
+							local otherTrace = assert(target:getStackTrace(otherThread.id))
+							local line = otherTrace[#otherTrace].line
+							check.that(line >= 18 and line <= 20)
+						end
+					end
 					bpHit2 += 1
+					local vars = assert(target:getVariablesByScopeType(threadStack.id, "locals"))
+					checkVariable(check, vars, "_i", tostring(bpHit2), "number", false)
+				else
+					local stoppedThread = assert(target:getStoppedThread())
+					check.eq(stoppedThread.id, 1)
+					local threads = target:getThreads()
+					check.eq(thread.id, 1)
+					check.eq(#threads, 1)
+					check.eq(threads[1].id, 1)
+					check.eq(threads[1].name, "Main Coroutine")
 				end
-				local threads = target:getThreads()
-				maxThreads = math.max(maxThreads, #threads)
 				local continued = target:continueProcess()
 				check.that(continued)
 			end,

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -1,3 +1,5 @@
+#include "lute/debuginternals.h"
+
 #include "Luau/StringUtils.h"
 
 #include <chrono>
@@ -531,6 +533,30 @@ TEST_SUITE("Debug")
                     CHECK(std::find(threads.begin(), threads.end(), t2) != threads.end());
                     CHECK(std::find(threads.begin(), threads.end(), t3) != threads.end());
                 }
+                std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
+                REQUIRE(stackTrace.has_value());
+                StackFrame threadStack = stackTrace->at(stackTrace->size() - 1);
+                CHECK(threadStack.line == 7);
+                std::optional<std::vector<Variable>> vars = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Locals);
+                REQUIRE(vars.has_value());
+                checkVariable(*vars, "_i", std::to_string(hitsBp1), "number", false);
+                for (const Thread& thread : threads)
+                {
+                    if (thread.id == 3)
+                    {
+                        std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
+                        REQUIRE(stackTrace.has_value());
+                        int line = stackTrace->at(stackTrace->size() - 1).line;
+                        CHECK((line >= 12 && line <= 15));
+                    }
+                    if (thread.id == 1)
+                    {
+                        std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
+                        REQUIRE(stackTrace.has_value());
+                        int line = stackTrace->at(stackTrace->size() - 1).line;
+                        CHECK((line >= 18 && line <= 20));
+                    }
+                }
             }
             else if (bp.id == bp2.id)
             {
@@ -538,7 +564,32 @@ TEST_SUITE("Debug")
                 auto stoppedThread = target.getStoppedThread();
                 REQUIRE(stoppedThread.has_value());
                 CHECK(stoppedThread->id == 3);
+                std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
+                REQUIRE(stackTrace.has_value());
+                StackFrame threadStack = stackTrace->at(stackTrace->size() - 1);
+                CHECK(threadStack.line == 14);
+                const std::vector<Thread>& threads = target.getThreads();
+                for (const Thread& thread : threads)
+                {
+                    if (thread.id == 2)
+                    {
+                        std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
+                        REQUIRE(stackTrace.has_value());
+                        int line = stackTrace->at(stackTrace->size() - 1).line;
+                        CHECK((line >= 5 && line <= 8));
+                    }
+                    if (thread.id == 1)
+                    {
+                        std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
+                        REQUIRE(stackTrace.has_value());
+                        int line = stackTrace->at(stackTrace->size() - 1).line;
+                        CHECK((line >= 18 && line <= 20));
+                    }
+                }
                 hitsBp2++;
+                std::optional<std::vector<Variable>> vars = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Locals);
+                REQUIRE(vars.has_value());
+                checkVariable(*vars, "_i", std::to_string(hitsBp2), "number", false);
             }
             else
             {

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -1,5 +1,3 @@
-#include "lute/debuginternals.h"
-
 #include "Luau/StringUtils.h"
 
 #include <chrono>


### PR DESCRIPTION
this one line fix to stack frames corrects the stack frame display during multi-threading
* `stoppedLine` correction only should apply on the thread that was actually dequeued from the Lute runtime queue
* other threads are still stopped but can really on `lua_getinfo` for accurate information
* significantly buff multi-threaded testing

https://github.com/user-attachments/assets/5d688875-f4ad-40e4-adb6-b6b41e4f5c83

[ignore what happens when you need to press the resume button again at the end of the video to actually get the program to exit, this issue is caused by the one documented here https://github.com/luau-lang/lute/pull/1250]
