### PR TITLE
Adds opt-in support for comments and trailing commas to `@std/json`

### DIFF
--- a/lute/std/libs/json.luau
+++ b/lute/std/libs/json.luau
@@ -244,13 +244,63 @@ end
 
 -- deserialization
 
+--- Options for `deserialize`:
+--- - `comments`: If `true`, allows `//` line comments and `/* */` block comments. Defaults to `false`.
+--- - `trailingCommas`: If `true`, allows a trailing comma after the last element of an array or object. Defaults to `false`.
+export type DeserializeOptions = {
+	comments: boolean?,
+	trailingCommas: boolean?,
+}
+
 type DeserializerState = {
 	src: string,
 	cursor: number,
+	comments: boolean,
+	trailingCommas: boolean,
 }
 
 local function deserializerError(state: DeserializerState, msg: string): never
 	return error(`JSON error - {msg} around {state.cursor}`)
+end
+
+-- Consumes a run of comments along with the whitespace around them, starting at a '/'.
+-- Only reachable when comments are enabled.
+local function skipComments(state: DeserializerState): boolean
+	local src = state.src
+	local cursor = state.cursor
+
+	while string.byte(src, cursor) == 0x2F do -- '/'
+		local following = string.byte(src, cursor + 1)
+
+		if following == 0x2F then -- '//'
+			local lineEnd = string.find(src, "\n", cursor + 2, true)
+			if not lineEnd then
+				state.cursor = #src + 1
+				return false
+			end
+			cursor = lineEnd + 1
+		elseif following == 0x2A then -- '/*'
+			local _, blockEnd = string.find(src, "*/", cursor + 2, true)
+			if not blockEnd then
+				state.cursor = cursor
+				return deserializerError(state, "Unterminated block comment")
+			end
+			cursor = blockEnd + 1
+		else
+			-- A lone '/' never starts a comment, so leave it for the caller to reject.
+			break
+		end
+
+		local nextCursor = string.find(src, "[^ \n\r\t]", cursor)
+		if not nextCursor then
+			state.cursor = #src + 1
+			return false
+		end
+		cursor = nextCursor
+	end
+
+	state.cursor = cursor
+	return true
 end
 
 local function skipWhitespace(state: DeserializerState): boolean
@@ -259,12 +309,18 @@ local function skipWhitespace(state: DeserializerState): boolean
 		return false
 	end
 	if b ~= 0x20 and b ~= 0x09 and b ~= 0x0A and b ~= 0x0D then
+		if b == 0x2F and state.comments then -- '/'
+			return skipComments(state)
+		end
 		return true
 	end
 
 	state.cursor = string.find(state.src, "[^ \n\r\t]", state.cursor) :: number
 	if not state.cursor then
 		return false
+	end
+	if state.comments and string.byte(state.src, state.cursor) == 0x2F then -- '/'
+		return skipComments(state)
 	end
 	return true
 end
@@ -493,8 +549,8 @@ local function deserializeArray(state: DeserializerState): Array
 		else
 			-- Expect a value next
 			if currentByte(state) == string.byte("]") then
-				if index == 1 then
-					-- empty array is ok
+				-- an empty array is always ok, a trailing comma only when enabled
+				if index == 1 or state.trailingCommas then
 					state.cursor += 1
 					return current
 				else
@@ -558,7 +614,7 @@ local function deserializeObject(state: DeserializerState): Object
 		end
 	end
 
-	if expectingValue then
+	if expectingValue and not state.trailingCommas then
 		return deserializerError(state, "Trailing comma")
 	end
 
@@ -629,11 +685,13 @@ function json.serialize(value: Value, prettyPrint: boolean?): string
 	return buffer.readstring(state.buf, 0, state.cursor)
 end
 
