### PR TITLE
`lute/debug`: source breakpoints

### DIFF
--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -6,11 +6,18 @@ local debugger = {}
 export type BreakpointStatus = "pendingInstall" | "pendingUninstall" | "installed" | "invalid"
 
 --- A breakpoint that stops execution when encountered during runtime
+--- if condition is not "", the condition must evaluate to true before stopping.
+--- if hitCondition is not "", a condition involving the hitCount must be true before stopping.
+--- if logMessage is not "", then instead of stopping we simply output an interpolated log message to the relevant callback.
 export type Breakpoint = {
 	id: number,
 	line: number,
 	--- this source path will use forward slashes
 	sourcePath: string,
+	condition: string,
+	hitCondition: string,
+	hitCount: number,
+	logMessage: string,
 	status: BreakpointStatus,
 }
 
@@ -100,13 +107,16 @@ export type LaunchConfig = {
 	onPrint: ((message: string, source: string, line: number) -> ())?,
 	--- called when our script finishes stepping on `thread`. `info` reflects the information about our stepping command.
 	onStepStop: ((thread: Thread, info: StepInfo) -> ())?,
+	--- called when we hit a log point `bp` and we are asked to log `message`
+	onLogpointHit: ((message: string, bp: Breakpoint) -> ())?,
 }
 
 --- A `Target` represents the target program under the debugger.
 export type Target = {
 	--- Sets a breakpoint at `sourcePath` with a given line and queue it for installation.
 	--- If this bp already existed return the preexisting breakpoint. Otherwise, it returns the new one.
-	setBreakpoint: (self: Target, sourcePath: string, line: number) -> Breakpoint,
+	--- Use `config` to add settings for conditional bps, hit condition bps, or logpoints.
+	setBreakpoint: (self: Target, sourcePath: string, line: number, config: BreakpointConfig?) -> Breakpoint,
 	--- Remove a breakpoint with a given `id` and queue for uninstall.
 	--- Returns whether it was successful or not.
 	removeBreakpoint: (self: Target, id: number) -> boolean,

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -7,15 +7,15 @@ export type BreakpointStatus = "pendingInstall" | "pendingUninstall" | "installe
 
 --- A config for advanced breakpoint features
 export type BreakpointConfig = {
-	--- if condition is not "", the condition must evaluate to true before we stop on this bp.
+	--- if condition is not "" and not nil, the condition must evaluate to true before we stop on this bp.
 	condition: string?,
-	--- if hitCondition is not "", a condition involving the hitCount must be true before we stop on this bp.
+	--- if hitCondition is not "" and not nil, a condition involving the hitCount must be true before we stop on this bp.
 	--- if hitCondition is a single integer N, only stop when we have hit N times exactly.
 	--- if hitCondition is of the form "% N", only stop every N times we have hit this bp.
 	--- if hitCondition is anything else, we insert the number of times we hit in front of hitCondition and
 	--- attempt to evaluate an expression. For example, we can have ">= 5" or "* 3 - 5 > 6".
 	hitCondition: string?,
-	--- if logMessage is not "", then instead of stopping we simply output an interpolated log message to the relevant callback.
+	--- if logMessage is not "" and not nil, then instead of stopping we simply output an interpolated log message to the relevant callback.
 	--- all expressions within '{}' are interpolated.
 	logMessage: string?,
 }

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -5,12 +5,8 @@ local debugger = {}
 --- operation is queued to happen when the script is next paused.
 export type BreakpointStatus = "pendingInstall" | "pendingUninstall" | "installed" | "invalid"
 
---- A breakpoint that stops execution when encountered during runtime
-export type Breakpoint = {
-	id: number,
-	line: number,
-	--- this source path will use forward slashes
-	sourcePath: string,
+--- A config for advanced breakpoint features
+export type BreakpointConfig = {
 	--- if condition is not "", the condition must evaluate to true before stopping.
 	condition: string,
 	--- if hitCondition is not "", a condition involving the hitCount must be true before stopping.
@@ -19,10 +15,21 @@ export type Breakpoint = {
 	--- if hitCondition is anything else, we insert the number of times we hit in front of hitCondition and
 	--- attempt to evaluate an expression. For example, we can have ">= 5" or "* 3 - 5 > 6".
 	hitCondition: string,
-	--- the number of times this bp has been hit (note that we can hit a bp but not stop it due to conditions above).
-	hitCount: number,
 	--- if logMessage is not "", then instead of stopping we simply output an interpolated log message to the relevant callback.
 	--- all expressions within '{}' are interpolated.
+	logMessage: string,
+}
+
+--- A breakpoint that stops execution when encountered during runtime
+export type Breakpoint = {
+	id: number,
+	line: number,
+	--- this source path will use forward slashes
+	sourcePath: string,
+	condition: string,
+	hitCondition: string,
+	--- the number of times this bp has been hit (note that we can hit a bp but not stop it due to conditions above).
+	hitCount: number,
 	logMessage: string,
 	status: BreakpointStatus,
 }

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -6,17 +6,23 @@ local debugger = {}
 export type BreakpointStatus = "pendingInstall" | "pendingUninstall" | "installed" | "invalid"
 
 --- A breakpoint that stops execution when encountered during runtime
---- if condition is not "", the condition must evaluate to true before stopping.
---- if hitCondition is not "", a condition involving the hitCount must be true before stopping.
---- if logMessage is not "", then instead of stopping we simply output an interpolated log message to the relevant callback.
 export type Breakpoint = {
 	id: number,
 	line: number,
 	--- this source path will use forward slashes
 	sourcePath: string,
+	--- if condition is not "", the condition must evaluate to true before stopping.
 	condition: string,
+	--- if hitCondition is not "", a condition involving the hitCount must be true before stopping.
+	--- if hitCondition is a single integer N, only stop when we have hit N times exactly.
+	--- if hitCondition is of the form "% N", only stop every N times we have hit this bp.
+	--- if hitCondition is anything else, we insert the number of times we hit in front of hitCondition and
+	--- attempt to evaluate an expression. For example, we can have ">= 5" or "* 3 - 5 > 6".
 	hitCondition: string,
+	--- the number of times this bp has been hit (note that we can hit a bp but not stop it due to conditions above).
 	hitCount: number,
+	--- if logMessage is not "", then instead of stopping we simply output an interpolated log message to the relevant callback.
+	--- all expressions within '{}' are interpolated.
 	logMessage: string,
 	status: BreakpointStatus,
 }

--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -7,17 +7,17 @@ export type BreakpointStatus = "pendingInstall" | "pendingUninstall" | "installe
 
 --- A config for advanced breakpoint features
 export type BreakpointConfig = {
-	--- if condition is not "", the condition must evaluate to true before stopping.
-	condition: string,
-	--- if hitCondition is not "", a condition involving the hitCount must be true before stopping.
+	--- if condition is not "", the condition must evaluate to true before we stop on this bp.
+	condition: string?,
+	--- if hitCondition is not "", a condition involving the hitCount must be true before we stop on this bp.
 	--- if hitCondition is a single integer N, only stop when we have hit N times exactly.
 	--- if hitCondition is of the form "% N", only stop every N times we have hit this bp.
 	--- if hitCondition is anything else, we insert the number of times we hit in front of hitCondition and
 	--- attempt to evaluate an expression. For example, we can have ">= 5" or "* 3 - 5 > 6".
-	hitCondition: string,
+	hitCondition: string?,
 	--- if logMessage is not "", then instead of stopping we simply output an interpolated log message to the relevant callback.
 	--- all expressions within '{}' are interpolated.
-	logMessage: string,
+	logMessage: string?,
 }
 
 --- A breakpoint that stops execution when encountered during runtime

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -40,13 +40,20 @@ local function clearAndSetBreakpoints(
 			target:removeBreakpoint(bp.id)
 		end
 	end
-	local resultBps = {}
+	local requestedBps = {}
 	if requestedBreakpoints then
 		for _, setBp in requestedBreakpoints do
-			table.insert(resultBps, debugToDapBreakpoint(target:setBreakpoint(sourcePath, setBp.line)))
+			table.insert(
+				requestedBps,
+				debugToDapBreakpoint(target:setBreakpoint(sourcePath, setBp.line, {
+					condition = setBp.condition,
+					hitCondition = setBp.hitCondition,
+					logMessage = setBp.logMessage,
+				}))
+			)
 		end
 	end
-	return resultBps
+	return requestedBps
 end
 
 local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
@@ -97,6 +104,14 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 				allThreadsStopped = true,
 			})
 		end,
+		onLogpointHit = function(message: string, breakpoint: debugger.Breakpoint)
+			ioSession.writeEvent("output", {
+				category = "stdout",
+				output = message,
+				source = createSource(breakpoint.sourcePath),
+				line = breakpoint.line,
+			})
+		end,
 	}
 	local configurationDone = false
 	local launchConfig: dapTypes.LaunchArgs? = nil
@@ -113,6 +128,9 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 				supportsDelayedStackTraceLoading = true,
 				supportsVariableType = true,
 				supportsEvaluateForHovers = true,
+				supportsConditionalBreakpoints = true,
+				supportsHitConditionalBreakpoints = true,
+				supportsLogPoints = true,
 			}
 			ioSession.writeResponse(reqSeq, true, command, nil, capabilities)
 			ioSession.writeEvent("initialized")

