### PR TITLE
`lute/debug`: fix global scoping across files

### DIFF
--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -47,7 +47,7 @@ export type VariableScopeType = "local" | "upvalue" | "global" | "table"
 --- A VariableScope contains the contextual information for a collection of Variables
 --- such as what variable reference ID number to refer to this collection, what type of collection
 --- it is, etc. Variable reference IDs are reset upon continuing execution.
---- Generally, VariableScope will have a type `locals`, `upvalues`, or `globals`. `table` is used in the C++ implementation
+--- Generally, VariableScope will have a type `local`, `upvalue`, or `global`. `table` is used in the C++ implementation
 --- but generally is not used in Luau code currently.
 export type VariableScope = {
 	variableRef: number,

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -71,14 +71,14 @@ struct VariableScope
     int variableReference;
     VariableScopeType type;
     std::string name;
-    int threadId; // for locals and upvalues
-    int level;    // for locals and upvalues
+    int threadId; // for locals, upvalues, and globals
+    int level;    // for locals, upvalues, and globals
     int luaref;   // for tables
 
     explicit VariableScope(int variableReference, VariableScopeType type, std::string name, int threadId = -1, int level = -1, int luaref = -1);
     static VariableScope makeLocals(int variableReference, int threadId, int level);
     static VariableScope makeUpvalues(int variableReference, int threadId, int level);
-    static VariableScope makeGlobals(int variableReference);
+    static VariableScope makeGlobals(int variableReference, int threadId, int level);
     static VariableScope makeTable(int variableReference, int luaref);
 };
 
@@ -233,7 +233,6 @@ private:
     // variable information
     // scope and variable information also resets upon every continue(). The base id resets to 1.
     int variableRefId = 1;
-    std::optional<int> globalVariableRef;
     std::unordered_map<int, std::vector<VariableScope>> scopeCache; // stack frame id -> scope
     std::unordered_map<int, std::vector<Variable>> variableCache;   // var reference -> all variables under that reference
     std::unordered_map<int, VariableScope> variableContexts;        // var reference -> variableContext
@@ -261,7 +260,7 @@ private:
     Variable makeVariable(lua_State* L, const std::string& name);
     std::vector<Variable> getLocalsHelper(lua_State* L, int level);
     std::vector<Variable> getUpvaluesHelper(lua_State* L, int level);
-    std::vector<Variable> getGlobalsHelper();
+    std::vector<Variable> getGlobalsHelper(lua_State* L, int level);
     std::vector<Variable> getTableHelper(lua_State* L, int idx);
 
     void injectLocals(lua_State* L, int level, lua_State* eval, int evalTableIndex);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -58,22 +58,22 @@ VariableScope::VariableScope(int variableReference, VariableScopeType type, std:
 
 VariableScope VariableScope::makeLocals(int variableReference, int threadId, int level)
 {
-    return VariableScope(variableReference, VariableScopeType::Local, "Locals", threadId, level, -1);
+    return VariableScope{variableReference, VariableScopeType::Local, "Locals", threadId, level, -1};
 }
 
 VariableScope VariableScope::makeUpvalues(int variableReference, int threadId, int level)
 {
-    return VariableScope(variableReference, VariableScopeType::Upvalue, "Upvalues", threadId, level, -1);
+    return VariableScope{variableReference, VariableScopeType::Upvalue, "Upvalues", threadId, level, -1};
 }
 
 VariableScope VariableScope::makeGlobals(int variableReference, int threadId, int level)
 {
-    return VariableScope(variableReference, VariableScopeType::Global, "Globals", threadId, level, -1);
+    return VariableScope{variableReference, VariableScopeType::Global, "Globals", threadId, level, -1};
 }
 
 VariableScope VariableScope::makeTable(int variableReference, int luaref)
 {
-    return VariableScope(variableReference, VariableScopeType::Table, "Table", -1, -1, luaref);
+    return VariableScope{variableReference, VariableScopeType::Table, "Table", -1, -1, luaref};
 }
 
 Target::Target(Runtime& parentRuntime)
@@ -475,7 +475,7 @@ std::optional<std::string> Target::launch(std::string sourcePath, const std::vec
             lua_pushstring(thread, arg.c_str());
         // thread initialization
         threadIdToState.insert_or_assign(threadId, thread);
-        stateToThread.insert_or_assign(thread, Thread(threadId, "Main Coroutine"));
+        stateToThread.insert_or_assign(thread, Thread{threadId, "Main Coroutine"});
         threadId++;
 
         scriptThread = thread;
@@ -627,7 +627,7 @@ void Target::installThreadCallback()
         else
         {
             target->threadIdToState.insert_or_assign(target->threadId, L);
-            target->stateToThread.insert_or_assign(L, Thread(target->threadId, "Coroutine " + std::to_string(target->threadId)));
+            target->stateToThread.insert_or_assign(L, Thread{target->threadId, "Coroutine " + std::to_string(target->threadId)});
             target->threadId++;
         }
     };

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -66,9 +66,9 @@ VariableScope VariableScope::makeUpvalues(int variableReference, int threadId, i
     return VariableScope(variableReference, VariableScopeType::Upvalue, "Upvalues", threadId, level, -1);
 }
 
-VariableScope VariableScope::makeGlobals(int variableReference)
+VariableScope VariableScope::makeGlobals(int variableReference, int threadId, int level)
 {
-    return VariableScope(variableReference, VariableScopeType::Global, "Globals", -1, -1, -1);
+    return VariableScope(variableReference, VariableScopeType::Global, "Globals", threadId, level, -1);
 }
 
 VariableScope VariableScope::makeTable(int variableReference, int luaref)
@@ -764,18 +764,10 @@ std::optional<std::vector<VariableScope>> Target::getScopesHelper(int threadId, 
     variableContexts.insert_or_assign(variableRefId, upvalues);
     variableRefId++;
     contexts.emplace_back(upvalues);
-    if (globalVariableRef)
-    {
-        contexts.emplace_back(variableContexts.at(*globalVariableRef));
-    }
-    else
-    {
-        VariableScope globals = VariableScope::makeGlobals(variableRefId);
-        variableContexts.insert_or_assign(variableRefId, globals);
-        globalVariableRef = variableRefId;
-        variableRefId++;
-        contexts.emplace_back(globals);
-    }
+    VariableScope globals = VariableScope::makeGlobals(variableRefId, threadId, level);
+    variableContexts.insert_or_assign(variableRefId, globals);
+    variableRefId++;
+    contexts.emplace_back(globals);
     scopeCache[frame->id] = contexts;
     return contexts;
 }
@@ -984,9 +976,14 @@ std::vector<Variable> Target::getUpvaluesHelper(lua_State* L, int level)
     return vars;
 }
 
