### PR TITLE
Add CstStatConst type export to @std/syntax

### DIFF
--- a/lute/std/libs/syntax/init.luau
+++ b/lute/std/libs/syntax/init.luau
@@ -111,6 +111,8 @@ export type CstStatExpr = cst.CstStatExpr
 
 export type CstStatLocal = cst.CstStatLocal
 
+export type CstStatConst = cst.CstStatConst
+
 export type CstStatFor = cst.CstStatFor
 
 export type CstStatForIn = cst.CstStatForIn


### PR DESCRIPTION
All of the exports from `@std/syntax/types` are exported from `@std/syntax` except `CstStatConst`, which has now been added.

Assuming this was missed in #1050, as the nodes should be exported from both files.