### PR TITLE
`lute/debug`: solve race condition bug involving stopping the debugger

### DIFF
--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -255,6 +255,8 @@ private:
     std::pair<std::vector<Breakpoint>, std::vector<Breakpoint>> modifyPendingBreakpoints(lua_State* L);
 
     void computeStoppedLocation(lua_State* L);
+    void stoppedSetState(lua_State* L);
+    void stoppedDispatchCallback(std::function<void()> debugStopCallback);
 
     Variable makeVariable(lua_State* L, const std::string& name);
     std::vector<Variable> getLocalsHelper(lua_State* L, int level);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -913,7 +913,7 @@ std::vector<Variable> Target::getLocalsHelper(lua_State* L, int level)
     // when hitting a bp we try to re-enter
     bool fixedSavedpc = false;
     const Instruction* original = L->ci->savedpc;
-    if (level == 0 && L == stoppedThread)
+    if (level == 0 && !stoppedNoYield && L == stoppedThread)
     {
         L->ci->savedpc = stoppedPc;
         fixedSavedpc = true;
@@ -1038,7 +1038,7 @@ void Target::injectLocals(lua_State* L, int level, lua_State* eval, int evalTabl
 {
     bool fixedSavedpc = false;
     const Instruction* original = L->ci->savedpc;
-    if (level == 0 && L == stoppedThread && L->ci)
+    if (level == 0 && !stoppedNoYield && L == stoppedThread && L->ci)
     {
         L->ci->savedpc = stoppedPc;
         fixedSavedpc = true;

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -361,6 +361,47 @@ void Target::computeStoppedLocation(lua_State* L)
         stoppedLocation = "";
 }
 
+void Target::stoppedSetState(lua_State* L)
+{
+    paused = true;
+    childRuntime->stopDebug();
+    computeStoppedLocation(L);
+    stoppedThread = L;
+    stoppedThreadRef = getRefForThread(L);
+    stepInfo = std::nullopt;
+    // Clear out stepping and pausing when this happens.
+    lua_callbacks(L)->debugstep = nullptr;
+    lua_callbacks(L)->interrupt = nullptr;
+    // When in a yieldable state, we call lua_break to notify the runtime
+    // to yield our current thread of execution and then stop running further coroutines in the runtime.
+    // Otherwise, in a nonyieldable state, we simply set stoppedNoYield to be true. This
+    // will later force us to wait on a condition variable, preventing execution from continuing in our
+    // current coroutine.
+    if (lua_isyieldable(L))
+        lua_break(L);
+    else
+        stoppedNoYield = true;
+}
+
+void Target::stoppedDispatchCallback(std::function<void()> debugStopCallback)
+{
+    if (!stoppedNoYield)
+    {
+        // In a yieldable state, we add a pending callback that the runtime runs
+        // only after runOnce() returns. Thus, it is guaranteed that the entire runtime is paused.
+        // If we call immediately, the debuggee coroutine still needs to unwind and is still running
+        // leading to possible race conditons.
+        childRuntime->pendingDebugStopNotification = std::move(debugStopCallback);
+    }
+    else
+    {
+        // We are already inside the debug hook so the runtime cannot run any other code during this time.
+        // We can thus run the callbacks inline and then block here until continued.
+        debugStopCallback();
+        childRuntime->waitForDebugContinue();
+    }
+}
+
 std::optional<std::string> Target::launch(std::string sourcePath, const std::vector<std::string>& args, LaunchConfig config)
 {
     std::vector<Breakpoint> installedBps;
@@ -490,28 +531,22 @@ void Target::installBpHitCallback()
         if (bp && bp->status == BreakpointStatus::Installed)
         {
             target->bpHit = *bp;
-            target->paused = true;
-            target->childRuntime->stopDebug();
-            target->computeStoppedLocation(L);
-            target->stoppedThread = L;
-            target->stoppedThreadRef = getRefForThread(L);
-            // Clear out stepping when this happens.
-            lua_callbacks(L)->debugstep = nullptr;
-            if (lua_isyieldable(L))
-                lua_break(L);
-            else
-                target->stoppedNoYield = true;
+            target->stoppedSetState(L);
             auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
             debug::Thread thread = target->stateToThread.at(L);
             lock.unlock();
-            if (target->launchConfig.onBreakpointHit)
-                target->launchConfig.onBreakpointHit(thread, bp.value());
-            for (auto& bp : installed)
-                target->launchConfig.onBreakpointInstall(bp);
-            for (auto& bp : uninstalled)
-                target->launchConfig.onBreakpointUninstall(bp);
-            if (target->stoppedNoYield)
-                target->childRuntime->waitForDebugContinue();
+            // these are our callbacks to we wish to run to notify the Target's client that we are stopped
+            target->stoppedDispatchCallback(
+                [target, thread, hitBp = bp.value(), installed = std::move(installed), uninstalled = std::move(uninstalled)]()
+                {
+                    if (target->launchConfig.onBreakpointHit)
+                        target->launchConfig.onBreakpointHit(thread, hitBp);
+                    for (auto& bp : installed)
+                        target->launchConfig.onBreakpointInstall(bp);
+                    for (auto& bp : uninstalled)
+                        target->launchConfig.onBreakpointUninstall(bp);
+                }
+            );
         }
         else if (!bp || bp->status != BreakpointStatus::PendingUninstall)
         {
@@ -1252,31 +1287,22 @@ bool Target::pauseProcess()
             return;
         auto target = static_cast<Target*>(lua_callbacks(L)->userdata);
         std::unique_lock lock(target->targetMutex);
-        target->paused = true;
-        target->childRuntime->stopDebug();
-        target->stoppedThread = L;
-        target->stoppedThreadRef = getRefForThread(L);
+        target->stoppedSetState(L);
         debug::Thread thread = target->stateToThread.at(L);
         // We transition into a paused state. Let's modify all pending breakpoints.
         auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
-        target->computeStoppedLocation(L);
-        if (lua_isyieldable(L))
-            lua_break(L);
-        else
-            target->stoppedNoYield = true;
-        // Clear out the interrupt and debugstep callback after we are done.
-        lua_callbacks(L)->interrupt = nullptr;
-        lua_callbacks(L)->debugstep = nullptr;
         lock.unlock();
-        // Since pausing actually only happens when the interrupt callback runs we have a callback
-        if (target->launchConfig.onPause)
-            target->launchConfig.onPause(thread);
-        for (auto& bp : installed)
-            target->launchConfig.onBreakpointInstall(bp);
-        for (auto& bp : uninstalled)
-            target->launchConfig.onBreakpointUninstall(bp);
-        if (target->stoppedNoYield)
-            target->childRuntime->waitForDebugContinue();
+        target->stoppedDispatchCallback(
+            [target, thread, installed = std::move(installed), uninstalled = std::move(uninstalled)]()
+            {
+                if (target->launchConfig.onPause)
+                    target->launchConfig.onPause(thread);
+                for (auto& bp : installed)
+                    target->launchConfig.onBreakpointInstall(bp);
+                for (auto& bp : uninstalled)
+                    target->launchConfig.onBreakpointUninstall(bp);
+            }
+        );
     };
     return true;
 }
@@ -1332,30 +1358,23 @@ bool Target::step(int threadId, StepType type)
         }
         if (stopStepping)
         {
-            target->paused = true;
-            target->childRuntime->stopDebug();
-            target->stoppedThread = L;
-            target->stoppedThreadRef = getRefForThread(L);
-            target->computeStoppedLocation(L);
-            target->stepInfo = std::nullopt;
-            auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
-            if (lua_isyieldable(L))
-                lua_break(L);
-            else
-                target->stoppedNoYield = true;
+            target->stoppedSetState(L);
             lua_singlestep(L, 0);
-            lua_callbacks(L)->debugstep = nullptr;
+            auto [installed, uninstalled] = target->modifyPendingBreakpoints(target->scriptThread);
             Thread thread = target->stateToThread.at(L);
             lock.unlock();
             // Since pausing actually only happens when the step callback runs we have a callback
-            if (target->launchConfig.onStepStop)
-                target->launchConfig.onStepStop(thread, stepInfo);
-            for (auto& bp : installed)
-                target->launchConfig.onBreakpointInstall(bp);
-            for (auto& bp : uninstalled)
-                target->launchConfig.onBreakpointUninstall(bp);
-            if (target->stoppedNoYield)
-                target->childRuntime->waitForDebugContinue();
+            target->stoppedDispatchCallback(
+                [target, thread, stepInfo, installed = std::move(installed), uninstalled = std::move(uninstalled)]()
+                {
+                    if (target->launchConfig.onStepStop)
+                        target->launchConfig.onStepStop(thread, stepInfo);
+                    for (auto& bp : installed)
+                        target->launchConfig.onBreakpointInstall(bp);
+                    for (auto& bp : uninstalled)
+                        target->launchConfig.onBreakpointUninstall(bp);
+                }
+            );
         }
         else
         {

--- a/lute/runtime/include/lute/runtime.h
+++ b/lute/runtime/include/lute/runtime.h
@@ -142,6 +142,7 @@ struct Runtime
     // for debug mode only:
     const bool debugMode;
     std::atomic<int> numLaunchedDebuggees = 0;
+    std::function<void()> pendingDebugStopNotification;
     void stopDebug();
     void continueDebug();
     void waitForDebugContinue();

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -414,10 +414,9 @@ void Runtime::continueDebug()
 }
 
 // stopDebug() actually allows for some C bookkeeping when we are unwinding the stack
-// when it is called within a callback such as debugbreak or debugInterrupt, which you could imagine might
-// lead to a race condition. The important thing is that this bookkeeping does not touch the Luau state that we can inspect
-// making this a nonissue.
-// We never schedule any Luau code to run afterwards, which means this is fine.
+// when it is called within a callback such as debugbreak or debugInterrupt.
+// We thus schedule any Luau callbacks to run after we are guaranteed to be stopped 
+// in runToCompletion().
 void Runtime::stopDebug()
 {
     LUTE_ASSERT(debugMode);

--- a/lute/runtime/src/runtime.cpp
+++ b/lute/runtime/src/runtime.cpp
@@ -180,6 +180,13 @@ bool Runtime::runToCompletion()
 
         auto step = runOnce();
 
+        if (debugMode && pendingDebugStopNotification)
+        {
+            auto debugStopNotification = std::move(pendingDebugStopNotification);
+            pendingDebugStopNotification = nullptr;
+            debugStopNotification();
+        }
+
         if (auto err = Luau::get_if<StepErr>(&step))
         {
             if (err->L == nullptr)

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -266,6 +266,116 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		check.that(table.find(source, normalizePath(mainPath)))
 		check.that(table.find(source, normalizePath(triangPath)))
 	end)
+	-- this test case focuses on multiple threads
+	suite:case("multithread", function(check)
+		local target = debug.newTarget()
+		check.eq(typeof(target), "Target")
+		local mainPath = path.format(path.join(proc.cwd(), "tests/src/debug/task.luau"))
+		local bp1 = target:setBreakpoint(mainPath, 7)
+		local bp2 = target:setBreakpoint(mainPath, 14)
+		local _bp3 = target:setBreakpoint(mainPath, 22)
+		local bpHit1 = 0
+		local bpHit2 = 0
+		local onFinished = false
+		local maxThreads = 0
+		local launchError = target:launch(mainPath, {}, {
+			onBreakpointHit = function(thread, bp)
+				if bp.id == bp1.id then
+					check.eq(thread.id, 2)
+					local stoppedThread = assert(target:getStoppedThread())
+					check.eq(stoppedThread.id, 2)
+					bpHit1 += 1
+					local threads = target:getThreads()
+					maxThreads = math.max(maxThreads, #threads)
+					if #threads == 3 then
+						local nameById = {}
+						for _, t in threads do
+							nameById[t.id] = t.name
+						end
+						check.eq(nameById[1], "Main Coroutine")
+						check.eq(nameById[2], "Coroutine 2")
+						check.eq(nameById[3], "Coroutine 3")
+					end
+					local stackTrace = assert(target:getStackTrace(thread.id))
+					local threadStack = stackTrace[#stackTrace]
+					check.eq(threadStack.line, 7)
+					local vars = assert(target:getVariablesByScopeType(threadStack.id, "local"))
+					checkVariable(check, vars, "_i", tostring(bpHit1), "number", false)
+					for _, otherThread in threads do
+						if otherThread.id == 3 then
+							local otherTrace = assert(target:getStackTrace(otherThread.id))
+							if #otherTrace > 0 then
+								local line = otherTrace[#otherTrace].line
+								check.that(line >= 12 and line <= 16)
+							end
+						end
+						if otherThread.id == 1 then
+							local otherTrace = assert(target:getStackTrace(otherThread.id))
+							if #otherTrace > 0 then
+								local line = otherTrace[#otherTrace].line
+								check.that(line >= 18 and line <= 20)
+							end
+						end
+					end
+				elseif bp.id == bp2.id then
+					check.eq(thread.id, 3)
+					local stoppedThread = assert(target:getStoppedThread())
+					check.eq(stoppedThread.id, 3)
+					local stackTrace = assert(target:getStackTrace(thread.id))
+					local threadStack = stackTrace[#stackTrace]
+					check.eq(threadStack.line, 14)
+					local threads = target:getThreads()
+					for _, otherThread in threads do
+						if otherThread.id == 2 then
+							local otherTrace = assert(target:getStackTrace(otherThread.id))
+							if #otherTrace > 0 then
+								local line = otherTrace[#otherTrace].line
+								check.that(line >= 5 and line <= 9)
+							end
+						end
+						if otherThread.id == 1 then
+							local otherTrace = assert(target:getStackTrace(otherThread.id))
+							if #otherTrace > 0 then
+								local line = otherTrace[#otherTrace].line
+								check.that(line >= 18 and line <= 20)
+							end
+						end
+					end
+					bpHit2 += 1
+					local vars = assert(target:getVariablesByScopeType(threadStack.id, "local"))
+					checkVariable(check, vars, "_i", tostring(bpHit2), "number", false)
+				else
+					local stoppedThread = assert(target:getStoppedThread())
+					check.eq(stoppedThread.id, 1)
+					local threads = target:getThreads()
+					check.eq(thread.id, 1)
+					check.eq(#threads, 1)
+					check.eq(threads[1].id, 1)
+					check.eq(threads[1].name, "Main Coroutine")
+				end
+				local continued = target:continueProcess()
+				check.that(continued)
+			end,
+			onExit = function(status)
+				if status then
+					onFinished = true
+				end
+			end,
+		})
+		check.eq(launchError, nil)
+		local stoppedThread = assert(target:getMainThread())
+		check.eq(stoppedThread.id, 1)
+		check.eq(stoppedThread.name, "Main Coroutine")
+		check.eq(
+			waitUntil(function()
+				return onFinished
+			end),
+			true
+		)
+		check.eq(bpHit1, 5)
+		check.eq(bpHit2, 5)
+		check.eq(maxThreads, 3)
+	end)
 	-- this test case focuses on replacing print
 	suite:case("print", function(check)
 		local target = debug.newTarget()

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -550,15 +550,21 @@ TEST_SUITE("Debug")
                     {
                         std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
                         REQUIRE(stackTrace.has_value());
-                        int line = stackTrace->at(stackTrace->size() - 1).line;
-                        CHECK((line >= 12 && line <= 16));
+                        if (stackTrace->size() > 0)
+                        {
+                            int line = stackTrace->at(stackTrace->size() - 1).line;
+                            CHECK((line >= 12 && line <= 16));
+                        }
                     }
                     if (thread.id == 1)
                     {
                         std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
                         REQUIRE(stackTrace.has_value());
-                        int line = stackTrace->at(stackTrace->size() - 1).line;
-                        CHECK((line >= 18 && line <= 20));
+                        if (stackTrace->size() > 0)
+                        {
+                            int line = stackTrace->at(stackTrace->size() - 1).line;
+                            CHECK((line >= 18 && line <= 20));
+                        }
                     }
                 }
             }
@@ -579,15 +585,21 @@ TEST_SUITE("Debug")
                     {
                         std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
                         REQUIRE(stackTrace.has_value());
-                        int line = stackTrace->at(stackTrace->size() - 1).line;
-                        CHECK((line >= 5 && line <= 9));
+                        if (stackTrace->size() > 0)
+                        {
+                            int line = stackTrace->at(stackTrace->size() - 1).line;
+                            CHECK((line >= 5 && line <= 9));
+                        }
                     }
                     if (thread.id == 1)
                     {
                         std::optional<std::vector<StackFrame>> stackTrace = target.getStackTrace(thread.id);
                         REQUIRE(stackTrace.has_value());
-                        int line = stackTrace->at(stackTrace->size() - 1).line;
-                        CHECK((line >= 18 && line <= 20));
+                        if (stackTrace->size() > 0)
+                        {
+                            int line = stackTrace->at(stackTrace->size() - 1).line;
+                            CHECK((line >= 18 && line <= 20));
+                        }
                     }
                 }
                 hitsBp2++;


### PR DESCRIPTION
Fixes https://github.com/luau-lang/lute/issues/1310. In order to do so, in yieldable contexts, we don't fire the callback immediately when receiving notification of hitting a breakpoint. instead, we wait for the current coroutine to yield and then fire this callback (after which the runtime will now be paused).

**Bug**
The root cause of the issue is that in the child runtime we schedule a debug callback on the parent runtime that inspects the child runtime in this time. This can race when the child runtime unwinds from `luau_callhook` leading to a corruption of the instruction pointer of the VM.

In particular, the issue is that in `getLocalVars()` in `debuginternals.cpp`
```
const Instruction* original = L->ci->savedpc;   // (A) read live pc
... L->ci->savedpc = stoppedPc;                 // (B)
... lua_getlocal loop ...
L->ci->savedpc = original;                      // (C) restore what A read
```

can race with in `luau_callhook` in `lvmexecute.cpp` in the Luau VM

```
oldsavedpc = L->ci->savedpc;      // = break_pc (line 185)
L->ci->savedpc++;                 // now break_pc+1   (line 188)
hook(L, &ar);                     // <-- our debugbreak runs here, schedules onBreakpointHit, returns (line 199)
L->ci->savedpc = oldsavedpc;      // restore break_pc (line 201)
```

Line 201 and (C) can race, resulting in L->ci->savedpc being set to break_pc + 1 instead of break_pc.

**Fix**
We fire the callback after the child runtime unwinds from `luau_callhook` and has already yielded the current coroutine. We do this right after yielding and right before the pause freezes further coroutines from firing on the runtime. 

Thus, since `luau_callhook` has already finishing calling and the thread it is being called on is yielded, there is no more opportunity for a race condtion.