### PR TITLE
`lute/debug`: enable stopping in non-yieldable contexts

### DIFF
--- a/.styluaignore
+++ b/.styluaignore
@@ -1,3 +1,4 @@
 **/*.d.luau
 **/generated-types.luau
 tests/src/debug/compile_error.luau
+tests/src/debug/xpcall.luau

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -205,6 +205,7 @@ private:
     std::shared_ptr<Ref> scriptThreadRef;
 
     // our stopped thread that we need to requeue when we continue
+    bool stoppedNoYield = false;
     lua_State* stoppedThread = nullptr;
     std::shared_ptr<Ref> stoppedThreadRef;
     // Due to the way Lua debugger callbacks works, we need to set the stopped line/instruction in the callback. otherwise, outside of the callback,

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -497,7 +497,10 @@ void Target::installBpHitCallback()
             target->stoppedThreadRef = getRefForThread(L);
             // Clear out stepping when this happens.
             lua_callbacks(L)->debugstep = nullptr;
-            lua_break(L);
+            if (lua_isyieldable(L))
+                lua_break(L);
+            else
+                target->stoppedNoYield = true;
             auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
             debug::Thread thread = target->stateToThread.at(L);
             lock.unlock();
@@ -507,6 +510,8 @@ void Target::installBpHitCallback()
                 target->launchConfig.onBreakpointInstall(bp);
             for (auto& bp : uninstalled)
                 target->launchConfig.onBreakpointUninstall(bp);
+            if (target->stoppedNoYield)
+                target->childRuntime->waitForDebugContinue();
         }
         else if (!bp || bp->status != BreakpointStatus::PendingUninstall)
         {
@@ -1201,10 +1206,17 @@ void Target::continueProcessHelper()
                 continueRequestedBp.insert(stoppedThread);
             bpHit = std::nullopt;
         }
-        childRuntime->runningThreads.emplace_front(true, stoppedThreadRef, 0);
-        // This schedule() wakes up the runtime in runContinuously() to re-run runToCompletion() in case that has exited. This is a no-op if
-        // runToCompletion() has not exited.
-        childRuntime->schedule([]() {});
+        if (!stoppedNoYield)
+        {
+            childRuntime->runningThreads.emplace_front(true, stoppedThreadRef, 0);
+            // This schedule() wakes up the runtime in runContinuously() to re-run runToCompletion() in case that has exited. This is a no-op if
+            // runToCompletion() has not exited.
+            childRuntime->schedule([]() {});
+        }
+        else
+        {
+            stoppedNoYield = false;
+        }
         stoppedThread = nullptr;
         stoppedThreadRef = nullptr;
         stoppedLine = -1;
@@ -1248,7 +1260,10 @@ bool Target::pauseProcess()
         // We transition into a paused state. Let's modify all pending breakpoints.
         auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
         target->computeStoppedLocation(L);
-        lua_break(L);
+        if (lua_isyieldable(L))
+            lua_break(L);
+        else
+            target->stoppedNoYield = true;
         // Clear out the interrupt and debugstep callback after we are done.
         lua_callbacks(L)->interrupt = nullptr;
         lua_callbacks(L)->debugstep = nullptr;
@@ -1260,6 +1275,8 @@ bool Target::pauseProcess()
             target->launchConfig.onBreakpointInstall(bp);
         for (auto& bp : uninstalled)
             target->launchConfig.onBreakpointUninstall(bp);
+        if (target->stoppedNoYield)
+            target->childRuntime->waitForDebugContinue();
     };
     return true;
 }
@@ -1322,7 +1339,10 @@ bool Target::step(int threadId, StepType type)
             target->computeStoppedLocation(L);
             target->stepInfo = std::nullopt;
             auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
-            lua_break(L);
+            if (lua_isyieldable(L))
+                lua_break(L);
+            else
+                target->stoppedNoYield = true;
             lua_singlestep(L, 0);
             lua_callbacks(L)->debugstep = nullptr;
             Thread thread = target->stateToThread.at(L);
@@ -1334,6 +1354,8 @@ bool Target::step(int threadId, StepType type)
                 target->launchConfig.onBreakpointInstall(bp);
             for (auto& bp : uninstalled)
                 target->launchConfig.onBreakpointUninstall(bp);
+            if (target->stoppedNoYield)
+                target->childRuntime->waitForDebugContinue();
         }
         else
         {

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -1202,7 +1202,7 @@ void Target::continueProcessHelper()
             // we need to check if our breakpoint is still currently installed after
             // onBreakpointHit() callback
             std::optional<Breakpoint> currentBp = getBreakpointByIdHelper(bpHit->id);
-            if (currentBp && currentBp->status == BreakpointStatus::Installed)
+            if (currentBp && !stoppedNoYield && currentBp->status == BreakpointStatus::Installed)
                 continueRequestedBp.insert(stoppedThread);
             bpHit = std::nullopt;
         }

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -144,6 +144,7 @@ struct Runtime
     std::atomic<int> numLaunchedDebuggees = 0;
     void stopDebug();
     void continueDebug();
