### PR TITLE
Add registry support to loom.config.luau

### DIFF
--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -112,7 +112,7 @@ local function serializeOverrides(overrides: { [string]: manifest.DependencySpec
 	local result: { [string]: string } = {}
 	for name, spec in overrides do
 		if spec.sourceKind == "registry" then
-			result[name] = spec.version
+			result[name] = if spec.registry then `{spec.version}@{spec.registry}` else spec.version
 		elseif spec.sourceKind == "path" then
 			result[name] = `path:{spec.source}`
 		elseif spec.sourceKind == "github" then

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -10,6 +10,7 @@ export type LockfileDependency = {
 	read sourceKind: manifest.SourceKind,
 	read installPath: string,
 	read dependencies: { [string]: string },
+	read registry: string?,
 }
 
 export type Lockfile = {
@@ -17,6 +18,7 @@ export type Lockfile = {
 	read packages: { [string]: LockfileDependency },
 	read dependencies: { [string]: string },
 	read overrides: { [string]: string }?,
+	read registry: manifest.RegistryMap?,
 }
 
 local function validatePackageEntry(key: string, entry: any)
@@ -38,6 +40,10 @@ local function validatePackageEntry(key: string, entry: any)
 		assert(typeof(depKey) == "string", `Expected dependency key to be a string for dependency '{key}'`)
 	end
 	table.freeze(entry.dependencies)
+	assert(
+		entry.registry == nil or typeof(entry.registry) == "string",
+		`Expected 'registry' field to be a string or nil for dependency '{key}'`
+	)
 end
 
 local function parseLockfile(t: any): Lockfile
@@ -66,6 +72,21 @@ local function parseLockfile(t: any): Lockfile
 			assert(typeof(value) == "string", "Expected override value to be a string")
 		end
 		table.freeze(t.overrides)
+	end
+
+	if t.registry ~= nil then
+		assert(typeof(t.registry) == "table", "Expected 'registry' field to be a table")
+		for name, entry in t.registry do
+			assert(typeof(name) == "string", "Expected registry key to be a string")
+			assert(typeof(entry) == "table", `Expected registry entry '{name}' to be a table`)
+			assert(typeof(entry.url) == "string", `Expected 'url' field in registry '{name}'`)
+			assert(
+				entry.default == nil or typeof(entry.default) == "boolean",
+				`Expected 'default' to be a boolean or nil in registry '{name}'`
+			)
+			table.freeze(entry)
+		end
+		table.freeze(t.registry)
 	end
 
 	return table.freeze(t)
@@ -112,6 +133,43 @@ local function overridesMatch(locked: { [string]: string }?, current: { [string]
 		for name in locked do
 			if current[name] == nil then
 				return false, `override removed: {name}`
+			end
+		end
+	end
+
+	return true, nil
+end
+
+local function serializeRegistry(registryMap: manifest.RegistryMap): manifest.RegistryMap
+	local result: manifest.RegistryMap = {}
+	for name, config in registryMap do
+		result[name] = table.freeze({
+			url = config.url,
+			default = if config.default == true then true else nil,
+		})
+	end
+	return result
+end
+
+local function registryMatch(locked: manifest.RegistryMap?, current: manifest.RegistryMap): (boolean, string?)
+	for name, currentConfig in current do
+		if locked == nil or locked[name] == nil then
+			return false, `registry added: {name}`
+		end
+		if locked[name].url ~= currentConfig.url then
+			return false, `registry url changed: {name}`
+		end
+		local lockedDefault = locked[name].default == true
+		local currentDefault = currentConfig.default == true
+		if lockedDefault ~= currentDefault then
+			return false, `registry default changed: {name}`
+		end
+	end
+
+	if locked then
+		for name in locked do
+			if current[name] == nil then
+				return false, `registry removed: {name}`
 			end
 		end
 	end
@@ -189,6 +247,12 @@ local function satisfiesManifest(
 		return false, overridesReason
 	end
 
+	local currentRegistry = serializeRegistry(rootManifest.registry)
+	local registryOk, registryReason = registryMatch(lock.registry, currentRegistry)
+	if not registryOk then
+		return false, registryReason
+	end
+
 	return true, nil
 end
 
@@ -197,4 +261,5 @@ return {
 	tryParseFile = tryParseFile,
 	satisfiesManifest = satisfiesManifest,
 	serializeOverrides = serializeOverrides,
+	serializeRegistry = serializeRegistry,
 }

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -140,17 +140,6 @@ local function overridesMatch(locked: { [string]: string }?, current: { [string]
 	return true, nil
 end
 
-local function serializeRegistry(registryMap: manifest.RegistryMap): manifest.RegistryMap
-	local result: manifest.RegistryMap = {}
-	for name, config in registryMap do
-		result[name] = table.freeze({
-			url = config.url,
-			default = config.default,
-		})
-	end
-	return result
-end
-
 local function registryMatch(locked: manifest.RegistryMap?, current: manifest.RegistryMap): (boolean, string?)
 	for name, currentConfig in current do
 		if locked == nil or locked[name] == nil then
@@ -251,8 +240,7 @@ local function satisfiesManifest(
 		return false, overridesReason
 	end
 
-	local currentRegistry = serializeRegistry(rootManifest.registry)
-	local registryOk, registryReason = registryMatch(lock.registry, currentRegistry)
+	local registryOk, registryReason = registryMatch(lock.registry, rootManifest.registry)
 	if not registryOk then
 		return false, registryReason
 	end
@@ -265,5 +253,4 @@ return {
 	tryParseFile = tryParseFile,
 	satisfiesManifest = satisfiesManifest,
 	serializeOverrides = serializeOverrides,
-	serializeRegistry = serializeRegistry,
 }

--- a/lute/cli/commands/pkg/loom-core/src/lockfile.luau
+++ b/lute/cli/commands/pkg/loom-core/src/lockfile.luau
@@ -145,7 +145,7 @@ local function serializeRegistry(registryMap: manifest.RegistryMap): manifest.Re
 	for name, config in registryMap do
 		result[name] = table.freeze({
 			url = config.url,
-			default = if config.default == true then true else nil,
+			default = config.default,
 		})
 	end
 	return result
@@ -231,6 +231,10 @@ local function satisfiesManifest(
 			local lockedVersion = semver.tryParse(pkg.rev :: string)
 			if lockedVersion == nil or not semver.satisfies(lockedVersion, constraint) then
 				return false, `registry constraint no longer satisfied for: {alias}`
+			end
+			local expectedRegistry = spec.registry or rootManifest.defaultRegistry
+			if pkg.registry ~= expectedRegistry then
+				return false, `registry assignment changed for: {alias}`
 			end
 		end
 	end

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -124,6 +124,7 @@ local function parseRegistryMap(raw: any): (RegistryMap, string?)
 
 	local defaultCount = 0
 	local defaultName: string? = nil
+	local hasExplicitFalse = false
 	local firstName: string? = nil
 	local count = 0
 
@@ -139,6 +140,8 @@ local function parseRegistryMap(raw: any): (RegistryMap, string?)
 			if isDefault then
 				defaultCount += 1
 				defaultName = name
+			else
+				hasExplicitFalse = true
 			end
 		end
 
@@ -148,21 +151,25 @@ local function parseRegistryMap(raw: any): (RegistryMap, string?)
 
 		result[name] = table.freeze({
 			url = entry.url,
-			default = isDefault,
+			default = if isDefault == true then true else nil,
 		})
 		count += 1
 	end
 
-	if count > 1 then
-		assert(
-			defaultCount == 1,
-			if defaultCount == 0
-				then "Multiple registries defined but none has 'default = true'"
-				else `Multiple registries have 'default = true' (found {defaultCount})`
-		)
+	if count > 0 and defaultCount == 0 then
+		if count > 1 or hasExplicitFalse then
+			assert(false, "Registry configuration must have exactly one registry with 'default = true'")
+		end
+	elseif count > 1 and defaultCount > 1 then
+		assert(false, `Multiple registries have 'default = true' (found {defaultCount})`)
 	end
 
-	local resolvedDefault = if count == 1 then firstName else defaultName
+	local resolvedDefault: string? = nil
+	if defaultCount == 1 then
+		resolvedDefault = defaultName
+	elseif count == 1 and defaultCount == 0 then
+		resolvedDefault = firstName
+	end
 
 	return table.freeze(result), resolvedDefault
 end

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -20,7 +20,15 @@ export type RegistryDependencySpec = {
 	read name: string,
 	read source: string,
 	read version: string,
+	read registry: string?,
 }
+
+export type RegistryConfig = {
+	read url: string,
+	read default: boolean?,
+}
+
+export type RegistryMap = { [string]: RegistryConfig }
 
 export type DependencySpec = PathDependencySpec | GitHubDependencySpec | RegistryDependencySpec
 
@@ -34,6 +42,8 @@ export type PackageManifest = {
 export type ProjectManifest = {
 	read package: PackageManifest,
 	read overrides: { [string]: DependencySpec },
+	read registry: RegistryMap,
+	read defaultRegistry: string?,
 }
 
 local function isSourceKind(s: unknown): boolean
@@ -87,17 +97,76 @@ local function parseDependencyMap(raw: any, sectionName: string): { [string]: De
 				typeof(spec.version) == "string",
 				`Expected 'version' field for registry dependency '{name}' in {sectionName}`
 			)
+			assert(
+				spec.registry == nil or typeof(spec.registry) == "string",
+				`Optional 'registry' field for dependency '{name}' in {sectionName} must be a string`
+			)
 			result[name] = table.freeze({
 				name = spec.name or name,
 				sourceKind = "registry" :: "registry",
 				source = spec.source,
 				version = spec.version,
+				registry = spec.registry,
 			})
 		end
 	end
 
 	return table.freeze(result)
 end
+
+local function parseRegistryMap(raw: any): (RegistryMap, string?)
+	local result: RegistryMap = {}
+	if raw == nil then
+		return table.freeze(result), nil
+	end
+
+	assert(typeof(raw) == "table", "Expected 'registry' to be a table")
+
+	local defaultCount = 0
+	local defaultName: string? = nil
+	local firstName: string? = nil
+	local count = 0
+
+	for name, entry in raw do
+		assert(typeof(name) == "string", "Expected registry key to be a string")
+		assert(typeof(entry) == "table", `Expected registry entry '{name}' to be a table`)
+		assert(typeof(entry.url) == "string", `Expected 'url' field in registry '{name}'`)
+
+		local isDefault: boolean? = nil
+		if entry.default ~= nil then
+			assert(typeof(entry.default) == "boolean", `Expected 'default' to be a boolean in registry '{name}'`)
+			isDefault = entry.default
+			if isDefault then
+				defaultCount += 1
+				defaultName = name
+			end
+		end
+
+		if count == 0 then
+			firstName = name
+		end
+
+		result[name] = table.freeze({
+			url = entry.url,
+			default = isDefault,
+		})
+		count += 1
+	end
+
+	if count > 1 then
+		assert(
+			defaultCount == 1,
+			if defaultCount == 0
+				then "Multiple registries defined but none has 'default = true'"
+				else `Multiple registries have 'default = true' (found {defaultCount})`
+		)
+	end
+
+	local resolvedDefault = if count == 1 then firstName else defaultName
+
+	return table.freeze(result), resolvedDefault
+end
+
 
 -- TODO: We should do proper error handling because this is user input.
 local function parseManifest(t: unknown): ProjectManifest
@@ -122,6 +191,7 @@ local function parseManifest(t: unknown): ProjectManifest
 	end
 
 	local overrides = parseDependencyMap((t :: any).overrides, "overrides")
+	local registryMap, defaultRegistry = parseRegistryMap((t :: any).registry)
 
 	return table.freeze({
 		package = table.freeze({
@@ -131,6 +201,8 @@ local function parseManifest(t: unknown): ProjectManifest
 			devDependencies = devDependencies,
 		}),
 		overrides = overrides,
+		registry = registryMap,
+		defaultRegistry = defaultRegistry,
 	})
 end
 

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -65,6 +65,17 @@ local function parseDependencyMap(raw: any, sectionName: string): { [string]: De
 	end
 
 	for name, spec in raw do
+		if typeof(spec) == "string" then
+			result[name] = table.freeze({
+				name = name,
+				sourceKind = "registry" :: "registry",
+				source = name,
+				version = spec,
+				registry = nil,
+			})
+			continue
+		end
+
 		assert(
 			spec.name == nil or typeof(spec.name) == "string",
 			`Optional 'name' field in dependency spec for '{name}' in {sectionName} expected to be a string`
@@ -120,7 +131,15 @@ local function parseRegistryMap(raw: any): (RegistryMap, string?)
 		return table.freeze(result), nil
 	end
 
-	assert(typeof(raw) == "table", "Expected 'registry' to be a table")
+	if typeof(raw) == "string" then
+		result.main = table.freeze({
+			url = raw,
+			default = nil,
+		})
+		return table.freeze(result), "main"
+	end
+
+	assert(typeof(raw) == "table", "Expected 'registry' to be a table or a string")
 
 	local defaultCount = 0
 	local defaultName: string? = nil

--- a/lute/cli/commands/pkg/loom-core/src/manifest.luau
+++ b/lute/cli/commands/pkg/loom-core/src/manifest.luau
@@ -167,7 +167,6 @@ local function parseRegistryMap(raw: any): (RegistryMap, string?)
 	return table.freeze(result), resolvedDefault
 end
 
-
 -- TODO: We should do proper error handling because this is user input.
 local function parseManifest(t: unknown): ProjectManifest
 	assert(t ~= nil and typeof(t) == "table", "Expected a table")

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -469,12 +469,26 @@ local function collectRootDependencies(rootManifest: manifest.ProjectManifest, e
 	}
 
 	for dependencyAlias, dependencySpec in rootManifest.package.dependencies do
-		collectRootDependency(state, rootManifest.package.name, dependencyAlias, dependencySpec, rootManifest.registry, rootManifest.defaultRegistry)
+		collectRootDependency(
+			state,
+			rootManifest.package.name,
+			dependencyAlias,
+			dependencySpec,
+			rootManifest.registry,
+			rootManifest.defaultRegistry
+		)
 	end
 
 	if not excludeDev then
 		for dependencyAlias, dependencySpec in rootManifest.package.devDependencies do
-			collectRootDependency(state, rootManifest.package.name, dependencyAlias, dependencySpec, rootManifest.registry, rootManifest.defaultRegistry)
+			collectRootDependency(
+				state,
+				rootManifest.package.name,
+				dependencyAlias,
+				dependencySpec,
+				rootManifest.registry,
+				rootManifest.defaultRegistry
+			)
 		end
 	end
 

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -365,8 +365,9 @@ local function pathDepsAreStale(
 		end
 
 		for alias, depSpec in depManifest.package.dependencies do
-			local ok, normalizedDepSpec = pcall(normalizePathDependency, depSpec, packageInstallPath, rootDirectory)
-			if not ok then
+			local normalizeOk, normalizedDepSpec =
+				pcall(normalizePathDependency, depSpec, packageInstallPath, rootDirectory)
+			if not normalizeOk then
 				return true
 			end
 			depSpec = overrides[(normalizedDepSpec :: manifest.DependencySpec).name] or normalizedDepSpec
@@ -391,6 +392,9 @@ local function pathDepsAreStale(
 					return true
 				end
 			elseif depSpec.sourceKind == "registry" then
+				if recordedPkg.source ~= depSpec.source then
+					return true
+				end
 				local expectedRegistry = depSpec.registry or defaultRegistry
 				if recordedPkg.registry ~= expectedRegistry then
 					return true
@@ -455,8 +459,7 @@ local function collectRootDependency(
 	state: ResolutionState,
 	rootPackageName: string,
 	dependencyAlias: string,
-	dependencySpec: manifest.DependencySpec,
-	defaultRegistry: string?
+	dependencySpec: manifest.DependencySpec
 )
 	if dependencySpec.sourceKind == "registry" then
 		state.registryRequirements[dependencyAlias] = {
@@ -468,7 +471,7 @@ local function collectRootDependency(
 
 		state.registrySources[dependencySpec.name] = dependencySpec.source
 
-		local registryName = dependencySpec.registry or defaultRegistry
+		local registryName = dependencySpec.registry or state.defaultRegistry
 		if registryName then
 			if not state.rootRegistryMap[registryName] then
 				error(`Dependency '{dependencyAlias}' references registry '{registryName}' which is not defined`)
@@ -507,24 +510,12 @@ local function collectRootDependencies(rootManifest: manifest.ProjectManifest, e
 	}
 
 	for dependencyAlias, dependencySpec in rootManifest.package.dependencies do
-		collectRootDependency(
-			state,
-			rootManifest.package.name,
-			dependencyAlias,
-			dependencySpec,
-			rootManifest.defaultRegistry
-		)
+		collectRootDependency(state, rootManifest.package.name, dependencyAlias, dependencySpec)
 	end
 
 	if not excludeDev then
 		for dependencyAlias, dependencySpec in rootManifest.package.devDependencies do
-			collectRootDependency(
-				state,
-				rootManifest.package.name,
-				dependencyAlias,
-				dependencySpec,
-				rootManifest.defaultRegistry
-			)
+			collectRootDependency(state, rootManifest.package.name, dependencyAlias, dependencySpec)
 		end
 	end
 

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -100,6 +100,7 @@ type ResolutionState = {
 	packages: { [string]: lockfile.LockfileDependency },
 	registryRequirements: { [string]: semver.Requirement },
 	registrySources: { [string]: string },
+	registryAssignments: { [string]: string },
 	rootRegistryAliases: { RootRegistryAlias },
 	unresolvedRegistryDependencies: { [string]: { [string]: string } },
 	openDependencies: { [string]: { [string]: string } },
@@ -121,6 +122,7 @@ local function collectSourcePackageDependencies(
 	queue: { manifest.DependencySpec },
 	registryRequirements: { [string]: semver.Requirement },
 	registrySources: { [string]: string },
+	registryAssignments: { [string]: string },
 	unresolvedRegistryDependencies: { [string]: { [string]: string } }
 )
 	local nestedManifestPath = getManifestPath(installPath)
@@ -141,6 +143,10 @@ local function collectSourcePackageDependencies(
 			}
 
 			registrySources[normalizedSpec.name] = normalizedSpec.source
+
+			if normalizedSpec.registry and not registryAssignments[normalizedSpec.name] then
+				registryAssignments[normalizedSpec.name] = normalizedSpec.registry
+			end
 
 			if not unresolvedRegistryDependencies[key] then
 				unresolvedRegistryDependencies[key] = {}
@@ -163,6 +169,7 @@ local function resolveSourcePackage(
 	queue: { manifest.DependencySpec },
 	registryRequirements: { [string]: semver.Requirement },
 	registrySources: { [string]: string },
+	registryAssignments: { [string]: string },
 	unresolvedRegistryDependencies: { [string]: { [string]: string } }
 ): string
 	local key = getKey(spec)
@@ -193,6 +200,7 @@ local function resolveSourcePackage(
 		queue,
 		registryRequirements,
 		registrySources,
+		registryAssignments,
 		unresolvedRegistryDependencies
 	)
 
@@ -223,6 +231,7 @@ local function processSourceQueue(state: ResolutionState, rootDirectory: string)
 			state.queue,
 			state.registryRequirements,
 			state.registrySources,
+			state.registryAssignments,
 			state.unresolvedRegistryDependencies
 		)
 	end
@@ -415,7 +424,9 @@ local function collectRootDependency(
 	state: ResolutionState,
 	rootPackageName: string,
 	dependencyAlias: string,
-	dependencySpec: manifest.DependencySpec
+	dependencySpec: manifest.DependencySpec,
+	registryMap: manifest.RegistryMap,
+	defaultRegistry: string?
 )
 	if dependencySpec.sourceKind == "registry" then
 		state.registryRequirements[dependencyAlias] = {
@@ -426,6 +437,15 @@ local function collectRootDependency(
 		}
 
 		state.registrySources[dependencySpec.name] = dependencySpec.source
+
+		local registryName = dependencySpec.registry or defaultRegistry
+		if registryName then
+			if not registryMap[registryName] then
+				error(`Dependency '{dependencyAlias}' references registry '{registryName}' which is not defined`)
+			end
+			state.registryAssignments[dependencySpec.name] = registryName
+		end
+
 		table.insert(state.rootRegistryAliases, { alias = dependencyAlias, name = dependencySpec.name })
 		return
 	end
@@ -442,18 +462,19 @@ local function collectRootDependencies(rootManifest: manifest.ProjectManifest, e
 		packages = {},
 		registryRequirements = {},
 		registrySources = {},
+		registryAssignments = {},
 		rootRegistryAliases = {},
 		unresolvedRegistryDependencies = {},
 		openDependencies = {},
 	}
 
 	for dependencyAlias, dependencySpec in rootManifest.package.dependencies do
-		collectRootDependency(state, rootManifest.package.name, dependencyAlias, dependencySpec)
+		collectRootDependency(state, rootManifest.package.name, dependencyAlias, dependencySpec, rootManifest.registry, rootManifest.defaultRegistry)
 	end
 
 	if not excludeDev then
 		for dependencyAlias, dependencySpec in rootManifest.package.devDependencies do
-			collectRootDependency(state, rootManifest.package.name, dependencyAlias, dependencySpec)
+			collectRootDependency(state, rootManifest.package.name, dependencyAlias, dependencySpec, rootManifest.registry, rootManifest.defaultRegistry)
 		end
 	end
 
@@ -491,6 +512,7 @@ local function applyOverrides(
 				state.queue,
 				state.registryRequirements,
 				state.registrySources,
+				state.registryAssignments,
 				state.unresolvedRegistryDependencies
 			)
 
@@ -578,6 +600,7 @@ local function resolveRegistryDependencies(
 			sourceKind = "registry" :: "registry",
 			installPath = store.toStorePath(key),
 			dependencies = table.freeze(transitiveDependencies),
+			registry = state.registryAssignments[name],
 		})
 	end
 
@@ -606,6 +629,7 @@ end
 local function buildLockfile(
 	state: ResolutionState,
 	overrides: { [string]: manifest.DependencySpec },
+	registryMap: manifest.RegistryMap,
 	lockfilePath: string
 ): lockfile.Lockfile
 	for _, packageDependencies in state.openDependencies do
@@ -620,11 +644,17 @@ local function buildLockfile(
 		then table.freeze(serializedOverrides)
 		else nil
 
+	local serializedRegistry = lockfile.serializeRegistry(registryMap)
+	local frozenRegistry: manifest.RegistryMap? = if next(serializedRegistry)
+		then table.freeze(serializedRegistry)
+		else nil
+
 	local lock: lockfile.Lockfile = table.freeze({
 		version = 3,
 		packages = state.packages,
 		dependencies = state.dependencies,
 		overrides = frozenOverrides,
+		registry = frozenRegistry,
 	})
 
 	fs.writeStringToFile(lockfilePath, `return {pp(lock)}\n`)
@@ -658,7 +688,7 @@ local function resolve(rootDirectory: string, universe: semver.Universe?, option
 
 	resolveRegistryDependencies(state, overriddenPackages, universe, overrides, lockedRegistryVersions)
 
-	return buildLockfile(state, overrides, lockfilePath)
+	return buildLockfile(state, overrides, rootManifest.registry, lockfilePath)
 end
 
 return {

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -101,6 +101,7 @@ type ResolutionState = {
 	registryRequirements: { [string]: semver.Requirement },
 	registrySources: { [string]: string },
 	registryAssignments: { [string]: string },
+	rootRegistryMap: manifest.RegistryMap,
 	rootRegistryAliases: { RootRegistryAlias },
 	unresolvedRegistryDependencies: { [string]: { [string]: string } },
 	openDependencies: { [string]: { [string]: string } },
@@ -123,6 +124,7 @@ local function collectSourcePackageDependencies(
 	registryRequirements: { [string]: semver.Requirement },
 	registrySources: { [string]: string },
 	registryAssignments: { [string]: string },
+	rootRegistryMap: manifest.RegistryMap,
 	unresolvedRegistryDependencies: { [string]: { [string]: string } }
 )
 	local nestedManifestPath = getManifestPath(installPath)
@@ -144,8 +146,15 @@ local function collectSourcePackageDependencies(
 
 			registrySources[normalizedSpec.name] = normalizedSpec.source
 
-			if normalizedSpec.registry and not registryAssignments[normalizedSpec.name] then
-				registryAssignments[normalizedSpec.name] = normalizedSpec.registry
+			if normalizedSpec.registry then
+				if not rootRegistryMap[normalizedSpec.registry] then
+					error(
+						`Transitive dependency '{dependencyAlias}' in '{key}' references registry '{normalizedSpec.registry}' which is not defined in the workspace`
+					)
+				end
+				if not registryAssignments[normalizedSpec.name] then
+					registryAssignments[normalizedSpec.name] = normalizedSpec.registry
+				end
 			end
 
 			if not unresolvedRegistryDependencies[key] then
@@ -170,6 +179,7 @@ local function resolveSourcePackage(
 	registryRequirements: { [string]: semver.Requirement },
 	registrySources: { [string]: string },
 	registryAssignments: { [string]: string },
+	rootRegistryMap: manifest.RegistryMap,
 	unresolvedRegistryDependencies: { [string]: { [string]: string } }
 ): string
 	local key = getKey(spec)
@@ -201,6 +211,7 @@ local function resolveSourcePackage(
 		registryRequirements,
 		registrySources,
 		registryAssignments,
+		rootRegistryMap,
 		unresolvedRegistryDependencies
 	)
 
@@ -232,6 +243,7 @@ local function processSourceQueue(state: ResolutionState, rootDirectory: string)
 			state.registryRequirements,
 			state.registrySources,
 			state.registryAssignments,
+			state.rootRegistryMap,
 			state.unresolvedRegistryDependencies
 		)
 	end
@@ -425,7 +437,6 @@ local function collectRootDependency(
 	rootPackageName: string,
 	dependencyAlias: string,
 	dependencySpec: manifest.DependencySpec,
-	registryMap: manifest.RegistryMap,
 	defaultRegistry: string?
 )
 	if dependencySpec.sourceKind == "registry" then
@@ -440,7 +451,7 @@ local function collectRootDependency(
 
 		local registryName = dependencySpec.registry or defaultRegistry
 		if registryName then
-			if not registryMap[registryName] then
+			if not state.rootRegistryMap[registryName] then
 				error(`Dependency '{dependencyAlias}' references registry '{registryName}' which is not defined`)
 			end
 			state.registryAssignments[dependencySpec.name] = registryName
@@ -463,6 +474,7 @@ local function collectRootDependencies(rootManifest: manifest.ProjectManifest, e
 		registryRequirements = {},
 		registrySources = {},
 		registryAssignments = {},
+		rootRegistryMap = rootManifest.registry,
 		rootRegistryAliases = {},
 		unresolvedRegistryDependencies = {},
 		openDependencies = {},
@@ -474,7 +486,6 @@ local function collectRootDependencies(rootManifest: manifest.ProjectManifest, e
 			rootManifest.package.name,
 			dependencyAlias,
 			dependencySpec,
-			rootManifest.registry,
 			rootManifest.defaultRegistry
 		)
 	end
@@ -486,7 +497,6 @@ local function collectRootDependencies(rootManifest: manifest.ProjectManifest, e
 				rootManifest.package.name,
 				dependencyAlias,
 				dependencySpec,
-				rootManifest.registry,
 				rootManifest.defaultRegistry
 			)
 		end
@@ -527,6 +537,7 @@ local function applyOverrides(
 				state.registryRequirements,
 				state.registrySources,
 				state.registryAssignments,
+				state.rootRegistryMap,
 				state.unresolvedRegistryDependencies
 			)
 

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -102,6 +102,7 @@ type ResolutionState = {
 	registrySources: { [string]: string },
 	registryAssignments: { [string]: string },
 	rootRegistryMap: manifest.RegistryMap,
+	defaultRegistry: string?,
 	rootRegistryAliases: { RootRegistryAlias },
 	unresolvedRegistryDependencies: { [string]: { [string]: string } },
 	openDependencies: { [string]: { [string]: string } },
@@ -125,6 +126,7 @@ local function collectSourcePackageDependencies(
 	registrySources: { [string]: string },
 	registryAssignments: { [string]: string },
 	rootRegistryMap: manifest.RegistryMap,
+	defaultRegistry: string?,
 	unresolvedRegistryDependencies: { [string]: { [string]: string } }
 )
 	local nestedManifestPath = getManifestPath(installPath)
@@ -146,14 +148,19 @@ local function collectSourcePackageDependencies(
 
 			registrySources[normalizedSpec.name] = normalizedSpec.source
 
-			if normalizedSpec.registry then
-				if not rootRegistryMap[normalizedSpec.registry] then
+			local registryName = normalizedSpec.registry or defaultRegistry
+			if registryName then
+				if normalizedSpec.registry and not rootRegistryMap[normalizedSpec.registry] then
 					error(
 						`Transitive dependency '{dependencyAlias}' in '{key}' references registry '{normalizedSpec.registry}' which is not defined in the workspace`
 					)
 				end
 				if not registryAssignments[normalizedSpec.name] then
-					registryAssignments[normalizedSpec.name] = normalizedSpec.registry
+					registryAssignments[normalizedSpec.name] = registryName
+				elseif registryAssignments[normalizedSpec.name] ~= registryName then
+					error(
+						`Conflicting registry for '{normalizedSpec.name}': '{registryAssignments[normalizedSpec.name]}' vs '{registryName}' (from transitive dependency '{dependencyAlias}' in '{key}')`
+					)
 				end
 			end
 
@@ -180,6 +187,7 @@ local function resolveSourcePackage(
 	registrySources: { [string]: string },
 	registryAssignments: { [string]: string },
 	rootRegistryMap: manifest.RegistryMap,
+	defaultRegistry: string?,
 	unresolvedRegistryDependencies: { [string]: { [string]: string } }
 ): string
 	local key = getKey(spec)
@@ -212,6 +220,7 @@ local function resolveSourcePackage(
 		registrySources,
 		registryAssignments,
 		rootRegistryMap,
+		defaultRegistry,
 		unresolvedRegistryDependencies
 	)
 
@@ -244,6 +253,7 @@ local function processSourceQueue(state: ResolutionState, rootDirectory: string)
 			state.registrySources,
 			state.registryAssignments,
 			state.rootRegistryMap,
+			state.defaultRegistry,
 			state.unresolvedRegistryDependencies
 		)
 	end
@@ -323,7 +333,8 @@ end
 local function pathDepsAreStale(
 	lock: lockfile.Lockfile,
 	rootDirectory: string,
-	overrides: { [string]: manifest.DependencySpec }
+	overrides: { [string]: manifest.DependencySpec },
+	defaultRegistry: string?
 ): boolean
 	for _, pkg in lock.packages do
 		if pkg.sourceKind ~= "path" then
@@ -379,6 +390,11 @@ local function pathDepsAreStale(
 				if recordedPkg.source ~= depSpec.source then
 					return true
 				end
+			elseif depSpec.sourceKind == "registry" then
+				local expectedRegistry = depSpec.registry or defaultRegistry
+				if recordedPkg.registry ~= expectedRegistry then
+					return true
+				end
 			end
 		end
 	end
@@ -408,7 +424,7 @@ local function tryReuseLockfile(
 			return existingLock, nil
 		end
 
-		if satisfied and not pathDepsAreStale(existingLock, rootDirectory, rootManifest.overrides) then
+		if satisfied and not pathDepsAreStale(existingLock, rootDirectory, rootManifest.overrides, rootManifest.defaultRegistry) then
 			return existingLock, nil
 		end
 	end
@@ -454,6 +470,12 @@ local function collectRootDependency(
 			if not state.rootRegistryMap[registryName] then
 				error(`Dependency '{dependencyAlias}' references registry '{registryName}' which is not defined`)
 			end
+			local existing = state.registryAssignments[dependencySpec.name]
+			if existing and existing ~= registryName then
+				error(
+					`Conflicting registry for '{dependencySpec.name}': '{existing}' vs '{registryName}' (from dependency '{dependencyAlias}')`
+				)
+			end
 			state.registryAssignments[dependencySpec.name] = registryName
 		end
 
@@ -475,6 +497,7 @@ local function collectRootDependencies(rootManifest: manifest.ProjectManifest, e
 		registrySources = {},
 		registryAssignments = {},
 		rootRegistryMap = rootManifest.registry,
+		defaultRegistry = rootManifest.defaultRegistry,
 		rootRegistryAliases = {},
 		unresolvedRegistryDependencies = {},
 		openDependencies = {},
@@ -527,6 +550,14 @@ local function applyOverrides(
 			if not state.registrySources[overrideName] then
 				state.registrySources[overrideName] = overrideSpec.source
 			end
+
+			local registryName = overrideSpec.registry or state.defaultRegistry
+			if registryName then
+				if not state.rootRegistryMap[registryName] then
+					error(`Override '{overrideName}' references registry '{registryName}' which is not defined`)
+				end
+				state.registryAssignments[overrideName] = registryName
+			end
 		else
 			local overrideKey = resolveSourcePackage(
 				overrideSpec,
@@ -538,6 +569,7 @@ local function applyOverrides(
 				state.registrySources,
 				state.registryAssignments,
 				state.rootRegistryMap,
+				state.defaultRegistry,
 				state.unresolvedRegistryDependencies
 			)
 
@@ -669,10 +701,7 @@ local function buildLockfile(
 		then table.freeze(serializedOverrides)
 		else nil
 
-	local serializedRegistry = lockfile.serializeRegistry(registryMap)
-	local frozenRegistry: manifest.RegistryMap? = if next(serializedRegistry)
-		then table.freeze(serializedRegistry)
-		else nil
+	local frozenRegistry: manifest.RegistryMap? = if next(registryMap) then registryMap else nil
 
 	local lock: lockfile.Lockfile = table.freeze({
 		version = 3,

--- a/lute/cli/commands/pkg/loom-core/src/resolution.luau
+++ b/lute/cli/commands/pkg/loom-core/src/resolution.luau
@@ -424,7 +424,10 @@ local function tryReuseLockfile(
 			return existingLock, nil
 		end
 
-		if satisfied and not pathDepsAreStale(existingLock, rootDirectory, rootManifest.overrides, rootManifest.defaultRegistry) then
+		if
+			satisfied
+			and not pathDepsAreStale(existingLock, rootDirectory, rootManifest.overrides, rootManifest.defaultRegistry)
+		then
 			return existingLock, nil
 		end
 	end

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -2213,4 +2213,95 @@ test.suite("RegistryConfiguration", function(suite)
 		assert.eq(lock2.packages["citrus@1.0.0"].registry, "main")
 		assert.neq(lock1, lock2)
 	end)
+
+	suite:case("errorOnSingleRegistryExplicitDefaultFalse", function(assert)
+		local ok = pcall(function()
+			writeConfigWithRegistry(
+				registryWorkingDirectory,
+				"root",
+				[[
+
+				citrus = {
+					sourceKind = "registry",
+					source = "citrus",
+					version = "^1.0.0",
+				},]],
+				[[
+
+				main = {
+					url = "https://registry.example.com",
+					default = false,
+				},]]
+			)
+
+			local universe: solver.Universe = {
+				citrus = {
+					namedVersion("citrus", "1.0.0"),
+				},
+			}
+
+			resolution.resolve(path.format(registryWorkingDirectory), universe)
+		end)
+
+		assert.eq(ok, false)
+	end)
+
+	suite:case("reResolvesWhenDepRegistryFieldChanges", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+				registry = "main",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+				default = true,
+			},
+			other = {
+				url = "https://other.example.com",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock1 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock1.packages["citrus@1.0.0"].registry, "main")
+
+		-- Change the dep's registry assignment from "main" to "other"
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+				registry = "other",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+				default = true,
+			},
+			other = {
+				url = "https://other.example.com",
+			},]]
+		)
+
+		local lock2 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock2.packages["citrus@1.0.0"].registry, "other")
+	end)
 end)

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -2584,4 +2584,143 @@ test.suite("RegistryConfiguration", function(suite)
 
 		assert.eq(ok, false)
 	end)
+
+	suite:case("reResolvesWhenOverrideRegistryFieldChanges", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+				default = true,
+			},
+			other = {
+				url = "https://other.example.com",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "1.0.0",
+				registry = "main",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock1 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock1.packages["citrus@1.0.0"].registry, "main")
+
+		-- Change only the override's registry field (same version). The serialized
+		-- override must encode the registry so this triggers re-resolution.
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+				default = true,
+			},
+			other = {
+				url = "https://other.example.com",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "1.0.0",
+				registry = "other",
+			},]]
+		)
+
+		local lock2 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock2.packages["citrus@1.0.0"].registry, "other")
+	end)
+
+	suite:case("reResolvesWhenPathDepRegistrySourceChanges", function(assert)
+		local libDir = path.join(registryWorkingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfigWithRegistry(
+			libDir,
+			"lib",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]]
+		)
+
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+			lemon = {
+				namedVersion("lemon", "1.0.0"),
+			},
+		}
+
+		local lock1 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock1.packages["citrus@1.0.0"].registry, "main")
+
+		-- Change the path dep's transitive registry dep to point at a different
+		-- source (same alias, same registry). Staleness must detect the source change.
+		writeConfigWithRegistry(
+			libDir,
+			"lib",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				name = "lemon",
+				source = "lemon",
+				version = "^1.0.0",
+			},]]
+		)
+
+		local lock2 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock2.packages["citrus@1.0.0"], nil)
+		assert.eq(lock2.packages["lemon@1.0.0"].registry, "main")
+	end)
 end)

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -2304,4 +2304,284 @@ test.suite("RegistryConfiguration", function(suite)
 		local lock2 = resolution.resolve(path.format(registryWorkingDirectory), universe)
 		assert.eq(lock2.packages["citrus@1.0.0"].registry, "other")
 	end)
+
+	suite:case("overrideRegistryFieldPropagates", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+				default = true,
+			},
+			other = {
+				url = "https://other.example.com",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "1.0.0",
+				registry = "other",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock.packages["citrus@1.0.0"].registry, "other")
+
+		-- Resolve again to confirm the lockfile is reused (no perpetual re-resolution)
+		local lock2 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock2.packages["citrus@1.0.0"].registry, "other")
+	end)
+
+	suite:case("overrideInheritsDefaultRegistry", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+			},]],
+			nil,
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "1.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock.packages["citrus@1.0.0"].registry, "main")
+
+		-- Confirm lockfile is stable on re-resolution
+		local lock2 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock2.packages["citrus@1.0.0"].registry, "main")
+	end)
+
+	suite:case("errorOnConflictingRootRegistryAssignment", function(assert)
+		local ok = pcall(function()
+			writeConfigWithRegistry(
+				registryWorkingDirectory,
+				"root",
+				[[
+
+				mylib = {
+					sourceKind = "registry",
+					name = "citrus",
+					source = "citrus",
+					version = "^1.0.0",
+					registry = "main",
+				},]],
+				[[
+
+				main = {
+					url = "https://registry.example.com",
+					default = true,
+				},
+				other = {
+					url = "https://other.example.com",
+				},]],
+				[[
+
+				mylib2 = {
+					sourceKind = "registry",
+					name = "citrus",
+					source = "citrus",
+					version = "^1.0.0",
+					registry = "other",
+				},]]
+			)
+
+			local universe: solver.Universe = {
+				citrus = {
+					namedVersion("citrus", "1.0.0"),
+				},
+			}
+
+			resolution.resolve(path.format(registryWorkingDirectory), universe)
+		end)
+
+		assert.eq(ok, false)
+	end)
+
+	suite:case("errorOnConflictingTransitiveRegistryAssignment", function(assert)
+		local ok = pcall(function()
+			local libADir = path.join(registryWorkingDirectory, "libA")
+			fs.createDirectory(libADir)
+			writeConfigWithRegistry(
+				libADir,
+				"libA",
+				[[
+
+				citrus = {
+					sourceKind = "registry",
+					source = "citrus",
+					version = "^1.0.0",
+					registry = "main",
+				},]]
+			)
+
+			local libBDir = path.join(registryWorkingDirectory, "libB")
+			fs.createDirectory(libBDir)
+			writeConfigWithRegistry(
+				libBDir,
+				"libB",
+				[[
+
+				citrus = {
+					sourceKind = "registry",
+					source = "citrus",
+					version = "^1.0.0",
+					registry = "other",
+				},]]
+			)
+
+			writeConfigWithRegistry(
+				registryWorkingDirectory,
+				"root",
+				[[
+
+				libA = {
+					sourceKind = "path",
+					source = "./libA",
+				},
+				libB = {
+					sourceKind = "path",
+					source = "./libB",
+				},]],
+				[[
+
+				main = {
+					url = "https://registry.example.com",
+					default = true,
+				},
+				other = {
+					url = "https://other.example.com",
+				},]]
+			)
+
+			local universe: solver.Universe = {
+				citrus = {
+					namedVersion("citrus", "1.0.0"),
+				},
+			}
+
+			resolution.resolve(path.format(registryWorkingDirectory), universe)
+		end)
+
+		assert.eq(ok, false)
+	end)
+
+	suite:case("transitiveDepsInheritDefaultRegistry", function(assert)
+		local libDir = path.join(registryWorkingDirectory, "lib")
+		fs.createDirectory(libDir)
+		writeConfigWithRegistry(
+			libDir,
+			"lib",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]]
+		)
+
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			lib = {
+				sourceKind = "path",
+				source = "./lib",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock.packages["citrus@1.0.0"].registry, "main")
+	end)
+
+	suite:case("errorOnOverrideReferencingUndefinedRegistry", function(assert)
+		local ok = pcall(function()
+			writeConfigWithRegistry(
+				registryWorkingDirectory,
+				"root",
+				[[
+
+				citrus = {
+					sourceKind = "registry",
+					source = "citrus",
+					version = "^1.0.0",
+				},]],
+				[[
+
+				main = {
+					url = "https://registry.example.com",
+				},]],
+				nil,
+				[[
+
+				citrus = {
+					sourceKind = "registry",
+					source = "citrus",
+					version = "1.0.0",
+					registry = "nonexistent",
+				},]]
+			)
+
+			local universe: solver.Universe = {
+				citrus = {
+					namedVersion("citrus", "1.0.0"),
+				},
+			}
+
+			resolution.resolve(path.format(registryWorkingDirectory), universe)
+		end)
+
+		assert.eq(ok, false)
+	end)
 end)

--- a/tests/cli/pkg/resolution.test.luau
+++ b/tests/cli/pkg/resolution.test.luau
@@ -1730,3 +1730,487 @@ test.suite("Overrides", function(suite)
 		assert.eq(lock.overrides, nil)
 	end)
 end)
+
+local registryWorkingDirectory = path.join(temporaryDirectory, "lute-pkg-registry-config")
+
+local function writeConfigWithRegistry(
+	dir: path.Path,
+	name: string,
+	deps: string,
+	registrySection: string?,
+	devDeps: string?,
+	overrides: string?
+)
+	local sections = `\t\tdependencies = \{{deps}\n\t\t}`
+	if devDeps then
+		sections ..= `,\n\t\tdev_dependencies = \{{devDeps}\n\t\t}`
+	end
+
+	local overridesSection = ""
+	if overrides then
+		overridesSection = `\n\toverrides = \{{overrides}\n\t},`
+	end
+
+	local registryPart = ""
+	if registrySection then
+		registryPart = `\n\tregistry = \{{registrySection}\n\t},`
+	end
+
+	fs.writeStringToFile(
+		path.join(dir, "loom.config.luau"),
+		`return \{\n\tpackage = \{\n\t\tname = "{name}",\n\t\tversion = "0.0.0",\n{sections},\n\t},{overridesSection}{registryPart}\n}\n`
+	)
+end
+
+test.suite("RegistryConfiguration", function(suite)
+	suite:beforeEach(function()
+		if fs.exists(registryWorkingDirectory) then
+			fs.removeDirectory(registryWorkingDirectory, { recursive = true })
+		end
+		fs.createDirectory(registryWorkingDirectory)
+	end)
+
+	suite:case("singleRegistryImplicitDefault", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(registryWorkingDirectory), universe)
+
+		local entry = lock.packages["citrus@1.0.0"]
+		assert.neq(entry, nil)
+		assert.eq(entry.registry, "main")
+	end)
+
+	suite:case("multipleRegistriesExplicitDefault", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+				default = true,
+			},
+			other = {
+				url = "https://other.example.com",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(registryWorkingDirectory), universe)
+
+		local entry = lock.packages["citrus@1.0.0"]
+		assert.neq(entry, nil)
+		assert.eq(entry.registry, "main")
+	end)
+
+	suite:case("depReferencesNonDefaultRegistry", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+				registry = "other",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+				default = true,
+			},
+			other = {
+				url = "https://other.example.com",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(registryWorkingDirectory), universe)
+
+		local entry = lock.packages["citrus@1.0.0"]
+		assert.neq(entry, nil)
+		assert.eq(entry.registry, "other")
+	end)
+
+	suite:case("errorOnMultipleRegistriesNoDefault", function(assert)
+		local ok = pcall(function()
+			writeConfigWithRegistry(
+				registryWorkingDirectory,
+				"root",
+				[[
+
+				citrus = {
+					sourceKind = "registry",
+					source = "citrus",
+					version = "^1.0.0",
+				},]],
+				[[
+
+				main = {
+					url = "https://registry.example.com",
+				},
+				other = {
+					url = "https://other.example.com",
+				},]]
+			)
+
+			local universe: solver.Universe = {
+				citrus = {
+					namedVersion("citrus", "1.0.0"),
+				},
+			}
+
+			resolution.resolve(path.format(registryWorkingDirectory), universe)
+		end)
+
+		assert.eq(ok, false)
+	end)
+
+	suite:case("errorOnMultipleRegistriesDuplicateDefault", function(assert)
+		local ok = pcall(function()
+			writeConfigWithRegistry(
+				registryWorkingDirectory,
+				"root",
+				[[
+
+				citrus = {
+					sourceKind = "registry",
+					source = "citrus",
+					version = "^1.0.0",
+				},]],
+				[[
+
+				main = {
+					url = "https://registry.example.com",
+					default = true,
+				},
+				other = {
+					url = "https://other.example.com",
+					default = true,
+				},]]
+			)
+
+			local universe: solver.Universe = {
+				citrus = {
+					namedVersion("citrus", "1.0.0"),
+				},
+			}
+
+			resolution.resolve(path.format(registryWorkingDirectory), universe)
+		end)
+
+		assert.eq(ok, false)
+	end)
+
+	suite:case("errorOnUndefinedRegistryReference", function(assert)
+		local ok = pcall(function()
+			writeConfigWithRegistry(
+				registryWorkingDirectory,
+				"root",
+				[[
+
+				citrus = {
+					sourceKind = "registry",
+					source = "citrus",
+					version = "^1.0.0",
+					registry = "nonexistent",
+				},]],
+				[[
+
+				main = {
+					url = "https://registry.example.com",
+				},]]
+			)
+
+			local universe: solver.Universe = {
+				citrus = {
+					namedVersion("citrus", "1.0.0"),
+				},
+			}
+
+			resolution.resolve(path.format(registryWorkingDirectory), universe)
+		end)
+
+		assert.eq(ok, false)
+	end)
+
+	suite:case("noRegistrySectionBackwardCompat", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock = resolution.resolve(path.format(registryWorkingDirectory), universe)
+
+		local entry = lock.packages["citrus@1.0.0"]
+		assert.neq(entry, nil)
+		assert.eq(entry.registry, nil)
+	end)
+
+	suite:case("reResolvesWhenRegistryUrlChanges", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock1 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock1.packages["citrus@1.0.0"].registry, "main")
+
+		-- Change the URL
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://new-registry.example.com",
+			},]]
+		)
+
+		local lock2 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock2.packages["citrus@1.0.0"].registry, "main")
+		assert.neq(lock1, lock2)
+	end)
+
+	suite:case("reResolvesWhenDefaultRegistryChanges", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+				default = true,
+			},
+			other = {
+				url = "https://other.example.com",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock1 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock1.packages["citrus@1.0.0"].registry, "main")
+
+		-- Swap the default
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+			},
+			other = {
+				url = "https://other.example.com",
+				default = true,
+			},]]
+		)
+
+		local lock2 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock2.packages["citrus@1.0.0"].registry, "other")
+	end)
+
+	suite:case("reResolvesWhenRegistryAdded", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock1 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock1.packages["citrus@1.0.0"].registry, "main")
+
+		-- Add a new registry and make it default
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+			},
+			other = {
+				url = "https://other.example.com",
+				default = true,
+			},]]
+		)
+
+		local lock2 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock2.packages["citrus@1.0.0"].registry, "other")
+	end)
+
+	suite:case("reResolvesWhenRegistryRemoved", function(assert)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+				default = true,
+			},
+			other = {
+				url = "https://other.example.com",
+			},]]
+		)
+
+		local universe: solver.Universe = {
+			citrus = {
+				namedVersion("citrus", "1.0.0"),
+			},
+		}
+
+		local lock1 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock1.packages["citrus@1.0.0"].registry, "main")
+
+		-- Remove "other", keep only "main" (now implicit default)
+		writeConfigWithRegistry(
+			registryWorkingDirectory,
+			"root",
+			[[
+
+			citrus = {
+				sourceKind = "registry",
+				source = "citrus",
+				version = "^1.0.0",
+			},]],
+			[[
+
+			main = {
+				url = "https://registry.example.com",
+			},]]
+		)
+
+		local lock2 = resolution.resolve(path.format(registryWorkingDirectory), universe)
+		assert.eq(lock2.packages["citrus@1.0.0"].registry, "main")
+		assert.neq(lock1, lock2)
+	end)
+end)