--- a/lute/cli/commands/debug/dapTypes.luau
+++ b/lute/cli/commands/debug/dapTypes.luau
@@ -9,6 +9,9 @@ export type Capability = {
 	supportsDelayedStackTraceLoading: boolean,
 	supportsVariableType: boolean,
 	supportsEvaluateForHovers: boolean,
+	supportsConditionalBreakpoints: boolean,
+	supportsHitConditionalBreakpoints: boolean,
+	supportsLogPoints: boolean,
 }
 
 export type Source = {
@@ -18,6 +21,9 @@ export type Source = {
 
 export type SourceBreakpoint = {
 	line: number,
+	condition: string?,
+	hitCondition: string?,
+	logMessage: string?,
 }
 
 export type SetBreakpointsArgs = {

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -183,7 +183,7 @@ struct Target
     std::optional<std::vector<Variable>> getVariablesByScopeType(int frameId, VariableScopeType contextType);
 
     // For evaluation:
-    EvaluateResult evaluateExpression(const std::string& expression, int frameId = -1);
+    EvaluateResult evaluateExpression(std::string expression, int frameId = -1);
 
     // For actively running scripts:
     std::optional<std::string> launch(std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
@@ -259,7 +259,7 @@ private:
     std::optional<StackFrame> getStackFrameHelper(int threadId, int level);
     std::optional<std::vector<VariableScope>> getScopesHelper(int threadId, int level);
     std::optional<std::vector<Variable>> getVariablesHelper(int varRef);
-    EvaluateResult evaluateExpressionHelper(lua_State* L, int level, const std::string& expression);
+    EvaluateResult evaluateExpressionHelper(lua_State* L, int level, std::string expression);
     void continueProcessHelper();
 
     bool installBreakpoint(lua_State* L, Breakpoint& bp);

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -27,14 +27,24 @@ enum class BreakpointStatus
     Invalid,
 };
 
+struct BreakpointConfig
+{
+    std::string condition = "";
+    std::string hitCondition = "";
+    std::string logMessage = "";
+};
+
 struct Breakpoint
 {
     int id;
-    // This will use forward slashes instead of backwards.
     std::string sourcePath;
     int line;
+    std::string condition;
+    std::string hitCondition;
+    int hitCount = 0;
+    std::string logMessage;
     BreakpointStatus status;
-    explicit Breakpoint(int id, std::string sourcePath, int line, BreakpointStatus status);
+    Breakpoint(int id, std::string sourcePath, int line, BreakpointConfig config, BreakpointStatus status);
 };
 
 // Each Thread represents one coroutine in our Lute runtime.
@@ -91,6 +101,7 @@ struct Variable
     std::string value;
     std::string type;
     int variableReference = 0;
+    bool isTrue();
 };
 
 using EvaluateResult = std::variant<Variable, std::string>;
@@ -117,6 +128,7 @@ struct LaunchConfig
     std::function<void(const Breakpoint& bp)> onBreakpointInstall;
     std::function<void(const Breakpoint& bp)> onBreakpointUninstall;
     std::function<void(const Thread& thread, const Breakpoint& bp)> onBreakpointHit;
+    std::function<void(const std::string& message, const Breakpoint& bp)> onLogpointHit;
     std::function<void(bool success)> onExit;
     std::function<void(const Thread& thread)> onPause;
     std::function<void(const std::string& message, const std::string& source, int line)> onPrint;
@@ -143,7 +155,7 @@ struct Target
     // Any breakpoint that is placed when the target process is paused (including before launch) and that
     // have a loaded source are guaranteed to be installed before the process is resumed. Breakpoints placed on a loaded source
     // when the target script is running may not be installed until the next time that script is paused.
-    Breakpoint setBreakpoint(std::string sourcePath, int line);
+    Breakpoint setBreakpoint(std::string sourcePath, int line, BreakpointConfig config = {});
     bool removeBreakpoint(int bpId);
 
     std::vector<Breakpoint> getBreakpoints() const;
@@ -252,6 +264,11 @@ private:
     bool installBreakpoint(lua_State* L, Breakpoint& bp);
     bool uninstallBreakpoint(lua_State* L, Breakpoint& bp);
     std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> modifyPendingBreakpoints(lua_State* L);
+
+    // for conditional breakpoints:
+    bool evaluateBpCondition(lua_State* L, const Breakpoint& bp);
+    bool evaluateBpHitCondition(lua_State* L, const Breakpoint& bp);
+    std::string evaluateLogMessage(lua_State* L, const Breakpoint& bp);
 
     void computeStoppedLocation(lua_State* L);
     void stoppedSetState(lua_State* L);

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -37,6 +37,7 @@ struct BreakpointConfig
 struct Breakpoint
 {
     int id;
+    // This will use forward slashes instead of backwards.
     std::string sourcePath;
     int line;
     std::string condition;
@@ -182,7 +183,7 @@ struct Target
     std::optional<std::vector<Variable>> getVariablesByScopeType(int frameId, VariableScopeType contextType);
 
     // For evaluation:
-    EvaluateResult evaluateExpression(std::string expression, int frameId = -1);
+    EvaluateResult evaluateExpression(const std::string& expression, int frameId = -1);
 
     // For actively running scripts:
     std::optional<std::string> launch(std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config = {});
@@ -258,7 +259,7 @@ private:
     std::optional<StackFrame> getStackFrameHelper(int threadId, int level);
     std::optional<std::vector<VariableScope>> getScopesHelper(int threadId, int level);
     std::optional<std::vector<Variable>> getVariablesHelper(int varRef);
-    EvaluateResult evaluateExpressionHelper(lua_State* L, int level, std::string expression);
+    EvaluateResult evaluateExpressionHelper(lua_State* L, int level, const std::string& expression);
     void continueProcessHelper();
 
     bool installBreakpoint(lua_State* L, Breakpoint& bp);

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -272,6 +272,7 @@ private:
     std::string evaluateLogMessage(lua_State* L, const Breakpoint& bp);
 
     void computeStoppedLocation(lua_State* L);
+    void unsetStoppedLocation();    
     void stoppedSetState(lua_State* L);
     void stoppedDispatchCallback(std::function<void()> debugStopCallback);
 

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -129,21 +129,33 @@ static StepType stepStringToStatus(const char* status)
 // id: number
 // line: number
 // sourcePath: string
+// condition: string
+// hitCondition: string
+// logMessage: string
 // status: BreakpointStatus
 static int pushBreakpoint(lua_State* L, const Breakpoint& bp)
 {
     checkStack(L, 2);
-    lua_createtable(L, 0, 4);
+    lua_createtable(L, 0, 8);
     lua_pushinteger(L, bp.id);
     lua_setfield(L, -2, "id");
     lua_pushinteger(L, bp.line);
     lua_setfield(L, -2, "line");
     lua_pushstring(L, bp.sourcePath.c_str());
     lua_setfield(L, -2, "sourcePath");
+    lua_pushstring(L, bp.condition.c_str());
+    lua_setfield(L, -2, "condition");
+    lua_pushstring(L, bp.hitCondition.c_str());
+    lua_setfield(L, -2, "hitCondition");
+    lua_pushinteger(L, bp.hitCount);
+    lua_setfield(L, -2, "hitCount");
+    lua_pushstring(L, bp.logMessage.c_str());
+    lua_setfield(L, -2, "logMessage");
     lua_pushstring(L, breakpointStatusToString(bp.status));
     lua_setfield(L, -2, "status");
     return 1;
 }
+
 
 // Helper to push a Thread type, which is
 // id: number
@@ -242,14 +254,33 @@ static int pushStepInfo(lua_State* L, const StepInfo& stepInfo)
     return 1;
 }
 
-// target.setBreakpoint(string sourcePath, int line)
+// target.setBreakpoint(string sourcePath, int line, BreakpointConfig config)
+// BreakpointConfig = {condition: string, hitCondition: string, logMessage: string}
 // returns a breakpoint
 static int target_setBreakpoint(lua_State* L)
 {
     Target* target = getTarget(L, 1);
     const char* source = luaL_checkstring(L, 2);
     int line = luaL_checkinteger(L, 3);
-    Breakpoint bp = target->setBreakpoint(source, line);
+    BreakpointConfig config;
+    if (lua_istable(L, 4))
+    {
+        lua_getfield(L, 4, "condition");
+        if (lua_isstring(L, -1))
+            config.condition = lua_tostring(L, -1);
+        lua_pop(L, 1);
+
+        lua_getfield(L, 4, "hitCondition");
+        if (lua_isstring(L, -1))
+            config.hitCondition = lua_tostring(L, -1);
+        lua_pop(L, 1);
+
+        lua_getfield(L, 4, "logMessage");
+        if (lua_isstring(L, -1))
+            config.logMessage = lua_tostring(L, -1);
+        lua_pop(L, 1);
+    }
+    Breakpoint bp = target->setBreakpoint(source, line, config);
     return pushBreakpoint(L, bp);
 }
 
@@ -298,7 +329,6 @@ static int target_getBreakpointsByStatus(lua_State* L)
     }
     return 1;
 }
