### PR TITLE
`lute/debug`: fix thread ordering

### DIFF
--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -1068,7 +1068,7 @@ void Target::continueProcessHelper()
                 continueRequestedBp.insert(stoppedThread);
             bpHit = std::nullopt;
         }
-        childRuntime->runningThreads.push_back({true, stoppedThreadRef, 0});
+        childRuntime->runningThreads.push_front({true, stoppedThreadRef, 0});
         // This schedule() wakes up the runtime in runContinuously() to re-run runToCompletion() in case that has exited. This is a no-op if
         // runToCompletion() has not exited.
         childRuntime->schedule([]() {});

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -439,7 +439,7 @@ std::optional<std::string> Target::launch(std::string sourcePath, const std::vec
 
         scriptThread = thread;
         scriptThreadRef = getRefForThread(scriptThread);
-        childRuntime->runningThreads.push_back({true, scriptThreadRef, static_cast<int>(args.size())});
+        childRuntime->runningThreads.emplace_back(true, scriptThreadRef, static_cast<int>(args.size()));
         lua_pop(childRuntime->GL, 1);
         lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
         cb->userdata = this;
@@ -1068,7 +1068,7 @@ void Target::continueProcessHelper()
                 continueRequestedBp.insert(stoppedThread);
             bpHit = std::nullopt;
         }
-        childRuntime->runningThreads.push_front({true, stoppedThreadRef, 0});
+        childRuntime->runningThreads.emplace_front(true, stoppedThreadRef, 0);
         // This schedule() wakes up the runtime in runContinuously() to re-run runToCompletion() in case that has exited. This is a no-op if
         // runToCompletion() has not exited.
         childRuntime->schedule([]() {});

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -30,6 +30,8 @@ struct ThreadToContinue
     std::shared_ptr<Ref> ref;
     int argumentCount = 0;
     std::function<void()> cont;
+    ThreadToContinue() = default;
+    ThreadToContinue(bool success, std::shared_ptr<Ref> ref, int argumentCount);
 };
 
 // Optional completion hook for threads that need native follow-up work once

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -20,6 +20,13 @@ static void lua_close_checked(lua_State* L)
         lua_close(L);
 }
 