---- Parses a JSON string and returns the corresponding Luau value. Returns `json.null` for a JSON `null` literal; compare with `json.null` rather than `nil` to check for null.
-function json.deserialize(src: string): (Array | Object | boolean | number | string)?
-	local state = {
+--- Parses a JSON string and returns the corresponding Luau value. Returns `json.null` for a JSON `null` literal; compare with `json.null` rather than `nil` to check for null. Pass `options` to also accept comments and trailing commas, as found in files like `.luaurc`.
+function json.deserialize(src: string, options: DeserializeOptions?): (Array | Object | boolean | number | string)?
+	local state: DeserializerState = {
 		src = src,
 		cursor = 1,
+		comments = (options and options.comments) or false,
+		trailingCommas = (options and options.trailingCommas) or false,
 	}
 
 	local result = deserialize(state)

--- a/tests/std/json.test.luau
+++ b/tests/std/json.test.luau
@@ -121,4 +121,114 @@ test.suite("JSONParsingTestSuite", function(suite)
 			end
 		end
 	end)
+
+	suite:case("deserializeRejectsJsoncByDefault", function(assert)
+		assert.throws(json.deserialize, '{"a": 1} // a comment')
+		assert.throws(json.deserialize, '{/* a comment */ "a": 1}')
+		assert.throws(json.deserialize, '{"a": 1,}')
+		assert.throws(json.deserialize, "[1, 2,]")
+	end)
+
+	suite:case("deserializeAllowsLineComments", function(assert)
+		local src = [[
+		// a leading comment
+		{
+			"a": 1, // after a value
+			"b": "two"
+		}
+		// a trailing comment
+		]]
+
+		local obj = json.asObject(json.deserialize(src, { comments = true }))
+		if not obj then
+			failure.assertion("Expected the parsed value to be an object")
+			return
+		end
+
+		assert.eq(obj.a, 1)
+		assert.eq(obj.b, "two")
+	end)
+
+	suite:case("deserializeAllowsBlockComments", function(assert)
+		local src = '{ /* one */ "a": /* two */ [1, /* three */ 2] /* four */ }'
+
+		local obj = json.asObject(json.deserialize(src, { comments = true }))
+		if not obj then
+			failure.assertion("Expected the parsed value to be an object")
+			return
+		end
+
+		local array = json.asArray(obj.a)
+		if not array then
+			failure.assertion("Expected a to be an array")
+			return
+		end
+
+		assert.eq(array[1], 1)
+		assert.eq(array[2], 2)
+	end)
+
+	suite:case("deserializeKeepsCommentCharactersInsideStrings", function(assert)
+		local obj = json.asObject(json.deserialize('{"a": "// not /* a */ comment"}', { comments = true }))
+		if not obj then
+			failure.assertion("Expected the parsed value to be an object")
+			return
+		end
+
+		assert.eq(obj.a, "// not /* a */ comment")
+	end)
+
+	suite:case("deserializeAllowsTrailingCommas", function(assert)
+		local obj = json.asObject(json.deserialize('{"a": 1,}', { trailingCommas = true }))
+		if not obj then
+			failure.assertion("Expected the parsed value to be an object")
+			return
+		end
+
+		assert.eq(obj.a, 1)
+
+		local array = json.asArray(json.deserialize("[1, 2,]", { trailingCommas = true }))
+		if not array then
+			failure.assertion("Expected the parsed value to be an array")
+			return
+		end
+
+		assert.eq(#array, 2)
+		assert.eq(array[2], 2)
+	end)
+
+	suite:case("deserializeAcceptsLuaurcStyleConfig", function(assert)
+		local src = [[
+		{
+			// how strictly luau should typecheck this project
+			"languageMode": "strict",
+			"aliases": {
+				"std": "~/.lute/typedefs",
+			},
+		}
+		]]
+
+		local obj = json.asObject(json.deserialize(src, { comments = true, trailingCommas = true }))
+		if not obj then
+			failure.assertion("Expected the parsed value to be an object")
+			return
+		end
+
+		assert.eq(obj.languageMode, "strict")
+
+		local aliases = json.asObject(obj.aliases)
+		if not aliases then
+			failure.assertion("Expected aliases to be an object")
+			return
+		end
+
+		assert.eq(aliases.std, "~/.lute/typedefs")
+	end)
+
+	suite:case("deserializeRejectsMalformedComments", function(assert)
+		-- a block comment that is never closed
+		assert.throws(json.deserialize, "[1, 2] /* unterminated", { comments = true })
+		-- a lone slash is not a comment
+		assert.throws(json.deserialize, "[1, / 2]", { comments = true })
+	end)
 end)

--- a/tests/std/json.test.luau
+++ b/tests/std/json.test.luau
@@ -123,10 +123,18 @@ test.suite("JSONParsingTestSuite", function(suite)
 	end)
 
 	suite:case("deserializeRejectsJsoncByDefault", function(assert)
-		assert.throws(json.deserialize, '{"a": 1} // a comment')
-		assert.throws(json.deserialize, '{/* a comment */ "a": 1}')
-		assert.throws(json.deserialize, '{"a": 1,}')
-		assert.throws(json.deserialize, "[1, 2,]")
+		local sources = {
+			'{"a": 1} // a comment',
+			'{/* a comment */ "a": 1}',
+			'{"a": 1,}',
+			"[1, 2,]",
+		}
+
+		for _, src in sources do
+			assert.throws(function()
+				json.deserialize(src)
+			end)
+		end
 	end)
 
 	suite:case("deserializeAllowsLineComments", function(assert)
@@ -227,8 +235,12 @@ test.suite("JSONParsingTestSuite", function(suite)
 
 	suite:case("deserializeRejectsMalformedComments", function(assert)
 		-- a block comment that is never closed
-		assert.throws(json.deserialize, "[1, 2] /* unterminated", { comments = true })
+		assert.throws(function()
+			json.deserialize("[1, 2] /* unterminated", { comments = true })
+		end)
 		-- a lone slash is not a comment
-		assert.throws(json.deserialize, "[1, / 2]", { comments = true })
+		assert.throws(function()
+			json.deserialize("[1, / 2]", { comments = true })
+		end)
 	end)
 end)


### PR DESCRIPTION
`.luaurc` and Rojo project files are JSONC, so `json.deserialize` rejects them as soon as they contain a comment or a trailing comma. #1265 reports this through `lute setup --with-luaurc`.

This adds an options table to `json.deserialize`:

```luau
json.deserialize(src, { comments = true, trailingCommas = true })
```

- `comments` accepts `//` line comments and `/* */` block comments
- `trailingCommas` accepts a trailing comma after the last element of an array or object

Both default to `false`, so existing callers keep strict JSON parsing.

### Scope

I deliberately stopped at JSONC rather than implementing JSON5. Unquoted keys, single-quoted strings, hex literals and `Infinity`/`NaN` would mean rewriting the value and string parsers, which reads to me like the kind of sweeping change CONTRIBUTING.md asks contributors to discuss first. The two extensions here are the ones that actually block `.luaurc` and Rojo files. Happy to follow up with the rest if that is what you want.

I also left `lute setup --with-luaurc` alone. Passing the options there is a one-line change, but the command then rewrites the file through `json.serialize`, which would silently drop the comments the user wrote. That seems worth deciding separately, possibly alongside the `--with-config-luau` idea raised in the issue.

### Performance

The standard JSON path is unchanged. In `skipWhitespace` the new branch compares the byte against `/` before reading the option, and `/` can never begin a value in strict JSON, so the check falls through on its first comparison.

### Testing

`tests/std/json.test.luau` gains cases for line comments, block comments, comment characters inside strings, trailing commas in both containers, a `.luaurc`-shaped document, and rejection of unterminated block comments and lone slashes.

I could not run those cases against the patched library locally: `lute test` resolves `@std/json` to the standard library embedded in the lute binary, and I have no MSVC toolchain on this machine to rebuild it. Instead I verified the patched module directly with a harness that requires it by path, covering the same inputs plus a sweep of `tests/std/JSONParsingTestSuite` - 316 checks over 318 corpus files, all passing.

Of the negative corpus cases, exactly seven begin parsing once both options are enabled, and all seven are comment or trailing-comma cases:

```
n_array_extra_comma.json
n_array_number_and_comma.json
n_object_lone_continuation_byte_in_key_and_trailing_comma.json
n_object_trailing_comma.json
n_object_trailing_comment.json
n_object_trailing_comment_slash_open.json
n_structure_object_with_comment.json
```

The lone continuation byte case flips because the trailing comma was the only reason it was rejected; the parser does not validate UTF-8 inside strings today, and that is unchanged here.

Running the suite as-is against the shipped library gives 327 passed and 4 failed, where the four failures are exactly the new cases that need the patched parser.

Addresses #1265. I cannot set labels on this repository, so this one wants the `std` label.