+    void waitForDebugContinue();
     // Same as scheduleLuauCallback but we since we don't call this within a libuv completion callback
     // we need to wake up the libuv event loop.
     void scheduleDebugLuauCallback(std::shared_ptr<Ref> callbackRef, std::function<int(lua_State*)> argPusher);

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -175,10 +175,7 @@ bool Runtime::runToCompletion()
     {
         if (debugMode)
         {
-            // when paused while debugging, nothing should happen
-            std::unique_lock<std::mutex> lock(debugMutex);
-            while (debugStopped)
-                debugStoppedCv.wait(lock);
+            waitForDebugContinue();
         }
 
         auto step = runOnce();
@@ -419,6 +416,14 @@ void Runtime::stopDebug()
     LUTE_ASSERT(debugMode);
     std::unique_lock<std::mutex> lock(debugMutex);
     debugStopped = true;
+}
+
+void Runtime::waitForDebugContinue()
+{
+    LUTE_ASSERT(debugMode);
+    std::unique_lock<std::mutex> lock(debugMutex);
+    while (debugStopped)
+        debugStoppedCv.wait(lock);
 }
 
 uv_loop_t* Runtime::getEventLoop()

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -691,7 +691,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				local locals = target:getVariablesByScopeType(stacktrace[1].id, "local")
 				assert(locals)
 				if bp.id == bpErrorHandler.id then
-					local errorValue = string.format('"%s:2: attempt to call a nil value"', fixturePath)
+					local errorValue = string.format('"%s:2: attempt to call a nil value"', normalizePath(fixturePath))
 					checkVariable(check, locals, "_err", errorValue, "string", false)
 				end
 				if bp.id == bpOutside.id then

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -674,4 +674,84 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 			true
 		)
 	end)
+	-- this test case checks we can pause in an error handler
+	suite:case("xpcall", function(check)
+		local target = debug.newTarget()
+		check.eq(typeof(target), "Target")
+		local fixturePath = path.format(path.join(proc.cwd(), "tests/src/debug/xpcall.luau"))
+		local bpErrorHandler = target:setBreakpoint(fixturePath, 4)
+		local bpOutside = target:setBreakpoint(fixturePath, 7)
+		local onFinished = false
+		local launchError = target:launch(fixturePath, {}, {
+			onBreakpointHit = function(_thread, bp)
+				local threads = target:getThreads()
+				check.eq(#threads, 1)
+				local stacktrace = target:getStackTrace(threads[1].id)
+				assert(stacktrace)
+				local locals = target:getVariablesByScopeType(stacktrace[1].id, "local")
+				assert(locals)
+				if bp.id == bpErrorHandler.id then
+					local errorValue = string.format('"%s:2: attempt to call a nil value"', fixturePath)
+					checkVariable(check, locals, "_err", errorValue, "string", false)
+				end
+				if bp.id == bpOutside.id then
+					checkVariable(check, locals, "returned", "false", "boolean", false)
+					checkVariable(check, locals, "_data", '"error found"', "string", false)
+				end
+				local continued = target:continueProcess()
+				check.that(continued)
+			end,
+			onExit = function(status)
+				if status then
+					onFinished = true
+				end
+			end,
+		})
+		check.eq(launchError, nil)
+		check.eq(
+			waitUntil(function()
+				return onFinished
+			end),
+			true
+		)
+	end)
+	-- this test case checks we can pause in metatable methods
+	suite:case("metatable", function(check)
+		local target = debug.newTarget()
+		check.eq(typeof(target), "Target")
+		local fixturePath = path.format(path.join(proc.cwd(), "tests/src/debug/metatable.luau"))
+		local bpIndex = target:setBreakpoint(fixturePath, 4)
+		local bpCall = target:setBreakpoint(fixturePath, 7)
+		local onFinished = false
+		local launchError = target:launch(fixturePath, {}, {
+			onBreakpointHit = function(_thread, bp)
+				local threads = target:getThreads()
+				check.eq(#threads, 1)
+				local stacktrace = target:getStackTrace(threads[1].id)
+				assert(stacktrace)
+				local locals = target:getVariablesByScopeType(stacktrace[1].id, "local")
+				assert(locals)
+				if bp.id == bpIndex.id then
+					checkVariable(check, locals, "k", "7", "number", false)
+				end
+				if bp.id == bpCall.id then
+					checkVariable(check, locals, "k", "5", "number", false)
+				end
+				local continued = target:continueProcess()
+				check.that(continued)
+			end,
+			onExit = function(status)
+				if status then
+					onFinished = true
+				end
+			end,
+		})
+		check.eq(launchError, nil)
+		check.eq(
+			waitUntil(function()
+				return onFinished
+			end),
+			true
+		)
+	end)
 end)

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -682,6 +682,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local bpErrorHandler = target:setBreakpoint(fixturePath, 4)
 		local bpOutside = target:setBreakpoint(fixturePath, 7)
 		local onFinished = false
+		local numHits = 0
 		local launchError = target:launch(fixturePath, {}, {
 			onBreakpointHit = function(_thread, bp)
 				local threads = target:getThreads()
@@ -693,10 +694,12 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				if bp.id == bpErrorHandler.id then
 					local errorValue = string.format('"%s:2: attempt to call a nil value"', normalizePath(fixturePath))
 					checkVariable(check, locals, "_err", errorValue, "string", false)
+					numHits += 1
 				end
 				if bp.id == bpOutside.id then
 					checkVariable(check, locals, "returned", "false", "boolean", false)
 					checkVariable(check, locals, "_data", '"error found"', "string", false)
+					numHits += 1
 				end
 				local continued = target:continueProcess()
 				check.that(continued)
@@ -714,6 +717,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 			end),
 			true
 		)
+		check.eq(numHits, 2)
 	end)
 	-- this test case checks we can pause in metatable methods
 	suite:case("metatable", function(check)
@@ -723,6 +727,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local bpIndex = target:setBreakpoint(fixturePath, 4)
 		local bpCall = target:setBreakpoint(fixturePath, 7)
 		local onFinished = false
+		local numHits = 0
 		local launchError = target:launch(fixturePath, {}, {
 			onBreakpointHit = function(_thread, bp)
 				local threads = target:getThreads()
@@ -733,9 +738,11 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				assert(locals)
 				if bp.id == bpIndex.id then
 					checkVariable(check, locals, "k", "7", "number", false)
+					numHits += 1
 				end
 				if bp.id == bpCall.id then
 					checkVariable(check, locals, "k", "5", "number", false)
+					numHits += 1
 				end
 				local continued = target:continueProcess()
 				check.that(continued)
@@ -753,5 +760,6 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 			end),
 			true
 		)
+		check.eq(numHits, 2)
 	end)
 end)

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -850,6 +850,7 @@ TEST_SUITE("Debug")
         Target target(*runtime);
         Breakpoint bpErrorHandler = target.setBreakpoint(fixturePath, 4);
         Breakpoint bpOutside = target.setBreakpoint(fixturePath, 7);