+ThreadToContinue::ThreadToContinue(bool success, std::shared_ptr<Ref> ref, int argumentCount)
+    : success(success)
+    , ref(std::move(ref))
+    , argumentCount(argumentCount)
+{
+}
+
 Runtime::Runtime(LuteReporter& reporter, bool debugMode)
     : reporter(reporter)
     , globalState(nullptr, lua_close_checked)

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -280,7 +280,6 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local maxThreads = 0
 		local launchError = target:launch(mainPath, {}, {
 			onBreakpointHit = function(thread, bp)
-				print(bp.id, bpHit1, bpHit2)
 				if bp.id == bp1.id then
 					check.eq(thread.id, 2)
 					local stoppedThread = assert(target:getStoppedThread())
@@ -306,7 +305,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 						if otherThread.id == 3 then
 							local otherTrace = assert(target:getStackTrace(otherThread.id))
 							local line = otherTrace[#otherTrace].line
-							check.that(line >= 20 and line <= 15)
+							check.that(line >= 12 and line <= 16)
 						end
 						if otherThread.id == 1 then
 							local otherTrace = assert(target:getStackTrace(otherThread.id))
@@ -326,7 +325,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 						if otherThread.id == 2 then
 							local otherTrace = assert(target:getStackTrace(otherThread.id))
 							local line = otherTrace[#otherTrace].line
-							check.that(line >= 5 and line <= 8)
+							check.that(line >= 5 and line <= 9)
 						end
 						if otherThread.id == 1 then
 							local otherTrace = assert(target:getStackTrace(otherThread.id))

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -306,7 +306,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 						if otherThread.id == 3 then
 							local otherTrace = assert(target:getStackTrace(otherThread.id))
 							local line = otherTrace[#otherTrace].line
-							check.that(line >= 12 and line <= 15)
+							check.that(line >= 20 and line <= 15)
 						end
 						if otherThread.id == 1 then
 							local otherTrace = assert(target:getStackTrace(otherThread.id))

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -280,6 +280,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local maxThreads = 0
 		local launchError = target:launch(mainPath, {}, {
 			onBreakpointHit = function(thread, bp)
+				print(bp.id, bpHit1, bpHit2)
 				if bp.id == bp1.id then
 					check.eq(thread.id, 2)
 					local stoppedThread = assert(target:getStoppedThread())

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -510,7 +510,7 @@ TEST_SUITE("Debug")
         Breakpoint bp3 = target.setBreakpoint(fixturePath, 22);
 
         int maxThreadsSeen = 0;
-        int hitsBp1 = 0, hitsBp2 = 0;
+        int hitsBp1 = 0, hitsBp2 = 0, total_sum_val = 0;
         config.onBreakpointHit = [&](const Thread& thread, const Breakpoint& bp)
         {
             if (bp.id == bp1.id)
@@ -538,6 +538,10 @@ TEST_SUITE("Debug")
                 std::optional<std::vector<Variable>> vars = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Local);
                 REQUIRE(vars.has_value());
                 checkVariable(*vars, "_i", std::to_string(hitsBp1), "number", false);
+                std::optional<std::vector<Variable>> upvalues = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Upvalues);
+                REQUIRE(upvalues.has_value());
+                checkVariable(*upvalues, "total_sum", std::to_string(total_sum_val), "number", false);
+                total_sum_val++;
                 for (const Thread& thread : threads)
                 {
                     if (thread.id == 3)
@@ -588,6 +592,10 @@ TEST_SUITE("Debug")
                 std::optional<std::vector<Variable>> vars = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Local);
                 REQUIRE(vars.has_value());
                 checkVariable(*vars, "_i", std::to_string(hitsBp2), "number", false);
+                std::optional<std::vector<Variable>> upvalues = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Upvalues);
+                REQUIRE(upvalues.has_value());
+                checkVariable(*upvalues, "total_sum", std::to_string(total_sum_val), "number", false);
+                total_sum_val++;
             }
             else
             {
@@ -613,6 +621,7 @@ TEST_SUITE("Debug")
         CHECK(maxThreadsSeen == 3);
         CHECK(hitsBp1 == 5);
         CHECK(hitsBp2 == 5);
+        CHECK(total_sum_val == 10);
     }
 
     TEST_CASE_FIXTURE(DebugFixture, "Debug_stackFrame")

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -549,7 +549,7 @@ TEST_SUITE("Debug")
                         std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
                         REQUIRE(stackTrace.has_value());
                         int line = stackTrace->at(stackTrace->size() - 1).line;
-                        CHECK((line >= 12 && line <= 15));
+                        CHECK((line >= 12 && line <= 16));
                     }
                     if (thread.id == 1)
                     {
@@ -578,7 +578,7 @@ TEST_SUITE("Debug")
                         std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
                         REQUIRE(stackTrace.has_value());
                         int line = stackTrace->at(stackTrace->size() - 1).line;
-                        CHECK((line >= 5 && line <= 8));
+                        CHECK((line >= 5 && line <= 9));
                     }
                     if (thread.id == 1)
                     {

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -510,7 +510,9 @@ TEST_SUITE("Debug")
         Breakpoint bp3 = target.setBreakpoint(fixturePath, 22);
 
         int maxThreadsSeen = 0;
-        int hitsBp1 = 0, hitsBp2 = 0, total_sum_val = 0;
+        int hitsBp1 = 0;
+        int hitsBp2 = 0;
+        int total_sum_val = 0;
         config.onBreakpointHit = [&](const Thread& thread, const Breakpoint& bp)
         {
             if (bp.id == bp1.id)

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -540,7 +540,7 @@ TEST_SUITE("Debug")
                 std::optional<std::vector<Variable>> vars = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Local);
                 REQUIRE(vars.has_value());
                 checkVariable(*vars, "_i", std::to_string(hitsBp1), "number", false);
-                std::optional<std::vector<Variable>> upvalues = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Upvalues);
+                std::optional<std::vector<Variable>> upvalues = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Upvalue);
                 REQUIRE(upvalues.has_value());
                 checkVariable(*upvalues, "total_sum", std::to_string(total_sum_val), "number", false);
                 total_sum_val++;
@@ -594,7 +594,7 @@ TEST_SUITE("Debug")
                 std::optional<std::vector<Variable>> vars = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Local);
                 REQUIRE(vars.has_value());
                 checkVariable(*vars, "_i", std::to_string(hitsBp2), "number", false);
-                std::optional<std::vector<Variable>> upvalues = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Upvalues);
+                std::optional<std::vector<Variable>> upvalues = target.getVariablesByScopeType(threadStack.id, VariableScopeType::Upvalue);
                 REQUIRE(upvalues.has_value());
                 checkVariable(*upvalues, "total_sum", std::to_string(total_sum_val), "number", false);
                 total_sum_val++;


### PR DESCRIPTION
when we continue execution, always restart execution from the currently stopped coroutine
* while the previous behavior wasn't objectively wrong, it was weird in the sense that pausing your code yielded your stopped coroutine, leading sometimes to counterintuitive results
* also fixes a bug in debug tests leading to flaky Windows tests