### PR TITLE
fix 2: update logic of resolving ambiguous modules

### DIFF
--- a/lute/require/src/modulepath.cpp
+++ b/lute/require/src/modulepath.cpp
@@ -136,13 +136,12 @@ ResolvedRealPath ModulePath::getRealPath() const
         if (hasInit && resolvedType)
             return {NavigationStatus::Ambiguous};
 
-        // Path is a directory with no init file and no sibling file, so we know this is a directory.
-        if (!resolvedType)
-            resolvedType = ResolvedRealPath::PathType::Directory;
-
         // Path is a directory with an init file and no sibling file, so we know this is a file (the init file).
+        // Otherwise if there is no sibling file either, we know this is a directory.
         if (hasInit)
             resolvedType = ResolvedRealPath::PathType::File;
+        else if (!resolvedType)
+            resolvedType = ResolvedRealPath::PathType::Directory;
     }
 
     if (!resolvedType)

--- a/tests/src/modulepath.test.cpp
+++ b/tests/src/modulepath.test.cpp
@@ -84,6 +84,14 @@ TEST_CASE("module_path_bare_directory_not_ambiguous")
             CHECK(mp->getRealPath().type == ResolvedRealPath::PathType::File);
         }
 
+        SUBCASE("bare_directory_without_init_or_sibling_resolves_to_directory")
+        {
+            CHECK(mp->toParent() == NavigationStatus::Success);
+            CHECK(mp->toChild("plaindir") == NavigationStatus::Success);
+            CHECK(mp->getRealPath().realPath == joinPaths(modulePathRoot, "plaindir"));
+            CHECK(mp->getRealPath().type == ResolvedRealPath::PathType::Directory);
+        }
+
         SUBCASE("file_with_sibling_init_directory_is_ambiguous")
         {
             CHECK(mp->toParent() == NavigationStatus::Success);

--- a/tests/src/modulepath.test.cpp
+++ b/tests/src/modulepath.test.cpp
@@ -76,6 +76,14 @@ TEST_CASE("module_path_bare_directory_not_ambiguous")
             CHECK(mp->getRealPath().realPath == joinPaths(modulePathRoot, "baredir/child.luau"));
         }
 
+        SUBCASE("directory_with_init_and_no_sibling_resolves_to_file")
+        {
+            CHECK(mp->toParent() == NavigationStatus::Success);
+            CHECK(mp->toChild("module") == NavigationStatus::Success);
+            CHECK(mp->getRealPath().realPath == joinPaths(modulePathRoot, "module/init.luau"));
+            CHECK(mp->getRealPath().type == ResolvedRealPath::PathType::File);
+        }
+
         SUBCASE("file_with_sibling_init_directory_is_ambiguous")
         {
             CHECK(mp->toParent() == NavigationStatus::Success);

--- a/tests/src/modulepathroot/plaindir/child.luau
+++ b/tests/src/modulepathroot/plaindir/child.luau
@@ -1,0 +1,1 @@
+return { "child" }


### PR DESCRIPTION
@Vighnesh-V mentioned the https://github.com/luau-lang/lute/pull/1289 logic might've not been fully correct, so this reworks the logic and adds another test case

logic and the cases we could have are now:
* `if (hasInit && resolvedType)` -> init + sibling (file w same name as dir) -> ambiguous
* `if hasInit` -> init + no sibling -> file
* `else if !resolvedType` -> no init + no sibling -> directory
* no init -> sibling -> file (already set earlier in the code)