### PR TITLE
`lute/debug`: add onSourceLoad

### DIFF
--- a/definitions/debugger.luau
+++ b/definitions/debugger.luau
@@ -133,6 +133,8 @@ export type LaunchConfig = {
 	--- called when hitting an exception on `thread`. `bpId` reflects the id of the bp hit. These ids
 	--- match what is returned by setExceptionBreakpoint. `message` is the message thrown by the exception.
 	onException: ((thread: Thread, bpId: number, message: string) -> ())?,
+	--- called when we load a source `source` (using absolute path)
+	onSourceLoad: ((source: string) -> ())?,
 }
 
 --- A `Target` represents the target program under the debugger.

--- a/lute/cli/commands/debug/dap.luau
+++ b/lute/cli/commands/debug/dap.luau
@@ -121,6 +121,12 @@ local function dapLoop(reader: dapStream.Reader, writer: dapStream.Writer)
 				hitBreakpointIds = { bpId },
 			})
 		end,
+		onSourceLoad = function(source: string)
+			local dapSource = createSource(source)
+			if dapSource then
+				ioSession.writeEvent("loadedSource", { reason = "new", source = dapSource })
+			end
+		end,
 	}
 	local configurationDone = false
 	local launchConfig: dapTypes.LaunchArgs? = nil

--- a/lute/debug/include/lute/debuginternals.h
+++ b/lute/debug/include/lute/debuginternals.h
@@ -146,6 +146,7 @@ struct LaunchConfig
     std::function<void(const std::string& message, const std::string& source, int line)> onPrint;
     std::function<void(const Thread& thread, const StepInfo& stepInfo)> onStepStop;
     std::function<void(const Thread& thread, int bpId, const std::string& errorMessage)> onException;
+    std::function<void(const std::string& source)> onSourceLoad;
 };
 
 struct Target

--- a/lute/debug/src/debug.cpp
+++ b/lute/debug/src/debug.cpp
@@ -845,6 +845,21 @@ static int target_launch(lua_State* L)
                 );
             };
         }