-
 
 // target.getBreakpointById(int bpId)
 // returns Breakpoint | nil
@@ -645,6 +675,7 @@ static std::function<void(const Breakpoint&)> makeBreakpointCallback(std::shared
 //     onPause(Thread thread) -> ()
 //     onPrint(string message, string source, int line) -> ()
 //     onStepStop(Thread thread, StepInfo stepInfo) -> ()
+//     onLogpointHit(string message, Breakpoint bp) -> ()
 // }
 // returns string | nil
 static int target_launch(lua_State* L)
@@ -745,6 +776,22 @@ static int target_launch(lua_State* L)
                     {
                         pushThread(L, thread);
                         pushStepInfo(L, stepInfo);
+                        return 2;
+                    }
+                );
+            };
+        }
+        if (auto ref = getOptionalCallback(L, 4, "onLogpointHit"))
+        {
+            config.onLogpointHit = [ref, runtime](std::string message, const Breakpoint& bp)
+            {
+                runtime->scheduleLuauCallback(
+                    ref,
+                    [message, bp](lua_State* L)
+                    {
+                        checkStack(L, 2);
+                        lua_pushstring(L, message.c_str());
+                        pushBreakpoint(L, bp);
                         return 2;
                     }
                 );

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -785,7 +785,7 @@ static int target_launch(lua_State* L)
         {
             config.onLogpointHit = [ref, runtime](std::string message, const Breakpoint& bp)
             {
-                runtime->scheduleLuauCallback(
+                runtime->scheduleDebugLuauCallback(
                     ref,
                     [message, bp](lua_State* L)
                     {

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -81,7 +81,7 @@ VariableScope VariableScope::makeTable(int variableReference, int luaref)
 
 bool Variable::isTrue()
 {
-    return value != "false" && value != "nil" && type != "void";
+    return value != "false" && value != "nil";
 }
 
 Target::Target(Runtime& parentRuntime)
@@ -524,9 +524,13 @@ std::string convertHitConditionToExpression(int hitCount, std::string hitExpress
         return hitString + " == " + hitExpression;
     if (hitExpression.size() > 0 && hitExpression[0] == '%')
     {
-        hitExpression = hitExpression.substr(hitExpression.find_first_not_of(" \t", 1));
-        if (std::all_of(hitExpression.begin() + 1, hitExpression.end(), ::isdigit))
-            return hitString + "%" + hitExpression + " == 0";
+        size_t digitsStart = hitExpression.find_first_not_of(" \t", 1);
+        if (digitsStart != std::string::npos)
+        {
+            std::string digits = hitExpression.substr(digitsStart);
+            if (!digits.empty() && std::all_of(digits.begin(), digits.end(), ::isdigit))
+                return hitString + "%" + digits + " == 0";
+        }
     }
     return hitString + hitExpression;
 }
@@ -1217,7 +1221,7 @@ void Target::injectUpvalues(lua_State* L, int level, lua_State* eval, int evalTa
     lua_pop(L, 1);
 }
 
-EvaluateResult Target::evaluateExpressionHelper(lua_State* L, int level, std::string expression)
+EvaluateResult Target::evaluateExpressionHelper(lua_State* L, int level, const std::string& expression)
 {
     // this guards against leaving the evalthread on the global thread of the child runtime.
     struct StackGuard
@@ -1303,7 +1307,7 @@ EvaluateResult Target::evaluateExpressionHelper(lua_State* L, int level, std::st
     return makeVariable(evalThread, expression);
 }
 
-EvaluateResult Target::evaluateExpression(std::string expression, int frameId)
+EvaluateResult Target::evaluateExpression(const std::string& expression, int frameId)
 {
     std::unique_lock lock(targetMutex);
     if (!launched)

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -369,6 +369,13 @@ void Target::computeStoppedLocation(lua_State* L)
         stoppedLocation = "";
 }
 
+void Target::unsetStoppedLocation()
+{
+    stoppedLine = -1;
+    stoppedPc = nullptr;
+    stoppedLocation = "";
+}
+
 void Target::stoppedSetState(lua_State* L)
 {
     paused = true;
@@ -602,8 +609,9 @@ void Target::installBpHitCallback()
     cb->debugbreak = [](lua_State* L, lua_Debug* ar)
     {
         auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
-        // We land on the same instruction after a continue() after hitting a bp so we basically don't do anything
         std::unique_lock lock(target->targetMutex);
+        // We land on the same instruction after a continue() after hitting a bp so if we have
+        // already have continue() on this thread, we basically don't do anything
         if (auto it = target->continueRequestedBp.find(L); it != target->continueRequestedBp.end())
         {
             target->continueRequestedBp.erase(it);
@@ -611,14 +619,12 @@ void Target::installBpHitCallback()
         }
         lua_Debug info = {};
         lua_getinfo(L, 0, "s", &info);
-        target->stoppedLine = ar->currentline;
         int line = ar->currentline;
         if (!info.source)
         {
             target->parentRuntime.reporter.reportError(Luau::format("breakpoint hit at line %d could not find a runtime source", line));
             return;
         }
-        target->stoppedPc = L->ci->savedpc;
         std::string chunkname = info.source;
         std::optional<Breakpoint> bp = target->getBreakpointBySourceLineHelper(getSourceFromChunk(chunkname), line);
         // Only stop execution on installed breakpoints; otherwise, don't stop.
@@ -626,16 +632,21 @@ void Target::installBpHitCallback()
         {
             target->breakpoints.at(bp->id).hitCount++;
             bp->hitCount = target->breakpoints.at(bp->id).hitCount;
+            // We need to compute locations here for accurate evaluation.
+            target->computeStoppedLocation(L);
             if (bp->condition != "" && !target->evaluateBpCondition(L, *bp))
             {
+                target->unsetStoppedLocation();
                 return;
             }
             if (bp->hitCondition != "" && !target->evaluateBpHitCondition(L, *bp))
             {
+                target->unsetStoppedLocation();
                 return;
             }
             if (bp->logMessage != "")
             {
+                target->unsetStoppedLocation();
                 lock.unlock();
                 std::string message = target->evaluateLogMessage(L, *bp);
                 if (target->launchConfig.onLogpointHit)
@@ -1221,7 +1232,7 @@ void Target::injectUpvalues(lua_State* L, int level, lua_State* eval, int evalTa
     lua_pop(L, 1);
 }
 
-EvaluateResult Target::evaluateExpressionHelper(lua_State* L, int level, const std::string& expression)
+EvaluateResult Target::evaluateExpressionHelper(lua_State* L, int level, std::string expression)
 {
     // this guards against leaving the evalthread on the global thread of the child runtime.
     struct StackGuard
@@ -1307,7 +1318,7 @@ EvaluateResult Target::evaluateExpressionHelper(lua_State* L, int level, const s
     return makeVariable(evalThread, expression);
 }
 
-EvaluateResult Target::evaluateExpression(const std::string& expression, int frameId)
+EvaluateResult Target::evaluateExpression(std::string expression, int frameId)
 {
     std::unique_lock lock(targetMutex);
     if (!launched)
@@ -1373,9 +1384,7 @@ void Target::continueProcessHelper()
         }
         stoppedThread = nullptr;
         stoppedThreadRef = nullptr;
-        stoppedLine = -1;
-        stoppedLocation = "";
-        stoppedPc = nullptr;
+        unsetStoppedLocation();
     }
     paused = false;
     childRuntime->continueDebug();

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -27,10 +27,13 @@
 
 namespace debug
 {
-Breakpoint::Breakpoint(int id, std::string sourcePath, int line, BreakpointStatus status)
+Breakpoint::Breakpoint(int id, std::string sourcePath, int line, BreakpointConfig config, BreakpointStatus status)
     : id(id)
     , sourcePath(sourcePath)
     , line(line)
+    , condition(config.condition)
+    , hitCondition(config.hitCondition)
+    , logMessage(config.logMessage)
     , status(status)
 {
 }
@@ -76,6 +79,11 @@ VariableScope VariableScope::makeTable(int variableReference, int luaref)
     return VariableScope{variableReference, VariableScopeType::Table, "Table", -1, -1, luaref};
 }
 
+bool Variable::isTrue()
+{
+    return value != "false" && value != "nil" && type != "void";
+}
+
 Target::Target(Runtime& parentRuntime)
     : parentRuntime(parentRuntime)
     , loadedSources("")
@@ -118,7 +126,7 @@ static std::string getSourceFromChunk(const std::string& chunkname)
     return chunkname;
 }
 
-Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
+Breakpoint Target::setBreakpoint(std::string sourcePath, int line, BreakpointConfig config)
 {
     std::unique_lock lock(targetMutex);
     sourcePath = normalizePath(sourcePath);
@@ -127,7 +135,7 @@ Breakpoint Target::setBreakpoint(std::string sourcePath, int line)
         return *preexistingBp;
     int id = currentBreakpointId;
     currentBreakpointId++;
-    auto [it, _] = breakpoints.insert_or_assign(id, Breakpoint{id, sourcePath, line, BreakpointStatus::PendingInstall});
+    auto [it, _] = breakpoints.insert_or_assign(id, Breakpoint{id, sourcePath, line, config, BreakpointStatus::PendingInstall});
     // We schedule breakpoint installs to happen when the runtime exists and we are paused. Otherwise,
     // they are scheduled for pending installs.
     if (childRuntime && paused)
@@ -503,15 +511,95 @@ std::optional<std::string> Target::launch(std::string sourcePath, const std::vec
     return std::nullopt;
 }
 
+std::string convertHitConditionToExpression(int hitCount, std::string hitExpression)
+{
+    size_t start = hitExpression.find_first_not_of(" \t");
+    if (start == std::string::npos)
+        return "true";
+    hitExpression = hitExpression.substr(start);
+    size_t end = hitExpression.find_last_not_of(" \t");
+    hitExpression = hitExpression.substr(0, end + 1);
+    std::string hitString = std::to_string(hitCount);
+    if (std::all_of(hitExpression.begin(), hitExpression.end(), ::isdigit))
+        return hitString + " == " + hitExpression;
+    if (hitExpression.size() > 0 && hitExpression[0] == '%')
+    {
+        hitExpression = hitExpression.substr(hitExpression.find_first_not_of(" \t", 1));
+        if (std::all_of(hitExpression.begin() + 1, hitExpression.end(), ::isdigit))
+            return hitString + "%" + hitExpression + " == 0";
+    }
+    return hitString + hitExpression;
+}
+
+bool Target::evaluateBpCondition(lua_State* L, const Breakpoint& bp)
+{
+    EvaluateResult result = evaluateExpressionHelper(L, 0, bp.condition);
+    if (std::holds_alternative<std::string>(result))
+    {
+        parentRuntime.reporter.reportError(
+            Luau::format("cannot evaluate breakpoint condition %s at line %d in %s", bp.condition.c_str(), bp.line, bp.sourcePath.c_str())
+        );
+        return false;
+    }
+    Variable var = std::get<Variable>(result);
+    return var.isTrue();
+}
+
+bool Target::evaluateBpHitCondition(lua_State* L, const Breakpoint& bp)
+{
+    std::string hitExpression = convertHitConditionToExpression(bp.hitCount, bp.hitCondition);
+    EvaluateResult result = evaluateExpressionHelper(L, 0, hitExpression);
+    if (std::holds_alternative<std::string>(result))
+    {
+        parentRuntime.reporter.reportError(
+            Luau::format(
+                "cannot evaluate breakpoint hit condition %s with %d hits at line %d in %s",
+                bp.hitCondition.c_str(),
+                bp.hitCount,
+                bp.line,
+                bp.sourcePath.c_str()
+            )
+        );
+        return false;
+    }
+    Variable var = std::get<Variable>(result);
+    return var.isTrue();
+}
+
+std::string Target::evaluateLogMessage(lua_State* L, const Breakpoint& bp)
+{
+    std::string logMessage = bp.logMessage;
+    size_t start;
+    while ((start = logMessage.find('{')) != std::string::npos)
+    {
+        size_t end = logMessage.find('}', start);
+        if (end == std::string::npos)
+        {
+            break;
+        }
+        std::string interpolateExpr = logMessage.substr(start + 1, end - start - 1);
+        EvaluateResult result = evaluateExpressionHelper(L, 0, interpolateExpr);
+        if (std::holds_alternative<std::string>(result))
+        {
+            parentRuntime.reporter.reportError(
+                Luau::format("cannot evaluate log point message %s at line %d in %s", logMessage.c_str(), bp.line, bp.sourcePath.c_str())
+            );
+            return logMessage;
+        }
+        Variable var = std::get<Variable>(result);
+        logMessage.replace(start, end - start + 1, var.value);
+    }
+    return logMessage + '\n';
+}
+
 void Target::installBpHitCallback()
 {
     lua_Callbacks* cb = lua_callbacks(childRuntime->GL);
     cb->debugbreak = [](lua_State* L, lua_Debug* ar)
     {
         auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
+        // We land on the same instruction after a continue() after hitting a bp so we basically don't do anything
         std::unique_lock lock(target->targetMutex);
-        // We land on the same instruction after a continue() after hitting a bp so if we have
-        // already have continue() on this thread, we basically don't do anything
         if (auto it = target->continueRequestedBp.find(L); it != target->continueRequestedBp.end())
         {
             target->continueRequestedBp.erase(it);
@@ -519,21 +607,41 @@ void Target::installBpHitCallback()
         }
         lua_Debug info = {};
         lua_getinfo(L, 0, "s", &info);
+        target->stoppedLine = ar->currentline;
         int line = ar->currentline;
         if (!info.source)
         {
             target->parentRuntime.reporter.reportError(Luau::format("breakpoint hit at line %d could not find a runtime source", line));
             return;
         }
+        target->stoppedPc = L->ci->savedpc;
         std::string chunkname = info.source;
         std::optional<Breakpoint> bp = target->getBreakpointBySourceLineHelper(getSourceFromChunk(chunkname), line);
         // Only stop execution on installed breakpoints; otherwise, don't stop.
         if (bp && bp->status == BreakpointStatus::Installed)
         {
+            target->breakpoints.at(bp->id).hitCount++;
+            bp->hitCount = target->breakpoints.at(bp->id).hitCount;
+            if (bp->condition != "" && !target->evaluateBpCondition(L, *bp))
+            {
+                return;
+            }
+            if (bp->hitCondition != "" && !target->evaluateBpHitCondition(L, *bp))
+            {
+                return;
+            }
+            if (bp->logMessage != "")
+            {
+                lock.unlock();
+                std::string message = target->evaluateLogMessage(L, *bp);
+                if (target->launchConfig.onLogpointHit)
+                    target->launchConfig.onLogpointHit(message, bp.value());
+                return;
+            }
             target->bpHit = *bp;
             target->stoppedSetState(L);
             auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
-            debug::Thread thread = target->stateToThread.at(L);
+            Thread thread = target->stateToThread.at(L);
             lock.unlock();
             // these are our callbacks to we wish to run to notify the Target's client that we are stopped
             target->stoppedDispatchCallback(
@@ -1295,7 +1403,7 @@ bool Target::pauseProcess()
         auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
         std::unique_lock lock(target->targetMutex);
         target->stoppedSetState(L);
-        debug::Thread thread = target->stateToThread.at(L);
+        Thread thread = target->stateToThread.at(L);
         // We transition into a paused state. Let's modify all pending breakpoints.
         auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
         lock.unlock();

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -770,4 +770,59 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		)
 		check.eq(numHits, 2)
 	end)
+	-- this test case focuses on source breakpoints
+	suite:case("sourceBreakpoints", function(check)
+		local target = debug.newTarget()
+		check.eq(typeof(target), "Target")
+		local mainPath = path.format(path.join(proc.cwd(), "tests/src/debug/loop.luau"))
+		local normalBp = target:setBreakpoint(mainPath, 6)
+		local conditionalBp = target:setBreakpoint(mainPath, 7, { condition = "_step2 > 10" })
+		local hitConditionBp = target:setBreakpoint(mainPath, 8, { hitCondition = "3" })
+		local logPoint = target:setBreakpoint(mainPath, 4, { logMessage = "wow {_step2}" })
+		local onFinished = false
+		local logs = {}
+		local normalHits = 0
+		local conditionalHits = 0
+		local hitConditionHits = 0
+		local targetLaunched = target:launch(mainPath, {}, {
+			onBreakpointHit = function(thread, bp)
+				if bp.id == normalBp.id then
+					normalHits += 1
+				elseif bp.id == conditionalBp.id then
+					conditionalHits += 1
+					check.that(normalHits > 5)
+				elseif bp.id == hitConditionBp.id then
+					hitConditionHits += 1
+					check.eq(normalHits, 3)
+				end
+				local continued = target:continueProcess()
+				check.that(continued)
+			end,
+			onLogpointHit = function(message, bp)
+				table.insert(logs, message)
+				check.eq(bp.id, logPoint.id)
+				check.eq(bp.sourcePath, mainPath)
+				check.eq(bp.line, 4)
+			end,
+			onExit = function(status)
+				if status then
+					onFinished = true
+				end
+			end,
+		})
+		check.eq(targetLaunched, nil)
+		check.eq(
+			waitUntil(function()
+				return onFinished
+			end),
+			true
+		)
+		check.eq(normalHits, 25)
+		check.eq(conditionalHits, 20)
+		check.eq(hitConditionHits, 1)
+		check.eq(#logs, 5)
+		for i = 1, 5 do
+			check.eq(logs[i], `wow {10 * (i - 1)}\n`)
+		end
+	end)
 end)

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -785,7 +785,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local conditionalHits = 0
 		local hitConditionHits = 0
 		local targetLaunched = target:launch(mainPath, {}, {
-			onBreakpointHit = function(thread, bp)
+			onBreakpointHit = function(_thread, bp)
 				if bp.id == normalBp.id then
 					normalHits += 1
 				elseif bp.id == conditionalBp.id then

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -974,4 +974,57 @@ TEST_SUITE("Debug")
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         CHECK(numHits == 2);
     };
+
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_sourceBreakpoints")
+    {
+        std::string fixturePath = getDebugFixturePath("loop.luau");
+        Target target(*runtime);
+        BreakpointConfig conditional = {"_step2 > 6"};
+        BreakpointConfig hitCondition;
+        hitCondition.hitCondition = " % 5";
+        BreakpointConfig log;
+        log.logMessage = "} my value is {_step2 * 3} and {_step1 + 5}";
+        Breakpoint normalBp = target.setBreakpoint(fixturePath, 6);
+        Breakpoint conditionalBp = target.setBreakpoint(fixturePath, 7, conditional);
+        Breakpoint hitConditionBp = target.setBreakpoint(fixturePath, 8, hitCondition);
+        Breakpoint logpoints = target.setBreakpoint(fixturePath, 4, log);
+        std::vector<std::string> logs;
+        config.onLogpointHit = [&](std::string message, const Breakpoint& bpHit)
+        {
+            logs.push_back(message);
+            CHECK(bpHit.sourcePath == fixturePath);
+            CHECK(bpHit.line == 4);
+        };
+        int hits = 0, conditionalStops = 0, hitConditionStops = 0;
+        config.onBreakpointHit = [&](const Thread&, const Breakpoint& bpHit)
+        {
+            if (bpHit.id == normalBp.id)
+            {
+                hits++;
+            }
+            else if (bpHit.id == conditionalBp.id)
+            {
+                conditionalStops++;
+                CHECK(hits >= 3);
+                CHECK(conditionalStops == hits - 3);
+            }
+            else if (bpHit.id == hitConditionBp.id)
+            {
+                hitConditionStops++;
+                CHECK(hits % 5 == 0);
+            }
+            target.continueProcess();
+        };
+        target.launch(fixturePath, {}, config);
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        CHECK(hits == 25);
+        CHECK(conditionalStops == 22);
+        CHECK(hitConditionStops == 5);
+        CHECK(logs.size() == 5);
+        for (int i = 0; i < (int)(logs.size()); i++)
+        {
+            std::string expected = Luau::format("} my value is %d and %d\n", 30 * i, 6 * i + 5);
+            CHECK(logs[i] == expected);
+        }
+    };
 }

--- a/tests/src/debug/loop.luau
+++ b/tests/src/debug/loop.luau
@@ -5,5 +5,6 @@ for _ = 1, 5 do
 	for _ = 1, 5 do
 		_step2 = _step2 + 1
 		_step2 = _step2 + 1
+		_step1 = _step1 + 1
 	end
 end


### PR DESCRIPTION
This allows additional capability to breakpoints, allowing it to conform to the DAP `sourceBreakpoint` specification
* It adds conditional breakpoints, hit condition breakpoints, and logpoints
* Conditional breakpoints only stop once a condition evaluates to non-false
* Hit conditional breakpoints stop according to an expression based on the number of times that bp has been hit
* Logpoints don't stop execution and instead log a statement to the debug console (this statement can do evaluation interpolation)

conditional bps:
https://github.com/user-attachments/assets/6702c791-7b7d-433d-95e1-453108e43730

hit conditional bps:
https://github.com/user-attachments/assets/f37a11f0-97e8-4777-afc2-4d1ca8daf033

logpoints:
https://github.com/user-attachments/assets/6fe8909f-15c0-464f-a7a5-36f342f3587f