-std::vector<Variable> Target::getGlobalsHelper()
+std::vector<Variable> Target::getGlobalsHelper(lua_State* L, int level)
 {
-    return getTableHelper(scriptThread, LUA_GLOBALSINDEX);
+    lua_Debug ar = {};
+    lua_getinfo(L, level, "f", &ar);
+    lua_getfenv(L, -1);
+    std::vector<Variable> vars = getTableHelper(L, -1);
+    lua_pop(L, 2);
+    return vars;
 }
 
 std::vector<Variable> Target::getTableHelper(lua_State* L, int idx)
@@ -1022,7 +1019,7 @@ std::optional<std::vector<Variable>> Target::getVariablesHelper(int varRef)
     }
     else if (context.type == VariableScopeType::Global)
     {
-        vars = getGlobalsHelper();
+        vars = getGlobalsHelper(threadIdToState.at(context.threadId), context.level);
     }
     else
     {
@@ -1152,11 +1149,22 @@ EvaluateResult Target::evaluateExpressionHelper(lua_State* L, int level, std::st
     lua_State* evalThread = lua_newthread(childRuntime->GL);
     StackGuard stackGuard{childRuntime->GL};
     lua_newtable(evalThread);
-    // sets the main script thread's global table as the top most scope of all variables for evaluation
-    // this is safe since globals are shared among tasks.
     lua_newtable(evalThread);
-    lua_pushvalue(scriptThread, LUA_GLOBALSINDEX);
-    lua_xmove(scriptThread, evalThread, 1);
+    if (L != nullptr)
+    {
+        // use the fenv of the frame being evaluated as the top most scope
+        lua_Debug ar = {};
+        lua_getinfo(L, level, "f", &ar);
+        lua_getfenv(L, -1);
+        lua_xmove(L, evalThread, 1);
+        lua_pop(L, 1);
+    }
+    else
+    {
+        // fall back to the main script thread's globals if in global context
+        lua_pushvalue(scriptThread, LUA_GLOBALSINDEX);
+        lua_xmove(scriptThread, evalThread, 1);
+    }
     lua_setfield(evalThread, 2, "__index");
     lua_setmetatable(evalThread, 1);
     // inject locals + upvalues
@@ -1221,7 +1229,6 @@ void Target::continueProcessHelper()
     idToStackFrameInfo.clear();
 
     variableRefId = 1;
-    globalVariableRef = std::nullopt;
     for (auto& [_, scope] : variableContexts)
         if (scope.type == VariableScopeType::Table)
             lua_unref(childRuntime->GL, scope.luaref);

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -575,7 +575,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				check.eq(#scopes, 3)
 				checkScope(check, scopes, "Locals", "local", threads[1].id, 0)
 				checkScope(check, scopes, "Upvalues", "upvalue", threads[1].id, 0)
-				checkScope(check, scopes, "Globals", "global", -1, -1)
+				checkScope(check, scopes, "Globals", "global", threads[1].id, 0)
 				for _, scope in scopes do
 					if scope.type == "local" then
 						local locals = target:getVariables(scope.variableRef)

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -925,4 +925,53 @@ TEST_SUITE("Debug")
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
         CHECK(numHits == 2);
     };
+
+    TEST_CASE_FIXTURE(DebugFixture, "Debug_globalscoping")
+    {
+        std::string fixturePath = getDebugFixturePath("global_scope.luau");
+        std::string importPath = getDebugFixturePath("global_import.luau");
+
+        Target target(*runtime);
+        Breakpoint bp1 = target.setBreakpoint(fixturePath, 5);
+        Breakpoint bp2 = target.setBreakpoint(importPath, 6);
+        int numHits = 0;
+        config.onBreakpointHit = [&](const Thread&, const Breakpoint& bp)
+        {
+            const std::vector<Thread>& threads = target.getThreads();
+            REQUIRE(threads.size() == 1);
+            const std::optional<std::vector<StackFrame>> st = target.getStackTrace(threads[0].id);
+            REQUIRE(st.has_value());
+            if (bp.id == bp1.id)
+            {
+                std::optional<std::vector<Variable>> globals = target.getVariablesByScopeType(st->at(0).id, VariableScopeType::Global);
+                REQUIRE(globals.has_value());
+                checkVariable(*globals, "_global_var", "3", "number", false);
+                checkVariable(*globals, "_global_var2", "5", "number", false);
+                REQUIRE(globals->size() == 2);
+                EvaluateResult result = target.evaluateExpression("_global_var * 5", st->at(0).id);
+                REQUIRE(std::holds_alternative<Variable>(result));
+                Variable var = std::get<Variable>(result);
+                CHECK(var.value == "15");
+                CHECK(var.type == "number");
+                numHits++;
+            }
+            if (bp.id == bp2.id)
+            {
+                std::optional<std::vector<Variable>> globals = target.getVariablesByScopeType(st->at(0).id, VariableScopeType::Global);
+                REQUIRE(globals.has_value());
+                checkVariable(*globals, "_global_var", "6", "number", false);
+                REQUIRE(globals->size() == 1);
+                EvaluateResult result = target.evaluateExpression("_global_var * 5", st->at(0).id);
+                REQUIRE(std::holds_alternative<Variable>(result));
+                Variable var = std::get<Variable>(result);
+                CHECK(var.value == "30");
+                CHECK(var.type == "number");
+                numHits++;
+            }
+            target.continueProcess();
+        };
+        target.launch(fixturePath, {}, config);
+        REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
+        CHECK(numHits == 2);
+    };
 }

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -728,7 +728,7 @@ TEST_SUITE("Debug")
             REQUIRE(scopes.has_value());
             checkScope(*scopes, VariableScopeType::Local, "Locals", 1, 0);
             checkScope(*scopes, VariableScopeType::Upvalue, "Upvalues", 1, 0);
-            checkScope(*scopes, VariableScopeType::Global, "Globals", -1, -1);
+            checkScope(*scopes, VariableScopeType::Global, "Globals", 1, 0);
             std::optional<std::vector<Variable>> upvalues0 = target.getVariablesByScopeType(stackframe->at(0).id, VariableScopeType::Upvalue);
             REQUIRE(upvalues0.has_value());
             checkVariable(*upvalues0, "a", "24", "number", false);
@@ -743,7 +743,7 @@ TEST_SUITE("Debug")
             REQUIRE(scopes.has_value());
             checkScope(*scopes, VariableScopeType::Local, "Locals", 1, 1);
             checkScope(*scopes, VariableScopeType::Upvalue, "Upvalues", 1, 1);
-            checkScope(*scopes, VariableScopeType::Global, "Globals", -1, -1);
+            checkScope(*scopes, VariableScopeType::Global, "Globals", 1, 1);
             std::optional<std::vector<Variable>> locals1 = target.getVariablesByScopeType(stackframe->at(1).id, VariableScopeType::Local);
             REQUIRE(locals1.has_value());
             checkVariable(*locals1, "a", "24", "number", false);

--- a/tests/src/debug/global_import.luau
+++ b/tests/src/debug/global_import.luau
@@ -1,0 +1,8 @@
+local M = {}
+
+_global_var = 6
+
+function M.f()
+	return 1
+end
+return M

--- a/tests/src/debug/global_scope.luau
+++ b/tests/src/debug/global_scope.luau
@@ -1,0 +1,5 @@
+local imp = require("./global_import")
+
+_global_var = 3
+_global_var2 = 5
+imp.f()


### PR DESCRIPTION
Fixes global scopes across files, since each file has its own set of globals. Previously, global scopes always defaulted to the main script file's globals.

https://github.com/user-attachments/assets/632e665f-4c24-406e-af8e-8ab39d8358cd

