### PR TITLE
`lute/debug`: add tracking for user-defined global variables

### DIFF
--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -46,7 +46,7 @@ export type VariableScopeType = "locals" | "upvalues" | "globals" | "table"
 
 --- A VariableScope contains the contextual information for a collection of Variables
 --- such as what variable reference ID number to refer to this collection, what type of collection
---- it is, etc. Variable reference IDs are reset upon continuing execution. 
+--- it is, etc. Variable reference IDs are reset upon continuing execution.
 --- Generally, VariableScope will have a type `locals`, `upvalues`, or `globals`. `table` is used in the C++ implementation
 --- but generally is not used in Luau code currently.
 export type VariableScope = {

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -42,7 +42,7 @@ export type StackFrame = {
 
 --- The type of a VariableScope (i.e. whether it contains local variables, upvalues, globals, or
 --- values from a table)
-export type VariableScopeType = "locals" | "upvalues" | "globals" | "table"
+export type VariableScopeType = "local" | "upvalue" | "global" | "table"
 
 --- A VariableScope contains the contextual information for a collection of Variables
 --- such as what variable reference ID number to refer to this collection, what type of collection
@@ -167,7 +167,7 @@ export type Target = {
 	--- or if such a scope does not exist.
 	getVariables: (self: Target, variableRef: number) -> { Variable }?,
 	--- Gets a set of variables belonging on the stack frame with id `frameID` with a certain `scopeType`.
-	--- `scopeType` should be `locals`, `globals`, or `upvalues`, not `table`.
+	--- `scopeType` should be `local`, `global`, or `upvalue`, not `table`.
 	--- Return `nil` if script is running or if such variables can not be found.
 	getVariablesByScopeType: (self: Target, frameId: number, scopeType: VariableScopeType) -> { Variable }?,
 }

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -40,18 +40,22 @@ export type StackFrame = {
 	column: number,
 }
 
---- The type of a VariableScope (i.e. whether it contains local variables, upvalues, or
+--- The type of a VariableScope (i.e. whether it contains local variables, upvalues, globals, or
 --- values from a table)
-export type VariableScopeType = "locals" | "upvalues" | "table"
+export type VariableScopeType = "locals" | "upvalues" | "globals" | "table"
 
 --- A VariableScope contains the contextual information for a collection of Variables
 --- such as what variable reference ID number to refer to this collection, what type of collection
---- it is, etc. Variable reference IDs are reset upon continuing execution.
+--- it is, etc. Variable reference IDs are reset upon continuing execution. 
+--- Generally, VariableScope will have a type `locals`, `upvalues`, or `globals`. `table` is used in the C++ implementation
+--- but generally is not used in Luau code currently.
 export type VariableScope = {
 	variableRef: number,
 	type: VariableScopeType,
 	name: string,
+	--- threadId is `-1` for globals or tables
 	threadId: number,
+	--- level is `-1` for globals or tables
 	level: number,
 }
 
@@ -163,7 +167,7 @@ export type Target = {
 	--- or if such a scope does not exist.
 	getVariables: (self: Target, variableRef: number) -> { Variable }?,
 	--- Gets a set of variables belonging on the stack frame with id `frameID` with a certain `scopeType`.
-	--- `scopeType` should be `locals` or `upvalues`, not `table`.
+	--- `scopeType` should be `locals`, `globals`, or `upvalues`, not `table`.
 	--- Return `nil` if script is running or if such variables can not be found.
 	getVariablesByScopeType: (self: Target, frameId: number, scopeType: VariableScopeType) -> { Variable }?,
 }

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -58,6 +58,7 @@ enum class VariableScopeType
 {
     Locals,
     Upvalues,
+    Globals,
     Table
 };
 
@@ -76,6 +77,7 @@ struct VariableScope
     explicit VariableScope(int variableReference, VariableScopeType type, std::string name, int threadId = -1, int level = -1, int luaref = -1);
     static VariableScope makeLocals(int variableReference, int threadId, int level);
     static VariableScope makeUpvalues(int variableReference, int threadId, int level);
+    static VariableScope makeGlobals(int variableReference);
     static VariableScope makeTable(int variableReference, int luaref);
 };
 
@@ -199,8 +201,8 @@ private:
     // our stopped thread that we need to requeue when we continue
     lua_State* stoppedThread = nullptr;
     std::shared_ptr<Ref> stoppedThreadRef;
-    // Due to the way Lua debugger callbacks works, we need to set the stopped line/instruction in the callback. otherwise, outside of the callback, lua_getinfo
-    // will return the previous line/instruction.
+    // Due to the way Lua debugger callbacks works, we need to set the stopped line/instruction in the callback. otherwise, outside of the callback,
+    // lua_getinfo will return the previous line/instruction.
     int stoppedLine = -1;
     std::string stoppedLocation = "";
     const uint32_t* stoppedPc = nullptr;
@@ -224,6 +226,7 @@ private:
     // variable information
     // scope and variable information also resets upon every continue(). The base id resets to 1.
     int variableRefId = 1;
+    std::optional<int> globalVariableRef;
     std::unordered_map<int, std::vector<VariableScope>> scopeCache; // stack frame id -> scope
     std::unordered_map<int, std::vector<Variable>> variableCache;   // var reference -> all variables under that reference
     std::unordered_map<int, VariableScope> variableContexts;        // var reference -> variableContext
@@ -248,6 +251,7 @@ private:
     Variable makeVariable(lua_State* L, const std::string& name);
     std::vector<Variable> getLocalsHelper(lua_State* L, int level);
     std::vector<Variable> getUpvaluesHelper(lua_State* L, int level);
+    std::vector<Variable> getGlobalsHelper();
     std::vector<Variable> getTableHelper(lua_State* L, int idx);
 
     void installBpHitCallback();

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -56,9 +56,9 @@ struct StackFrame
 
 enum class VariableScopeType
 {
-    Locals,
-    Upvalues,
-    Globals,
+    Local,
+    Upvalue,
+    Global,
     Table
 };
 

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -64,17 +64,17 @@ static BreakpointStatus breakpointStringToStatus(const char* status)
 }
 
 // VariableScopeType is
-// "locals" | "upvalues" | "globals" | "table"
+// "local" | "upvalue" | "global" | "table"
 static const char* scopeTypeToString(VariableScopeType type)
 {
     switch (type)
     {
-    case VariableScopeType::Locals:
-        return "locals";
-    case VariableScopeType::Upvalues:
-        return "upvalues";
-    case VariableScopeType::Globals:
-        return "globals";
+    case VariableScopeType::Local:
+        return "local";
+    case VariableScopeType::Upvalue:
+        return "upvalue";
+    case VariableScopeType::Global:
+        return "global";
     case VariableScopeType::Table:
         return "table";
     }
@@ -84,12 +84,12 @@ static const char* scopeTypeToString(VariableScopeType type)
 
 static VariableScopeType scopeStringToType(const char* type)
 {
-    if (strcmp(type, "locals") == 0)
-        return VariableScopeType::Locals;
-    if (strcmp(type, "upvalues") == 0)
-        return VariableScopeType::Upvalues;
-    if (strcmp(type, "globals") == 0)
-        return VariableScopeType::Globals;
+    if (strcmp(type, "local") == 0)
+        return VariableScopeType::Local;
+    if (strcmp(type, "upvalue") == 0)
+        return VariableScopeType::Upvalue;
+    if (strcmp(type, "global") == 0)
+        return VariableScopeType::Global;
     if (strcmp(type, "table") == 0)
         return VariableScopeType::Table;
     LUAU_ASSERT(false);

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -64,7 +64,7 @@ static BreakpointStatus breakpointStringToStatus(const char* status)
 }
 
 // VariableScopeType is
-// "locals" | "upvalues" | "table"
+// "locals" | "upvalues" | "globals" | "table"
 static const char* scopeTypeToString(VariableScopeType type)
 {
     switch (type)
@@ -73,6 +73,8 @@ static const char* scopeTypeToString(VariableScopeType type)
         return "locals";
     case VariableScopeType::Upvalues:
         return "upvalues";
+    case VariableScopeType::Globals:
+        return "globals";
     case VariableScopeType::Table:
         return "table";
     }
@@ -86,6 +88,8 @@ static VariableScopeType scopeStringToType(const char* type)
         return VariableScopeType::Locals;
     if (strcmp(type, "upvalues") == 0)
         return VariableScopeType::Upvalues;
+    if (strcmp(type, "globals") == 0)
+        return VariableScopeType::Globals;
     if (strcmp(type, "table") == 0)
         return VariableScopeType::Table;
     LUAU_ASSERT(false);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -58,17 +58,17 @@ VariableScope::VariableScope(int variableReference, VariableScopeType type, std:
 
 VariableScope VariableScope::makeLocals(int variableReference, int threadId, int level)
 {
-    return VariableScope(variableReference, VariableScopeType::Locals, "Locals", threadId, level, -1);
+    return VariableScope(variableReference, VariableScopeType::Local, "Locals", threadId, level, -1);
 }
 
 VariableScope VariableScope::makeUpvalues(int variableReference, int threadId, int level)
 {
-    return VariableScope(variableReference, VariableScopeType::Upvalues, "Upvalues", threadId, level, -1);
+    return VariableScope(variableReference, VariableScopeType::Upvalue, "Upvalues", threadId, level, -1);
 }
 
 VariableScope VariableScope::makeGlobals(int variableReference)
 {
-    return VariableScope(variableReference, VariableScopeType::Globals, "Globals", -1, -1, -1);
+    return VariableScope(variableReference, VariableScopeType::Global, "Globals", -1, -1, -1);
 }
 
 VariableScope VariableScope::makeTable(int variableReference, int luaref)
@@ -976,15 +976,15 @@ std::optional<std::vector<Variable>> Target::getVariablesHelper(int varRef)
     if (auto it2 = variableCache.find(varRef); it2 != variableCache.end())
         return it2->second;
     std::vector<Variable> vars;
-    if (context.type == VariableScopeType::Locals)
+    if (context.type == VariableScopeType::Local)
     {
         vars = getLocalsHelper(threadIdToState.at(context.threadId), context.level);
     }
-    else if (context.type == VariableScopeType::Upvalues)
+    else if (context.type == VariableScopeType::Upvalue)
     {
         vars = getUpvaluesHelper(threadIdToState.at(context.threadId), context.level);
     }
-    else if (context.type == VariableScopeType::Globals)
+    else if (context.type == VariableScopeType::Global)
     {
         vars = getGlobalsHelper();
     }

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -66,6 +66,11 @@ VariableScope VariableScope::makeUpvalues(int variableReference, int threadId, i
     return VariableScope(variableReference, VariableScopeType::Upvalues, "Upvalues", threadId, level, -1);
 }
 
+VariableScope VariableScope::makeGlobals(int variableReference)
+{
+    return VariableScope(variableReference, VariableScopeType::Globals, "Globals", -1, -1, -1);
+}
+
 VariableScope VariableScope::makeTable(int variableReference, int luaref)
 {
     return VariableScope(variableReference, VariableScopeType::Table, "Table", -1, -1, luaref);
@@ -718,11 +723,23 @@ std::optional<std::vector<VariableScope>> Target::getScopesHelper(int threadId, 
     VariableScope locals = VariableScope::makeLocals(variableRefId, threadId, level);
     variableContexts.insert_or_assign(variableRefId, locals);
     variableRefId++;
-    contexts.push_back(locals);
+    contexts.emplace_back(locals);
     VariableScope upvalues = VariableScope::makeUpvalues(variableRefId, threadId, level);
     variableContexts.insert_or_assign(variableRefId, upvalues);
     variableRefId++;
-    contexts.push_back(upvalues);
+    contexts.emplace_back(upvalues);
+    if (globalVariableRef)
+    {
+        contexts.emplace_back(variableContexts.at(*globalVariableRef));
+    }
+    else
+    {
+        VariableScope globals = VariableScope::makeGlobals(variableRefId);
+        variableContexts.insert_or_assign(variableRefId, globals);
+        globalVariableRef = variableRefId;
+        variableRefId++;
+        contexts.emplace_back(globals);
+    }
     scopeCache[frame->id] = contexts;
     return contexts;
 }
@@ -829,7 +846,7 @@ static std::string printTable(lua_State* L, int idx, int levelsToPrint)
             value = lua_typename(L, lua_type(L, -1));
             break;
         }
-        keyValues.push_back(std::make_pair(key, value));
+        keyValues.emplace_back(std::make_pair(key, value));
         lua_pop(L, 1);
     }
     // this is a "pure" array
@@ -905,7 +922,7 @@ std::vector<Variable> Target::getLocalsHelper(lua_State* L, int level)
     std::vector<Variable> vars;
     while ((name = lua_getlocal(L, level, n)) != nullptr)
     {
-        vars.push_back(makeVariable(L, name));
+        vars.emplace_back(makeVariable(L, name));
         lua_pop(L, 1);
         n++;
     }
@@ -923,12 +940,17 @@ std::vector<Variable> Target::getUpvaluesHelper(lua_State* L, int level)
     const char* name;
     while ((name = lua_getupvalue(L, -1, n)) != nullptr)
     {
-        vars.push_back(makeVariable(L, name));
+        vars.emplace_back(makeVariable(L, name));
         lua_pop(L, 1);
         n++;
     }
     lua_pop(L, 1);
     return vars;
+}
+
+std::vector<Variable> Target::getGlobalsHelper()
+{
+    return getTableHelper(scriptThread, LUA_GLOBALSINDEX);
 }
 
 std::vector<Variable> Target::getTableHelper(lua_State* L, int idx)
@@ -939,7 +961,7 @@ std::vector<Variable> Target::getTableHelper(lua_State* L, int idx)
     while (lua_next(L, absoluteIndex))
     {
         std::string key = getKeyFromTableType(L);
-        vars.push_back(makeVariable(L, key));
+        vars.emplace_back(makeVariable(L, key));
         lua_pop(L, 1);
     }
     return vars;
@@ -961,6 +983,10 @@ std::optional<std::vector<Variable>> Target::getVariablesHelper(int varRef)
     else if (context.type == VariableScopeType::Upvalues)
     {
         vars = getUpvaluesHelper(threadIdToState.at(context.threadId), context.level);
+    }
+    else if (context.type == VariableScopeType::Globals)
+    {
+        vars = getGlobalsHelper();
     }
     else
     {
@@ -1022,6 +1048,7 @@ void Target::continueProcessHelper()
     idToStackFrameInfo.clear();
 
     variableRefId = 1;
+    globalVariableRef = std::nullopt;
     for (auto& [_, scope] : variableContexts)
         if (scope.type == VariableScopeType::Table)
             lua_unref(childRuntime->GL, scope.luaref);

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -553,7 +553,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local target = debug.newTarget()
 		check.eq(typeof(target), "Target")
 		local mainPath = path.format(path.join(proc.cwd(), "tests/src/debug/variables.luau"))
-		target:setBreakpoint(mainPath, 15)
+		target:setBreakpoint(mainPath, 16)
 		local onFinished = false
 		local targetLaunched = target:launch(mainPath, {}, {
 			onBreakpointHit = function(_thread, _bp)
@@ -564,9 +564,10 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				check.eq(#stacktrace, 2)
 				local scopes = target:getScopes(stacktrace[1].id)
 				assert(scopes)
-				check.eq(#scopes, 2)
+				check.eq(#scopes, 3)
 				checkScope(check, scopes, "Locals", "locals", threads[1].id, 0)
 				checkScope(check, scopes, "Upvalues", "upvalues", threads[1].id, 0)
+				checkScope(check, scopes, "Globals", "globals", -1, -1)
 				for _, scope in scopes do
 					if scope.type == "locals" then
 						local locals = target:getVariables(scope.variableRef)
@@ -580,6 +581,12 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 						check.eq(#upvalues, 2)
 						checkVariable(check, upvalues, "a", "24", "number", false)
 						checkVariable(check, upvalues, "_b", "1.2", "number", false)
+					end
+					if scope.type == "globals" then
+						local globals = target:getVariables(scope.variableRef)
+						assert(globals)
+						check.eq(#globals, 1)
+						checkVariable(check, globals, "_global_var", "16", "number", false)
 					end
 				end
 				local locals = target:getVariablesByScopeType(stacktrace[2].id, "locals")
@@ -603,6 +610,10 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				checkVariable(check, tables, "[1]", "1", "number", false)
 				checkVariable(check, tables, "[2]", "2", "number", false)
 				checkVariable(check, tables, "[3]", "3", "number", false)
+				local globals = target:getVariablesByScopeType(stacktrace[2].id, "globals")
+				assert(globals)
+				check.eq(#globals, 1)
+				checkVariable(check, globals, "_global_var", "16", "number", false)
 				local continued = target:continueProcess()
 				check.that(continued)
 			end,

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -299,7 +299,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 					local stackTrace = assert(target:getStackTrace(thread.id))
 					local threadStack = stackTrace[#stackTrace]
 					check.eq(threadStack.line, 7)
-					local vars = assert(target:getVariablesByScopeType(threadStack.id, "locals"))
+					local vars = assert(target:getVariablesByScopeType(threadStack.id, "local"))
 					checkVariable(check, vars, "_i", tostring(bpHit1), "number", false)
 					for _, otherThread in threads do
 						if otherThread.id == 3 then
@@ -334,7 +334,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 						end
 					end
 					bpHit2 += 1
-					local vars = assert(target:getVariablesByScopeType(threadStack.id, "locals"))
+					local vars = assert(target:getVariablesByScopeType(threadStack.id, "local"))
 					checkVariable(check, vars, "_i", tostring(bpHit2), "number", false)
 				else
 					local stoppedThread = assert(target:getStoppedThread())
@@ -565,31 +565,31 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				local scopes = target:getScopes(stacktrace[1].id)
 				assert(scopes)
 				check.eq(#scopes, 3)
-				checkScope(check, scopes, "Locals", "locals", threads[1].id, 0)
-				checkScope(check, scopes, "Upvalues", "upvalues", threads[1].id, 0)
-				checkScope(check, scopes, "Globals", "globals", -1, -1)
+				checkScope(check, scopes, "Locals", "local", threads[1].id, 0)
+				checkScope(check, scopes, "Upvalues", "upvalue", threads[1].id, 0)
+				checkScope(check, scopes, "Globals", "global", -1, -1)
 				for _, scope in scopes do
-					if scope.type == "locals" then
+					if scope.type == "local" then
 						local locals = target:getVariables(scope.variableRef)
 						assert(locals)
 						check.eq(#locals, 1)
 						checkVariable(check, locals, "_k", "25.2", "number", false)
 					end
-					if scope.type == "upvalues" then
+					if scope.type == "upvalue" then
 						local upvalues = target:getVariables(scope.variableRef)
 						assert(upvalues)
 						check.eq(#upvalues, 2)
 						checkVariable(check, upvalues, "a", "24", "number", false)
 						checkVariable(check, upvalues, "_b", "1.2", "number", false)
 					end
-					if scope.type == "globals" then
+					if scope.type == "global" then
 						local globals = target:getVariables(scope.variableRef)
 						assert(globals)
 						check.eq(#globals, 1)
 						checkVariable(check, globals, "_global_var", "16", "number", false)
 					end
 				end
-				local locals = target:getVariablesByScopeType(stacktrace[2].id, "locals")
+				local locals = target:getVariablesByScopeType(stacktrace[2].id, "local")
 				assert(locals)
 				check.eq(#locals, 12)
 				checkVariable(check, locals, "a", "24", "number", false)
@@ -610,7 +610,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				checkVariable(check, tables, "[1]", "1", "number", false)
 				checkVariable(check, tables, "[2]", "2", "number", false)
 				checkVariable(check, tables, "[3]", "3", "number", false)
-				local globals = target:getVariablesByScopeType(stacktrace[2].id, "globals")
+				local globals = target:getVariablesByScopeType(stacktrace[2].id, "global")
 				assert(globals)
 				check.eq(#globals, 1)
 				checkVariable(check, globals, "_global_var", "16", "number", false)

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -535,7 +535,7 @@ TEST_SUITE("Debug")
                 REQUIRE(stackTrace.has_value());
                 StackFrame threadStack = stackTrace->at(stackTrace->size() - 1);
                 CHECK(threadStack.line == 7);
-                std::optional<std::vector<Variable>> vars = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Locals);
+                std::optional<std::vector<Variable>> vars = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Local);
                 REQUIRE(vars.has_value());
                 checkVariable(*vars, "_i", std::to_string(hitsBp1), "number", false);
                 for (const Thread& thread : threads)
@@ -585,7 +585,7 @@ TEST_SUITE("Debug")
                     }
                 }
                 hitsBp2++;
-                std::optional<std::vector<Variable>> vars = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Locals);
+                std::optional<std::vector<Variable>> vars = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Local);
                 REQUIRE(vars.has_value());
                 checkVariable(*vars, "_i", std::to_string(hitsBp2), "number", false);
             }
@@ -703,25 +703,25 @@ TEST_SUITE("Debug")
             // stack frame at level 0
             std::optional<std::vector<VariableScope>> scopes = target.getScopes(stackframe->at(0).id);
             REQUIRE(scopes.has_value());
-            checkScope(*scopes, VariableScopeType::Locals, "Locals", 1, 0);
-            checkScope(*scopes, VariableScopeType::Upvalues, "Upvalues", 1, 0);
-            checkScope(*scopes, VariableScopeType::Globals, "Globals", -1, -1);
-            std::optional<std::vector<Variable>> upvalues0 = target.getVariablesByScopeType(stackframe->at(0).id, VariableScopeType::Upvalues);
+            checkScope(*scopes, VariableScopeType::Local, "Locals", 1, 0);
+            checkScope(*scopes, VariableScopeType::Upvalue, "Upvalues", 1, 0);
+            checkScope(*scopes, VariableScopeType::Global, "Globals", -1, -1);
+            std::optional<std::vector<Variable>> upvalues0 = target.getVariablesByScopeType(stackframe->at(0).id, VariableScopeType::Upvalue);
             REQUIRE(upvalues0.has_value());
             checkVariable(*upvalues0, "a", "24", "number", false);
             checkVariable(*upvalues0, "_b", "1.2", "number", false);
-            std::optional<std::vector<Variable>> locals0 = target.getVariablesByScopeType(stackframe->at(0).id, VariableScopeType::Locals);
+            std::optional<std::vector<Variable>> locals0 = target.getVariablesByScopeType(stackframe->at(0).id, VariableScopeType::Local);
             checkVariable(*locals0, "_k", "25.2", "number", false);
-            std::optional<std::vector<Variable>> globals = target.getVariablesByScopeType(stackframe->at(0).id, VariableScopeType::Globals);
+            std::optional<std::vector<Variable>> globals = target.getVariablesByScopeType(stackframe->at(0).id, VariableScopeType::Global);
             REQUIRE(globals.has_value());
             checkVariable(*globals, "_global_var", "16", "number", false);
             // stack frame at level 1
             scopes = target.getScopes(stackframe->at(1).id);
             REQUIRE(scopes.has_value());
-            checkScope(*scopes, VariableScopeType::Locals, "Locals", 1, 1);
-            checkScope(*scopes, VariableScopeType::Upvalues, "Upvalues", 1, 1);
-            checkScope(*scopes, VariableScopeType::Globals, "Globals", -1, -1);
-            std::optional<std::vector<Variable>> locals1 = target.getVariablesByScopeType(stackframe->at(1).id, VariableScopeType::Locals);
+            checkScope(*scopes, VariableScopeType::Local, "Locals", 1, 1);
+            checkScope(*scopes, VariableScopeType::Upvalue, "Upvalues", 1, 1);
+            checkScope(*scopes, VariableScopeType::Global, "Globals", -1, -1);
+            std::optional<std::vector<Variable>> locals1 = target.getVariablesByScopeType(stackframe->at(1).id, VariableScopeType::Local);
             REQUIRE(locals1.has_value());
             checkVariable(*locals1, "a", "24", "number", false);
             checkVariable(*locals1, "_b", "1.2", "number", false);
@@ -748,10 +748,10 @@ TEST_SUITE("Debug")
             table = target.getVariables(ref3);
             REQUIRE(table.has_value());
             checkVariable(*table, "r", "13", "number", false);
-            std::optional<std::vector<Variable>> upvalues1 = target.getVariablesByScopeType(stackframe->at(1).id, VariableScopeType::Upvalues);
+            std::optional<std::vector<Variable>> upvalues1 = target.getVariablesByScopeType(stackframe->at(1).id, VariableScopeType::Upvalue);
             REQUIRE(upvalues1.has_value());
             CHECK(upvalues1->size() == 0);
-            globals = target.getVariablesByScopeType(stackframe->at(1).id, VariableScopeType::Globals);
+            globals = target.getVariablesByScopeType(stackframe->at(1).id, VariableScopeType::Global);
             REQUIRE(globals.has_value());
             checkVariable(*globals, "_global_var", "16", "number", false);
             target.continueProcess();

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -693,7 +693,7 @@ TEST_SUITE("Debug")
     {
         std::string fixturePath = getDebugFixturePath("variables.luau");
         Target target(*runtime);
-        target.setBreakpoint(fixturePath, 15);
+        target.setBreakpoint(fixturePath, 16);
         config.onBreakpointHit = [&](const Thread&, const Breakpoint&)
         {
             const std::vector<Thread>& threads = target.getThreads();
@@ -705,17 +705,22 @@ TEST_SUITE("Debug")
             REQUIRE(scopes.has_value());
             checkScope(*scopes, VariableScopeType::Locals, "Locals", 1, 0);
             checkScope(*scopes, VariableScopeType::Upvalues, "Upvalues", 1, 0);
+            checkScope(*scopes, VariableScopeType::Globals, "Globals", -1, -1);
             std::optional<std::vector<Variable>> upvalues0 = target.getVariablesByScopeType(stackframe->at(0).id, VariableScopeType::Upvalues);
             REQUIRE(upvalues0.has_value());
             checkVariable(*upvalues0, "a", "24", "number", false);
             checkVariable(*upvalues0, "_b", "1.2", "number", false);
             std::optional<std::vector<Variable>> locals0 = target.getVariablesByScopeType(stackframe->at(0).id, VariableScopeType::Locals);
             checkVariable(*locals0, "_k", "25.2", "number", false);
+            std::optional<std::vector<Variable>> globals = target.getVariablesByScopeType(stackframe->at(0).id, VariableScopeType::Globals);
+            REQUIRE(globals.has_value());
+            checkVariable(*globals, "_global_var", "16", "number", false);
             // stack frame at level 1
             scopes = target.getScopes(stackframe->at(1).id);
             REQUIRE(scopes.has_value());
             checkScope(*scopes, VariableScopeType::Locals, "Locals", 1, 1);
             checkScope(*scopes, VariableScopeType::Upvalues, "Upvalues", 1, 1);
+            checkScope(*scopes, VariableScopeType::Globals, "Globals", -1, -1);
             std::optional<std::vector<Variable>> locals1 = target.getVariablesByScopeType(stackframe->at(1).id, VariableScopeType::Locals);
             REQUIRE(locals1.has_value());
             checkVariable(*locals1, "a", "24", "number", false);
@@ -746,6 +751,9 @@ TEST_SUITE("Debug")
             std::optional<std::vector<Variable>> upvalues1 = target.getVariablesByScopeType(stackframe->at(1).id, VariableScopeType::Upvalues);
             REQUIRE(upvalues1.has_value());
             CHECK(upvalues1->size() == 0);
+            globals = target.getVariablesByScopeType(stackframe->at(1).id, VariableScopeType::Globals);
+            REQUIRE(globals.has_value());
+            checkVariable(*globals, "_global_var", "16", "number", false);
             target.continueProcess();
         };
         target.launch(fixturePath, {}, config);

--- a/tests/src/debug/variables.luau
+++ b/tests/src/debug/variables.luau
@@ -1,3 +1,4 @@
+_global_var = 16
 local a = 12
 local _b = 1.2
 local _c = "test"


### PR DESCRIPTION
This updates `lute/debug` to track user-defined global variables. We still don't track in-built globals because this clogs up the interface and generally these in-built globals are unlikely to be changed by the user.

https://github.com/user-attachments/assets/1863efd3-e42b-498b-b8e6-80fd599b9588