+        if (auto ref = getOptionalCallback(L, 4, "onSourceLoad"))
+        {
+            config.onSourceLoad = [ref, runtime](std::string source)
+            {
+                runtime->scheduleDebugLuauCallback(
+                    ref,
+                    [source](lua_State* L)
+                    {
+                        checkStack(L, 1);
+                        lua_pushstring(L, source.c_str());
+                        return 1;
+                    }
+                );
+            };
+        }
     }
     std::optional<std::string> error = target->launch(source, args, config);
     checkStack(L, 1);

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -454,6 +454,8 @@ std::optional<std::string> Target::launch(std::string sourcePath, const std::vec
         std::function<void(lua_State * L, const std::string& chunkName)> onChunkLoad = [this](lua_State* ML, const std::string& chunkName)
         {
             std::string source = getSourceFromChunk(chunkName);
+            if (launchConfig.onSourceLoad)
+                launchConfig.onSourceLoad(source);
             std::vector<Breakpoint> installed;
             std::vector<Breakpoint> uninstalled;
             {
@@ -500,7 +502,15 @@ std::optional<std::string> Target::launch(std::string sourcePath, const std::vec
             childRuntime.reset();
             return error;
         }
+        // All VM setup happens synchronously before runContinuously starts the background thread.
+        // The no-op schedule wakes the event loop so it picks up the queued thread.
+        paused = false;
+        launched = true;
+        parentRuntime.numLaunchedDebuggees++;
+
         loadedSources[sourcePath] = std::make_shared<Ref>(thread, -1);
+        if (launchConfig.onSourceLoad)
+            launchConfig.onSourceLoad(sourcePath);
 
         std::tie(installedBps, uninstalledBps) = modifyPendingBreakpoints(thread);
         for (const std::string& arg : args)
@@ -521,11 +531,6 @@ std::optional<std::string> Target::launch(std::string sourcePath, const std::vec
         installThreadCallback();
         installExceptionCallback();
 
-        // All VM setup happens synchronously before runContinuously starts the background thread.
-        // The no-op schedule wakes the event loop so it picks up the queued thread.
-        paused = false;
-        launched = true;
-        parentRuntime.numLaunchedDebuggees++;
         childRuntime->schedule([]() {});
         childRuntime->runContinuously();
     }

--- a/lute/debug/src/debuginternals.cpp
+++ b/lute/debug/src/debuginternals.cpp
@@ -502,8 +502,6 @@ std::optional<std::string> Target::launch(std::string sourcePath, const std::vec
             childRuntime.reset();
             return error;
         }
-        // All VM setup happens synchronously before runContinuously starts the background thread.
-        // The no-op schedule wakes the event loop so it picks up the queued thread.
         paused = false;
         launched = true;
         parentRuntime.numLaunchedDebuggees++;
@@ -531,6 +529,8 @@ std::optional<std::string> Target::launch(std::string sourcePath, const std::vec
         installThreadCallback();
         installExceptionCallback();
 
+        // All VM setup happens synchronously before runContinuously starts the background thread.
+        // The no-op schedule wakes the event loop so it picks up the queued thread.
         childRuntime->schedule([]() {});
         childRuntime->runContinuously();
     }

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -237,6 +237,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		local bpHit1 = 0
 		local bpHit2 = 0
 		local onFinished = false
+		local sourceEvents = {}
 		local targetLaunched = target:launch(mainPath, {}, {
 			onBreakpointHit = function(_thread, bp)
 				if bp.id == bp1.id then
@@ -246,6 +247,9 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				end
 				local continued = target:continueProcess()
 				check.that(continued)
+			end,
+			onSourceLoad = function(source) 
+				table.insert(sourceEvents, source)
 			end,
 			onExit = function(status)
 				if status then
@@ -263,8 +267,12 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 		check.eq(bpHit1, 5)
 		check.eq(bpHit2, 15)
 		local source = target:getLoadedSources()
+		check.eq(#source, 2)
 		check.that(table.find(source, normalizePath(mainPath)))
 		check.that(table.find(source, normalizePath(triangPath)))
+		check.eq(#sourceEvents, 2)
+		check.that(table.find(sourceEvents, normalizePath(mainPath)))
+		check.that(table.find(sourceEvents, normalizePath(triangPath)))
 	end)
 	-- this test case focuses on multiple threads
 	suite:case("multithread", function(check)

--- a/tests/lute/debugger.test.luau
+++ b/tests/lute/debugger.test.luau
@@ -248,7 +248,7 @@ test.suite("LuteDebugLibrarySuite", function(suite)
 				local continued = target:continueProcess()
 				check.that(continued)
 			end,
-			onSourceLoad = function(source) 
+			onSourceLoad = function(source)
 				table.insert(sourceEvents, source)
 			end,
 			onExit = function(status)

--- a/tests/src/debug.test.cpp
+++ b/tests/src/debug.test.cpp
@@ -373,6 +373,7 @@ TEST_SUITE("Debug")
         Target target(*runtime);
         Breakpoint bp1 = target.setBreakpoint(mainPath, 5);
         Breakpoint bp2 = target.setBreakpoint(triangPath, 5);
+        std::vector<std::string> sourceEvents;
         config.onBreakpointInstall = [&](const Breakpoint& bp)
         {
             bpInstalled++;
@@ -385,7 +386,10 @@ TEST_SUITE("Debug")
                 bpHit2++;
             target.continueProcess();
         };
-        std::optional<std::string> error = target.launch(mainPath, {}, config);
+        config.onSourceLoad = [&](const std::string& source) {
+            sourceEvents.push_back(source);
+        };
+         std::optional<std::string> error = target.launch(mainPath, {}, config);
         CHECK(!error);
         // check we are done
         REQUIRE(exitFuture.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
@@ -394,6 +398,9 @@ TEST_SUITE("Debug")
         CHECK(bpInstalled == 2);
         std::vector<std::string> sources = target.getLoadedSources();
         CHECK(sources.size() == 2);
+        CHECK(std::find(sources.begin(), sources.end(), mainPath) != sources.end());
+        CHECK(std::find(sources.begin(), sources.end(), triangPath) != sources.end());
+        CHECK(sourceEvents.size() == 2);
         CHECK(std::find(sources.begin(), sources.end(), mainPath) != sources.end());
         CHECK(std::find(sources.begin(), sources.end(), triangPath) != sources.end());
     }


### PR DESCRIPTION
adds `onSourceLoad` to inform when sources are loaded. this is used in dap to send the `loadedSource` event.
* this is apparently what the emacs `dape` adapter uses to track sources instead of the `loadedSources`request and is easily implementable