### PR DESCRIPTION
# Summary
First step to adding registry configuration support to lute. This change focuses on adding registry configuration to the manifest. 

## Manifest Configuration
```
return {
    package = {
        name = "my-package",       -- required: string
        version = "1.0.0",         -- required: string (semver)
        dependencies = {
            ...
            -- registry dependency shorthand
            jest = "^1.0.0",
            cryo = "^2.0.0",
            -- registry dependency (defualt registry)
            citrus = {
                sourceKind = "registry",
                source = "citrus",         -- package name in registry
                version = "^1.0.0",        -- semver constraint
            },
            -- registry dependency (specified registry)
            apple = {
                sourceKind = "registry",
                source = "citrus",         -- package name in registry
                version = "^1.0.0",        -- semver constraint
                registry = "other",
            },
        },
        dev_dependencies = {
            ...
        },
    },
    overrides = {
        ...
    },
    registry = {
        main = {
            url = "https://registry.example.com",
        },
        other = {
            url = "https://other.example.com",
            default = true,
        },
    },

    -- registry shorthand if only one using all default configuration
    registry = "https://registry.example.com",
}
```

## Design Decisions
- manifest decisions
  - default registry logic: if only one registry exists, it is implicitly the default, otherwise exactly one default must be explicitely set to true
  - for now the registry section is just url and default, in the future having a separate registry section with its own fields allows for per registry configuration such as format (i.e. is it .zip or .tar.gz) and auth
  - in registry dependency fields, if registry is ommited the default resolution is used

- lockfile
  - lockfile is stale if any registry config changes (url, default, add/removing registries) or a package's registry assignment changes -- this encludes overrrides

- resolution behavior
  - right now, the current PR only address the assignment and validation mapping a package to a registry
    - in the follow up PR will handle actual resolution changes needed for registry (i.e. unlike with path or github dependency where the resolution reads the loom.config.luau and iterates through dependencies to find the transitive dependency, registry  get the dependencies from the registry instead.)
  - registry assignment granularity is explicit per dependency or inherited from default, default is from the root manifest's default
  - validation is done against the root manifest. anything that references an undefined registry (a registry not defined by the root manifest's registry section errors)
  - conflict detection: for now if a package has an assignment, and later in resolution the same package name has a different registry hard errors
    - this error exists because the way packages are keyed in resolution is by package name being a unique identifier, after resolution is implemeted for registry then a follow up follow up can handle this identifier problem in the solver