+        int numHits = 0;
         config.onBreakpointHit = [&](const Thread&, const Breakpoint& bp)
         {
             const std::vector<Thread>& threads = target.getThreads();
@@ -862,6 +863,7 @@ TEST_SUITE("Debug")
                 REQUIRE(locals.has_value());
                 std::string errorValue = "\"" + Luau::format("%s:2: attempt to call a nil value", fixturePath.c_str()) + "\"";
                 checkVariable(*locals, "_err", errorValue, "string", false);
+                numHits++;
             }
             if (bp.id == bpOutside.id)
             {
@@ -869,11 +871,13 @@ TEST_SUITE("Debug")
                 REQUIRE(locals.has_value());
                 checkVariable(*locals, "returned", "false", "boolean", false);
                 checkVariable(*locals, "_data", "\"error found\"", "string", false);
+                numHits++;
             }
             target.continueProcess();
         };
         target.launch(fixturePath, {}, config);
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        CHECK(numHits == 2);
     };
 
     TEST_CASE_FIXTURE(DebugFixture, "Debug_metatable")
@@ -882,6 +886,7 @@ TEST_SUITE("Debug")
         Target target(*runtime);
         Breakpoint bpIndex = target.setBreakpoint(fixturePath, 4);
         Breakpoint bpCall = target.setBreakpoint(fixturePath, 7);
+        int numHits = 0;
         config.onBreakpointHit = [&](const Thread&, const Breakpoint& bp)
         {
             const std::vector<Thread>& threads = target.getThreads();
@@ -893,16 +898,19 @@ TEST_SUITE("Debug")
                 std::optional<std::vector<Variable>> locals = target.getVariablesByScopeType(st->at(0).id, VariableScopeType::Local);
                 REQUIRE(locals.has_value());
                 checkVariable(*locals, "k", "7", "number", false);
+                numHits++;
             }
             if (bp.id == bpCall.id)
             {
                 std::optional<std::vector<Variable>> locals = target.getVariablesByScopeType(st->at(0).id, VariableScopeType::Local);
                 REQUIRE(locals.has_value());
                 checkVariable(*locals, "k", "5", "number", false);
+                numHits++;
             }
             target.continueProcess();
         };
         target.launch(fixturePath, {}, config);
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        CHECK(numHits == 2);
     };
 }

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -843,4 +843,66 @@ TEST_SUITE("Debug")
         target.launch(fixturePath, {}, config);
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
     };
+
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_xpcall")
+    {
+        std::string fixturePath = getDebugFixturePath("xpcall.luau");
+        Target target(*runtime);
+        Breakpoint bpErrorHandler = target.setBreakpoint(fixturePath, 4);
+        Breakpoint bpOutside = target.setBreakpoint(fixturePath, 7);
+        config.onBreakpointHit = [&](const Thread&, const Breakpoint& bp)
+        {
+            const std::vector<Thread>& threads = target.getThreads();
+            REQUIRE(threads.size() == 1);
+            const std::optional<std::vector<StackFrame>> st = target.getStackTrace(threads[0].id);
+            REQUIRE(st.has_value());
+            if (bp.id == bpErrorHandler.id)
+            {
+                std::optional<std::vector<Variable>> locals = target.getVariablesByScopeType(st->at(0).id, VariableScopeType::Local);
+                REQUIRE(locals.has_value());
+                std::string errorValue = "\"" + Luau::format("%s:2: attempt to call a nil value", fixturePath.c_str()) + "\"";
+                checkVariable(*locals, "_err", errorValue, "string", false);
+            }
+            if (bp.id == bpOutside.id)
+            {
+                std::optional<std::vector<Variable>> locals = target.getVariablesByScopeType(st->at(0).id, VariableScopeType::Local);
+                REQUIRE(locals.has_value());
+                checkVariable(*locals, "returned", "false", "boolean", false);
+                checkVariable(*locals, "_data", "\"error found\"", "string", false);
+            }
+            target.continueProcess();
+        };
+        target.launch(fixturePath, {}, config);
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+    };
+
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_metatable")
+    {
+        std::string fixturePath = getDebugFixturePath("metatable.luau");
+        Target target(*runtime);
+        Breakpoint bpIndex = target.setBreakpoint(fixturePath, 4);
+        Breakpoint bpCall = target.setBreakpoint(fixturePath, 7);
+        config.onBreakpointHit = [&](const Thread&, const Breakpoint& bp)
+        {
+            const std::vector<Thread>& threads = target.getThreads();
+            REQUIRE(threads.size() == 1);
+            const std::optional<std::vector<StackFrame>> st = target.getStackTrace(threads[0].id);
+            REQUIRE(st.has_value());
+            if (bp.id == bpIndex.id)
+            {
+                std::optional<std::vector<Variable>> locals = target.getVariablesByScopeType(st->at(0).id, VariableScopeType::Local);
+                REQUIRE(locals.has_value());
+                checkVariable(*locals, "k", "7", "number", false);
+            }
+            if (bp.id == bpCall.id)
+            {
+                std::optional<std::vector<Variable>> locals = target.getVariablesByScopeType(st->at(0).id, VariableScopeType::Local);
+                REQUIRE(locals.has_value());
+                checkVariable(*locals, "k", "5", "number", false);
+            }
+            target.continueProcess();
+        };
+        target.launch(fixturePath, {}, config);
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+    };
 }

--- a/tests/src/debug/metatable.luau
+++ b/tests/src/debug/metatable.luau
@@ -1,0 +1,12 @@
+local t = {}
+setmetatable(t, {
+	__index = function(_, k)
+		return k
+	end,
+	__call = function(_, k)
+		return k
+	end,
+})
+
+t(5)
+local _z = t[7]

--- a/tests/src/debug/xpcall.luau
+++ b/tests/src/debug/xpcall.luau
@@ -1,7 +1,7 @@
 local returned, _data = xpcall(function()
 	x("This will error")
 end, function(_err)
-    return "error found"
+	return "error found"
 end)
 
 local _test = returned

--- a/tests/src/debug/xpcall.luau
+++ b/tests/src/debug/xpcall.luau
@@ -1,0 +1,7 @@
+local returned, _data = xpcall(function()
+	x("This will error")
+end, function(_err)
+    return "error found"
+end)
+
+local _test = returned


### PR DESCRIPTION
Enable stopping in non-yieldable contexts (such as metatable `__index` or inside error handlers)
* Our previous stopping mechanism required yielding our current coroutine in Lute, but this fails inside certain non-yieldable contexts, such as above
* Add an alternative stopping mechanism in these cases that relies on stopping the child runtime by waiting on a condition variable inside the runtime

let me know whether we want to proceed with this change. it's somewhat messy architecturally but solves real bugs we encountered in the bug bash, since previously these cases would result in the debugger crashing/behaving unexpectedly.


https://github.com/user-attachments/assets/8f4abe4c-37c2-4367-bc98-188cad9ffa9b

